### PR TITLE
feat(components/toast-content): create component

### DIFF
--- a/src/components/ToastContent/ToastContent.constants.ts
+++ b/src/components/ToastContent/ToastContent.constants.ts
@@ -1,0 +1,21 @@
+const CLASS_PREFIX = 'md-toast-content';
+
+const DEFAULTS = {};
+
+const ACTION_COLORS = {
+  CANCEL: 'cancel',
+  JOIN: 'join',
+  SUCCESS: 'success',
+  WARNING: 'warning',
+};
+
+const STYLE = {
+  action: `${CLASS_PREFIX}-action`,
+  actions: `${CLASS_PREFIX}-actions`,
+  actor: `${CLASS_PREFIX}-actor`,
+  info: `${CLASS_PREFIX}-info`,
+  scope: `${CLASS_PREFIX}-scope`,
+  wrapper: `${CLASS_PREFIX}-wrapper`,
+};
+
+export { CLASS_PREFIX, DEFAULTS, ACTION_COLORS, STYLE };

--- a/src/components/ToastContent/ToastContent.stories.args.ts
+++ b/src/components/ToastContent/ToastContent.stories.args.ts
@@ -1,0 +1,83 @@
+import { commonStyles } from '../../storybook/helper.stories.argtypes';
+
+import { TOAST_CONTENT_CONSTANTS as CONSTANTS } from './';
+
+export default {
+  ...commonStyles,
+  action: {
+    description: 'Action the actor executed.',
+    control: { type: 'text' },
+    table: {
+      type: {
+        summary: 'string',
+      },
+      defaultValue: {
+        summary: 'undefined',
+      },
+    },
+  },
+  actionColor: {
+    description: 'Action the actor executed.',
+    control: { type: 'select' },
+    options: [undefined, ...Object.values(CONSTANTS.ACTION_COLORS)],
+    table: {
+      type: {
+        summary: 'string',
+      },
+      defaultValue: {
+        summary: 'undefined',
+      },
+    },
+  },
+  actions: {
+    description:
+      'Selectable actions that can be taken on behalf of the scope of this `<ToastDetails />`.',
+    control: { type: 'none' },
+    table: {
+      type: {
+        summary: 'ButtonGroup',
+      },
+      defaultValue: {
+        summary: 'undefined',
+      },
+    },
+  },
+  actor: {
+    description: 'Actor for the action of this `<ToastContent />`.',
+    control: { type: 'text' },
+    table: {
+      type: {
+        summary: 'string',
+      },
+      defaultValue: {
+        summary: 'undefined',
+      },
+    },
+  },
+  children: {
+    description:
+      'Information associated with this `<ToastContent />`. The info prop overrides this.',
+    control: { type: 'text' },
+    table: {
+      type: {
+        summary: 'string',
+      },
+      defaultValue: {
+        summary: 'undefined',
+      },
+    },
+  },
+  info: {
+    description:
+      'Information associated with this `<ToastContent />`. This overrides the children prop.',
+    control: { type: 'text' },
+    table: {
+      type: {
+        summary: 'string',
+      },
+      defaultValue: {
+        summary: 'undefined',
+      },
+    },
+  },
+};

--- a/src/components/ToastContent/ToastContent.stories.docs.mdx
+++ b/src/components/ToastContent/ToastContent.stories.docs.mdx
@@ -1,0 +1,1 @@
+The `<ToastContent />` component. This component is meant to be consumed by only the `<Toast />` component.

--- a/src/components/ToastContent/ToastContent.stories.tsx
+++ b/src/components/ToastContent/ToastContent.stories.tsx
@@ -1,0 +1,147 @@
+import React from 'react';
+
+import { MultiTemplate, Template } from '../../storybook/helper.stories.templates';
+import { DocumentationPage } from '../../storybook/helper.stories.docs';
+import StyleDocs from '../../storybook/docs.stories.style.mdx';
+
+import ButtonCircle from '../ButtonCircle';
+import ButtonGroup from '../ButtonGroup';
+import ButtonPill from '../ButtonPill';
+import Icon from '../Icon';
+
+import ToastContent, { ToastContentProps } from './';
+import argTypes from './ToastContent.stories.args';
+import Documentation from './ToastContent.stories.docs.mdx';
+
+export default {
+  title: 'Momentum UI/ToastContent',
+  component: ToastContent,
+  parameters: {
+    expanded: true,
+    docs: {
+      page: DocumentationPage(Documentation, StyleDocs),
+    },
+  },
+};
+
+const Example = Template<ToastContentProps>(ToastContent).bind({});
+
+Example.argTypes = { ...argTypes };
+
+Example.args = {
+  action: 'Performed Action 👍',
+  actionColor: 'success',
+  actions: (
+    <ButtonGroup spaced>
+      <ButtonCircle outline size={28}>
+        <Icon name="alarm" weight="bold" autoScale={125} />
+      </ButtonCircle>
+      <ButtonPill color="message" size={28}>
+        Message
+      </ButtonPill>
+      <ButtonPill color="cancel" size={28}>
+        Decline
+      </ButtonPill>
+      <ButtonPill color="join" size={28}>
+        Answer
+      </ButtonPill>
+    </ButtonGroup>
+  ),
+  actor: 'Actor',
+  info: 'Lorem ipsum dolor site aw aetns ctetuer adipiscing. \n\n- Example Bullet\n- Example Bullet',
+};
+
+const Colors = MultiTemplate<ToastContentProps>(ToastContent).bind({});
+
+Colors.argTypes = { ...argTypes };
+delete Colors.argTypes.actionColor;
+
+Colors.args = {
+  action: 'Performed Action 👍',
+  actor: 'Actor',
+  info: 'Lorem ipsum dolor site aw aetns ctetuer adipiscing.',
+};
+
+Colors.parameters = {
+  variants: [
+    {},
+    { actionColor: 'cancel' },
+    { actionColor: 'join' },
+    { actionColor: 'success' },
+    { actionColor: 'warning' },
+  ],
+};
+
+const Common = MultiTemplate<ToastContentProps>(ToastContent).bind({});
+
+Common.argTypes = { ...argTypes };
+delete Common.argTypes.children;
+
+Common.parameters = {
+  variants: [
+    {
+      action: 'Performed Action 👍',
+      actionColor: 'join',
+      actions: (
+        <ButtonGroup spaced>
+          <ButtonCircle outline size={28}>
+            <Icon name="alarm" weight="bold" autoScale={125} />
+          </ButtonCircle>
+          <ButtonPill color="message" size={28}>
+            Message
+          </ButtonPill>
+          <ButtonPill color="cancel" size={28}>
+            Decline
+          </ButtonPill>
+          <ButtonPill color="join" size={28}>
+            Answer
+          </ButtonPill>
+        </ButtonGroup>
+      ),
+      actor: 'Actor',
+      info: 'Lorem ipsum dolor site aw aetns ctetuer adipiscing.',
+    },
+    {
+      action: 'Performed a very long action ✅',
+      actionColor: 'success',
+      actor: 'Actor',
+      info: 'Lorem ipsum dolor site aw aetns ctetuer adipiscing.',
+      actions: (
+        <ButtonGroup spaced>
+          <ButtonCircle outline size={28}>
+            <Icon name="alarm" weight="bold" autoScale={125} />
+          </ButtonCircle>
+          <ButtonPill color="join" size={28}>
+            Accept
+          </ButtonPill>
+        </ButtonGroup>
+      ),
+    },
+    {
+      action: 'Performed an action 🛑',
+      actionColor: 'warning',
+      actions: (
+        <ButtonGroup spaced>
+          <ButtonPill color="cancel" size={28}>
+            End Call
+          </ButtonPill>
+        </ButtonGroup>
+      ),
+      info: 'Lorem ipsum dolor site aw aetns ctetuer adipiscing.',
+    },
+    {
+      action: 'Action',
+      actor: 'Actor',
+      actions: (
+        <ButtonGroup spaced>
+          <ButtonPill outline size={28}>
+            Snooze
+          </ButtonPill>
+        </ButtonGroup>
+      ),
+      info: 'A generic item list:\n- Item A\n- Item B',
+    },
+  ],
+};
+
+export { Example, Colors, Common };

--- a/src/components/ToastContent/ToastContent.style.scss
+++ b/src/components/ToastContent/ToastContent.style.scss
@@ -1,0 +1,39 @@
+.md-toast-content-wrapper {
+  margin: 0 1rem 1rem 1rem;
+  max-width: 20.75rem;
+  width: 100%;
+
+  > .md-toast-content-scope {
+    font-size: 0.875rem;
+
+    > .md-toast-content-action {
+      &[data-color="cancel"] {
+        color: var(--theme-text-error-normal);
+      }
+
+      &[data-color="join"] {
+        color: var(--theme-text-accent-normal);
+      }
+
+      &[data-color="success"] {
+        color: var(--theme-text-success-normal);
+      }
+
+      &[data-color="warning"] {
+        color: var(--theme-text-warning-normal);
+      }
+    }
+  }
+
+  > .md-toast-content-info {
+    font-size: 0.875rem;
+    margin-top: 0.5rem;
+    white-space: pre-wrap;
+  }
+
+  > .md-toast-content-actions {
+    justify-content: flex-end;
+    margin: 0.5rem 0 0 0;
+    width: 100%;
+  }
+}

--- a/src/components/ToastContent/ToastContent.tsx
+++ b/src/components/ToastContent/ToastContent.tsx
@@ -1,0 +1,47 @@
+import React, { cloneElement, FC } from 'react';
+import classnames from 'classnames';
+
+import { STYLE } from './ToastContent.constants';
+import { Props } from './ToastContent.types';
+import './ToastContent.style.scss';
+
+/**
+ * The `<ToastContent />` component. This component is meant to be consumed by only the `<Toast />` component.
+ */
+const ToastContent: FC<Props> = (props: Props) => {
+  const { action, actionColor, actions, actor, children, className, id, info, style } = props;
+
+  const actorComponent = actor ? <span className={STYLE.actor}>{actor}</span> : null;
+
+  const actionComponent = action ? (
+    <span className={STYLE.action} data-color={actionColor}>
+      {action}
+    </span>
+  ) : null;
+
+  const scopeComponent =
+    action || actor ? (
+      <div className={STYLE.scope}>
+        {actorComponent} {actionComponent}
+      </div>
+    ) : null;
+
+  const infoComponent =
+    info || children ? <div className={STYLE.info}>{info || children}</div> : null;
+
+  const actionsComponent = actions
+    ? cloneElement(actions, {
+        className: classnames(STYLE.actions, actions.props.className),
+      })
+    : null;
+
+  return (
+    <div className={classnames(className, STYLE.wrapper)} id={id} style={style}>
+      {scopeComponent}
+      {infoComponent}
+      {actionsComponent}
+    </div>
+  );
+};
+
+export default ToastContent;

--- a/src/components/ToastContent/ToastContent.types.ts
+++ b/src/components/ToastContent/ToastContent.types.ts
@@ -1,0 +1,52 @@
+import { CSSProperties, ReactElement } from 'react';
+
+import { ButtonGroupProps } from '../ButtonGroup';
+
+export type SupportedActionsButtons = ButtonGroupProps;
+
+export interface Props {
+  /**
+   * Colorizable action the actor executed.
+   */
+  action?: string;
+
+  /**
+   * Color to render the action prop as.
+   */
+  actionColor?: 'cancel' | 'join' | 'success' | 'warning';
+
+  /**
+   * Selectable actions that can be taken on behalf of the scope of this ToastDetails.
+   */
+  actions?: ReactElement<SupportedActionsButtons>;
+
+  /**
+   * Actor for the action of this ToastContent.
+   */
+  actor?: string;
+
+  /**
+   * Information associated with this ToastContent. The info prop overrides this.
+   */
+  children?: string;
+
+  /**
+   * Custom class for overriding this component's CSS.
+   */
+  className?: string;
+
+  /**
+   * Custom id for overriding this component's CSS.
+   */
+  id?: string;
+
+  /**
+   * Information associated with this ToastContent. This overrides the children prop.
+   */
+  info?: string;
+
+  /**
+   * Custom style for overriding this component's CSS.
+   */
+  style?: CSSProperties;
+}

--- a/src/components/ToastContent/ToastContent.unit.test.tsx
+++ b/src/components/ToastContent/ToastContent.unit.test.tsx
@@ -1,0 +1,283 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import ButtonGroup from '../ButtonGroup';
+import ButtonPill from '../ButtonPill';
+
+import ToastContent, { TOAST_CONTENT_CONSTANTS as CONSTANTS, ToastContentProps } from './';
+
+describe('<ToastContent />', () => {
+  describe('snapshot', () => {
+    it('should match snapshot', () => {
+      expect.assertions(1);
+
+      const container = mount(<ToastContent />);
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match snapshot with className', () => {
+      expect.assertions(1);
+
+      const className = 'example-class';
+
+      const container = mount(<ToastContent className={className} />);
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match snapshot with id', () => {
+      expect.assertions(1);
+
+      const id = 'example-id';
+
+      const container = mount(<ToastContent id={id} />);
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match snapshot with style', () => {
+      expect.assertions(1);
+
+      const style = { color: 'pink' };
+
+      const container = mount(<ToastContent style={style} />);
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match snapshot with action', () => {
+      expect.assertions(1);
+
+      const action = 'Action';
+
+      const container = mount(<ToastContent action={action} />);
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match snapshot with action and actionColor', () => {
+      expect.assertions(1);
+
+      const action = 'Action';
+      const actionColor = 'success';
+
+      const container = mount(<ToastContent action={action} actionColor={actionColor} />);
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match snapshot with actor', () => {
+      expect.assertions(1);
+
+      const actor = 'Actor';
+
+      const container = mount(<ToastContent actor={actor} />);
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match snapshot with info', () => {
+      expect.assertions(1);
+
+      const info = 'Information';
+
+      const container = mount(<ToastContent info={info} />);
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match snapshot with children', () => {
+      expect.assertions(1);
+
+      const children = 'Information';
+
+      const container = mount(<ToastContent>{children}</ToastContent>);
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match snapshot with children and info', () => {
+      expect.assertions(1);
+
+      const children = 'Information';
+      const info = 'Information';
+
+      const container = mount(<ToastContent info={info}>{children}</ToastContent>);
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match snapshot with complex props', () => {
+      expect.assertions(1);
+
+      const props: ToastContentProps = {
+        action: 'Action',
+        actionColor: 'success',
+        actions: (
+          <ButtonGroup spaced>
+            <ButtonPill>Button</ButtonPill>
+          </ButtonGroup>
+        ),
+        actor: 'Actor',
+        children: 'Children',
+        info: 'Information',
+      };
+
+      const container = mount(<ToastContent {...props} />);
+
+      expect(container).toMatchSnapshot();
+    });
+  });
+
+  describe('attributes', () => {
+    it('should have its wrapper class', () => {
+      expect.assertions(1);
+
+      const element = mount(<ToastContent />)
+        .find(ToastContent)
+        .getDOMNode();
+
+      expect(element.classList.contains(CONSTANTS.STYLE.wrapper)).toBe(true);
+    });
+
+    it('should have provided class when className is provided', () => {
+      expect.assertions(1);
+
+      const className = 'example-class';
+
+      const element = mount(<ToastContent className={className} />)
+        .find(ToastContent)
+        .getDOMNode();
+
+      expect(element.classList.contains(className)).toBe(true);
+    });
+
+    it('should have provided id when id is provided', () => {
+      expect.assertions(1);
+
+      const id = 'example-id';
+
+      const element = mount(<ToastContent id={id} />)
+        .find(ToastContent)
+        .getDOMNode();
+
+      expect(element.id).toBe(id);
+    });
+
+    it('should have provided style when style is provided', () => {
+      expect.assertions(1);
+
+      const style = { color: 'pink' };
+      const styleString = 'color: pink;';
+
+      const element = mount(<ToastContent style={style} />)
+        .find(ToastContent)
+        .getDOMNode();
+
+      expect(element.getAttribute('style')).toBe(styleString);
+    });
+
+    it('should have provided action when action is provided', () => {
+      expect.assertions(1);
+
+      const action = 'Action';
+
+      const element = mount(<ToastContent action={action} />)
+        .find(ToastContent)
+        .getDOMNode();
+
+      const target = element.getElementsByClassName(CONSTANTS.STYLE.action)[0];
+
+      expect(target.innerHTML).toBe(action);
+    });
+
+    it('should have provided data-color when actionColor is provided', () => {
+      expect.assertions(1);
+
+      const action = 'Action';
+      const actionColor = 'success';
+
+      const element = mount(<ToastContent action={action} actionColor={actionColor} />)
+        .find(ToastContent)
+        .getDOMNode();
+
+      const target = element.getElementsByClassName(CONSTANTS.STYLE.action)[0];
+
+      expect(target.getAttribute('data-color')).toBe(actionColor);
+    });
+
+    it('should have a ButtonGroup when actions is provided', () => {
+      expect.assertions(1);
+
+      const actions = (
+        <ButtonGroup spaced>
+          <ButtonPill>Button</ButtonPill>
+        </ButtonGroup>
+      );
+
+      const component = mount(<ToastContent actions={actions} />).find(ToastContent);
+
+      const target = component.find(ButtonGroup);
+
+      expect(target).toBeDefined();
+    });
+
+    it('should have provided actor when actor is provided', () => {
+      expect.assertions(1);
+
+      const actor = 'Actor';
+
+      const element = mount(<ToastContent actor={actor} />)
+        .find(ToastContent)
+        .getDOMNode();
+
+      const target = element.getElementsByClassName(CONSTANTS.STYLE.actor)[0];
+
+      expect(target.innerHTML).toBe(actor);
+    });
+
+    it('should have provided info when info is provided', () => {
+      expect.assertions(1);
+
+      const info = 'Information';
+
+      const element = mount(<ToastContent info={info} />)
+        .find(ToastContent)
+        .getDOMNode();
+
+      const target = element.getElementsByClassName(CONSTANTS.STYLE.info)[0];
+
+      expect(target.innerHTML).toBe(info);
+    });
+
+    it('should have provided info when children is provided', () => {
+      expect.assertions(1);
+
+      const children = 'Children';
+
+      const element = mount(<ToastContent>{children}</ToastContent>)
+        .find(ToastContent)
+        .getDOMNode();
+
+      const target = element.getElementsByClassName(CONSTANTS.STYLE.info)[0];
+
+      expect(target.innerHTML).toBe(children);
+    });
+
+    it('should prioritize info over children with info and children are provided', () => {
+      expect.assertions(1);
+
+      const children = 'Children';
+      const info = 'Information';
+
+      const element = mount(<ToastContent info={info}>{children}</ToastContent>)
+        .find(ToastContent)
+        .getDOMNode();
+
+      const target = element.getElementsByClassName(CONSTANTS.STYLE.info)[0];
+
+      expect(target.innerHTML).toBe(info);
+    });
+  });
+});

--- a/src/components/ToastContent/ToastContent.unit.test.tsx.snap
+++ b/src/components/ToastContent/ToastContent.unit.test.tsx.snap
@@ -1,0 +1,249 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ToastContent /> snapshot should match snapshot 1`] = `
+<ToastContent>
+  <div
+    className="md-toast-content-wrapper"
+  />
+</ToastContent>
+`;
+
+exports[`<ToastContent /> snapshot should match snapshot with action 1`] = `
+<ToastContent
+  action="Action"
+>
+  <div
+    className="md-toast-content-wrapper"
+  >
+    <div
+      className="md-toast-content-scope"
+    >
+       
+      <span
+        className="md-toast-content-action"
+      >
+        Action
+      </span>
+    </div>
+  </div>
+</ToastContent>
+`;
+
+exports[`<ToastContent /> snapshot should match snapshot with action and actionColor 1`] = `
+<ToastContent
+  action="Action"
+  actionColor="success"
+>
+  <div
+    className="md-toast-content-wrapper"
+  >
+    <div
+      className="md-toast-content-scope"
+    >
+       
+      <span
+        className="md-toast-content-action"
+        data-color="success"
+      >
+        Action
+      </span>
+    </div>
+  </div>
+</ToastContent>
+`;
+
+exports[`<ToastContent /> snapshot should match snapshot with actor 1`] = `
+<ToastContent
+  actor="Actor"
+>
+  <div
+    className="md-toast-content-wrapper"
+  >
+    <div
+      className="md-toast-content-scope"
+    >
+      <span
+        className="md-toast-content-actor"
+      >
+        Actor
+      </span>
+       
+    </div>
+  </div>
+</ToastContent>
+`;
+
+exports[`<ToastContent /> snapshot should match snapshot with children 1`] = `
+<ToastContent>
+  <div
+    className="md-toast-content-wrapper"
+  >
+    <div
+      className="md-toast-content-info"
+    >
+      Information
+    </div>
+  </div>
+</ToastContent>
+`;
+
+exports[`<ToastContent /> snapshot should match snapshot with children and info 1`] = `
+<ToastContent
+  info="Information"
+>
+  <div
+    className="md-toast-content-wrapper"
+  >
+    <div
+      className="md-toast-content-info"
+    >
+      Information
+    </div>
+  </div>
+</ToastContent>
+`;
+
+exports[`<ToastContent /> snapshot should match snapshot with className 1`] = `
+<ToastContent
+  className="example-class"
+>
+  <div
+    className="example-class md-toast-content-wrapper"
+  />
+</ToastContent>
+`;
+
+exports[`<ToastContent /> snapshot should match snapshot with complex props 1`] = `
+<ToastContent
+  action="Action"
+  actionColor="success"
+  actions={
+    <ButtonGroup
+      spaced={true}
+    >
+      <ButtonPill>
+        Button
+      </ButtonPill>
+    </ButtonGroup>
+  }
+  actor="Actor"
+  info="Information"
+>
+  <div
+    className="md-toast-content-wrapper"
+  >
+    <div
+      className="md-toast-content-scope"
+    >
+      <span
+        className="md-toast-content-actor"
+      >
+        Actor
+      </span>
+       
+      <span
+        className="md-toast-content-action"
+        data-color="success"
+      >
+        Action
+      </span>
+    </div>
+    <div
+      className="md-toast-content-info"
+    >
+      Information
+    </div>
+    <ButtonGroup
+      className="md-toast-content-actions"
+      spaced={true}
+    >
+      <div
+        className="md-button-group-wrapper md-toast-content-actions"
+        data-round={false}
+        data-spaced={true}
+      >
+        <ButtonPill>
+          <FocusRing>
+            <FocusRing
+              focusClass="children"
+              focusRingClass="md-focus-ring-wrapper children"
+            >
+              <button
+                className="md-button-pill-wrapper"
+                data-color="primary"
+                data-disabled={false}
+                data-ghost={false}
+                data-outline={false}
+                data-size={40}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onDragStart={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchCancel={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                type="button"
+              >
+                Button
+              </button>
+            </FocusRing>
+          </FocusRing>
+        </ButtonPill>
+      </div>
+    </ButtonGroup>
+  </div>
+</ToastContent>
+`;
+
+exports[`<ToastContent /> snapshot should match snapshot with id 1`] = `
+<ToastContent
+  id="example-id"
+>
+  <div
+    className="md-toast-content-wrapper"
+    id="example-id"
+  />
+</ToastContent>
+`;
+
+exports[`<ToastContent /> snapshot should match snapshot with info 1`] = `
+<ToastContent
+  info="Information"
+>
+  <div
+    className="md-toast-content-wrapper"
+  >
+    <div
+      className="md-toast-content-info"
+    >
+      Information
+    </div>
+  </div>
+</ToastContent>
+`;
+
+exports[`<ToastContent /> snapshot should match snapshot with style 1`] = `
+<ToastContent
+  style={
+    Object {
+      "color": "pink",
+    }
+  }
+>
+  <div
+    className="md-toast-content-wrapper"
+    style={
+      Object {
+        "color": "pink",
+      }
+    }
+  />
+</ToastContent>
+`;

--- a/src/components/ToastContent/index.ts
+++ b/src/components/ToastContent/index.ts
@@ -1,0 +1,9 @@
+import { default as ToastContent } from './ToastContent';
+import * as CONSTANTS from './ToastContent.constants';
+import { Props } from './ToastContent.types';
+
+export { CONSTANTS as TOAST_CONTENT_CONSTANTS };
+
+export type ToastContentProps = Props;
+
+export default ToastContent;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -12,6 +12,7 @@ export { default as ButtonPill } from './ButtonPill';
 export { default as ButtonSimple } from './ButtonSimple';
 export { default as FocusRing } from './FocusRing';
 export { default as ThemeProvider } from './ThemeProvider';
+export { default as ToastContent } from './ToastContent';
 export { default as ToastDetails } from './ToastDetails';
 export { default as ExampleComponent } from './ExampleComponent';
 export { default as CodeInput } from './CodeInput';

--- a/src/index.js
+++ b/src/index.js
@@ -118,6 +118,7 @@ export {
   ExampleComponent,
   Icon as IconNext,
   ToastDetails,
+  ToastContent,
   ThemeProvider,
   Text,
   ContentSeparator,


### PR DESCRIPTION
# Description

The scope of the changes in this pull request are to add the `<Toast />` subcomponent `<ToastContent />`. This component exists in the lower section of the `<Toast />` component and is intended for exclusive use within the `<Toast />` at this time.

## Screenshots

![Screen Shot 2021-09-08 at 2 36 47 PM](https://user-images.githubusercontent.com/14828820/132566548-8a63ae2e-34d4-47e5-8a9d-6213a33f74ba.png)
![Screen Shot 2021-09-08 at 2 36 52 PM](https://user-images.githubusercontent.com/14828820/132566553-4e4e2f7a-2fe2-4025-9ebd-5d965865929d.png)
![Screen Shot 2021-09-08 at 2 36 57 PM](https://user-images.githubusercontent.com/14828820/132566560-d013d771-0a71-4e94-8e0c-12e80c3e5263.png)

# Links

[SPARK-265244](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-265244)
[Figma](https://www.figma.com/file/NaNrfXjygZtRgMfHAFHjsp/Components---Windows%2BWeb?node-id=4775%3A332).