### PR TITLE
feat(globalsearch): fix overflow for large filters

### DIFF
--- a/src/components/GlobalSearchInput/GlobalSearchInput.stories.tsx
+++ b/src/components/GlobalSearchInput/GlobalSearchInput.stories.tsx
@@ -97,15 +97,17 @@ const BetterExample: FC<GlobalSearchInputExampleProps> = (props: GlobalSearchInp
   };
 
   return (
-    <GlobalSearchInput
-      value={val}
-      filters={filters}
-      onFiltersChange={handleFiltersChange}
-      onChange={handleChange}
-      initialLabel={initialLabel}
-      {...mutatedProps}
-      searching={searching}
-    />
+    <div style={{ width: '40rem' }}>
+      <GlobalSearchInput
+        value={val}
+        filters={filters}
+        onFiltersChange={handleFiltersChange}
+        onChange={handleChange}
+        initialLabel={initialLabel}
+        {...mutatedProps}
+        searching={searching}
+      />
+    </div>
   );
 };
 
@@ -122,7 +124,7 @@ Example.argTypes = { ...argTypes };
 
 const PaddedExample: FC<GlobalSearchInputProps> = (props: GlobalSearchInputProps) => {
   return (
-    <div style={{ margin: '1rem' }}>
+    <div style={{ margin: '1rem', width: '20rem' }}>
       <GlobalSearchInput {...props} />
     </div>
   );
@@ -181,6 +183,22 @@ Common.parameters = {
             text: 'In: A Space',
             empty: 'Choose a space to filter by',
             nonempty: 'Filtering in a space',
+          },
+        },
+      ],
+    },
+    {
+      value: 'search term',
+      filters: [
+        {
+          term: 'in',
+          value: 'A really long filter name that is longer than the input width',
+          translations: {
+            filterAdded: 'In filter added',
+            filterRemoved: 'In filter removed',
+            text: 'In: A really long filter name that is longer than the input width',
+            empty: 'Choose a space to filter by',
+            nonempty: '',
           },
         },
       ],

--- a/src/components/GlobalSearchInput/GlobalSearchInput.style.scss
+++ b/src/components/GlobalSearchInput/GlobalSearchInput.style.scss
@@ -20,6 +20,16 @@
     position: relative;
     display: flex;
     flex-grow: 1;
+    align-items: center;
+    overflow-x: scroll;
+    overflow-y: hidden;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+
+    -ms-overflow-style: none;
+    scrollbar-width: none;
   }
 
   label {
@@ -35,7 +45,7 @@
     color: var(--globalHeader-textfield-text);
     font-family: var(--md-globals-font-default);
     font-size: 0.875rem;
-    height: 1.75rem;
+    height: 100%;
     display: inline-block;
     flex: 1;
 
@@ -78,7 +88,7 @@
     justify-content: center;
     align-content: center;
     flex-direction: column;
-    height: 1.625rem;
+    height: 100%;
     padding-right: 0.25rem;
 
     p {


### PR DESCRIPTION
# Description

Fix overflow issue that happens when the filter text is too long. The filter container now scrolls.

Also added a storybook example for a long filter term.

![global_search_filter_overflow](https://user-images.githubusercontent.com/3998548/138467824-9040af57-bf6e-4fde-8a1c-fffa1d500625.PNG)


