### PR TITLE
feat(buttongroup): unstyled button group

### DIFF
--- a/scss/components/button-group/button-group.scss
+++ b/scss/components/button-group/button-group.scss
@@ -1,7 +1,7 @@
 /** @component button-group */
 
 @include exports('md-button-group') {
-  .#{$button-group__class} {
+  .#{$button-group__class}:not(.#{$button-group__class}--unstyled) {
     display: flex;
     width: 100%;
 

--- a/src/lib/Button/examples/FileWhiteboard.js
+++ b/src/lib/Button/examples/FileWhiteboard.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import { Button } from '@momentum-ui/react';
+import { Button, ButtonGroup } from '@momentum-ui/react';
 export default function ButtonFileWhiteboard() {
   return(
-    <React.Fragment>
+    <ButtonGroup type="unstyled">
     <Button
       className='files'
       children='Files'
@@ -17,6 +17,6 @@ export default function ButtonFileWhiteboard() {
       ariaLabel='Test'
       color='whiteboards'
     />
-    </React.Fragment>
+    </ButtonGroup>
   );
 }

--- a/src/lib/ButtonGroup/index.js
+++ b/src/lib/ButtonGroup/index.js
@@ -323,7 +323,7 @@ ButtonGroup.propTypes = {
   /** @prop Optional Button color theme for ButtonGroup | '' */
   theme: PropTypes.oneOf(['', 'dark']),
   /** @prop Optional Button type for ButtonGroup | '' */
-  type: PropTypes.oneOf(['', 'pill']),
+  type: PropTypes.oneOf(['', 'pill', 'unstyled']),
 };
 
 ButtonGroup.defaultProps = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Button groups don't work with colored buttons right now. I've created an "unstyled" button group type that allows you to use the rest of the button group features but without changing the style of the individual buttons.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots:
**Before** (If applicable):
<!--- Please add before images, gifs or videos here: -->

**After**:
<!--- Please add after images, gifs or videos here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
