### PR TITLE
fix(avatar): icon mismatch failure badge

### DIFF
--- a/scss/components/avatar/avatar.scss
+++ b/scss/components/avatar/avatar.scss
@@ -21,7 +21,8 @@
       font-size: $avatar-failure-badge__size;
       color: $avatar-failure-badge__color;
       background-color: $avatar-failure-badge__background;
-      content: $icon-priority_12;
+      content: $icon-private_12;
+      font-weight: $font-weight-bold;
 
       @include flex;
       @include border-radius($global-rounded);


### PR DESCRIPTION


# Description

Icon mismatch failure badge in Avatar
*The full description of the changes made in this request.*

# Links
Previously Icon badge coming with share
![Screenshot 2021-08-09 161127](https://user-images.githubusercontent.com/11908216/128698468-d8406dfe-f0cb-4259-a071-94ecb9fe88b3.png)
Now coming with failure icon on avatar
![Screenshot 2021-08-09 163533](https://user-images.githubusercontent.com/11908216/128698499-c92218ce-31df-4ebf-814d-f3a403b2935e.png)

*Links to relevent resources.*
