### PR TITLE
refactor(components/toast): max width to match alert

### DIFF
--- a/src/components/Toast/Toast.style.scss
+++ b/src/components/Toast/Toast.style.scss
@@ -2,7 +2,7 @@
   background-color: var(--theme-background-solid-primary-normal);
   border: 0.0625rem solid var(--modal-primary-border-color);
   margin: 0.5rem;
-  width: 20.75rem;
+  width: 25rem;
   flex-grow: 0;
 
   > .md-toast-header {

--- a/src/components/ToastContent/ToastContent.style.scss
+++ b/src/components/ToastContent/ToastContent.style.scss
@@ -1,24 +1,24 @@
 .md-toast-content-wrapper {
   margin: 0 1rem 1rem 1rem;
-  max-width: 20.75rem;
+  max-width: 25rem;
 
   > .md-toast-content-scope {
     font-size: 0.875rem;
 
     > .md-toast-content-action {
-      &[data-color="cancel"] {
+      &[data-color='cancel'] {
         color: var(--theme-text-error-normal);
       }
 
-      &[data-color="join"] {
+      &[data-color='join'] {
         color: var(--theme-text-accent-normal);
       }
 
-      &[data-color="success"] {
+      &[data-color='success'] {
         color: var(--theme-text-success-normal);
       }
 
-      &[data-color="warning"] {
+      &[data-color='warning'] {
         color: var(--theme-text-warning-normal);
       }
     }

--- a/src/components/ToastDetails/ToastDetails.style.scss
+++ b/src/components/ToastDetails/ToastDetails.style.scss
@@ -2,7 +2,7 @@
   align-items: flex-start;
   display: flex;
   margin: 1rem;
-  max-width: 20.75rem;
+  max-width: 25rem;
 
   &:not(:last-child) {
     margin-bottom: 0.5rem;
@@ -28,7 +28,7 @@
       font-size: 1rem;
       margin-bottom: 0;
 
-      &[data-centered="true"] {
+      &[data-centered='true'] {
         align-items: center;
         display: flex;
         height: 2rem;
@@ -44,19 +44,19 @@
     > .md-toast-details-info {
       font-size: 0.875rem;
 
-      &[data-color="cancel"] {
+      &[data-color='cancel'] {
         color: var(--theme-text-error-normal);
       }
 
-      &[data-color="join"] {
+      &[data-color='join'] {
         color: var(--theme-text-accent-normal);
       }
 
-      &[data-color="success"] {
+      &[data-color='success'] {
         color: var(--theme-text-success-normal);
       }
 
-      &[data-color="warning"] {
+      &[data-color='warning'] {
         color: var(--theme-text-warning-normal);
       }
     }


### PR DESCRIPTION
# Description

The scope of the changes in this pull request are to update the widths for toast items to match that of alert items. This fixes artifacts in the web client, as there wasn't an explicit design spec for web toasts.

## Screenshots

![Screen Shot 2021-10-07 at 10 31 56 AM](https://user-images.githubusercontent.com/14828820/136405952-42e120ca-54e1-402b-a398-939309fd8990.png)
![Screen Shot 2021-10-07 at 10 32 06 AM](https://user-images.githubusercontent.com/14828820/136405954-f82f7918-ee27-4d99-9e81-a17b7377dbd6.png)

# Links

[SPARK-273043](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-273043)