### PR TITLE
feat(components/modal-container): add menu list bg design req

### DIFF
--- a/src/components/ModalContainer/ModalContainer.stories.args.ts
+++ b/src/components/ModalContainer/ModalContainer.stories.args.ts
@@ -17,28 +17,55 @@ export default {
     },
   },
   color: {
-    description: 'Provides the child nodes for this `<ModalContainer />`.',
+    description: 'Provides the color of this `<ModalContainer />`.',
     control: { type: 'select' },
     options: [undefined, ...Object.values(CONSTANTS.COLORS)],
     table: {
       type: {
-        summary: 'ReactNode',
+        summary: 'string',
       },
       defaultValue: {
-        summary: 'undefined',
+        summary: 'primary',
       },
     },
   },
   elevation: {
-    description: 'Provides the child nodes for this `<ModalContainer />`.',
+    description:
+      'Provides the elevation for this `<ModalContainer />`. This only applies to the box-shadow depth.',
     control: { type: 'select' },
     options: [undefined, ...Object.values(CONSTANTS.ELEVATIONS)],
     table: {
       type: {
-        summary: 'ReactNode',
+        summary: 'number',
       },
       defaultValue: {
-        summary: 'undefined',
+        summary: '0',
+      },
+    },
+  },
+  isPadded: {
+    description: 'Identifies if this `<ModalContainer />` should be rendered with padding.',
+    control: { type: 'boolean' },
+    options: [undefined, ...Object.values(CONSTANTS.ELEVATIONS)],
+    table: {
+      type: {
+        summary: 'boolean',
+      },
+      defaultValue: {
+        summary: 'false',
+      },
+    },
+  },
+  isRounded: {
+    description: 'Identifies if this `<ModalContainer />` should be rendered with round corners.',
+    control: { type: 'boolean' },
+    options: [undefined, ...Object.values(CONSTANTS.ELEVATIONS)],
+    table: {
+      type: {
+        summary: 'boolean',
+      },
+      defaultValue: {
+        summary: 'false',
       },
     },
   },

--- a/src/components/ModalContainer/ModalContainer.stories.tsx
+++ b/src/components/ModalContainer/ModalContainer.stories.tsx
@@ -4,8 +4,6 @@ import { MultiTemplate, Template } from '../../storybook/helper.stories.template
 import { DocumentationPage } from '../../storybook/helper.stories.docs';
 import StyleDocs from '../../storybook/docs.stories.style.mdx';
 
-import Text from '../Text';
-
 import ModalContainer, { ModalContainerProps, MODAL_CONTAINER_CONSTANTS as CONSTANTS } from './';
 import argTypes from './ModalContainer.stories.args';
 import Documentation from './ModalContainer.stories.docs.mdx';
@@ -21,13 +19,14 @@ export default {
   },
 };
 
-const commonChildren = <Text style={{ margin: '0.5rem' }}>Example Text</Text>;
+const commonChildren = <div>Example Text</div>;
 
 const Example = Template<ModalContainerProps>(ModalContainer).bind({});
 
 Example.argTypes = { ...argTypes };
 Example.args = {
   children: commonChildren,
+  isPadded: true,
 };
 
 const Colors = MultiTemplate<ModalContainerProps>(ModalContainer).bind({});
@@ -41,6 +40,7 @@ Colors.parameters = {
 
 Colors.args = {
   children: commonChildren,
+  isPadded: true,
 };
 
 const Elevations = MultiTemplate<ModalContainerProps>(ModalContainer).bind({});
@@ -54,6 +54,45 @@ Elevations.parameters = {
 
 Elevations.args = {
   children: commonChildren,
+  isPadded: true,
+};
+
+const Padding = MultiTemplate<ModalContainerProps>(ModalContainer).bind({});
+
+Padding.argTypes = { ...argTypes };
+delete Padding.argTypes.isPadded;
+
+Padding.parameters = {
+  variants: [
+    {
+      children: <div>isPadded != true</div>,
+    },
+    {
+      children: <div>isPadded = true</div>,
+      isPadded: true,
+    },
+  ],
+};
+
+const Rounding = MultiTemplate<ModalContainerProps>(ModalContainer).bind({});
+
+Rounding.argTypes = { ...argTypes };
+delete Rounding.argTypes.isRounded;
+
+Rounding.parameters = {
+  variants: [
+    {
+      children: <div>isRound != true</div>,
+    },
+    {
+      children: <div>isRound = true</div>,
+      isRounded: true,
+    },
+  ],
+};
+
+Rounding.args = {
+  isPadded: true,
 };
 
 const Common = MultiTemplate<ModalContainerProps>(ModalContainer).bind({});
@@ -67,9 +106,9 @@ Common.parameters = {
     {
       color: 'secondary',
       children: (
-        <Text style={{ margin: '0.5rem' }}>
-          This is a very long example text section. This shows a wide Modal.
-        </Text>
+        <div style={{ margin: '0.5rem' }}>
+          This is a very long `div` element with pre-defined margin.
+        </div>
       ),
       elevation: 16,
     },
@@ -84,8 +123,9 @@ Common.parameters = {
       ),
       color: 'tertiary',
       elevation: 48,
+      isPadded: true,
     },
   ],
 };
 
-export { Example, Colors, Elevations, Common };
+export { Example, Colors, Elevations, Padding, Rounding, Common };

--- a/src/components/ModalContainer/ModalContainer.style.scss
+++ b/src/components/ModalContainer/ModalContainer.style.scss
@@ -1,65 +1,75 @@
 // This file needs to be updated after shadow color black-alpha-16 is implemented, or a subsitute is defined.
 
 .md-modal-container-wrapper {
-  margin: 0.5rem;
+  list-style: none;
+  margin: 0;
   min-height: 2rem; // This can be adjusted once min/max sizes are defined.
   min-width: 6rem; // This can be adjusted once min/max sizes are defined.
   border: 0.0625rem solid rgba(0, 0, 0, 0.2); // IEFIX
   border: 0.0625rem solid var(--modal-primary-border);
+  outline: none;
 
-  &[data-color="primary"] {
+  &[data-rounded='true'] {
+    border-radius: 0.75rem;
+  }
+
+  &[data-padded='true'] {
+    padding: 0.5rem;
+  }
+
+  &[data-color='primary'] {
     background-color: rgba(255, 255, 255, 1); // IEFIX
     background-color: var(--theme-background-solid-primary-normal);
   }
 
-  &[data-color="secondary"] {
+  &[data-color='secondary'] {
     background-color: rgba(247, 247, 247, 1); // IEFIX
     background-color: var(--theme-background-solid-secondary-normal);
   }
 
-  &[data-color="tertiary"] {
+  &[data-color='tertiary'] {
     background-color: rgba(237, 237, 237, 1); // IEFIX
     background-color: var(--theme-background-solid-tertiary-normal);
   }
 
-  &[data-color="quaternary"] {
+  &[data-color='quaternary'] {
     background-color: rgba(255, 255, 255, 1); // IEFIX
     background-color: var(--theme-background-solid-quaternary-normal);
   }
 
-  &[data-elevation="0"] {
+  &[data-elevation='0'] {
     box-shadow: var(--md-globals-elevation-0);
   }
 
-  &[data-elevation="1"] {
+  &[data-elevation='1'] {
     box-shadow: var(--md-globals-elevation-1);
   }
 
-  &[data-elevation="2"] {
+  &[data-elevation='2'] {
     box-shadow: var(--md-globals-elevation-2);
   }
 
-  &[data-elevation="3"] {
+  &[data-elevation='3'] {
     box-shadow: var(--md-globals-elevation-3);
   }
 
-  &[data-elevation="4"] {
+  &[data-elevation='4'] {
     box-shadow: var(--md-globals-elevation-4);
   }
 
-  &[data-elevation="5"] {
+  &[data-elevation='5'] {
     box-shadow: var(--md-globals-elevation-5);
   }
 
-  &[data-elevation="6"] {
+  &[data-elevation='6'] {
     box-shadow: var(--md-globals-elevation-6);
   }
 
-  &[data-elevation="7"] {
+  &[data-elevation='7'] {
     box-shadow: var(--md-globals-elevation-7);
   }
 
-  &[data-elevation="8"] {
+  &[data-elevation='8'] {
     box-shadow: var(--md-globals-elevation-8);
   }
 }

--- a/src/components/ModalContainer/ModalContainer.tsx
+++ b/src/components/ModalContainer/ModalContainer.tsx
@@ -9,13 +9,15 @@ import './ModalContainer.style.scss';
  * The ModalContainer component.
  */
 const ModalContainer: FC<Props> = (props: Props) => {
-  const { className, children, color, elevation, id, style } = props;
+  const { className, children, color, elevation, id, isPadded, isRounded, style } = props;
 
   return (
     <div
       className={classnames(className, STYLE.wrapper)}
       data-color={color || DEFAULTS.COLOR}
       data-elevation={elevation || DEFAULTS.ELEVATION}
+      data-padded={isPadded}
+      data-rounded={isRounded}
       id={id}
       style={style}
     >

--- a/src/components/ModalContainer/ModalContainer.types.ts
+++ b/src/components/ModalContainer/ModalContainer.types.ts
@@ -30,6 +30,16 @@ export interface Props {
   id?: string;
 
   /**
+   * If this ModalContainer is padded.
+   */
+  isPadded?: boolean;
+
+  /**
+   * If this ModalContainer is round.
+   */
+  isRounded?: boolean;
+
+  /**
    * Custom style for overriding this component's CSS.
    */
   style?: CSSProperties;

--- a/src/components/ModalContainer/ModalContainer.unit.test.tsx
+++ b/src/components/ModalContainer/ModalContainer.unit.test.tsx
@@ -63,6 +63,22 @@ describe('<ModalContainer />', () => {
       expect(container).toMatchSnapshot();
     });
 
+    it('should match snapshot with isPadded', () => {
+      expect.assertions(1);
+
+      const container = mount(<ModalContainer isPadded />);
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match snapshot with isRounded', () => {
+      expect.assertions(1);
+
+      const container = mount(<ModalContainer isRounded />);
+
+      expect(container).toMatchSnapshot();
+    });
+
     it('should match snapshot with children', () => {
       expect.assertions(1);
 
@@ -144,6 +160,30 @@ describe('<ModalContainer />', () => {
         .getDOMNode();
 
       expect(element.getAttribute('data-elevation')).toBe(`${elevation}`);
+    });
+
+    it('should have provided data-padded when isPadded is provided', () => {
+      expect.assertions(1);
+
+      const isPadded = true;
+
+      const element = mount(<ModalContainer isPadded={isPadded} />)
+        .find(ModalContainer)
+        .getDOMNode();
+
+      expect(element.getAttribute('data-padded')).toBe(`${isPadded}`);
+    });
+
+    it('should have provided data-rounded when isRounded is provided', () => {
+      expect.assertions(1);
+
+      const isRounded = true;
+
+      const element = mount(<ModalContainer isRounded={isRounded} />)
+        .find(ModalContainer)
+        .getDOMNode();
+
+      expect(element.getAttribute('data-rounded')).toBe(`${isRounded}`);
     });
   });
 });

--- a/src/components/ModalContainer/ModalContainer.unit.test.tsx.snap
+++ b/src/components/ModalContainer/ModalContainer.unit.test.tsx.snap
@@ -73,6 +73,32 @@ exports[`<ModalContainer /> snapshot should match snapshot with id 1`] = `
 </ModalContainer>
 `;
 
+exports[`<ModalContainer /> snapshot should match snapshot with isPadded 1`] = `
+<ModalContainer
+  isPadded={true}
+>
+  <div
+    className="md-modal-container-wrapper"
+    data-color="primary"
+    data-elevation={0}
+    data-padded={true}
+  />
+</ModalContainer>
+`;
+
+exports[`<ModalContainer /> snapshot should match snapshot with isRounded 1`] = `
+<ModalContainer
+  isRounded={true}
+>
+  <div
+    className="md-modal-container-wrapper"
+    data-color="primary"
+    data-elevation={0}
+    data-rounded={true}
+  />
+</ModalContainer>
+`;
+
 exports[`<ModalContainer /> snapshot should match snapshot with style 1`] = `
 <ModalContainer
   style={


### PR DESCRIPTION
# Description

The scope of the changes in this pull request are to add the design elements and requirements of `menu-list-background` from the Figma article to `<ModalContainer />`. This does not include remapping other components to utilize the new `<ModalContainer />` props. This will come in the linked PR.

## Screenshots

![Screen Shot 2021-09-20 at 7 37 27 PM](https://user-images.githubusercontent.com/14828820/134091113-a5beafd4-f870-4491-ad73-51b8f84c9280.png)

# Links

[Add MenuListBackground functionality - SPARK-253320](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-253320)
[Refactor Existing MenuListBackground - SPARK-268337](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-268337)
[Figma](https://www.figma.com/file/NaNrfXjygZtRgMfHAFHjsp/Components---Windows%2BWeb?node-id=4518%3A11772)
