### PR TITLE
feat(components/alert-banner): add static

### DIFF
--- a/src/components/AlertBanner/AlertBanner.constants.ts
+++ b/src/components/AlertBanner/AlertBanner.constants.ts
@@ -14,10 +14,11 @@ const SIZES = {
 };
 
 const DEFAULTS = {
-  ISCENTERED: false,
   COLOR: 'default',
-  ISGROWN: false,
-  ISPILLED: false,
+  IS_CENTERED: false,
+  IS_GROWN: false,
+  IS_PILLED: false,
+  IS_STATIC: false,
   SIZE: 'default',
 };
 

--- a/src/components/AlertBanner/AlertBanner.stories.args.ts
+++ b/src/components/AlertBanner/AlertBanner.stories.args.ts
@@ -16,20 +16,8 @@ export default {
       },
     },
   },
-  isCentered: {
-    description: 'If this component should have its contents centered.',
-    control: { type: 'boolean' },
-    table: {
-      type: {
-        summary: 'boolean',
-      },
-      defaultValue: {
-        summary: CONSTANTS.DEFAULTS.ISCENTERED,
-      },
-    },
-  },
   children: {
-    description: 'Label or message to display on this component. Overrides `label`.',
+    description: 'Label or message to display on this component.',
     control: { type: 'text' },
     table: {
       type: {
@@ -53,6 +41,18 @@ export default {
       },
     },
   },
+  isCentered: {
+    description: 'If this component should have its contents centered.',
+    control: { type: 'boolean' },
+    table: {
+      type: {
+        summary: 'boolean',
+      },
+      defaultValue: {
+        summary: CONSTANTS.DEFAULTS.IS_CENTERED,
+      },
+    },
+  },
   isGrown: {
     description: 'If this component should grow its width to the parent container.',
     control: { type: 'boolean' },
@@ -61,7 +61,32 @@ export default {
         summary: 'boolean',
       },
       defaultValue: {
-        summary: CONSTANTS.DEFAULTS.ISGROWN,
+        summary: CONSTANTS.DEFAULTS.IS_GROWN,
+      },
+    },
+  },
+  isPilled: {
+    description: 'If this component should be the pill shape.',
+    control: { type: 'boolean' },
+    table: {
+      type: {
+        summary: 'boolean',
+      },
+      defaultValue: {
+        summary: CONSTANTS.DEFAULTS.IS_PILLED,
+      },
+    },
+  },
+  isStatic: {
+    description:
+      'If this `<AlertBanner />` is for displaying static children. This overrides the `color` prop.',
+    control: { type: 'boolean' },
+    table: {
+      type: {
+        summary: 'boolean',
+      },
+      defaultValue: {
+        summary: CONSTANTS.DEFAULTS.IS_STATIC,
       },
     },
   },
@@ -78,26 +103,15 @@ export default {
     },
   },
   label: {
-    description: 'Label or message to display on this component.',
-    control: { type: 'none' },
+    description:
+      'Label or message to display on this component. This overrides the `children` prop.',
+    control: { type: 'text' },
     table: {
       type: {
         summary: 'string',
       },
       defaultValue: {
         summary: 'undefined',
-      },
-    },
-  },
-  isPilled: {
-    description: 'If this component should be the pill shape.',
-    control: { type: 'boolean' },
-    table: {
-      type: {
-        summary: 'boolean',
-      },
-      defaultValue: {
-        summary: CONSTANTS.DEFAULTS.ISPILLED,
       },
     },
   },

--- a/src/components/AlertBanner/AlertBanner.stories.docs.mdx
+++ b/src/components/AlertBanner/AlertBanner.stories.docs.mdx
@@ -1,6 +1,6 @@
 The `<AlertBanner />` component. This component accepts multiple scopes of child-like props:
 
 * `image` - The image associated with this component. This will typically be an `<Icon />` component.
-* `label` - The label or message to be displayed with this component. This supports escape codes, such as `\n`.
-* `buttons` - One or more `<ButtonCircle />` components to be mapped to this `<AlertBanner />`. These are heavily re-styled for this component, use custom styling with caution.
-* `children` - Overrides the `label` prop, this is virtually identical to the `label` prop.
+* `label` - Overrides the `children` prop. The label or message to be displayed with this component. This supports escape codes, such as `\n`.
+* `buttons` - One or more `<ButtonSimple />` components to be mapped to this `<AlertBanner />`. These are heavily re-styled for this component, use custom styling with caution.
+* `children` - Virtually identical to the `label` prop, but is overriden by the `label` prop.

--- a/src/components/AlertBanner/AlertBanner.stories.tsx
+++ b/src/components/AlertBanner/AlertBanner.stories.tsx
@@ -4,7 +4,7 @@ import { MultiTemplate, Template } from '../../storybook/helper.stories.template
 import { DocumentationPage } from '../../storybook/helper.stories.docs';
 import StyleDocs from '../../storybook/docs.stories.style.mdx';
 
-import ButtonCircle from '../ButtonCircle';
+import ButtonSimple from '../ButtonSimple';
 import Icon from '../Icon';
 
 import AlertBanner, { AlertBannerProps } from './';
@@ -23,12 +23,12 @@ export default {
 };
 
 const commonButtons = [
-  <ButtonCircle key={0}>
+  <ButtonSimple key={0}>
     <Icon name="refresh" autoScale />
-  </ButtonCircle>,
-  <ButtonCircle key={1}>
+  </ButtonSimple>,
+  <ButtonSimple key={1}>
     <Icon name="cancel" autoScale />
-  </ButtonCircle>,
+  </ButtonSimple>,
 ];
 
 const Example = Template<AlertBannerProps>(AlertBanner).bind({});
@@ -212,6 +212,21 @@ Sizes.parameters = {
   ],
 };
 
+const Static = MultiTemplate<AlertBannerProps>(AlertBanner).bind({});
+
+Static.argTypes = { ...argTypes };
+delete Static.argTypes.isStatic;
+
+Static.args = {
+  buttons: commonButtons,
+  image: <Icon name="info-circle" autoScale />,
+  label: 'Example Label Default',
+};
+
+Static.parameters = {
+  variants: [{}, { isStatic: true }],
+};
+
 const Common = MultiTemplate<AlertBannerProps>(AlertBanner).bind({});
 
 Common.argTypes = { ...argTypes };
@@ -290,6 +305,19 @@ Common.parameters = {
       label: 'Error',
       isPilled: true,
     },
+    {
+      isCentered: true,
+      image: <Icon name="error-legacy" weight="filled" autoScale />,
+      label: 'isStatic',
+      isPilled: true,
+      isStatic: true,
+    },
+    {
+      image: <Icon name="error-legacy" weight="filled" autoScale />,
+      label: 'isStatic',
+      isPilled: true,
+      isStatic: true,
+    },
 
     // Lorem Ipsum.
     {
@@ -298,9 +326,9 @@ Common.parameters = {
     },
     {
       buttons: (
-        <ButtonCircle key={1}>
+        <ButtonSimple key={1}>
           <Icon name="cancel" autoScale />
-        </ButtonCircle>
+        </ButtonSimple>
       ),
       image: <Icon name="spinner-filled" autoScale />,
       label: 'Lorem ipsum dolor site aw aetns ctetuer adipiscing elit nullam amarte.',
@@ -312,9 +340,9 @@ Common.parameters = {
     },
     {
       buttons: (
-        <ButtonCircle key={1}>
+        <ButtonSimple key={1}>
           <Icon name="cancel" autoScale />
-        </ButtonCircle>
+        </ButtonSimple>
       ),
       color: 'theme',
       image: <Icon name="info-circle" weight="filled" autoScale />,
@@ -327,9 +355,9 @@ Common.parameters = {
     },
     {
       buttons: (
-        <ButtonCircle key={1}>
+        <ButtonSimple key={1}>
           <Icon name="cancel" autoScale />
-        </ButtonCircle>
+        </ButtonSimple>
       ),
       color: 'success',
       image: <Icon name="check" autoScale />,
@@ -342,9 +370,9 @@ Common.parameters = {
     },
     {
       buttons: (
-        <ButtonCircle key={1}>
+        <ButtonSimple key={1}>
           <Icon name="cancel" autoScale />
-        </ButtonCircle>
+        </ButtonSimple>
       ),
       color: 'warning',
       image: <Icon name="warning" autoScale />,
@@ -357,13 +385,28 @@ Common.parameters = {
     },
     {
       buttons: (
-        <ButtonCircle key={1}>
+        <ButtonSimple key={1}>
           <Icon name="cancel" autoScale />
-        </ButtonCircle>
+        </ButtonSimple>
       ),
       color: 'error',
       image: <Icon name="error-legacy" weight="filled" autoScale />,
       label: 'Lorem ipsum dolor site aw aetns ctetuer adipiscing elit nullam amarte.',
+    },
+    {
+      image: <Icon name="error-legacy" weight="filled" autoScale />,
+      label: 'Lorem ipsum dolor site aw aetns ctetuer adipiscing elit nullam amarte.',
+      isStatic: true,
+    },
+    {
+      buttons: (
+        <ButtonSimple key={1}>
+          <Icon name="cancel" autoScale />
+        </ButtonSimple>
+      ),
+      image: <Icon name="error-legacy" weight="filled" autoScale />,
+      label: 'Lorem ipsum dolor site aw aetns ctetuer adipiscing elit nullam amarte.',
+      isStatic: true,
     },
 
     // Lorem Ipsum Small.
@@ -374,9 +417,9 @@ Common.parameters = {
     },
     {
       buttons: (
-        <ButtonCircle key={1}>
+        <ButtonSimple key={1}>
           <Icon name="cancel" autoScale />
-        </ButtonCircle>
+        </ButtonSimple>
       ),
       image: <Icon name="spinner-filled" autoScale />,
       label: 'Lorem ipsum dolor site aw aetns ctetuer adipiscing elit nullam amarte.',
@@ -390,9 +433,9 @@ Common.parameters = {
     },
     {
       buttons: (
-        <ButtonCircle key={1}>
+        <ButtonSimple key={1}>
           <Icon name="cancel" autoScale />
-        </ButtonCircle>
+        </ButtonSimple>
       ),
       color: 'theme',
       image: <Icon name="info-circle" weight="filled" autoScale />,
@@ -407,9 +450,9 @@ Common.parameters = {
     },
     {
       buttons: (
-        <ButtonCircle key={1}>
+        <ButtonSimple key={1}>
           <Icon name="cancel" autoScale />
-        </ButtonCircle>
+        </ButtonSimple>
       ),
       color: 'success',
       image: <Icon name="check" autoScale />,
@@ -424,9 +467,9 @@ Common.parameters = {
     },
     {
       buttons: (
-        <ButtonCircle key={1}>
+        <ButtonSimple key={1}>
           <Icon name="cancel" autoScale />
-        </ButtonCircle>
+        </ButtonSimple>
       ),
       color: 'warning',
       image: <Icon name="warning" autoScale />,
@@ -441,12 +484,29 @@ Common.parameters = {
     },
     {
       buttons: (
-        <ButtonCircle key={1}>
+        <ButtonSimple key={1}>
           <Icon name="cancel" autoScale />
-        </ButtonCircle>
+        </ButtonSimple>
       ),
       color: 'error',
       image: <Icon name="error-legacy" weight="filled" autoScale />,
+      label: 'Lorem ipsum dolor site aw aetns ctetuer adipiscing elit nullam amarte.',
+      size: 'small',
+    },
+    {
+      image: <Icon name="error-legacy" weight="filled" autoScale />,
+      isStatic: true,
+      label: 'Lorem ipsum dolor site aw aetns ctetuer adipiscing elit nullam amarte.',
+      size: 'small',
+    },
+    {
+      buttons: (
+        <ButtonSimple key={1}>
+          <Icon name="cancel" autoScale />
+        </ButtonSimple>
+      ),
+      image: <Icon name="error-legacy" weight="filled" autoScale />,
+      isStatic: true,
       label: 'Lorem ipsum dolor site aw aetns ctetuer adipiscing elit nullam amarte.',
       size: 'small',
     },
@@ -515,7 +575,20 @@ Common.parameters = {
       label: 'Error [small] \n- Bulleted Message',
       size: 'small',
     },
+    {
+      buttons: commonButtons,
+      isPilled: true,
+      isStatic: true,
+      label: 'isStatic [small]',
+      size: 'small',
+    },
+    {
+      buttons: commonButtons,
+      isStatic: true,
+      label: 'isStatic [small] \n- Bulleted Message',
+      size: 'small',
+    },
   ],
 };
 
-export { Example, Centering, Colors, Growing, Pilling, Sizes, Common };
+export { Example, Centering, Colors, Growing, Pilling, Sizes, Static, Common };

--- a/src/components/AlertBanner/AlertBanner.style.scss
+++ b/src/components/AlertBanner/AlertBanner.style.scss
@@ -5,6 +5,34 @@
   transition: background-color 0.2s, color 0.2s, border-color 0.2s;
   width: 25rem;
 
+  &[data-static="true"] {
+    background-color: rgba(255, 255, 255, 1); // IEFIX
+    background-color: var(--theme-background-solid-primary-normal);
+    border: 0.0625rem solid rgba(0, 0, 0, 0.2); // IEFIX
+    border: 0.0625rem solid var(--theme-outline-secondary-normal);
+    color: rgba(0, 0, 0, 0.95); // IEFIX
+    color: var(--label-primary-text);
+
+    > .md-alert-banner-buttons > * {
+      background-color: rgba(0, 0, 0, 0); // IEFIX
+      background-color: var(--button-ghost-background);
+      color: rgba(0, 0, 0, 0.95); // IEFIX
+      color: var(--button-ghost-text);
+
+      &:hover {
+        color: rgba(0, 0, 0, 0.95); // IEFIX
+        color: var(--button-ghost-text-hovered);
+      }
+    
+      &:active {
+        background-color: rgba(0, 0, 0, 0.2); // IEFIX
+        background-color: var(--button-secondary-background-pressed);
+        color: rgba(0, 0, 0, 0.95); // IEFIX
+        color: var(--button-secondary-text-pressed);
+      }
+    }
+  }
+
   &[data-color="default"] {
     background-color: rgba(237, 237, 237, 1); // IEFIX
     background-color: var(--theme-background-alert-default-normal);
@@ -186,9 +214,18 @@
     display: flex;
 
     > .md-alert-banner-button {
-      border-radius: 0;
+      align-items: center;
+      border: 0rem solid rgba(0, 0, 0, 0); // IEFIX
+      border: var(--md-globals-border-clear);
+      cursor: pointer;
+      display: flex;
       height: 100%;
+      justify-content: center;
       margin: 0;
+      outline: none;
+      padding: 0;
+      transition: background-color 0.2s, color 0.2s, border-color 0.2s;
+      width: 2rem;
     }
 
     > .md-alert-banner-button:last-child {

--- a/src/components/AlertBanner/AlertBanner.tsx
+++ b/src/components/AlertBanner/AlertBanner.tsx
@@ -17,14 +17,14 @@ const AlertBanner: FC<Props> = (props: Props) => {
     image,
     label,
     isPilled,
+    isStatic,
     size,
     style,
   } = props;
 
   const mutatedButtons = Children.map(buttons, (button) =>
     cloneElement(button, {
-      className: classnames(button.props.className, STYLE.button),
-      ghost: true,
+      className: classnames(STYLE.button, button.props.className),
     })
   );
 
@@ -38,16 +38,17 @@ const AlertBanner: FC<Props> = (props: Props) => {
     <div className={STYLE.image} />
   );
 
-  const labelComponent = <p className={STYLE.label}>{children || label}</p>;
+  const labelComponent = <p className={STYLE.label}>{label || children}</p>;
 
   return (
     <div
-      data-centered={isCentered || DEFAULTS.ISCENTERED}
+      data-centered={isCentered || DEFAULTS.IS_CENTERED}
       className={classnames(STYLE.wrapper, className)}
-      data-color={color || DEFAULTS.COLOR}
-      data-grow={isGrown || DEFAULTS.ISGROWN}
-      data-pill={isPilled || DEFAULTS.ISPILLED}
+      data-color={isStatic ? undefined : color || DEFAULTS.COLOR}
+      data-grow={isGrown || DEFAULTS.IS_GROWN}
+      data-pill={isPilled || DEFAULTS.IS_PILLED}
       data-size={size || DEFAULTS.SIZE}
+      data-static={isStatic || DEFAULTS.IS_STATIC}
       id={id}
       style={style}
     >

--- a/src/components/AlertBanner/AlertBanner.types.ts
+++ b/src/components/AlertBanner/AlertBanner.types.ts
@@ -1,8 +1,8 @@
 import { CSSProperties, ReactElement } from 'react';
-import { ButtonCircleProps } from '../ButtonCircle';
+import { ButtonSimpleProps } from '../ButtonSimple';
 import { IconProps } from '../Icon';
 
-export type SupportedButtons = ButtonCircleProps;
+export type SupportedButtons = ButtonSimpleProps;
 export type SupportedImages = IconProps;
 
 export interface Props {
@@ -10,11 +10,6 @@ export interface Props {
    * Buttons to mount to this component.
    */
   buttons?: ReactElement<SupportedButtons> | Array<ReactElement<SupportedButtons>>;
-
-  /**
-   * If this component should have its contents centered.
-   */
-  isCentered?: boolean;
 
   /**
    * Label/message to be displayed with this component. Overrides `label`.
@@ -32,11 +27,6 @@ export interface Props {
   color?: 'default' | 'error' | 'success' | 'theme' | 'warning';
 
   /**
-   * If this component show grow its width to the parent container.
-   */
-  isGrown?: boolean;
-
-  /**
    * Custom id for overriding this component's CSS.
    */
   id?: string;
@@ -47,14 +37,29 @@ export interface Props {
   image?: ReactElement<SupportedImages>;
 
   /**
-   * Label/message to be displayed with this component.
+   * If this component should have its contents centered.
    */
-  label?: string;
+  isCentered?: boolean;
+
+  /**
+   * If this component show grow its width to the parent container.
+   */
+  isGrown?: boolean;
 
   /**
    * If this component should be the pill shape.
    */
   isPilled?: boolean;
+
+  /**
+   * If this ToastBanner will display static children. This will override the `color` prop.
+   */
+  isStatic?: boolean;
+
+  /**
+   * Label/message to be displayed with this component.
+   */
+  label?: string;
 
   /**
    * Size of this component.

--- a/src/components/AlertBanner/AlertBanner.unit.test.tsx
+++ b/src/components/AlertBanner/AlertBanner.unit.test.tsx
@@ -58,7 +58,7 @@ describe('<AlertBanner />', () => {
     it('should match snapshot with isCentered', () => {
       expect.assertions(1);
 
-      const isCentered = !DEFAULTS.ISCENTERED;
+      const isCentered = !DEFAULTS.IS_CENTERED;
 
       const container = mount(<AlertBanner isCentered={isCentered} />);
 
@@ -88,9 +88,19 @@ describe('<AlertBanner />', () => {
     it('should match snapshot with isGrown', () => {
       expect.assertions(1);
 
-      const isGrown = !DEFAULTS.ISGROWN;
+      const isGrown = !DEFAULTS.IS_GROWN;
 
       const container = mount(<AlertBanner isGrown={isGrown} />);
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match snapshot with isStatic', () => {
+      expect.assertions(1);
+
+      const isStatic = !DEFAULTS.IS_STATIC;
+
+      const container = mount(<AlertBanner isStatic={isStatic} />);
 
       expect(container).toMatchSnapshot();
     });
@@ -118,7 +128,7 @@ describe('<AlertBanner />', () => {
     it('should match snapshot with isPilled', () => {
       expect.assertions(1);
 
-      const isPilled = !DEFAULTS.ISPILLED;
+      const isPilled = !DEFAULTS.IS_PILLED;
 
       const container = mount(<AlertBanner isPilled={isPilled} />);
 
@@ -194,6 +204,18 @@ describe('<AlertBanner />', () => {
         .getDOMNode();
 
       expect(element.getAttribute('data-centered')).toBe(`${isCentered}`);
+    });
+
+    it('should have provided centered when isCentered is provided', () => {
+      expect.assertions(1);
+
+      const isStatic = true;
+
+      const element = mount(<AlertBanner isStatic={isStatic} />)
+        .find(AlertBanner)
+        .getDOMNode();
+
+      expect(element.getAttribute('data-static')).toBe(`${isStatic}`);
     });
 
     it('should have provided color when color is provided', () => {

--- a/src/components/AlertBanner/AlertBanner.unit.test.tsx.snap
+++ b/src/components/AlertBanner/AlertBanner.unit.test.tsx.snap
@@ -9,6 +9,7 @@ exports[`<AlertBanner /> snapshot should match snapshot 1`] = `
     data-grow={false}
     data-pill={false}
     data-size="default"
+    data-static={false}
   >
     <div
       className="md-alert-banner-image"
@@ -43,6 +44,7 @@ exports[`<AlertBanner /> snapshot should match snapshot with buttons 1`] = `
     data-grow={false}
     data-pill={false}
     data-size="default"
+    data-static={false}
   >
     <div
       className="md-alert-banner-image"
@@ -55,14 +57,12 @@ exports[`<AlertBanner /> snapshot should match snapshot with buttons 1`] = `
     >
       <div
         className="md-alert-banner-button"
-        ghost={true}
         key=".$0"
       >
         button 1
       </div>
       <div
         className="md-alert-banner-button"
-        ghost={true}
         key=".$1"
       >
         button 2
@@ -81,6 +81,7 @@ exports[`<AlertBanner /> snapshot should match snapshot with children 1`] = `
     data-grow={false}
     data-pill={false}
     data-size="default"
+    data-static={false}
   >
     <div
       className="md-alert-banner-image"
@@ -108,6 +109,7 @@ exports[`<AlertBanner /> snapshot should match snapshot with className 1`] = `
     data-grow={false}
     data-pill={false}
     data-size="default"
+    data-static={false}
   >
     <div
       className="md-alert-banner-image"
@@ -133,6 +135,7 @@ exports[`<AlertBanner /> snapshot should match snapshot with color 1`] = `
     data-grow={false}
     data-pill={false}
     data-size="default"
+    data-static={false}
   >
     <div
       className="md-alert-banner-image"
@@ -160,6 +163,7 @@ exports[`<AlertBanner /> snapshot should match snapshot with id 1`] = `
     data-grow={false}
     data-pill={false}
     data-size="default"
+    data-static={false}
     id="example-id"
   >
     <div
@@ -190,6 +194,7 @@ exports[`<AlertBanner /> snapshot should match snapshot with image 1`] = `
     data-grow={false}
     data-pill={false}
     data-size="default"
+    data-static={false}
   >
     <div
       className="md-alert-banner-image"
@@ -217,6 +222,7 @@ exports[`<AlertBanner /> snapshot should match snapshot with isCentered 1`] = `
     data-grow={false}
     data-pill={false}
     data-size="default"
+    data-static={false}
   >
     <div
       className="md-alert-banner-image"
@@ -242,6 +248,7 @@ exports[`<AlertBanner /> snapshot should match snapshot with isGrown 1`] = `
     data-grow={true}
     data-pill={false}
     data-size="default"
+    data-static={false}
   >
     <div
       className="md-alert-banner-image"
@@ -267,6 +274,32 @@ exports[`<AlertBanner /> snapshot should match snapshot with isPilled 1`] = `
     data-grow={false}
     data-pill={true}
     data-size="default"
+    data-static={false}
+  >
+    <div
+      className="md-alert-banner-image"
+    />
+    <p
+      className="md-alert-banner-label"
+    />
+    <div
+      className="md-alert-banner-buttons"
+    />
+  </div>
+</AlertBanner>
+`;
+
+exports[`<AlertBanner /> snapshot should match snapshot with isStatic 1`] = `
+<AlertBanner
+  isStatic={true}
+>
+  <div
+    className="md-alert-banner-wrapper"
+    data-centered={false}
+    data-grow={false}
+    data-pill={false}
+    data-size="default"
+    data-static={true}
   >
     <div
       className="md-alert-banner-image"
@@ -292,6 +325,7 @@ exports[`<AlertBanner /> snapshot should match snapshot with label 1`] = `
     data-grow={false}
     data-pill={false}
     data-size="default"
+    data-static={false}
   >
     <div
       className="md-alert-banner-image"
@@ -319,6 +353,7 @@ exports[`<AlertBanner /> snapshot should match snapshot with size 1`] = `
     data-grow={false}
     data-pill={false}
     data-size="small"
+    data-static={false}
   >
     <div
       className="md-alert-banner-image"
@@ -350,6 +385,7 @@ exports[`<AlertBanner /> snapshot should match snapshot with style 1`] = `
     data-grow={false}
     data-pill={false}
     data-size="default"
+    data-static={false}
     style={
       Object {
         "color": "pink",


### PR DESCRIPTION
# Description

The scope of the changes in this pull request are to add the `isStatic` prop to `<AlertBanner />` to cover the **Text Toast / Overlay** section of the [Figma for Toasts](https://www.figma.com/file/NaNrfXjygZtRgMfHAFHjsp/Components---Windows%2BWeb?node-id=4775%3A361).

Note, this also includes other changes:

* `<AlertBanner />` has been updated to support only `<ButtonSimple />` components instead of `<ButtonCircle />` components, now that `<ButtonSimple />` is available.

## Screenshots

![Screen Shot 2021-09-13 at 11 47 35 AM](https://user-images.githubusercontent.com/14828820/133115570-d61b6274-6149-46e3-9c12-9491da4b240e.png)
![Screen Shot 2021-09-13 at 11 47 48 AM](https://user-images.githubusercontent.com/14828820/133115572-d4be6d25-9f75-4911-8c6f-2d68a7875a61.png)
![Screen Shot 2021-09-13 at 11 47 55 AM](https://user-images.githubusercontent.com/14828820/133115574-6785a51f-90b8-4c14-9156-5ccbb9cbff84.png)

# Links

[SPARK](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-266369)
[Figma](https://www.figma.com/file/NaNrfXjygZtRgMfHAFHjsp/Components---Windows%2BWeb?node-id=4775%3A361).
