### PR TITLE
feat/codeinput/add-onChange

### DIFF
--- a/src/components/CodeInput/CodeInput.stories.tsx
+++ b/src/components/CodeInput/CodeInput.stories.tsx
@@ -43,9 +43,14 @@ export default {
       description: 'Whether the input is disabled or not',
       control: { type: 'boolean' },
     },
-    onCompleteChoice: {
+    onComplete: {
       description: 'What happens when the code is complete',
       options: ['show error', 'go disabled', 'alert'],
+      control: { type: 'select' },
+    },
+    onChange: {
+      description: 'If present, the this handler will fire whenever the code changes',
+      options: ['alert'],
       control: { type: 'select' },
     },
   },
@@ -53,11 +58,12 @@ export default {
 
 interface StoryProps extends CodeInputProps {
   messageArr: [];
-  onCompleteChoice;
+  onComplete;
+  onChange;
 }
 
 const Template: Story<StoryProps> = (args) => {
-  const { onCompleteChoice } = args;
+  const { onComplete, onChange } = args;
   const [messageArrInt, setMessageArr] = useState<Message[]>(args.messageArr);
   const [isDisabled, setDisabled] = useState(args.disabled);
 
@@ -67,7 +73,7 @@ const Template: Story<StoryProps> = (args) => {
       messageArr={messageArrInt}
       disabled={isDisabled}
       onComplete={(code) => {
-        switch (onCompleteChoice) {
+        switch (onComplete) {
           case 'show error':
             setMessageArr([{ message: 'test', type: 'error' }]);
             break;
@@ -75,7 +81,12 @@ const Template: Story<StoryProps> = (args) => {
             setDisabled(true);
             break;
           case 'alert':
-            alert(`code is ${code}`);
+            alert(`onComplete: code is ${code}`);
+        }
+      }}
+      onChange={(code) => {
+        if (onChange === 'alert') {
+          alert(`onChange: code is ${code}`);
         }
       }}
     />

--- a/src/components/CodeInput/CodeInput.tsx
+++ b/src/components/CodeInput/CodeInput.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useState, useEffect } from 'react';
+import React, { ReactElement, useState, useEffect, useRef } from 'react';
 import VerificationInput from 'react-verification-input';
 
 import './CodeInput.style.scss';
@@ -17,7 +17,19 @@ const filterMessagesByType = (array, value) => {
 };
 
 const CodeInput: React.FC<Props> = (props: Props): ReactElement => {
-  const { numDigits, onComplete, ariaLabel, messageArr = [], disabled = false, className } = props;
+  const {
+    numDigits,
+    onChange = () => {
+      /* Optional */
+    },
+    onComplete = () => {
+      /* Optional */
+    },
+    ariaLabel,
+    messageArr = [],
+    disabled = false,
+    className,
+  } = props;
 
   const [internalMessageArray, setInternalMessageArray] = useState(messageArr);
   const [isComplete, setComplete] = useState(false);
@@ -27,7 +39,13 @@ const CodeInput: React.FC<Props> = (props: Props): ReactElement => {
     (internalMessageArray.length > 0 && determineMessageType(internalMessageArray)) || 'none';
   const messages = (messageType && filterMessagesByType(internalMessageArray, messageType)) || null;
 
+  const firstUpdate = useRef(true);
   useEffect(() => {
+    if (firstUpdate.current) {
+      firstUpdate.current = false;
+      return;
+    }
+    onChange(value);
     if (value.length === numDigits) {
       onComplete(value);
       setComplete(true);

--- a/src/components/CodeInput/CodeInput.types.ts
+++ b/src/components/CodeInput/CodeInput.types.ts
@@ -13,6 +13,10 @@ export interface Props {
    */
   numDigits: number;
   /**
+   * onChange: callback that fires whenever the entered code changes
+   */
+  onChange?: (code: string) => void;
+  /**
    * onComplete: callback that fires when the user enters the final digit
    */
   onComplete?: (code: string) => void;

--- a/src/components/CodeInput/CodeInput.unit.test.tsx
+++ b/src/components/CodeInput/CodeInput.unit.test.tsx
@@ -94,17 +94,47 @@ describe('CodeInput', () => {
   });
 
   describe('digit entry', () => {
-    it('fires codeComplete when number of digits reached', () => {
+    it('fires onChange when digits are entered', () => {
+      const spy = jest.fn();
+      const codeInput = mount(<CodeInput numDigits={3} onChange={spy} />);
+      codeInput.simulate('click');
+
+      const testInput = (value) => {
+        codeInput.find('input').hostNodes().simulate('change', { target: { value } });
+        expect(codeInput.find('input').props().value).toEqual(value);
+        expect(spy).toBeCalledWith(value);
+        spy.mockClear();
+      };
+
+      testInput('1');
+      testInput('12');
+      testInput('123');
+      testInput('45');
+      testInput('6');
+    });
+
+    it('fires onComplete when number of digits reached', () => {
       const spy = jest.fn();
       const codeInput = mount(<CodeInput numDigits={3} onComplete={spy} />);
       codeInput.simulate('click');
-      codeInput
-        .find('input')
-        .hostNodes()
-        .simulate('change', { target: { value: '123' } });
-      const input = codeInput.find('input');
-      expect(input.props().value).toEqual('123');
-      expect(spy).toBeCalledWith('123');
+
+      const testInput = (value, expectOnComplete) => {
+        codeInput.find('input').hostNodes().simulate('change', { target: { value } });
+        expect(codeInput.find('input').props().value).toEqual(value);
+        if (expectOnComplete) {
+          expect(spy).toBeCalledWith(value);
+        } else {
+          expect(spy).not.toHaveBeenCalled();
+        }
+        spy.mockClear();
+      };
+
+      testInput('1', false);
+      testInput('12', false);
+      testInput('123', true);
+      testInput('45', false);
+      testInput('6', false);
+      testInput('789', true);
     });
   });
 });


### PR DESCRIPTION
# Description

CodeInput only provides an onComplete function, which was not sufficient for the pairing UI, where we want to know at any point in time what the value is so that we can enable/disable the "Ok" button accordingly. I've added a new test for onChange and improved the test for onComplete. I also added default values for onComplete and onChange, because previously throw an exception if onComplete was not provided (despite it being optional). I was going to add autoFocus to this PR as well but it looks like autoFocus props are banned by eslint in this repo - I'm assuming this is intentional so I'll improvise on the Cantina side, but if not let me know... 
