### PR TITLE
feat(components/Icon): add-specific-case-for-viewbox-size

### DIFF
--- a/src/components/Icon/Icon.constants.ts
+++ b/src/components/Icon/Icon.constants.ts
@@ -42,11 +42,24 @@ const SIZES: Record<number, number> = {
   124: 124,
 };
 
+const VIEW_BOX_SPECS = {
+  NORMAL: '0, 0, 32, 32',
+  SMALL: '0, 0, 14, 14',
+};
+
 const DEFAULTS = {
   WEIGHT: WEIGHTS.regular,
   SCALE: SIZES[32],
   AUTO_SCALE: false,
+  VIEW_BOX_SPEC: VIEW_BOX_SPECS.NORMAL,
 };
+
+const EXCEPTION_ICONS_LIST = [
+  'check-circle-badge',
+  'error-legacy-badge',
+  'info-badge',
+  'priority-badge',
+];
 
 const STYLE = {
   wrapper: `${CLASS_PREFIX}-wrapper`,
@@ -54,4 +67,15 @@ const STYLE = {
   coloured: `${CLASS_PREFIX}-coloured`,
 };
 
-export { CLASS_PREFIX, COLOR_INHERIT, DEFAULTS, GLYPH_NOT_FOUND, SCALES, SIZES, STYLE, WEIGHTS };
+export {
+  CLASS_PREFIX,
+  COLOR_INHERIT,
+  DEFAULTS,
+  EXCEPTION_ICONS_LIST,
+  GLYPH_NOT_FOUND,
+  SCALES,
+  SIZES,
+  STYLE,
+  VIEW_BOX_SPECS,
+  WEIGHTS,
+};

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -2,7 +2,14 @@ import React from 'react';
 import './Icon.style.scss';
 import { Props } from './Icon.types';
 import { useDynamicSVGImport } from '../../hooks/useDynamicSVGImport';
-import { COLOR_INHERIT, DEFAULTS, GLYPH_NOT_FOUND, STYLE } from './Icon.constants';
+import {
+  COLOR_INHERIT,
+  DEFAULTS,
+  EXCEPTION_ICONS_LIST,
+  GLYPH_NOT_FOUND,
+  STYLE,
+  VIEW_BOX_SPECS,
+} from './Icon.constants';
 import classnames from 'classnames';
 
 /**
@@ -62,16 +69,6 @@ const Icon: React.FC<Props> = (props: Props) => {
 
   const { inheritedColors, styleColors } = getColors();
 
-  const viewBoxDefault = '0, 0, 32, 32';
-  const viewBoxSmall = '0, 0, 14, 14';
-  //This exception list is added for Icons with scale 14, so that view box can setup properly
-  const exceptionIconsList = [
-    'check-circle-badge',
-    'error-legacy-badge',
-    'info-badge',
-    'priority-badge',
-  ];
-
   if (SvgIcon) {
     return (
       <div className={classnames(STYLE.wrapper, className)} id={id} style={style}>
@@ -81,7 +78,9 @@ const Icon: React.FC<Props> = (props: Props) => {
           className={classnames({ [STYLE.coloured]: isColoredIcon })}
           style={{ ...styleColors }}
           {...inheritedColors}
-          viewBox={exceptionIconsList.includes(name) ? viewBoxSmall : viewBoxDefault}
+          viewBox={
+            EXCEPTION_ICONS_LIST.includes(name) ? VIEW_BOX_SPECS.SMALL : VIEW_BOX_SPECS.NORMAL
+          }
           width="100%"
           height="100%"
           data-scale={!autoScale && (scale || DEFAULTS.SCALE)}

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -62,6 +62,16 @@ const Icon: React.FC<Props> = (props: Props) => {
 
   const { inheritedColors, styleColors } = getColors();
 
+  const viewBoxDefault = '0, 0, 32, 32';
+  const viewBoxSmall = '0, 0, 14, 14';
+  //This exception list is added for Icons with scale 14, so that view box can setup properly
+  const exceptionIconsList = [
+    'check-circle-badge',
+    'error-legacy-badge',
+    'info-badge',
+    'priority-badge',
+  ];
+
   if (SvgIcon) {
     return (
       <div className={classnames(STYLE.wrapper, className)} id={id} style={style}>
@@ -71,7 +81,7 @@ const Icon: React.FC<Props> = (props: Props) => {
           className={classnames({ [STYLE.coloured]: isColoredIcon })}
           style={{ ...styleColors }}
           {...inheritedColors}
-          viewBox="0, 0, 32, 32"
+          viewBox={exceptionIconsList.includes(name) ? viewBoxSmall : viewBoxDefault}
           width="100%"
           height="100%"
           data-scale={!autoScale && (scale || DEFAULTS.SCALE)}

--- a/src/components/Icon/Icon.unit.test.tsx
+++ b/src/components/Icon/Icon.unit.test.tsx
@@ -255,6 +255,22 @@ describe('<Icon />', () => {
 
       expect(icon.getAttribute('style')).toBe(null);
     });
+
+    EXCEPTION_ICONS_LIST.forEach((name) => {
+      it(`check if icon ${name} receive right viewBox size`, async () => {
+        const wrapper = await mountAndWait(<Icon name={name} scale={14} />);
+        const icon = wrapper.find('svg').getDOMNode();
+
+        expect(icon.getAttribute('viewBox')).toBe(VIEW_BOX_SPECS.SMALL);
+      });
+    });
+
+    it(`check if icon receive default viewBox size`, async () => {
+      const wrapper = await mountAndWait(<Icon name="accessibility" scale={32} />);
+      const icon = wrapper.find('svg').getDOMNode();
+
+      expect(icon.getAttribute('viewBox')).toBe(VIEW_BOX_SPECS.NORMAL);
+    });
   });
 
   describe('clean up', () => {
@@ -272,26 +288,6 @@ describe('<Icon />', () => {
       };
 
       await mountAndWait(<Component />);
-    });
-  });
-
-  describe('exception case for small icons', () => {
-    EXCEPTION_ICONS_LIST.forEach((name) => {
-      it(`check if icon ${name} receive right viewBox size`, async () => {
-        const wrapper = await mountAndWait(<Icon name={name} scale={14} />);
-        const icon = wrapper.find('svg').getDOMNode();
-
-        expect(icon.getAttribute('viewBox')).toBe(VIEW_BOX_SPECS.SMALL);
-      });
-    });
-  });
-
-  describe('case for regular default icons', () => {
-    it(`check if icon receive default viewBox size`, async () => {
-      const wrapper = await mountAndWait(<Icon name="accessibility" scale={32} />);
-      const icon = wrapper.find('svg').getDOMNode();
-
-      expect(icon.getAttribute('viewBox')).toBe(VIEW_BOX_SPECS.NORMAL);
     });
   });
 });

--- a/src/components/Icon/Icon.unit.test.tsx
+++ b/src/components/Icon/Icon.unit.test.tsx
@@ -1,6 +1,6 @@
 import Icon from '.';
 import React, { useEffect, useState } from 'react';
-import { STYLE } from './Icon.constants';
+import { STYLE, EXCEPTION_ICONS_LIST, VIEW_BOX_SPECS } from './Icon.constants';
 
 import { mountAndWait } from '../../../test/utils';
 
@@ -110,6 +110,14 @@ describe('<Icon />', () => {
 
       expect(container).toMatchSnapshot();
       jest.dontMock('@momentum-ui/icons-rebrand/svg/invalid_icon_name.svg');
+    });
+
+    it('should match snapshot with small icons', async () => {
+      expect.assertions(1);
+
+      container = await mountAndWait(<Icon name="info-badge" scale={14} />);
+
+      expect(container).toMatchSnapshot();
     });
   });
 
@@ -268,21 +276,22 @@ describe('<Icon />', () => {
   });
 
   describe('exception case for small icons', () => {
-    const exceptionIconsList = [
-      'check-circle-badge',
-      'error-legacy-badge',
-      'info-badge',
-      'priority-badge',
-    ];
-    const scale = 14;
-    const viewBoxSmall = '0, 0, 14, 14';
-    exceptionIconsList.forEach((name) => {
+    EXCEPTION_ICONS_LIST.forEach((name) => {
       it(`check if icon ${name} receive right viewBox size`, async () => {
-        const wrapper = await mountAndWait(<Icon name={name} scale={scale} />);
+        const wrapper = await mountAndWait(<Icon name={name} scale={14} />);
         const icon = wrapper.find('svg').getDOMNode();
 
-        expect(icon.getAttribute('viewBox')).toBe(viewBoxSmall);
+        expect(icon.getAttribute('viewBox')).toBe(VIEW_BOX_SPECS.SMALL);
       });
+    });
+  });
+
+  describe('case for regular default icons', () => {
+    it(`check if icon receive default viewBox size`, async () => {
+      const wrapper = await mountAndWait(<Icon name="accessibility" scale={32} />);
+      const icon = wrapper.find('svg').getDOMNode();
+
+      expect(icon.getAttribute('viewBox')).toBe(VIEW_BOX_SPECS.NORMAL);
     });
   });
 });

--- a/src/components/Icon/Icon.unit.test.tsx
+++ b/src/components/Icon/Icon.unit.test.tsx
@@ -266,4 +266,23 @@ describe('<Icon />', () => {
       await mountAndWait(<Component />);
     });
   });
+
+  describe('exception case for small icons', () => {
+    const exceptionIconsList = [
+      'check-circle-badge',
+      'error-legacy-badge',
+      'info-badge',
+      'priority-badge',
+    ];
+    const scale = 14;
+    const viewBoxSmall = '0, 0, 14, 14';
+    exceptionIconsList.forEach((name) => {
+      it(`check if icon ${name} receive right viewBox size`, async () => {
+        const wrapper = await mountAndWait(<Icon name={name} scale={scale} />);
+        const icon = wrapper.find('svg').getDOMNode();
+
+        expect(icon.getAttribute('viewBox')).toBe(viewBoxSmall);
+      });
+    });
+  });
 });

--- a/src/components/Icon/Icon.unit.test.tsx.snap
+++ b/src/components/Icon/Icon.unit.test.tsx.snap
@@ -216,6 +216,30 @@ exports[`<Icon /> snapshot should match snapshot with scale 1`] = `
 </Icon>
 `;
 
+exports[`<Icon /> snapshot should match snapshot with small icons 1`] = `
+<Icon
+  name="info-badge"
+  scale={14}
+>
+  <div
+    className="md-icon-wrapper"
+  >
+    <svg
+      className=""
+      data-autoscale={false}
+      data-scale={14}
+      data-test="info-badge"
+      fill="currentColor"
+      height="100%"
+      stroke="currentColor"
+      style={Object {}}
+      viewBox="0, 0, 14, 14"
+      width="100%"
+    />
+  </div>
+</Icon>
+`;
+
 exports[`<Icon /> snapshot should match snapshot with strokeColor 1`] = `
 <Icon
   name="accessibility"


### PR DESCRIPTION
# Description
The new svg Icon component forces the viewBox to be "0 0 32 32". For most icons this is fine. However some (like "info-badge-filled" and "error-legacy-badge-filled"), the viewPort in the svg is "0 0 14 14" . When this gets overwritten, the svg is now being drawn with the wrong viewPort, so it appears smaller than it should (14/32 of the size it should be for the two examples). This PR fixes that case.

# Links
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-281641

