### PR TITLE
feat(hooks): fix anti pattern

### DIFF
--- a/src/components/AlertBadge/AlertBadge.tsx
+++ b/src/components/AlertBadge/AlertBadge.tsx
@@ -12,7 +12,8 @@ import './AlertBadge.style.scss';
 const AlertBadge: FC<Props> = forwardRef(
   (props: Props, providedRef: RefObject<HTMLButtonElement>) => {
     const { children, className, color, image, id, label, style } = props;
-    const ref = providedRef || useRef();
+    const internalRef = useRef();
+    const ref = providedRef || internalRef;
 
     const mutatedChildren = children ? (
       <PrimitiveConverter>{children}</PrimitiveConverter>

--- a/src/components/ButtonCircle/ButtonCircle.tsx
+++ b/src/components/ButtonCircle/ButtonCircle.tsx
@@ -13,10 +13,12 @@ import './ButtonCircle.style.scss';
 const ButtonCircle: FC<Props> = forwardRef(
   (props: Props, providedRef: RefObject<HTMLButtonElement>) => {
     const { children, className, color, disabled, ghost, id, outline, size, style } = props;
-    const ref = providedRef || useRef();
+    const internalRef = useRef();
+    const ref = providedRef || internalRef;
+
     const mutatedProps = {
       ...props,
-      isDisbled: props.disabled,
+      isDisabled: props.disabled,
     };
 
     delete mutatedProps.className;

--- a/src/components/ButtonCircle/ButtonCircle.unit.test.tsx.snap
+++ b/src/components/ButtonCircle/ButtonCircle.unit.test.tsx.snap
@@ -97,6 +97,7 @@ exports[`<ButtonCircle /> snapshot should match snapshot when a ghost and disabl
         data-multiple-children={false}
         data-outline={false}
         data-size={40}
+        disabled={true}
         onBlur={[Function]}
         onClick={[Function]}
         onDragStart={[Function]}
@@ -180,6 +181,7 @@ exports[`<ButtonCircle /> snapshot should match snapshot when disabled 1`] = `
         data-multiple-children={false}
         data-outline={false}
         data-size={40}
+        disabled={true}
         onBlur={[Function]}
         onClick={[Function]}
         onDragStart={[Function]}

--- a/src/components/ButtonDialpad/ButtonDialpad.tsx
+++ b/src/components/ButtonDialpad/ButtonDialpad.tsx
@@ -10,7 +10,9 @@ import classnames from 'classnames';
 const ButtonDialpad: FC<Props> = forwardRef(
   (props: Props, providedRef: RefObject<HTMLButtonElement>) => {
     const { className } = props;
-    const ref = providedRef || useRef();
+    const internalRef = useRef();
+    const ref = providedRef || internalRef;
+
     const mutatedProps = {
       ...props,
       isDisabled: props.disabled,

--- a/src/components/ButtonHyperlink/ButtonHyperlink.tsx
+++ b/src/components/ButtonHyperlink/ButtonHyperlink.tsx
@@ -10,7 +10,9 @@ import classnames from 'classnames';
 const ButtonHyperlink: FC<Props> = forwardRef(
   (props: Props, providedRef: RefObject<HTMLButtonElement>) => {
     const { className } = props;
-    const ref = providedRef || useRef();
+    const internalRef = useRef();
+    const ref = providedRef || internalRef;
+
     const mutatedProps = {
       ...props,
       isDisabled: props.disabled,

--- a/src/components/ButtonPill/ButtonPill.tsx
+++ b/src/components/ButtonPill/ButtonPill.tsx
@@ -10,7 +10,9 @@ import './ButtonPill.style.scss';
 const ButtonPill: FC<Props> = forwardRef(
   (props: Props, providedRef: RefObject<HTMLButtonElement>) => {
     const { children, className, color, disabled, ghost, id, outline, size, style } = props;
-    const ref = providedRef || useRef();
+    const internalRef = useRef();
+    const ref = providedRef || internalRef;
+
     const mutatedProps = {
       ...props,
       isDisabled: props.disabled,

--- a/src/components/ButtonSimple/ButtonSimple.tsx
+++ b/src/components/ButtonSimple/ButtonSimple.tsx
@@ -11,7 +11,9 @@ import { Props } from './ButtonSimple.types';
 const ButtonSimple: FC<Props> = forwardRef(
   (props: Props, providedRef: RefObject<HTMLButtonElement>) => {
     const { children, className, isDisabled, id, style } = props;
-    const ref = providedRef || useRef();
+    const internalRef = useRef();
+    const ref = providedRef || internalRef;
+
     const mutatedProps = {
       ...props,
     };

--- a/src/components/ReactionBadge/ReactionBadge.tsx
+++ b/src/components/ReactionBadge/ReactionBadge.tsx
@@ -12,7 +12,8 @@ const ReactionBadge: FC<Props> = forwardRef(
     // for now children is the native emoji until i make the emoji/reaction component we discussed during
     // meeting today about mapping string -> SVG
     const { children, className, count, id, reacted, style, ...otherProps } = props;
-    const ref = providedRef || useRef();
+    const internalRef = useRef();
+    const ref = providedRef || internalRef;
 
     return (
       <ButtonPill


### PR DESCRIPTION
# Description
The changes in this PR address the anti-pattern of using the `useRef` hook. We're not supposed to call hooks in conditions [Rules of Hooks](https://reactjs.org/docs/hooks-rules.html).
There was also a tiny small bug in `ButtonCircle` which was fixed as well.
