### PR TITLE
fix(legacy/composit-avatar): positioning class names

### DIFF
--- a/scss/components/avatar/composite-avatar.scss
+++ b/scss/components/avatar/composite-avatar.scss
@@ -5,13 +5,13 @@
     position: relative;
     display: inline-block;
 
-    .#{$avatar__class}:nth-child(1) {
+    .#{$avatar__class}-wrapper:nth-child(1) {
       position: absolute;
       top: 0;
       left: 0;
     }
 
-    .#{$avatar__class}:nth-child(2) {
+    .#{$avatar__class}-wrapper:nth-child(2) {
       position: absolute;
       right: 0;
       bottom: 0;


### PR DESCRIPTION
# Description

The scope of the changes in this pull request are to fix the classnames within `<CompositeAvatar />` legacy component so that positioning of the composite avatar component reflects the intended styles.

## Before

![Screen Shot 2021-11-08 at 10 49 06 AM](https://user-images.githubusercontent.com/14828820/140786007-7acf0d77-3881-4db6-b4ce-19b3fed1d269.png)

## After

![Screen Shot 2021-11-08 at 12 00 11 PM](https://user-images.githubusercontent.com/14828820/140786010-ce009dbb-0104-4307-a1c4-d7c57161662d.png)

# Links

[SPARK-281692](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-281692)
