### PR TITLE
fix(percy): disable examples test

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -180,53 +180,53 @@ jobs:
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
 
-  test-examples:
-    name: Test - Examples
-    needs: build-source
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Checkout Project
-        uses: actions/checkout@v2
+  # test-examples:
+  #   name: Test - Examples
+  #   needs: build-source
+  #   runs-on: ubuntu-20.04
+  #   steps:
+  #     - name: Checkout Project
+  #       uses: actions/checkout@v2
 
-      - name: Setup Environment
-        uses: actions/setup-node@v2
-        with:
-          node-version: 14.x
-          check-latest: true
+  #     - name: Setup Environment
+  #       uses: actions/setup-node@v2
+  #       with:
+  #         node-version: 14.x
+  #         check-latest: true
 
-      - name: Uncache Dependencies
-        uses: actions/cache@v2
-        with:
-          path: node_modules/
-          key: node-modules-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+  #     - name: Uncache Dependencies
+  #       uses: actions/cache@v2
+  #       with:
+  #         path: node_modules/
+  #         key: node-modules-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
 
-      - name: Uncache Cypress
-        uses: actions/cache@v2
-        with:
-          path: /home/runner/.cache/Cypress
-          key: cypress-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+  #     - name: Uncache Cypress
+  #       uses: actions/cache@v2
+  #       with:
+  #         path: /home/runner/.cache/Cypress
+  #         key: cypress-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
 
-      - name: Uncache Dist
-        uses: actions/cache@v2
-        with:
-          path: dist/
-          key: dist-${{ runner.os }}-${{ env.rid }}
+  #     - name: Uncache Dist
+  #       uses: actions/cache@v2
+  #       with:
+  #         path: dist/
+  #         key: dist-${{ runner.os }}-${{ env.rid }}
 
-      - name: Uncache Docs
-        uses: actions/cache@v2
-        with:
-          path: docs/
-          key: docs-${{ runner.os }}-${{ env.rid }}
+  #     - name: Uncache Docs
+  #       uses: actions/cache@v2
+  #       with:
+  #         path: docs/
+  #         key: docs-${{ runner.os }}-${{ env.rid }}
 
-      - name: Uncache Styles
-        uses: actions/cache@v2
-        with:
-          path: scss/
-          key: scss-${{ runner.os }}-${{ env.rid }}
+  #     - name: Uncache Styles
+  #       uses: actions/cache@v2
+  #       with:
+  #         path: scss/
+  #         key: scss-${{ runner.os }}-${{ env.rid }}
 
-      - name: Test - Examples
-        uses: cypress-io/github-action@v2
-        with:
-          command: yarn ci:test:examples
-        env:
-          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+  #     - name: Test - Examples
+  #       uses: cypress-io/github-action@v2
+  #       with:
+  #         command: yarn ci:test:examples
+  #       env:
+  #         PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}


### PR DESCRIPTION
# Description

Percy requires all the snapshots to be sent at one time. We currently have two sets of snapshots being sent, one for examples and one for the storybook. This means we can't use either of them. While we work out a way of combining these, it is safer, given the rate of development on the new components to simply not run the examples tests.

# Links

*Links to relevent resources.*
