### PR TITLE
Firefox focus outline fix

### DIFF
--- a/scss/tools/mixins/focus.scss
+++ b/scss/tools/mixins/focus.scss
@@ -5,7 +5,7 @@
     border-color: $border-color;
   }
 
-  outline: none;
+  outline: none !important;
   box-shadow: var(--md-globals-focus-ring-box-shadow);
 
   @if $focus-visible-only {


### PR DESCRIPTION
# Description

Firefox has a fairly specific default rule which adds a dashed outline on focus. We don't want this in momentum, so making the rule important to overwrite it.

# Links

*Links to relevent resources.*
