### PR TITLE
feat(components/button-control): create component

### DIFF
--- a/src/components/ButtonControl/ButtonControl.constants.ts
+++ b/src/components/ButtonControl/ButtonControl.constants.ts
@@ -1,0 +1,23 @@
+import { ButtonControlControl } from './ButtonControl.types';
+
+const CLASS_PREFIX = 'md-button-control';
+
+const DEFAULTS = {};
+
+const CONTROLS: Record<string, ButtonControlControl> = {
+  CLOSE: 'close',
+  MAXIMIZE: 'maximize',
+  MINIMIZE: 'minimize',
+};
+
+const ICONS = {
+  close: 'cancel',
+  maximize: 'arrow-up',
+  minimize: 'arrow-down',
+};
+
+const STYLE = {
+  wrapper: `${CLASS_PREFIX}-wrapper`,
+};
+
+export { CLASS_PREFIX, CONTROLS, DEFAULTS, ICONS, STYLE };

--- a/src/components/ButtonControl/ButtonControl.stories.args.ts
+++ b/src/components/ButtonControl/ButtonControl.stories.args.ts
@@ -1,0 +1,21 @@
+import { commonAriaButton, commonStyles } from '../../storybook/helper.stories.argtypes';
+
+import { BUTTON_CONTROL_CONSTANTS as CONSTANTS } from './';
+
+export default {
+  ...commonStyles,
+  ...commonAriaButton,
+  control: {
+    description: 'Control type',
+    control: { type: 'select' },
+    options: [...Object.values(CONSTANTS.CONTROLS)],
+    table: {
+      type: {
+        summary: 'close',
+      },
+      defaultValue: {
+        summary: 'undefined',
+      },
+    },
+  },
+};

--- a/src/components/ButtonControl/ButtonControl.stories.docs.mdx
+++ b/src/components/ButtonControl/ButtonControl.stories.docs.mdx
@@ -1,0 +1,1 @@
+The `<ButtonControl />` component.

--- a/src/components/ButtonControl/ButtonControl.stories.tsx
+++ b/src/components/ButtonControl/ButtonControl.stories.tsx
@@ -1,0 +1,38 @@
+import { MultiTemplate, Template } from '../../storybook/helper.stories.templates';
+import { DocumentationPage } from '../../storybook/helper.stories.docs';
+import StyleDocs from '../../storybook/docs.stories.style.mdx';
+import AriaButtonDocs from '../../storybook/docs.stories.aria-button.mdx';
+
+import ButtonControl, { ButtonControlProps, BUTTON_CONTROL_CONSTANTS as CONSTANTS } from './';
+import argTypes from './ButtonControl.stories.args';
+import Documentation from './ButtonControl.stories.docs.mdx';
+
+export default {
+  title: 'Momentum UI/ButtonControl',
+  component: ButtonControl,
+  parameters: {
+    expanded: true,
+    docs: {
+      page: DocumentationPage(Documentation, StyleDocs, AriaButtonDocs),
+    },
+  },
+};
+
+const Example = Template<ButtonControlProps>(ButtonControl).bind({});
+
+Example.argTypes = { ...argTypes };
+
+Example.args = {
+  control: CONSTANTS.CONTROLS.CLOSE,
+};
+
+const Common = MultiTemplate<ButtonControlProps>(ButtonControl).bind({});
+
+Common.argTypes = { ...argTypes };
+delete Common.argTypes.children;
+
+Common.parameters = {
+  variants: [...Object.values(CONSTANTS.CONTROLS).map((control) => ({ control }))],
+};
+
+export { Example, Common };

--- a/src/components/ButtonControl/ButtonControl.style.scss
+++ b/src/components/ButtonControl/ButtonControl.style.scss
@@ -1,0 +1,34 @@
+.md-button-control-wrapper {
+  align-items: center;
+  background-color: rgba(0, 0, 0, 0); // IEFIX
+  background-color: var(--button-ghost-background);
+  border: 0rem solid rgba(0, 0, 0, 0); // IEFIX
+  border: var(--md-globals-border-clear);
+  color: rgba(0, 0, 0, 0.95); // IEFIX
+  color: var(--button-ghost-text);
+  cursor: pointer;
+  display: flex;
+  font-family: CiscoSansTT; // IEFIX
+  font-family: var(--md-globals-font-default);
+  height: 2rem;
+  justify-content: center;
+  margin: 0;
+  outline: none;
+  padding: 0;
+  transition: background-color 0.2s, color 0.2s, border-color 0.2s;
+  width: 2rem;
+
+  &:hover {
+    background-color: rgba(0, 0, 0, 0.07); // IEFIX
+    background-color: var(--button-ghost-background-hovered);
+    color: rgba(0, 0, 0, 0.95); // IEFIX
+    color: var(--button-ghost-text-hovered);
+  }
+
+  &:active {
+    background-color: rgba(0, 0, 0, 0.2); // IEFIX
+    background-color: var(--button-secondary-background-pressed);
+    color: rgba(0, 0, 0, 0.95); // IEFIX
+    color: var(--button-secondary-text-pressed);
+  }
+}

--- a/src/components/ButtonControl/ButtonControl.tsx
+++ b/src/components/ButtonControl/ButtonControl.tsx
@@ -1,0 +1,28 @@
+import React, { FC } from 'react';
+import classnames from 'classnames';
+
+import ButtonSimple from '../ButtonSimple';
+import Icon from '../Icon';
+
+import { ICONS, STYLE } from './ButtonControl.constants';
+import { Props } from './ButtonControl.types';
+import './ButtonControl.style.scss';
+
+/**
+ * `<ControlButtons />` are used to control [close, maximize, minimize, etc] components [usually panels] they are assigned to.
+ */
+const ButtonControl: FC<Props> = (props: Props) => {
+  const { className, control, ...otherProps } = props;
+
+  const iconName = ICONS[control] || 'not-found';
+
+  const controlElement = <Icon name={iconName} weight="bold" autoScale />;
+
+  return (
+    <ButtonSimple className={classnames(STYLE.wrapper, className)} {...otherProps}>
+      {controlElement}
+    </ButtonSimple>
+  );
+};
+
+export default ButtonControl;

--- a/src/components/ButtonControl/ButtonControl.types.ts
+++ b/src/components/ButtonControl/ButtonControl.types.ts
@@ -1,0 +1,26 @@
+import { CSSProperties } from 'react';
+import { AriaButtonProps } from '@react-types/button';
+
+export type ButtonControlControl = 'close' | 'maximize' | 'minimize';
+
+export interface Props extends AriaButtonProps {
+  /**
+   * Custom class for overriding this component's CSS.
+   */
+  className?: string;
+
+  /**
+   * The control type.
+   */
+  control: ButtonControlControl;
+
+  /**
+   * Custom id for overriding this component's CSS.
+   */
+  id?: string;
+
+  /**
+   * Custom style for overriding this component's CSS.
+   */
+  style?: CSSProperties;
+}

--- a/src/components/ButtonControl/ButtonControl.unit.test.tsx
+++ b/src/components/ButtonControl/ButtonControl.unit.test.tsx
@@ -1,0 +1,127 @@
+import React from 'react';
+import { mountAndWait } from '../../../test/utils';
+
+import Icon from '../Icon';
+
+import ButtonControl, { BUTTON_CONTROL_CONSTANTS as CONSTANTS } from './';
+
+describe('<ButtonControl />', () => {
+  describe('snapshot', () => {
+    it('should match snapshot', async () => {
+      expect.assertions(1);
+
+      const container = await mountAndWait(<ButtonControl control="close" />);
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match snapshot with className', async () => {
+      expect.assertions(1);
+
+      const className = 'example-class';
+
+      const container = await mountAndWait(<ButtonControl control="close" className={className} />);
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match snapshot with id', async () => {
+      expect.assertions(1);
+
+      const id = 'example-id';
+
+      const container = await mountAndWait(<ButtonControl control="close" id={id} />);
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match snapshot with style', async () => {
+      expect.assertions(1);
+
+      const style = { color: 'pink' };
+
+      const container = await mountAndWait(<ButtonControl control="close" style={style} />);
+
+      expect(container).toMatchSnapshot();
+    });
+  });
+
+  describe('attributes', () => {
+    it('should have its wrapper class', async () => {
+      expect.assertions(1);
+
+      const wrapper = await mountAndWait(<ButtonControl control="close" />);
+      const element = wrapper.find(ButtonControl).getDOMNode();
+
+      expect(element.classList.contains(CONSTANTS.STYLE.wrapper)).toBe(true);
+    });
+
+    it('should have provided class when className is provided', async () => {
+      expect.assertions(1);
+
+      const className = 'example-class';
+
+      const wrapper = await mountAndWait(<ButtonControl control="close" className={className} />);
+      const element = wrapper.find(ButtonControl).getDOMNode();
+
+      expect(element.classList.contains(className)).toBe(true);
+    });
+
+    it('should have provided id when id is provided', async () => {
+      expect.assertions(1);
+
+      const id = 'example-id';
+
+      const wrapper = await mountAndWait(<ButtonControl control="close" id={id} />);
+      const element = wrapper.find(ButtonControl).getDOMNode();
+
+      expect(element.id).toBe(id);
+    });
+
+    it('should have provided style when style is provided', async () => {
+      expect.assertions(1);
+
+      const style = { color: 'pink' };
+      const styleString = 'color: pink;';
+
+      const wrapper = await mountAndWait(<ButtonControl control="close" style={style} />);
+      const element = wrapper.find(ButtonControl).getDOMNode();
+
+      expect(element.getAttribute('style')).toBe(styleString);
+    });
+
+    it('should map the control name to the generated child', async () => {
+      expect.assertions(1);
+
+      const control = CONSTANTS.CONTROLS.CLOSE;
+      const icon = CONSTANTS.ICONS[control];
+
+      const wrapper = await mountAndWait(<ButtonControl control={control} />);
+      const child = wrapper.find(Icon);
+
+      expect(child.props().name).toBe(icon);
+    });
+  });
+
+  describe('actions', () => {
+    it('should handle mouse press events', async () => {
+      expect.assertions(1);
+
+      const mockCallback = jest.fn();
+
+      const wrapper = await mountAndWait(<ButtonControl control="close" onPress={mockCallback} />);
+      const component = wrapper.find(ButtonControl);
+
+      component.props().onPress({
+        type: 'press',
+        pointerType: 'mouse',
+        shiftKey: false,
+        ctrlKey: false,
+        metaKey: false,
+        target: component.getDOMNode(),
+      });
+
+      expect(mockCallback).toBeCalledTimes(1);
+    });
+  });
+});

--- a/src/components/ButtonControl/ButtonControl.unit.test.tsx.snap
+++ b/src/components/ButtonControl/ButtonControl.unit.test.tsx.snap
@@ -1,0 +1,252 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ButtonControl /> snapshot should match snapshot 1`] = `
+<ButtonControl
+  control="close"
+>
+  <ButtonSimple
+    className="md-button-control-wrapper"
+  >
+    <FocusRing>
+      <FocusRing
+        focusClass="children"
+        focusRingClass="md-focus-ring-wrapper children"
+      >
+        <button
+          className="md-button-control-wrapper"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onDragStart={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchCancel={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          type="button"
+        >
+          <Icon
+            autoScale={true}
+            name="cancel"
+            weight="bold"
+          >
+            <div
+              className="md-icon-wrapper"
+            >
+              <svg
+                className=""
+                data-autoscale={true}
+                data-scale={false}
+                fill="currentColor"
+                height="100%"
+                stroke="currentColor"
+                style={Object {}}
+                viewBox="0, 0, 32, 32"
+                width="100%"
+              />
+            </div>
+          </Icon>
+        </button>
+      </FocusRing>
+    </FocusRing>
+  </ButtonSimple>
+</ButtonControl>
+`;
+
+exports[`<ButtonControl /> snapshot should match snapshot with className 1`] = `
+<ButtonControl
+  className="example-class"
+  control="close"
+>
+  <ButtonSimple
+    className="md-button-control-wrapper example-class"
+  >
+    <FocusRing>
+      <FocusRing
+        focusClass="children"
+        focusRingClass="md-focus-ring-wrapper children"
+      >
+        <button
+          className="md-button-control-wrapper example-class"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onDragStart={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchCancel={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          type="button"
+        >
+          <Icon
+            autoScale={true}
+            name="cancel"
+            weight="bold"
+          >
+            <div
+              className="md-icon-wrapper"
+            >
+              <svg
+                className=""
+                data-autoscale={true}
+                data-scale={false}
+                fill="currentColor"
+                height="100%"
+                stroke="currentColor"
+                style={Object {}}
+                viewBox="0, 0, 32, 32"
+                width="100%"
+              />
+            </div>
+          </Icon>
+        </button>
+      </FocusRing>
+    </FocusRing>
+  </ButtonSimple>
+</ButtonControl>
+`;
+
+exports[`<ButtonControl /> snapshot should match snapshot with id 1`] = `
+<ButtonControl
+  control="close"
+  id="example-id"
+>
+  <ButtonSimple
+    className="md-button-control-wrapper"
+    id="example-id"
+  >
+    <FocusRing>
+      <FocusRing
+        focusClass="children"
+        focusRingClass="md-focus-ring-wrapper children"
+      >
+        <button
+          className="md-button-control-wrapper"
+          id="example-id"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onDragStart={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchCancel={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          type="button"
+        >
+          <Icon
+            autoScale={true}
+            name="cancel"
+            weight="bold"
+          >
+            <div
+              className="md-icon-wrapper"
+            >
+              <svg
+                className=""
+                data-autoscale={true}
+                data-scale={false}
+                fill="currentColor"
+                height="100%"
+                stroke="currentColor"
+                style={Object {}}
+                viewBox="0, 0, 32, 32"
+                width="100%"
+              />
+            </div>
+          </Icon>
+        </button>
+      </FocusRing>
+    </FocusRing>
+  </ButtonSimple>
+</ButtonControl>
+`;
+
+exports[`<ButtonControl /> snapshot should match snapshot with style 1`] = `
+<ButtonControl
+  control="close"
+  style={
+    Object {
+      "color": "pink",
+    }
+  }
+>
+  <ButtonSimple
+    className="md-button-control-wrapper"
+    style={
+      Object {
+        "color": "pink",
+      }
+    }
+  >
+    <FocusRing>
+      <FocusRing
+        focusClass="children"
+        focusRingClass="md-focus-ring-wrapper children"
+      >
+        <button
+          className="md-button-control-wrapper"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onDragStart={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchCancel={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          style={
+            Object {
+              "color": "pink",
+            }
+          }
+          type="button"
+        >
+          <Icon
+            autoScale={true}
+            name="cancel"
+            weight="bold"
+          >
+            <div
+              className="md-icon-wrapper"
+            >
+              <svg
+                className=""
+                data-autoscale={true}
+                data-scale={false}
+                fill="currentColor"
+                height="100%"
+                stroke="currentColor"
+                style={Object {}}
+                viewBox="0, 0, 32, 32"
+                width="100%"
+              />
+            </div>
+          </Icon>
+        </button>
+      </FocusRing>
+    </FocusRing>
+  </ButtonSimple>
+</ButtonControl>
+`;

--- a/src/components/ButtonControl/index.ts
+++ b/src/components/ButtonControl/index.ts
@@ -1,0 +1,9 @@
+import { default as ButtonControl } from './ButtonControl';
+import * as CONSTANTS from './ButtonControl.constants';
+import { Props } from './ButtonControl.types';
+
+export { CONSTANTS as BUTTON_CONTROL_CONSTANTS };
+
+export type ButtonControlProps = Props;
+
+export default ButtonControl;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -4,6 +4,7 @@ export { default as Avatar } from './Avatar';
 export { default as AvatarCompact } from './AvatarCompact';
 export { default as Badge } from './Badge';
 export { default as ButtonCircle } from './ButtonCircle';
+export { default as ButtonControl } from './ButtonControl';
 export { default as ButtonDialpad } from './ButtonDialpad';
 export { default as ButtonGroup } from './ButtonGroup';
 export { default as ButtonHyperlink } from './ButtonHyperlink';

--- a/src/index.js
+++ b/src/index.js
@@ -106,6 +106,7 @@ export {
   Avatar as AvatarNext,
   ButtonCircle,
   AvatarCompact as AvatarCompactNext,
+  ButtonControl,
   ButtonDialpad,
   ButtonGroup as ButtonGroupNext,
   ButtonHyperlink,


### PR DESCRIPTION
# Description

The scope of the changes in this pull request are to create a component for the commonly-appearing control buttons. These buttons appear on multiple panels, such as the **Toasts**, **Dialogs**, and **Popovers**. 

NOTE: `maximize` and `minimize` icons don't match spec, but can be easily changed once the design team updates the icons to include these.

![Screen Shot 2021-09-01 at 1 48 36 PM](https://user-images.githubusercontent.com/14828820/131723145-52296c50-634d-42bf-88eb-f70e8e58637f.png)
![Screen Shot 2021-09-01 at 1 48 41 PM](https://user-images.githubusercontent.com/14828820/131723149-61539945-d1e2-4c11-ad99-a23d0b173041.png)

# Links

[SPARK-262713](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-262713)