### PR TITLE
feat(sace-list-item): fix copact color

### DIFF
--- a/src/components/ListItemBase/ListItemBase.style.scss
+++ b/src/components/ListItemBase/ListItemBase.style.scss
@@ -5,7 +5,7 @@
   align-items: center;
   font-size: 1rem;
   line-height: 1.5rem;
-  color: var(--theme-text-primary-normal);
+  color: var(--listitem-textsecondary);
   transition: background-color 0.2s, color 0.2s, border-color 0.2s;
   box-sizing: border-box;
   outline: none;
@@ -20,7 +20,12 @@
 
     &:active,
     &.active {
+      color: var(--listitem-textprimary);
       background-color: var(--theme-background-primary-active);
+    }
+
+    &.focus {
+      color: var(--listitem-textprimary);
     }
   }
 
@@ -60,8 +65,13 @@
   }
 
   &[data-size='32'] {
+    & > *,
+    .md-text-wrapper {
+      font-weight: 500;
+      font-size: 0.75rem;
+    }
+
     height: 2rem;
-    font-size: 0.75rem;
   }
 
   &[data-size='40'] {

--- a/src/components/ListItemBase/ListItemBase.style.scss
+++ b/src/components/ListItemBase/ListItemBase.style.scss
@@ -65,6 +65,7 @@
   }
 
   &[data-size='32'] {
+    // All immediate children and any deep .md-text-wrapper child
     & > *,
     .md-text-wrapper {
       font-weight: 500;

--- a/src/components/SpaceListItem/SpaceListItem.style.scss
+++ b/src/components/SpaceListItem/SpaceListItem.style.scss
@@ -8,50 +8,49 @@
 .md-space-list-item-text-wrapper {
   display: flex;
   align-items: center;
+  min-width: 0;
+  max-width: 100%;
+  flex-grow: 1;
 
-  .text-row {
+  &.text-row {
     overflow: hidden;
     flex-direction: row;
     align-items: center;
     justify-content: flex-start;
 
-    p {
-      width: auto;
-    }
-
     small {
       margin-top: 0;
-      margin-left: 0.25rem;
+      width: unset;
     }
-  }
-
-  .text-column {
-    flex-direction: column;
-    align-items: flex-start;
-    justify-content: center;
-  }
-
-  div {
-    display: flex;
 
     p {
-      margin: 0;
-      float: left;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-      max-width: 15rem;
+      width: unset;
     }
+  }
 
-    small {
-      margin: 0;
-      color: var(--listitem-textsecondary);
-      margin-top: -4px;
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      max-width: 15rem;
-    }
+  &.text-column {
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: flex-start;
+  }
+
+  p {
+    margin: 0;
+    float: left;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    width: 100%;
+  }
+
+  small {
+    margin: 0;
+    color: var(--listitem-textsecondary);
+    margin-top: -4px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    width: 100%;
   }
 
   svg {

--- a/src/components/SpaceListItem/SpaceListItem.style.scss
+++ b/src/components/SpaceListItem/SpaceListItem.style.scss
@@ -1,6 +1,7 @@
 .md-space-list-item-is-new-activity {
   p {
     font-weight: bold !important;
+    color: var(--listitem-textprimary) !important;
   }
 }
 
@@ -44,7 +45,7 @@
 
     small {
       margin: 0;
-      color: var(--label-secondary-text);
+      color: var(--listitem-textsecondary);
       margin-top: -4px;
       white-space: nowrap;
       overflow: hidden;

--- a/src/components/SpaceListItem/SpaceListItem.tsx
+++ b/src/components/SpaceListItem/SpaceListItem.tsx
@@ -42,10 +42,12 @@ const SpaceListItem: FC<Props> = forwardRef(
 
       if (secondLine) {
         return (
-          <div className={isCompact ? 'text-row' : 'text-column'}>
+          <>
             <Text type="body-primary" data-test="list-item-first-line">
-              {firstLine} {isCompact && ' - '}
+              {firstLine}
             </Text>
+            {/* //TODO: change with dot divider when available */}
+            {isCompact && <span className={STYLE.dotDivider}> - </span>}
             <Text
               style={{ color: `var(--theme-text-team-${teamColor}-normal)` }}
               type="body-secondary"
@@ -54,15 +56,13 @@ const SpaceListItem: FC<Props> = forwardRef(
               {/* //TODO: change with dot divider when available */}
               {_secondLineArray.join(' - ')}
             </Text>
-          </div>
+          </>
         );
       } else {
         return (
-          <div>
-            <Text data-test="list-item-first-line" type="body-primary">
-              {firstLine}
-            </Text>
-          </div>
+          <Text data-test="list-item-first-line" type="body-primary">
+            {firstLine}
+          </Text>
         );
       }
     };
@@ -115,7 +115,10 @@ const SpaceListItem: FC<Props> = forwardRef(
         itemIndex={itemIndex}
       >
         <ListItemBaseSection position="start">{avatar}</ListItemBaseSection>
-        <ListItemBaseSection position="middle" className={STYLE.textWrapper}>
+        <ListItemBaseSection
+          position="middle"
+          className={classnames(STYLE.textWrapper, isCompact ? 'text-row' : 'text-column')}
+        >
           {renderText()}
         </ListItemBaseSection>
         <ListItemBaseSection position="end">{renderRightSection()}</ListItemBaseSection>

--- a/src/components/SpaceListItem/SpaceListItem.unit.test.tsx.snap
+++ b/src/components/SpaceListItem/SpaceListItem.unit.test.tsx.snap
@@ -47,25 +47,23 @@ exports[`<SpaceListItem /> snapshot should match snapshot 1`] = `
             />
           </ListItemBaseSection>
           <ListItemBaseSection
-            className="md-space-list-item-text-wrapper"
+            className="md-space-list-item-text-wrapper text-column"
             position="middle"
           >
             <div
-              className="md-space-list-item-text-wrapper"
+              className="md-space-list-item-text-wrapper text-column"
               data-position="middle"
             >
-              <div>
-                <Text
+              <Text
+                data-test="list-item-first-line"
+                type="body-primary"
+              >
+                <p
+                  className="md-text-wrapper"
                   data-test="list-item-first-line"
-                  type="body-primary"
-                >
-                  <p
-                    className="md-text-wrapper"
-                    data-test="list-item-first-line"
-                    data-type="body-primary"
-                  />
-                </Text>
-              </div>
+                  data-type="body-primary"
+                />
+              </Text>
             </div>
           </ListItemBaseSection>
           <ListItemBaseSection
@@ -135,25 +133,23 @@ exports[`<SpaceListItem /> snapshot should match snapshot with action 1`] = `
             />
           </ListItemBaseSection>
           <ListItemBaseSection
-            className="md-space-list-item-text-wrapper"
+            className="md-space-list-item-text-wrapper text-column"
             position="middle"
           >
             <div
-              className="md-space-list-item-text-wrapper"
+              className="md-space-list-item-text-wrapper text-column"
               data-position="middle"
             >
-              <div>
-                <Text
+              <Text
+                data-test="list-item-first-line"
+                type="body-primary"
+              >
+                <p
+                  className="md-text-wrapper"
                   data-test="list-item-first-line"
-                  type="body-primary"
-                >
-                  <p
-                    className="md-text-wrapper"
-                    data-test="list-item-first-line"
-                    data-type="body-primary"
-                  />
-                </Text>
-              </div>
+                  data-type="body-primary"
+                />
+              </Text>
             </div>
           </ListItemBaseSection>
           <ListItemBaseSection
@@ -223,25 +219,23 @@ exports[`<SpaceListItem /> snapshot should match snapshot with className 1`] = `
             />
           </ListItemBaseSection>
           <ListItemBaseSection
-            className="md-space-list-item-text-wrapper"
+            className="md-space-list-item-text-wrapper text-column"
             position="middle"
           >
             <div
-              className="md-space-list-item-text-wrapper"
+              className="md-space-list-item-text-wrapper text-column"
               data-position="middle"
             >
-              <div>
-                <Text
+              <Text
+                data-test="list-item-first-line"
+                type="body-primary"
+              >
+                <p
+                  className="md-text-wrapper"
                   data-test="list-item-first-line"
-                  type="body-primary"
-                >
-                  <p
-                    className="md-text-wrapper"
-                    data-test="list-item-first-line"
-                    data-type="body-primary"
-                  />
-                </Text>
-              </div>
+                  data-type="body-primary"
+                />
+              </Text>
             </div>
           </ListItemBaseSection>
           <ListItemBaseSection
@@ -307,27 +301,25 @@ exports[`<SpaceListItem /> snapshot should match snapshot with firstLine 1`] = `
             />
           </ListItemBaseSection>
           <ListItemBaseSection
-            className="md-space-list-item-text-wrapper"
+            className="md-space-list-item-text-wrapper text-column"
             position="middle"
           >
             <div
-              className="md-space-list-item-text-wrapper"
+              className="md-space-list-item-text-wrapper text-column"
               data-position="middle"
             >
-              <div>
-                <Text
+              <Text
+                data-test="list-item-first-line"
+                type="body-primary"
+              >
+                <p
+                  className="md-text-wrapper"
                   data-test="list-item-first-line"
-                  type="body-primary"
+                  data-type="body-primary"
                 >
-                  <p
-                    className="md-text-wrapper"
-                    data-test="list-item-first-line"
-                    data-type="body-primary"
-                  >
-                    firstLine
-                  </p>
-                </Text>
-              </div>
+                  firstLine
+                </p>
+              </Text>
             </div>
           </ListItemBaseSection>
           <ListItemBaseSection
@@ -395,25 +387,23 @@ exports[`<SpaceListItem /> snapshot should match snapshot with id 1`] = `
             />
           </ListItemBaseSection>
           <ListItemBaseSection
-            className="md-space-list-item-text-wrapper"
+            className="md-space-list-item-text-wrapper text-column"
             position="middle"
           >
             <div
-              className="md-space-list-item-text-wrapper"
+              className="md-space-list-item-text-wrapper text-column"
               data-position="middle"
             >
-              <div>
-                <Text
+              <Text
+                data-test="list-item-first-line"
+                type="body-primary"
+              >
+                <p
+                  className="md-text-wrapper"
                   data-test="list-item-first-line"
-                  type="body-primary"
-                >
-                  <p
-                    className="md-text-wrapper"
-                    data-test="list-item-first-line"
-                    data-type="body-primary"
-                  />
-                </Text>
-              </div>
+                  data-type="body-primary"
+                />
+              </Text>
             </div>
           </ListItemBaseSection>
           <ListItemBaseSection
@@ -479,25 +469,23 @@ exports[`<SpaceListItem /> snapshot should match snapshot with isAlert 1`] = `
             />
           </ListItemBaseSection>
           <ListItemBaseSection
-            className="md-space-list-item-text-wrapper"
+            className="md-space-list-item-text-wrapper text-column"
             position="middle"
           >
             <div
-              className="md-space-list-item-text-wrapper"
+              className="md-space-list-item-text-wrapper text-column"
               data-position="middle"
             >
-              <div>
-                <Text
+              <Text
+                data-test="list-item-first-line"
+                type="body-primary"
+              >
+                <p
+                  className="md-text-wrapper"
                   data-test="list-item-first-line"
-                  type="body-primary"
-                >
-                  <p
-                    className="md-text-wrapper"
-                    data-test="list-item-first-line"
-                    data-type="body-primary"
-                  />
-                </Text>
-              </div>
+                  data-type="body-primary"
+                />
+              </Text>
             </div>
           </ListItemBaseSection>
           <ListItemBaseSection
@@ -591,25 +579,23 @@ exports[`<SpaceListItem /> snapshot should match snapshot with isAlertMuted 1`] 
             />
           </ListItemBaseSection>
           <ListItemBaseSection
-            className="md-space-list-item-text-wrapper"
+            className="md-space-list-item-text-wrapper text-column"
             position="middle"
           >
             <div
-              className="md-space-list-item-text-wrapper"
+              className="md-space-list-item-text-wrapper text-column"
               data-position="middle"
             >
-              <div>
-                <Text
+              <Text
+                data-test="list-item-first-line"
+                type="body-primary"
+              >
+                <p
+                  className="md-text-wrapper"
                   data-test="list-item-first-line"
-                  type="body-primary"
-                >
-                  <p
-                    className="md-text-wrapper"
-                    data-test="list-item-first-line"
-                    data-type="body-primary"
-                  />
-                </Text>
-              </div>
+                  data-type="body-primary"
+                />
+              </Text>
             </div>
           </ListItemBaseSection>
           <ListItemBaseSection
@@ -703,25 +689,23 @@ exports[`<SpaceListItem /> snapshot should match snapshot with isEnterRoom 1`] =
             />
           </ListItemBaseSection>
           <ListItemBaseSection
-            className="md-space-list-item-text-wrapper"
+            className="md-space-list-item-text-wrapper text-column"
             position="middle"
           >
             <div
-              className="md-space-list-item-text-wrapper"
+              className="md-space-list-item-text-wrapper text-column"
               data-position="middle"
             >
-              <div>
-                <Text
+              <Text
+                data-test="list-item-first-line"
+                type="body-primary"
+              >
+                <p
+                  className="md-text-wrapper"
                   data-test="list-item-first-line"
-                  type="body-primary"
-                >
-                  <p
-                    className="md-text-wrapper"
-                    data-test="list-item-first-line"
-                    data-type="body-primary"
-                  />
-                </Text>
-              </div>
+                  data-type="body-primary"
+                />
+              </Text>
             </div>
           </ListItemBaseSection>
           <ListItemBaseSection
@@ -815,25 +799,23 @@ exports[`<SpaceListItem /> snapshot should match snapshot with isError 1`] = `
             />
           </ListItemBaseSection>
           <ListItemBaseSection
-            className="md-space-list-item-text-wrapper"
+            className="md-space-list-item-text-wrapper text-column"
             position="middle"
           >
             <div
-              className="md-space-list-item-text-wrapper"
+              className="md-space-list-item-text-wrapper text-column"
               data-position="middle"
             >
-              <div>
-                <Text
+              <Text
+                data-test="list-item-first-line"
+                type="body-primary"
+              >
+                <p
+                  className="md-text-wrapper"
                   data-test="list-item-first-line"
-                  type="body-primary"
-                >
-                  <p
-                    className="md-text-wrapper"
-                    data-test="list-item-first-line"
-                    data-type="body-primary"
-                  />
-                </Text>
-              </div>
+                  data-type="body-primary"
+                />
+              </Text>
             </div>
           </ListItemBaseSection>
           <ListItemBaseSection
@@ -927,25 +909,23 @@ exports[`<SpaceListItem /> snapshot should match snapshot with isMention 1`] = `
             />
           </ListItemBaseSection>
           <ListItemBaseSection
-            className="md-space-list-item-text-wrapper"
+            className="md-space-list-item-text-wrapper text-column"
             position="middle"
           >
             <div
-              className="md-space-list-item-text-wrapper"
+              className="md-space-list-item-text-wrapper text-column"
               data-position="middle"
             >
-              <div>
-                <Text
+              <Text
+                data-test="list-item-first-line"
+                type="body-primary"
+              >
+                <p
+                  className="md-text-wrapper"
                   data-test="list-item-first-line"
-                  type="body-primary"
-                >
-                  <p
-                    className="md-text-wrapper"
-                    data-test="list-item-first-line"
-                    data-type="body-primary"
-                  />
-                </Text>
-              </div>
+                  data-type="body-primary"
+                />
+              </Text>
             </div>
           </ListItemBaseSection>
           <ListItemBaseSection
@@ -1039,25 +1019,23 @@ exports[`<SpaceListItem /> snapshot should match snapshot with isNewActivity 1`]
             />
           </ListItemBaseSection>
           <ListItemBaseSection
-            className="md-space-list-item-text-wrapper"
+            className="md-space-list-item-text-wrapper text-column"
             position="middle"
           >
             <div
-              className="md-space-list-item-text-wrapper"
+              className="md-space-list-item-text-wrapper text-column"
               data-position="middle"
             >
-              <div>
-                <Text
+              <Text
+                data-test="list-item-first-line"
+                type="body-primary"
+              >
+                <p
+                  className="md-text-wrapper"
                   data-test="list-item-first-line"
-                  type="body-primary"
-                >
-                  <p
-                    className="md-text-wrapper"
-                    data-test="list-item-first-line"
-                    data-type="body-primary"
-                  />
-                </Text>
-              </div>
+                  data-type="body-primary"
+                />
+              </Text>
             </div>
           </ListItemBaseSection>
           <ListItemBaseSection
@@ -1124,25 +1102,23 @@ exports[`<SpaceListItem /> snapshot should match snapshot with isSelected 1`] = 
             />
           </ListItemBaseSection>
           <ListItemBaseSection
-            className="md-space-list-item-text-wrapper"
+            className="md-space-list-item-text-wrapper text-column"
             position="middle"
           >
             <div
-              className="md-space-list-item-text-wrapper"
+              className="md-space-list-item-text-wrapper text-column"
               data-position="middle"
             >
-              <div>
-                <Text
+              <Text
+                data-test="list-item-first-line"
+                type="body-primary"
+              >
+                <p
+                  className="md-text-wrapper"
                   data-test="list-item-first-line"
-                  type="body-primary"
-                >
-                  <p
-                    className="md-text-wrapper"
-                    data-test="list-item-first-line"
-                    data-type="body-primary"
-                  />
-                </Text>
-              </div>
+                  data-type="body-primary"
+                />
+              </Text>
             </div>
           </ListItemBaseSection>
           <ListItemBaseSection
@@ -1208,25 +1184,23 @@ exports[`<SpaceListItem /> snapshot should match snapshot with isUnread 1`] = `
             />
           </ListItemBaseSection>
           <ListItemBaseSection
-            className="md-space-list-item-text-wrapper"
+            className="md-space-list-item-text-wrapper text-column"
             position="middle"
           >
             <div
-              className="md-space-list-item-text-wrapper"
+              className="md-space-list-item-text-wrapper text-column"
               data-position="middle"
             >
-              <div>
-                <Text
+              <Text
+                data-test="list-item-first-line"
+                type="body-primary"
+              >
+                <p
+                  className="md-text-wrapper"
                   data-test="list-item-first-line"
-                  type="body-primary"
-                >
-                  <p
-                    className="md-text-wrapper"
-                    data-test="list-item-first-line"
-                    data-type="body-primary"
-                  />
-                </Text>
-              </div>
+                  data-type="body-primary"
+                />
+              </Text>
             </div>
           </ListItemBaseSection>
           <ListItemBaseSection
@@ -1320,51 +1294,45 @@ exports[`<SpaceListItem /> snapshot should match snapshot with secondLine 1`] = 
             />
           </ListItemBaseSection>
           <ListItemBaseSection
-            className="md-space-list-item-text-wrapper"
+            className="md-space-list-item-text-wrapper text-column"
             position="middle"
           >
             <div
-              className="md-space-list-item-text-wrapper"
+              className="md-space-list-item-text-wrapper text-column"
               data-position="middle"
             >
-              <div
-                className="text-column"
+              <Text
+                data-test="list-item-first-line"
+                type="body-primary"
               >
-                <Text
+                <p
+                  className="md-text-wrapper"
                   data-test="list-item-first-line"
-                  type="body-primary"
-                >
-                  <p
-                    className="md-text-wrapper"
-                    data-test="list-item-first-line"
-                    data-type="body-primary"
-                  >
-                     
-                  </p>
-                </Text>
-                <Text
+                  data-type="body-primary"
+                />
+              </Text>
+              <Text
+                data-test="list-item-second-line"
+                style={
+                  Object {
+                    "color": "var(--theme-text-team-default-normal)",
+                  }
+                }
+                type="body-secondary"
+              >
+                <small
+                  className="md-text-wrapper"
                   data-test="list-item-second-line"
+                  data-type="body-secondary"
                   style={
                     Object {
                       "color": "var(--theme-text-team-default-normal)",
                     }
                   }
-                  type="body-secondary"
                 >
-                  <small
-                    className="md-text-wrapper"
-                    data-test="list-item-second-line"
-                    data-type="body-secondary"
-                    style={
-                      Object {
-                        "color": "var(--theme-text-team-default-normal)",
-                      }
-                    }
-                  >
-                    secondLine
-                  </small>
-                </Text>
-              </div>
+                  secondLine
+                </small>
+              </Text>
             </div>
           </ListItemBaseSection>
           <ListItemBaseSection
@@ -1444,25 +1412,23 @@ exports[`<SpaceListItem /> snapshot should match snapshot with style 1`] = `
             />
           </ListItemBaseSection>
           <ListItemBaseSection
-            className="md-space-list-item-text-wrapper"
+            className="md-space-list-item-text-wrapper text-column"
             position="middle"
           >
             <div
-              className="md-space-list-item-text-wrapper"
+              className="md-space-list-item-text-wrapper text-column"
               data-position="middle"
             >
-              <div>
-                <Text
+              <Text
+                data-test="list-item-first-line"
+                type="body-primary"
+              >
+                <p
+                  className="md-text-wrapper"
                   data-test="list-item-first-line"
-                  type="body-primary"
-                >
-                  <p
-                    className="md-text-wrapper"
-                    data-test="list-item-first-line"
-                    data-type="body-primary"
-                  />
-                </Text>
-              </div>
+                  data-type="body-primary"
+                />
+              </Text>
             </div>
           </ListItemBaseSection>
           <ListItemBaseSection
@@ -1528,25 +1494,23 @@ exports[`<SpaceListItem /> snapshot should match snapshot with teamColor 1`] = `
             />
           </ListItemBaseSection>
           <ListItemBaseSection
-            className="md-space-list-item-text-wrapper"
+            className="md-space-list-item-text-wrapper text-column"
             position="middle"
           >
             <div
-              className="md-space-list-item-text-wrapper"
+              className="md-space-list-item-text-wrapper text-column"
               data-position="middle"
             >
-              <div>
-                <Text
+              <Text
+                data-test="list-item-first-line"
+                type="body-primary"
+              >
+                <p
+                  className="md-text-wrapper"
                   data-test="list-item-first-line"
-                  type="body-primary"
-                >
-                  <p
-                    className="md-text-wrapper"
-                    data-test="list-item-first-line"
-                    data-type="body-primary"
-                  />
-                </Text>
-              </div>
+                  data-type="body-primary"
+                />
+              </Text>
             </div>
           </ListItemBaseSection>
           <ListItemBaseSection

--- a/src/components/Text/Text.style.scss
+++ b/src/components/Text/Text.style.scss
@@ -1,7 +1,6 @@
 .md-text-wrapper {
   font-family: CiscoSansTT; // IEFIX
   font-family: var(--md-globals-font-default);
-  color: var(--label-primary-text);
 
   &[data-type='display'] {
     font-size: 2.5rem;


### PR DESCRIPTION
# Description

Small css fixes for compact mode / size 32 of the SpaceListItem component.
It also includes font colour correction for default vs activity states.

I have also removed the colour on the Text component. This should inherit the default colour from the theme provider. It makes it hard to override if it has a specific class with colour assigned to it.

