### PR TITLE
fix(focusoutline): fix focus outline on firefox

### DIFF
--- a/src/components/AlertBadge/AlertBadge.style.scss
+++ b/src/components/AlertBadge/AlertBadge.style.scss
@@ -12,7 +12,7 @@
   font-size: 0.875rem;
   height: 1.5rem;
   margin: 0.125rem;
-  outline: none;
+  outline: none !important;
   padding: 0 0.5rem;
   transition: background-color 0.2s, color 0.2s, border-color 0.2s;
   width: fit-content;
@@ -29,7 +29,7 @@
     background-color: var(--theme-background-alert-default-active);
   }
 
-  &[data-color="theme"] {
+  &[data-color='theme'] {
     color: rgba(3, 83, 168, 1); // IEFIX
     color: var(--theme-text-accent-normal);
     background-color: rgba(219, 240, 255, 1); // IEFIX
@@ -48,7 +48,7 @@
     }
   }
 
-  &[data-color="success"] {
+  &[data-color='success'] {
     color: rgba(24, 94, 70, 1); // IEFIX
     color: var(--theme-text-success-normal);
     background-color: rgba(206, 245, 235, 1); // IEFIX
@@ -67,7 +67,7 @@
     }
   }
 
-  &[data-color="warning"] {
+  &[data-color='warning'] {
     color: rgba(125, 71, 5, 1); // IEFIX
     color: var(--theme-text-warning-normal);
     background-color: rgba(255, 235, 194, 1); // IEFIX
@@ -86,7 +86,7 @@
     }
   }
 
-  &[data-color="error"] {
+  &[data-color='error'] {
     color: rgba(171, 10, 21, 1); // IEFIX
     color: var(--theme-text-error-normal);
     background-color: rgba(255, 232, 234, 1); // IEFIX
@@ -104,7 +104,7 @@
       background-color: var(--theme-background-alert-error-active);
     }
   }
-  
+
   > *:not(:last-child) {
     margin-right: 0.5rem;
   }

--- a/src/components/ButtonCircle/ButtonCircle.style.scss
+++ b/src/components/ButtonCircle/ButtonCircle.style.scss
@@ -9,7 +9,7 @@
   cursor: pointer;
   font-family: CiscoSansTT; // IEFIX
   font-family: var(--md-globals-font-default);
-  outline: none;
+  outline: none !important;
   transition: background-color 0.2s, color 0.2s, border-color 0.2s;
 
   &:hover {

--- a/src/components/ButtonControl/ButtonControl.style.scss
+++ b/src/components/ButtonControl/ButtonControl.style.scss
@@ -13,7 +13,7 @@
   height: 2rem;
   justify-content: center;
   margin: 0;
-  outline: none;
+  outline: none !important;
   padding: 0;
   transition: background-color 0.2s, color 0.2s, border-color 0.2s;
   width: 2rem;
@@ -32,7 +32,7 @@
     color: var(--button-secondary-text-pressed);
   }
 
-  &[data-circular="true"] {
+  &[data-circular='true'] {
     border-radius: 100vh;
     margin-left: 0.125rem;
   }

--- a/src/components/ButtonDialpad/ButtonDialpad.style.scss
+++ b/src/components/ButtonDialpad/ButtonDialpad.style.scss
@@ -2,7 +2,7 @@
   border: var(--md-globals-border-clear);
   cursor: pointer;
   font-family: var(--md-globals-font-default);
-  outline: none;
+  outline: none !important;
   transition: background-color 0.2s, color 0.2s, border-color 0.2s;
   background-color: var(--button-dialpad-background);
 

--- a/src/components/ButtonHyperlink/ButtonHyperlink.style.scss
+++ b/src/components/ButtonHyperlink/ButtonHyperlink.style.scss
@@ -4,7 +4,7 @@
   color: var(--theme-text-accent-normal);
   cursor: pointer;
   font-family: var(--md-globals-font-default);
-  outline: none;
+  outline: none !important;
   padding: 0;
   text-decoration: underline;
   transition: background-color 0.2s, color 0.2s, border-color 0.2s;

--- a/src/components/ButtonPill/ButtonPill.style.scss
+++ b/src/components/ButtonPill/ButtonPill.style.scss
@@ -5,7 +5,7 @@
   cursor: pointer;
   font-family: CiscoSansTT; // IEFIX
   font-family: var(--md-globals-font-default);
-  outline: none;
+  outline: none !important;
   transition: background-color 0.2s, color 0.2s, border-color 0.2s;
 
   /* Colorization */

--- a/src/components/NavigationTab/NavigationTab.style.scss
+++ b/src/components/NavigationTab/NavigationTab.style.scss
@@ -7,7 +7,7 @@
 
   // Circle/Pill //
   border-radius: 6rem;
-  outline: none;
+  outline: none !important;
   border-color: rgba(0, 0, 0, 0);
   background-color: rgba(0, 0, 0, 0); // IEFIX
   background-color: var(--navigationtab-background);

--- a/src/components/Select/Select.style.scss
+++ b/src/components/Select/Select.style.scss
@@ -27,7 +27,7 @@
   align-items: center;
   border-radius: 0.5rem;
   transition: background-color 0.2s, color 0.2s, border-color 0.2s;
-  outline: none;
+  outline: none !important;
   cursor: pointer;
 
   &:hover {

--- a/src/components/Tab/Tab.style.scss
+++ b/src/components/Tab/Tab.style.scss
@@ -4,7 +4,7 @@
   cursor: pointer;
   font-family: CiscoSansTT; // IEFIX
   font-family: var(--md-globals-font-default);
-  outline: none;
+  outline: none !important;
   transition: background-color 0.2s, color 0.2s, border-color 0.2s;
 
   /* Colorization */


### PR DESCRIPTION
# Description

The dotted focus outline was still present on firefox. Each component that showed this already had an `outline: none` rule but it seems !important is required to suppress it. 
