### PR TITLE
fix(searchinput): pass inputref into use search field

### DIFF
--- a/src/components/SearchInput/SearchInput.tsx
+++ b/src/components/SearchInput/SearchInput.tsx
@@ -24,7 +24,7 @@ const SearchInput = (props: Props, ref: RefObject<HTMLInputElement>): ReactEleme
   const inputRef = ref || componentRef;
   const { focusProps, isFocused } = useFocusState(props);
 
-  const { inputProps, clearButtonProps, labelProps } = useSearchField(props, state, ref);
+  const { inputProps, clearButtonProps, labelProps } = useSearchField(props, state, inputRef);
 
   const handleClick = () => {
     if (inputRef.current) {

--- a/src/components/SearchInput/SearchInput.unit.test.tsx
+++ b/src/components/SearchInput/SearchInput.unit.test.tsx
@@ -182,6 +182,11 @@ describe('<SearchInput />', () => {
       expect(ref.current).toBeInstanceOf(HTMLInputElement);
       expect(ref.current.value).toEqual('test');
     });
+
+    it('should work with autofocus', async () => {
+      // eslint-disable-next-line jsx-a11y/no-autofocus
+      await mountAndWait(<SearchInput autoFocus aria-label="search" value="test" />);
+    });
   });
 
   describe('actions', () => {


### PR DESCRIPTION
# Description

`useSearchField` requires a non null ref which it uses for auto focus. Without this it explodes here: https://github.com/adobe/react-spectrum/blob/main/packages/%40react-aria/focus/src/useFocusable.tsx#L75

