### PR TITLE
feat(icon): add fill color

### DIFF
--- a/src/components/Icon/Icon.stories.tsx
+++ b/src/components/Icon/Icon.stories.tsx
@@ -104,6 +104,19 @@ export default {
         },
       },
     },
+    fillColor: {
+      defaultValue: undefined,
+      description: 'Color for the icon to be filled with.',
+      control: { type: 'color' },
+      table: {
+        type: {
+          summary: 'string',
+        },
+        defaultValue: {
+          summary: undefined,
+        },
+      },
+    },
   },
 };
 

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -6,24 +6,35 @@ import { DEFAULTS, STYLE } from './Icon.constants';
 import classnames from 'classnames';
 
 const Icon: React.FC<Props> = (props: Props) => {
-  const { className, scale, name, weight, autoScale } = props;
+  const { className, scale, name, weight, autoScale, fillColor } = props;
   const { SvgIcon, error } = useDynamicSVGImport(`${name}-${weight || DEFAULTS.WEIGHT}`);
+
+  const isColoredIcon = name.indexOf('coloured') > 0;
 
   if (error) {
     return <p className={STYLE.notFound}>Icon not found.</p>;
   }
+
+  const getFillColor = () => {
+    if (fillColor && !isColoredIcon) {
+      return { fill: fillColor };
+    } else {
+      return null;
+    }
+  };
 
   if (SvgIcon) {
     return (
       <div className={STYLE.wrapper}>
         <SvgIcon
           // coloured class is added to avoid theming the fixed colours inside coloured icons
-          className={classnames(className, { [STYLE.coloured]: name.indexOf('coloured') > 0 })}
+          className={classnames(className, { [STYLE.coloured]: isColoredIcon })}
           viewBox="0, 0, 32, 32"
           width="100%"
           height="100%"
           data-scale={!autoScale && (scale || DEFAULTS.SCALE)}
           data-autoscale={autoScale || DEFAULTS.AUTO_SCALE}
+          style={getFillColor()}
         />
       </div>
     );

--- a/src/components/Icon/Icon.types.ts
+++ b/src/components/Icon/Icon.types.ts
@@ -23,4 +23,8 @@ export interface Props {
    * Note: Not all icons have all 4 styles.
    */
   weight?: 'light' | 'regular' | 'bold' | 'filled';
+  /**
+   * Color for the icon to be filled with
+   */
+  fillColor?: string;
 }

--- a/src/components/Icon/Icon.unit.test.tsx
+++ b/src/components/Icon/Icon.unit.test.tsx
@@ -53,6 +53,14 @@ describe('Icon', () => {
       expect(container).toMatchSnapshot();
     });
 
+    it('should match snapshot with fillColor', async () => {
+      expect.assertions(1);
+
+      container = await mountAndWait(<Icon name="accessibility" fillColor="red" />);
+
+      expect(container).toMatchSnapshot();
+    });
+
     it('should match snapshot with invalid name', async () => {
       expect.assertions(1);
       jest.setMock('@momentum-ui/icons-rebrand/svg/invalid_icon_name.svg', undefined);
@@ -105,6 +113,26 @@ describe('Icon', () => {
       const icon = wrapper.find('svg').getDOMNode();
 
       expect(icon.classList.contains('md-icon-coloured')).toBe(true);
+    });
+
+    it('should pass fillColor prop', async () => {
+      const fillColor = 'blue';
+
+      const wrapper = await mountAndWait(<Icon name={'accessibility'} fillColor={fillColor} />);
+      const icon = wrapper.find('svg').getDOMNode();
+
+      expect(icon.getAttribute('style')).toBe(`fill: ${fillColor};`);
+    });
+
+    it('should not pass fillColor prop if icon is already coloured', async () => {
+      const fillColor = 'blue';
+
+      const wrapper = await mountAndWait(
+        <Icon name={'accessibility-coloured'} fillColor={fillColor} />
+      );
+      const icon = wrapper.find('svg').getDOMNode();
+
+      expect(icon.getAttribute('style')).toBe(null);
     });
   });
 });

--- a/src/components/Icon/Icon.unit.test.tsx.snap
+++ b/src/components/Icon/Icon.unit.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`Icon snapshot should match snapshot 1`] = `
       data-autoscale={false}
       data-scale={32}
       height="100%"
+      style={null}
       viewBox="0, 0, 32, 32"
       width="100%"
     />
@@ -32,6 +33,32 @@ exports[`Icon snapshot should match snapshot with autoScale 1`] = `
       data-autoscale={true}
       data-scale={false}
       height="100%"
+      style={null}
+      viewBox="0, 0, 32, 32"
+      width="100%"
+    />
+  </div>
+</Icon>
+`;
+
+exports[`Icon snapshot should match snapshot with fillColor 1`] = `
+<Icon
+  fillColor="red"
+  name="accessibility"
+>
+  <div
+    className="md-icon-wrapper"
+  >
+    <svg
+      className=""
+      data-autoscale={false}
+      data-scale={32}
+      height="100%"
+      style={
+        Object {
+          "fill": "red",
+        }
+      }
       viewBox="0, 0, 32, 32"
       width="100%"
     />
@@ -64,6 +91,7 @@ exports[`Icon snapshot should match snapshot with scale 1`] = `
       data-autoscale={false}
       data-scale={16}
       height="100%"
+      style={null}
       viewBox="0, 0, 32, 32"
       width="100%"
     />
@@ -84,6 +112,7 @@ exports[`Icon snapshot should match snapshot with weight 1`] = `
       data-autoscale={false}
       data-scale={32}
       height="100%"
+      style={null}
       viewBox="0, 0, 32, 32"
       width="100%"
     />


### PR DESCRIPTION

# Description

Added `fillColor` prop to Icon so that consumers can override the fill colour of icons. The property is ignored if the icon is already coloured.