### PR TITLE
feat/components/create-button-simple

### DIFF
--- a/src/components/ButtonSimple/ButtonSimple.stories.args.ts
+++ b/src/components/ButtonSimple/ButtonSimple.stories.args.ts
@@ -1,0 +1,18 @@
+import { commonAriaButton, commonStyles } from '../../storybook/helper.stories.argtypes';
+
+export default {
+  ...commonStyles,
+  ...commonAriaButton,
+  children: {
+    description: 'Provides the child nodes for this element.',
+    control: { type: 'text' },
+    table: {
+      type: {
+        summary: 'ReactNode',
+      },
+      defaultValue: {
+        summary: 'undefined',
+      },
+    },
+  },
+};

--- a/src/components/ButtonSimple/ButtonSimple.stories.docs.mdx
+++ b/src/components/ButtonSimple/ButtonSimple.stories.docs.mdx
@@ -1,0 +1,1 @@
+The `<ButtonSimple />` component. This component is used when injecting buttons into other components that implement specific styling for their button components. This component should not be used unless it is being passed in as a prop of another **Momentum UI** component.

--- a/src/components/ButtonSimple/ButtonSimple.stories.tsx
+++ b/src/components/ButtonSimple/ButtonSimple.stories.tsx
@@ -1,0 +1,59 @@
+import { MultiTemplate, Template } from '../../storybook/helper.stories.templates';
+import { DocumentationPage } from '../../storybook/helper.stories.docs';
+import StyleDocs from '../../storybook/docs.stories.style.mdx';
+import AriaButtonDocs from '../../storybook/docs.stories.aria-button.mdx';
+
+import ButtonSimple, { ButtonSimpleProps } from './';
+import argTypes from './ButtonSimple.stories.args';
+import Documentation from './ButtonSimple.stories.docs.mdx';
+
+export default {
+  title: 'Momentum UI/ButtonSimple',
+  component: ButtonSimple,
+  parameters: {
+    expanded: true,
+    docs: {
+      page: DocumentationPage(Documentation, StyleDocs, AriaButtonDocs),
+    },
+  },
+  args: {
+    children: 'Example',
+  },
+};
+
+const Example = Template<ButtonSimpleProps>(ButtonSimple).bind({});
+
+Example.argTypes = { ...argTypes };
+
+const Common = MultiTemplate<ButtonSimpleProps>(ButtonSimple).bind({});
+
+Common.argTypes = { ...argTypes };
+
+Common.parameters = {
+  variants: [
+    {},
+    {
+      style: {
+        backgroundColor: 'pink',
+      },
+    },
+    {
+      style: {
+        padding: '1rem',
+      },
+    },
+    {
+      isDisabled: true,
+      style: {
+        backgroundColor: 'salmon',
+      },
+    },
+    {
+      style: {
+        borderRadius: '100vh',
+      },
+    },
+  ],
+};
+
+export { Example, Common };

--- a/src/components/ButtonSimple/ButtonSimple.tsx
+++ b/src/components/ButtonSimple/ButtonSimple.tsx
@@ -1,0 +1,37 @@
+import React, { forwardRef, FC, RefObject, useRef } from 'react';
+import classnames from 'classnames';
+import { useButton } from '@react-aria/button';
+import FocusRing from '../FocusRing';
+
+import { Props } from './ButtonSimple.types';
+
+/**
+ * A simple button component without overhead styling. This is used as an injectable button component for other sibling components.
+ */
+const ButtonSimple: FC<Props> = forwardRef(
+  (props: Props, providedRef: RefObject<HTMLButtonElement>) => {
+    const { children, className, isDisabled, id, style } = props;
+    const ref = providedRef || useRef();
+    const mutatedProps = {
+      ...props,
+    };
+
+    delete mutatedProps.className;
+    delete mutatedProps.id;
+    delete mutatedProps.style;
+
+    const { buttonProps } = useButton(mutatedProps, ref);
+
+    return (
+      <FocusRing disabled={isDisabled}>
+        <button className={classnames(className)} id={id} ref={ref} style={style} {...buttonProps}>
+          {children}
+        </button>
+      </FocusRing>
+    );
+  }
+);
+
+ButtonSimple.displayName = 'ButtonSimple';
+
+export default ButtonSimple;

--- a/src/components/ButtonSimple/ButtonSimple.types.ts
+++ b/src/components/ButtonSimple/ButtonSimple.types.ts
@@ -1,0 +1,24 @@
+import { CSSProperties, ReactNode } from 'react';
+import { AriaButtonProps } from '@react-types/button';
+
+export interface Props extends AriaButtonProps {
+  /**
+   * Child components of this ButtonPill.
+   */
+  children?: ReactNode;
+
+  /**
+   * Custom class for overriding this component's CSS.
+   */
+  className?: string;
+
+  /**
+   * Custom id for overriding this component's CSS.
+   */
+  id?: string;
+
+  /**
+   * Custom style for overriding this component's CSS.
+   */
+  style?: CSSProperties;
+}

--- a/src/components/ButtonSimple/ButtonSimple.unit.test.tsx
+++ b/src/components/ButtonSimple/ButtonSimple.unit.test.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import ButtonSimple from './';
+
+describe('<ButtonSimple />', () => {
+  describe('snapshot', () => {
+    it('should match snapshot', () => {
+      expect.assertions(1);
+
+      const container = mount(<ButtonSimple />);
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match snapshot with children', () => {
+      expect.assertions(1);
+
+      const children = 'example';
+
+      const container = mount(<ButtonSimple>{children}</ButtonSimple>);
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match snapshot with className', () => {
+      expect.assertions(1);
+
+      const className = 'example-class';
+
+      const container = mount(<ButtonSimple className={className} />);
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match snapshot with id', () => {
+      expect.assertions(1);
+
+      const id = 'example-id';
+
+      const container = mount(<ButtonSimple id={id} />);
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match snapshot with style', () => {
+      expect.assertions(1);
+
+      const style = { color: 'pink' };
+
+      const container = mount(<ButtonSimple style={style} />);
+
+      expect(container).toMatchSnapshot();
+    });
+
+    /* ...additional snapshot tests... */
+  });
+
+  describe('attributes', () => {
+    it('should have provided class when className is provided', () => {
+      expect.assertions(1);
+
+      const className = 'example-class';
+
+      const element = mount(<ButtonSimple className={className} />)
+        .find(ButtonSimple)
+        .getDOMNode();
+
+      expect(element.classList.contains(className)).toBe(true);
+    });
+
+    it('should have provided id when id is provided', () => {
+      expect.assertions(1);
+
+      const id = 'example-id';
+
+      const element = mount(<ButtonSimple id={id} />)
+        .find(ButtonSimple)
+        .getDOMNode();
+
+      expect(element.id).toBe(id);
+    });
+
+    it('should have provided style when style is provided', () => {
+      expect.assertions(1);
+
+      const style = { color: 'pink' };
+      const styleString = 'color: pink;';
+
+      const element = mount(<ButtonSimple style={style} />)
+        .find(ButtonSimple)
+        .getDOMNode();
+
+      expect(element.getAttribute('style')).toBe(styleString);
+    });
+
+    /* ...additional attribute tests... */
+  });
+
+  describe('actions', () => {
+    it('should handle mouse press events', () => {
+      expect.assertions(1);
+
+      const mockCallback = jest.fn();
+
+      const component = mount(<ButtonSimple onPress={mockCallback} />).find(ButtonSimple);
+
+      component.props().onPress({
+        type: 'press',
+        pointerType: 'mouse',
+        shiftKey: false,
+        ctrlKey: false,
+        metaKey: false,
+        target: component.getDOMNode(),
+      });
+
+      expect(mockCallback).toBeCalledTimes(1);
+    });
+  });
+});

--- a/src/components/ButtonSimple/ButtonSimple.unit.test.tsx.snap
+++ b/src/components/ButtonSimple/ButtonSimple.unit.test.tsx.snap
@@ -1,0 +1,169 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ButtonSimple /> snapshot should match snapshot 1`] = `
+<ButtonSimple>
+  <FocusRing>
+    <FocusRing
+      focusClass="children"
+      focusRingClass="md-focus-ring-wrapper children"
+    >
+      <button
+        className=""
+        onBlur={[Function]}
+        onClick={[Function]}
+        onDragStart={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        onTouchCancel={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
+        type="button"
+      />
+    </FocusRing>
+  </FocusRing>
+</ButtonSimple>
+`;
+
+exports[`<ButtonSimple /> snapshot should match snapshot with children 1`] = `
+<ButtonSimple>
+  <FocusRing>
+    <FocusRing
+      focusClass="children"
+      focusRingClass="md-focus-ring-wrapper children"
+    >
+      <button
+        className=""
+        onBlur={[Function]}
+        onClick={[Function]}
+        onDragStart={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        onTouchCancel={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
+        type="button"
+      >
+        example
+      </button>
+    </FocusRing>
+  </FocusRing>
+</ButtonSimple>
+`;
+
+exports[`<ButtonSimple /> snapshot should match snapshot with className 1`] = `
+<ButtonSimple
+  className="example-class"
+>
+  <FocusRing>
+    <FocusRing
+      focusClass="children"
+      focusRingClass="md-focus-ring-wrapper children"
+    >
+      <button
+        className="example-class"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onDragStart={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        onTouchCancel={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
+        type="button"
+      />
+    </FocusRing>
+  </FocusRing>
+</ButtonSimple>
+`;
+
+exports[`<ButtonSimple /> snapshot should match snapshot with id 1`] = `
+<ButtonSimple
+  id="example-id"
+>
+  <FocusRing>
+    <FocusRing
+      focusClass="children"
+      focusRingClass="md-focus-ring-wrapper children"
+    >
+      <button
+        className=""
+        id="example-id"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onDragStart={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        onTouchCancel={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
+        type="button"
+      />
+    </FocusRing>
+  </FocusRing>
+</ButtonSimple>
+`;
+
+exports[`<ButtonSimple /> snapshot should match snapshot with style 1`] = `
+<ButtonSimple
+  style={
+    Object {
+      "color": "pink",
+    }
+  }
+>
+  <FocusRing>
+    <FocusRing
+      focusClass="children"
+      focusRingClass="md-focus-ring-wrapper children"
+    >
+      <button
+        className=""
+        onBlur={[Function]}
+        onClick={[Function]}
+        onDragStart={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        onTouchCancel={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
+        style={
+          Object {
+            "color": "pink",
+          }
+        }
+        type="button"
+      />
+    </FocusRing>
+  </FocusRing>
+</ButtonSimple>
+`;

--- a/src/components/ButtonSimple/index.ts
+++ b/src/components/ButtonSimple/index.ts
@@ -1,0 +1,6 @@
+import { default as ButtonSimple } from './ButtonSimple';
+import { Props } from './ButtonSimple.types';
+
+export type ButtonSimpleProps = Props;
+
+export default ButtonSimple;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -8,6 +8,7 @@ export { default as ButtonDialpad } from './ButtonDialpad';
 export { default as ButtonGroup } from './ButtonGroup';
 export { default as ButtonHyperlink } from './ButtonHyperlink';
 export { default as ButtonPill } from './ButtonPill';
+export { default as ButtonSimple } from './ButtonSimple';
 export { default as FocusRing } from './FocusRing';
 export { default as ThemeProvider } from './ThemeProvider';
 export { default as ExampleComponent } from './ExampleComponent';

--- a/src/index.js
+++ b/src/index.js
@@ -110,6 +110,7 @@ export {
   ButtonGroup as ButtonGroupNext,
   ButtonHyperlink,
   ButtonPill,
+  ButtonSimple,
   CodeInput,
   FocusRing,
   InputMessage as InputMessageNew,


### PR DESCRIPTION
# Description

The scope of the changes in this pull request are to create the `<ButtonSimple />` component for downstream consumption amongst other components that have unique button formatting. This component provides an interface for other downstream consumers as well, so that styling is more consistent amongst components with unique buttons.

This button also provides as a shim layer for our generalized button components.

![Screen Shot 2021-08-30 at 11 59 12 AM](https://user-images.githubusercontent.com/14828820/131368566-d91d4d61-740f-4476-a8c6-1694bb3ec5fc.png)
![Screen Shot 2021-08-30 at 11 46 21 AM](https://user-images.githubusercontent.com/14828820/131368577-d3ada4ec-cd83-4022-8a12-e51bf0db1f55.png)

# Links

[SPARK-262372](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-262372)
