### PR TITLE
feat(components/modal-arrow): generate component

### DIFF
--- a/src/components/ModalArrow/ModalArrow.constants.ts
+++ b/src/components/ModalArrow/ModalArrow.constants.ts
@@ -1,0 +1,27 @@
+import { Color, Side } from './ModalArrow.types';
+
+const CLASS_PREFIX = 'md-modal-arrow';
+
+const COLORS: Record<string, Color> = {
+  PRIMARY: 'primary',
+  SECONDARY: 'secondary',
+  TERTIARY: 'tertiary',
+  QUATERNARY: 'quaternary',
+};
+
+const SIDES: Record<string, Side> = {
+  BOTTOM: 'bottom',
+  LEFT: 'left',
+  RIGHT: 'right',
+  TOP: 'top',
+};
+
+const DEFAULTS = {
+  COLOR: COLORS.PRIMARY,
+};
+
+const STYLE = {
+  wrapper: `${CLASS_PREFIX}-wrapper`,
+};
+
+export { CLASS_PREFIX, COLORS, DEFAULTS, SIDES, STYLE };

--- a/src/components/ModalArrow/ModalArrow.stories.args.ts
+++ b/src/components/ModalArrow/ModalArrow.stories.args.ts
@@ -1,0 +1,33 @@
+import { commonStyles } from '../../storybook/helper.stories.argtypes';
+
+import { MODAL_ARROW_CONSTANTS as CONSTANTS } from '.';
+
+export default {
+  ...commonStyles,
+  color: {
+    description: 'What color to render this `<ModalArrow />` as.',
+    control: { type: 'select' },
+    options: [...Object.values(CONSTANTS.COLORS)],
+    table: {
+      type: {
+        summary: 'string',
+      },
+      defaultValue: {
+        summary: 'undefined',
+      },
+    },
+  },
+  side: {
+    description: 'Defines which side this `<ModalArrow />` will appear on.',
+    control: { type: 'select' },
+    options: [undefined, ...Object.values(CONSTANTS.SIDES)],
+    table: {
+      type: {
+        summary: 'string',
+      },
+      defaultValue: {
+        summary: 'undefined',
+      },
+    },
+  },
+};

--- a/src/components/ModalArrow/ModalArrow.stories.docs.mdx
+++ b/src/components/ModalArrow/ModalArrow.stories.docs.mdx
@@ -1,0 +1,1 @@
+The `<ModalArrow />` component. This component is designed to be strictly consumbed by the `<Modal />` group of components.

--- a/src/components/ModalArrow/ModalArrow.stories.tsx
+++ b/src/components/ModalArrow/ModalArrow.stories.tsx
@@ -1,0 +1,77 @@
+import { MultiTemplate, Template } from '../../storybook/helper.stories.templates';
+import { DocumentationPage } from '../../storybook/helper.stories.docs';
+import StyleDocs from '../../storybook/docs.stories.style.mdx';
+
+import ModalArrow, { ModalArrowProps, MODAL_ARROW_CONSTANTS as CONSTANTS } from './';
+import argTypes from './ModalArrow.stories.args';
+import Documentation from './ModalArrow.stories.docs.mdx';
+
+export default {
+  title: 'Momentum UI/ModalArrow',
+  component: ModalArrow,
+  parameters: {
+    expanded: true,
+    docs: {
+      page: DocumentationPage(Documentation, StyleDocs),
+    },
+  },
+};
+
+const Example = Template<ModalArrowProps>(ModalArrow).bind({});
+
+Example.argTypes = { ...argTypes };
+
+Example.args = {
+  color: CONSTANTS.COLORS.TERTIARY,
+  side: CONSTANTS.SIDES.BOTTOM,
+};
+
+const Colors = MultiTemplate<ModalArrowProps>(ModalArrow).bind({});
+
+Colors.argTypes = { ...argTypes };
+delete Colors.argTypes.color;
+
+Colors.args = {
+  side: CONSTANTS.SIDES.BOTTOM,
+};
+
+Colors.parameters = {
+  variants: [
+    ...Object.values(CONSTANTS.COLORS).map((color) => ({ color, style: { margin: '1rem' } })),
+  ],
+};
+
+const Sides = MultiTemplate<ModalArrowProps>(ModalArrow).bind({});
+
+Sides.argTypes = { ...argTypes };
+delete Sides.argTypes.side;
+
+Sides.args = {
+  color: CONSTANTS.COLORS.TERTIARY,
+};
+
+Sides.parameters = {
+  variants: [
+    ...Object.values(CONSTANTS.SIDES).map((side) => ({ side, style: { margin: '1rem' } })),
+  ],
+};
+
+const Common = MultiTemplate<ModalArrowProps>(ModalArrow).bind({});
+
+Common.argTypes = { ...argTypes };
+delete Common.argTypes.color;
+delete Common.argTypes.side;
+
+Common.parameters = {
+  variants: [
+    ...Object.values(CONSTANTS.SIDES).map((side) =>
+      Object.values(CONSTANTS.COLORS).map((color) => ({
+        color,
+        side,
+        style: { margin: '1rem' },
+      }))
+    ),
+  ].flat(),
+};
+
+export { Example, Colors, Sides, Common };

--- a/src/components/ModalArrow/ModalArrow.style.scss
+++ b/src/components/ModalArrow/ModalArrow.style.scss
@@ -1,0 +1,27 @@
+.md-modal-arrow-wrapper {
+  path {
+    stroke: rgba(0, 0, 0, 0.2); // IEFIX
+    stroke: var(--menulistbackground-primary-border);
+    stroke-width: 0.125rem;
+
+    &[data-color='primary'] {
+      fill: rgba(255, 255, 255, 1); // IEFIX
+      fill: var(--theme-background-solid-primary-normal);
+    }
+
+    &[data-color='secondary'] {
+      fill: rgba(247, 247, 247, 1); // IEFIX
+      fill: var(--theme-background-solid-secondary-normal);
+    }
+
+    &[data-color='tertiary'] {
+      fill: rgba(237, 237, 237, 1); // IEFIX
+      fill: var(--theme-background-solid-tertiary-normal);
+    }
+
+    &[data-color='quaternary'] {
+      fill: rgba(255, 255, 255, 1); // IEFIX
+      fill: var(--theme-background-solid-quaternary-normal);
+    }
+  }
+}

--- a/src/components/ModalArrow/ModalArrow.tsx
+++ b/src/components/ModalArrow/ModalArrow.tsx
@@ -1,0 +1,91 @@
+import React, { FC } from 'react';
+import classnames from 'classnames';
+
+import { DEFAULTS, SIDES, STYLE } from './ModalArrow.constants';
+import { Props } from './ModalArrow.types';
+import './ModalArrow.style.scss';
+
+/**
+ * The ModalArrow component. This is designed to be strictly consumed by the ModalContainer component.
+ */
+const ModalArrow: FC<Props> = (props: Props) => {
+  const { className, color, id, side, style } = props;
+
+  // Point Reference.
+  const pr = {
+    end: '',
+    start: '',
+    tipEnd: '',
+    tipPeak: '',
+    tipStart: '',
+  };
+
+  const isVertical = side === SIDES.TOP || side === SIDES.BOTTOM;
+
+  switch (side) {
+    case SIDES.BOTTOM:
+      pr.start = '24 0';
+      pr.tipStart = '-10 10';
+      pr.tipPeak = '-2 2';
+      pr.tipEnd = '-4 0';
+      pr.end = '-10 -10';
+      break;
+
+    case SIDES.LEFT:
+      pr.start = '12 24';
+      pr.tipStart = '-10 -10';
+      pr.tipPeak = '-2 -2';
+      pr.tipEnd = '0 -4';
+      pr.end = '10 -10';
+      break;
+
+    case SIDES.RIGHT:
+      pr.start = '0 0';
+      pr.tipStart = '10 10';
+      pr.tipPeak = '2 2';
+      pr.tipEnd = '0 4';
+      pr.end = '-10 10';
+      break;
+
+    case SIDES.TOP:
+      pr.start = '0 12';
+      pr.tipStart = '10 -10';
+      pr.tipPeak = '2 -2';
+      pr.tipEnd = '4 0';
+      pr.end = '10 10';
+      break;
+  }
+
+  const pathData = `m ${pr.start} l ${pr.tipStart} q ${pr.tipPeak} ${pr.tipEnd} l ${pr.end}`;
+
+  const viewBoxHeight = isVertical ? 12 : 24;
+  const viewBoxWidth = isVertical ? 24 : 12;
+  const viewBox = `0 0 ${viewBoxWidth} ${viewBoxHeight}`;
+
+  return (
+    <svg
+      className={classnames(STYLE.wrapper, className)}
+      id={id}
+      style={style}
+      xmlns="http://www.w3.org/svg/2000"
+      width={viewBoxWidth}
+      height={viewBoxHeight}
+      viewBox={viewBox}
+      data-side={side}
+    >
+      <defs>
+        <clipPath id={`modal-arrow-cut-stroke-${side}`}>
+          <path d={pathData} />
+        </clipPath>
+      </defs>
+
+      <path
+        data-color={color || DEFAULTS.COLOR}
+        clipPath={`url(#modal-arrow-cut-stroke-${side})`}
+        d={pathData}
+      />
+    </svg>
+  );
+};
+
+export default ModalArrow;

--- a/src/components/ModalArrow/ModalArrow.types.ts
+++ b/src/components/ModalArrow/ModalArrow.types.ts
@@ -1,0 +1,31 @@
+import { CSSProperties } from 'react';
+
+export type Color = 'primary' | 'secondary' | 'tertiary' | 'quaternary';
+export type Side = 'bottom' | 'left' | 'right' | 'top';
+
+export interface Props {
+  /**
+   * Custom class for overriding this component's CSS.
+   */
+  className?: string;
+
+  /**
+   * The color of this ModalArrow.
+   */
+  color?: Color;
+
+  /**
+   * Custom id for overriding this component's CSS.
+   */
+  id?: string;
+
+  /**
+   * The side that this arrow will appear on.
+   */
+  side: Side;
+
+  /**
+   * Custom style for overriding this component's CSS.
+   */
+  style?: CSSProperties;
+}

--- a/src/components/ModalArrow/ModalArrow.unit.test.tsx
+++ b/src/components/ModalArrow/ModalArrow.unit.test.tsx
@@ -1,0 +1,136 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import ModalArrow, { MODAL_ARROW_CONSTANTS as CONSTANTS } from './';
+
+describe('<ModalArrow />', () => {
+  let side;
+
+  beforeEach(() => {
+    side = CONSTANTS.SIDES.BOTTOM;
+  });
+
+  describe('snapshot', () => {
+    it('should match snapshot', () => {
+      expect.assertions(1);
+
+      const container = mount(<ModalArrow side={side} />);
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match snapshot with className', () => {
+      expect.assertions(1);
+
+      const className = 'example-class';
+
+      const container = mount(<ModalArrow side={side} className={className} />);
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match snapshot with id', () => {
+      expect.assertions(1);
+
+      const id = 'example-id';
+
+      const container = mount(<ModalArrow side={side} id={id} />);
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match snapshot with style', () => {
+      expect.assertions(1);
+
+      const style = { color: 'pink' };
+
+      const container = mount(<ModalArrow side={side} style={style} />);
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match snapshot with color', () => {
+      expect.assertions(1);
+
+      const color = Object.values(CONSTANTS.COLORS).pop();
+
+      const container = mount(<ModalArrow color={color} side={side} />);
+
+      expect(container).toMatchSnapshot();
+    });
+  });
+
+  describe('attributes', () => {
+    it('should have its wrapper class', () => {
+      expect.assertions(1);
+
+      const element = mount(<ModalArrow side={side} />)
+        .find(ModalArrow)
+        .getDOMNode();
+
+      expect(element.classList.contains(CONSTANTS.STYLE.wrapper)).toBe(true);
+    });
+
+    it('should have provided class when className is provided', () => {
+      expect.assertions(1);
+
+      const className = 'example-class';
+
+      const element = mount(<ModalArrow className={className} side={side} />)
+        .find(ModalArrow)
+        .getDOMNode();
+
+      expect(element.classList.contains(className)).toBe(true);
+    });
+
+    it('should have provided id when id is provided', () => {
+      expect.assertions(1);
+
+      const id = 'example-id';
+
+      const element = mount(<ModalArrow id={id} side={side} />)
+        .find(ModalArrow)
+        .getDOMNode();
+
+      expect(element.id).toBe(id);
+    });
+
+    it('should have provided style when style is provided', () => {
+      expect.assertions(1);
+
+      const style = { color: 'pink' };
+      const styleString = 'color: pink;';
+
+      const element = mount(<ModalArrow style={style} side={side} />)
+        .find(ModalArrow)
+        .getDOMNode();
+
+      expect(element.getAttribute('style')).toBe(styleString);
+    });
+
+    it('should have provided data-side on path when side is provided', () => {
+      expect.assertions(1);
+
+      const side = Object.values(CONSTANTS.SIDES).pop();
+
+      const element = mount(<ModalArrow side={side} />)
+        .find(ModalArrow)
+        .getDOMNode();
+
+      expect(element.getAttribute('data-side')).toBe(side);
+    });
+
+    it('should have provided data-color when color is provided', () => {
+      expect.assertions(1);
+
+      const color = Object.values(CONSTANTS.COLORS).pop();
+
+      const element = mount(<ModalArrow color={color} side={side} />)
+        .find(ModalArrow)
+        .getDOMNode()
+        .getElementsByTagName('path')[1];
+
+      expect(element.getAttribute('data-color')).toBe(color);
+    });
+  });
+});

--- a/src/components/ModalArrow/ModalArrow.unit.test.tsx.snap
+++ b/src/components/ModalArrow/ModalArrow.unit.test.tsx.snap
@@ -1,0 +1,165 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ModalArrow /> snapshot should match snapshot 1`] = `
+<ModalArrow
+  side="bottom"
+>
+  <svg
+    className="md-modal-arrow-wrapper"
+    data-side="bottom"
+    height={12}
+    viewBox="0 0 24 12"
+    width={24}
+    xmlns="http://www.w3.org/svg/2000"
+  >
+    <defs>
+      <clipPath
+        id="modal-arrow-cut-stroke-bottom"
+      >
+        <path
+          d="m 24 0 l -10 10 q -2 2 -4 0 l -10 -10"
+        />
+      </clipPath>
+    </defs>
+    <path
+      clipPath="url(#modal-arrow-cut-stroke-bottom)"
+      d="m 24 0 l -10 10 q -2 2 -4 0 l -10 -10"
+      data-color="primary"
+    />
+  </svg>
+</ModalArrow>
+`;
+
+exports[`<ModalArrow /> snapshot should match snapshot with className 1`] = `
+<ModalArrow
+  className="example-class"
+  side="bottom"
+>
+  <svg
+    className="md-modal-arrow-wrapper example-class"
+    data-side="bottom"
+    height={12}
+    viewBox="0 0 24 12"
+    width={24}
+    xmlns="http://www.w3.org/svg/2000"
+  >
+    <defs>
+      <clipPath
+        id="modal-arrow-cut-stroke-bottom"
+      >
+        <path
+          d="m 24 0 l -10 10 q -2 2 -4 0 l -10 -10"
+        />
+      </clipPath>
+    </defs>
+    <path
+      clipPath="url(#modal-arrow-cut-stroke-bottom)"
+      d="m 24 0 l -10 10 q -2 2 -4 0 l -10 -10"
+      data-color="primary"
+    />
+  </svg>
+</ModalArrow>
+`;
+
+exports[`<ModalArrow /> snapshot should match snapshot with color 1`] = `
+<ModalArrow
+  color="quaternary"
+  side="bottom"
+>
+  <svg
+    className="md-modal-arrow-wrapper"
+    data-side="bottom"
+    height={12}
+    viewBox="0 0 24 12"
+    width={24}
+    xmlns="http://www.w3.org/svg/2000"
+  >
+    <defs>
+      <clipPath
+        id="modal-arrow-cut-stroke-bottom"
+      >
+        <path
+          d="m 24 0 l -10 10 q -2 2 -4 0 l -10 -10"
+        />
+      </clipPath>
+    </defs>
+    <path
+      clipPath="url(#modal-arrow-cut-stroke-bottom)"
+      d="m 24 0 l -10 10 q -2 2 -4 0 l -10 -10"
+      data-color="quaternary"
+    />
+  </svg>
+</ModalArrow>
+`;
+
+exports[`<ModalArrow /> snapshot should match snapshot with id 1`] = `
+<ModalArrow
+  id="example-id"
+  side="bottom"
+>
+  <svg
+    className="md-modal-arrow-wrapper"
+    data-side="bottom"
+    height={12}
+    id="example-id"
+    viewBox="0 0 24 12"
+    width={24}
+    xmlns="http://www.w3.org/svg/2000"
+  >
+    <defs>
+      <clipPath
+        id="modal-arrow-cut-stroke-bottom"
+      >
+        <path
+          d="m 24 0 l -10 10 q -2 2 -4 0 l -10 -10"
+        />
+      </clipPath>
+    </defs>
+    <path
+      clipPath="url(#modal-arrow-cut-stroke-bottom)"
+      d="m 24 0 l -10 10 q -2 2 -4 0 l -10 -10"
+      data-color="primary"
+    />
+  </svg>
+</ModalArrow>
+`;
+
+exports[`<ModalArrow /> snapshot should match snapshot with style 1`] = `
+<ModalArrow
+  side="bottom"
+  style={
+    Object {
+      "color": "pink",
+    }
+  }
+>
+  <svg
+    className="md-modal-arrow-wrapper"
+    data-side="bottom"
+    height={12}
+    style={
+      Object {
+        "color": "pink",
+      }
+    }
+    viewBox="0 0 24 12"
+    width={24}
+    xmlns="http://www.w3.org/svg/2000"
+  >
+    <defs>
+      <clipPath
+        id="modal-arrow-cut-stroke-bottom"
+      >
+        <path
+          d="m 24 0 l -10 10 q -2 2 -4 0 l -10 -10"
+        />
+      </clipPath>
+    </defs>
+    <path
+      clipPath="url(#modal-arrow-cut-stroke-bottom)"
+      d="m 24 0 l -10 10 q -2 2 -4 0 l -10 -10"
+      data-color="primary"
+    />
+  </svg>
+</ModalArrow>
+`;

--- a/src/components/ModalArrow/index.ts
+++ b/src/components/ModalArrow/index.ts
@@ -1,0 +1,9 @@
+import { default as ModalArrow } from './ModalArrow';
+import * as CONSTANTS from './ModalArrow.constants';
+import { Props } from './ModalArrow.types';
+
+export { CONSTANTS as MODAL_ARROW_CONSTANTS };
+
+export type ModalArrowProps = Props;
+
+export default ModalArrow;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -11,6 +11,7 @@ export { default as ButtonHyperlink } from './ButtonHyperlink';
 export { default as ButtonPill } from './ButtonPill';
 export { default as ButtonSimple } from './ButtonSimple';
 export { default as FocusRing } from './FocusRing';
+export { default as ModalArrow } from './ModalArrow';
 export { default as ModalContainer } from './ModalContainer';
 export { default as ThemeProvider } from './ThemeProvider';
 export { default as Toast } from './Toast';

--- a/src/index.js
+++ b/src/index.js
@@ -117,6 +117,7 @@ export {
   InputMessage as InputMessageNew,
   ExampleComponent,
   Icon as IconNext,
+  ModalArrow,
   ModalContainer,
   Toast,
   ToastDetails,


### PR DESCRIPTION
# Description

The scope of the changes in this pull request are to add the `<ModalArrow />` component, which will be consumed by the `<ModalContainer />` component.

## Screenshots

![Screen Shot 2021-09-27 at 5 03 32 PM](https://user-images.githubusercontent.com/14828820/134986152-cc0cf28e-b5d2-496c-afb3-e95e3a6e4ae9.png)
![Screen Shot 2021-09-27 at 5 03 37 PM](https://user-images.githubusercontent.com/14828820/134986153-eedc6193-9ede-4ec6-b128-de6a38fa3088.png)
![Screen Shot 2021-09-27 at 5 03 41 PM](https://user-images.githubusercontent.com/14828820/134986155-48b64beb-4673-414f-adde-964f94d37eb7.png)
![Screen Shot 2021-09-27 at 5 03 47 PM](https://user-images.githubusercontent.com/14828820/134986156-5d89a020-d5eb-4551-b118-6a3e956fa973.png)

# Links

[SPARK](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-270279)
[Figma](https://www.figma.com/file/NaNrfXjygZtRgMfHAFHjsp/Components---Windows%2BWeb?node-id=4486%3A785)
