### PR TITLE
feat(components/popover): add manual triggers

### DIFF
--- a/src/components/Popover/Popover.stories.args.ts
+++ b/src/components/Popover/Popover.stories.args.ts
@@ -8,7 +8,7 @@ export default {
   trigger: {
     description: `Determines the events that cause the Popover to show.
     Multiple event names should be separated by spaces. For example to allow both click and hover, use \`click mouseenter\` as the trigger.
-    Possible event names: \`click\`, \`mouseenter\`, \`focusin\`, \`manual\` (to programmatically trigger the popover)`,
+    Possible event names: \`click\`, \`mouseenter\`, \`focusin\`, \`manual\` (to programmatically trigger the popover, this disables the popover-close events on DOM focus change)`,
     control: { type: 'text' },
     table: {
       type: {

--- a/src/components/Popover/Popover.stories.docs.mdx
+++ b/src/components/Popover/Popover.stories.docs.mdx
@@ -1,3 +1,3 @@
-The `<Popover />` component allows adding a Popover to whatever provided as
-`triggerComponent`. It will show the Popover after a specific event, which is
-defined by the provided `trigger` prop.
+The `<Popover />` component allows adding a Popover to whatever provided as `triggerComponent`. It will show the Popover after a specific event, which is defined by the provided `trigger` prop.
+
+The `<Popover />` component also supports a manually-triggered appearance using the `manual` value assigned to the `trigger` prop. This allows for external visibility handling.

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -46,6 +46,8 @@ const Popover: FC<Props> = (props: Props) => {
   return (
     <LazyTippy
       ref={tippyRef}
+      /* needed to prevent the popover from closing when the focus is changed via click events */
+      hideOnClick={!trigger.includes('manual')}
       render={(attrs) => (
         <ModalContainer
           id={id}

--- a/src/components/Popover/Popover.types.ts
+++ b/src/components/Popover/Popover.types.ts
@@ -1,4 +1,5 @@
 import type { CSSProperties, ReactElement, ReactNode } from 'react';
+import type { Instance } from 'tippy.js';
 import type { TippyProps } from '@tippyjs/react';
 import type { Color } from '../ModalContainer/ModalContainer.types';
 
@@ -8,10 +9,10 @@ export type VariantType = 'small' | 'medium';
 export type PlacementType = TippyProps['placement'];
 export type TriggerType = TippyProps['trigger'];
 
-export type PopoverInstance = {
-  show: () => void;
-  hide: () => void;
-};
+/**
+ * Popover instance interface abstracted from Tippy.js
+ */
+export type PopoverInstance = Instance;
 
 export interface Props {
   /**

--- a/src/components/Popover/index.ts
+++ b/src/components/Popover/index.ts
@@ -1,9 +1,10 @@
 import { default as Popover } from './Popover';
 import * as CONSTANTS from './Popover.constants';
-import type { Props } from './Popover.types';
+import type { Props, PopoverInstance as Instance } from './Popover.types';
 
 export { CONSTANTS as POPOVER_CONSTANTS };
 
 export type PopoverProps = Props;
+export type PopoverInstance = Instance;
 
 export default Popover;


### PR DESCRIPTION
# Description

The scope of the changes in this pull request are to amend the abstracted functional logic from `Tippy.js` for externally handling popovers from outside of the provided trigger component.

# Links

[SPARK-300653](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-300653)
