### PR TITLE
refactor(legacy/ContentItem): adding object as additional prop type

### DIFF
--- a/src/legacy/ContentItem/ChatContent/index.js
+++ b/src/legacy/ContentItem/ChatContent/index.js
@@ -149,10 +149,7 @@ ChatContentItem.propTypes = {
   gifIcon: PropTypes.string,
   isProtected: PropTypes.bool,
   loading: PropTypes.bool,
-  subtitle: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.object
-  ]),
+  subtitle: PropTypes.node,
   onClick: PropTypes.func,
   style: PropTypes.object,
   title: PropTypes.string,

--- a/src/legacy/ContentItem/FileContent/index.js
+++ b/src/legacy/ContentItem/FileContent/index.js
@@ -141,10 +141,7 @@ FileContentItem.propTypes = {
   loadingText: PropTypes.string,
   onClick: PropTypes.func,
   style: PropTypes.object,
-  subtitle: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.object
-  ]),
+  subtitle: PropTypes.node,
   title: PropTypes.string,
 };
 

--- a/src/legacy/ContentItem/IconContent/index.js
+++ b/src/legacy/ContentItem/IconContent/index.js
@@ -75,10 +75,7 @@ IconContent.propTypes = {
   isProtected: PropTypes.bool,
   loading: PropTypes.bool,
   onClick: PropTypes.func,
-  subtitle: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.object
-  ]),
+  subtitle: PropTypes.node,
   title: PropTypes.string,
 };
 

--- a/src/legacy/ContentItem/index.js
+++ b/src/legacy/ContentItem/index.js
@@ -181,10 +181,7 @@ ContentItem.propTypes = {
   /** @prop Additional css styling applied to the button | null  */
   style: PropTypes.object,
   /** @prop Set the subtitle of the Content Item | '' */
-  subtitle: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.object
-  ]),
+  subtitle: PropTypes.node,
   /** @prop Set the title of the Content Item | '' */
   title: PropTypes.string,
   /** @prop Set the type of Content Item to display */


### PR DESCRIPTION
# Description

Changing that subtitle props inside ContentItem component can have one of two prop types string/object.

# Links

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-274467
https://www.figma.com/file/Wd5onvjSgBvgOPZWd9xM9Z/Malware-Scan-Status-Badge?node-id=1536%3A43122
