### PR TITLE
feat(components/badge): fit-content, delete defaultValue, include in …

### DIFF
--- a/src/components/Badge/Badge.stories.tsx
+++ b/src/components/Badge/Badge.stories.tsx
@@ -36,7 +36,6 @@ export default {
 
 const argTypes = {
   children: {
-    defaultValue: '1',
     description: 'Provides the child text for this element.',
     control: { type: 'text' },
     table: {
@@ -49,7 +48,6 @@ const argTypes = {
     },
   },
   size: {
-    defaultValue: CONSTANTS.DEFAULTS.SIZE,
     description: 'Modifies the size of this element.',
     options: [undefined, ...Object.values(CONSTANTS.SIZES)],
     control: { type: 'select' },

--- a/src/components/Badge/Badge.style.scss
+++ b/src/components/Badge/Badge.style.scss
@@ -12,7 +12,7 @@
         border-radius: 2rem;
         height: 1.125rem;
         min-width: 1.125rem;
-        width: auto;
+        width: fit-content;
         box-sizing: border-box;
         padding:0 0.25rem;
          /* Align */

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,6 +1,7 @@
 export { default as AlertBadge } from './AlertBadge';
 export { default as Avatar } from './Avatar';
 export { default as AvatarCompact } from './AvatarCompact';
+export { default as Badge } from './Badge';
 export { default as ButtonCircle } from './ButtonCircle';
 export { default as ButtonDialpad } from './ButtonDialpad';
 export { default as ButtonGroup } from './ButtonGroup';


### PR DESCRIPTION
# Description

As part of the badge component, three fixes were done:
1. width: fix-container was used to avoid the badge size 18 to stretching when on flex. 
2. defaultValue was taken out from stories
3. Badge was included in src/components/index.js

# Screenshots
Block
![image](https://user-images.githubusercontent.com/56999622/130597200-ce5abf61-7fc4-437e-b2d6-1fe9b79ab72c.png)
Flex
![image](https://user-images.githubusercontent.com/56999622/130597227-fab508ed-8886-4a6f-a034-6e1d4098e35d.png)

