### PR TITLE
fix(components/button-simple): Not bubble up onClick

### DIFF
--- a/src/components/ButtonControl/ButtonControl.types.ts
+++ b/src/components/ButtonControl/ButtonControl.types.ts
@@ -1,31 +1,15 @@
-import { CSSProperties } from 'react';
-import { AriaButtonProps } from '@react-types/button';
+import type { ButtonSimpleProps } from '../ButtonSimple';
 
 export type ButtonControlControl = 'close' | 'favorite' | 'maximize' | 'minimize' | 'mute';
 
-export interface Props extends AriaButtonProps {
-  /**
-   * Custom class for overriding this component's CSS.
-   */
-  className?: string;
-
+export interface Props extends ButtonSimpleProps {
   /**
    * The control type.
    */
   control: ButtonControlControl;
 
   /**
-   * Custom id for overriding this component's CSS.
-   */
-  id?: string;
-
-  /**
    * Whether to render this button as a circle.
    */
   isCircular?: boolean;
-
-  /**
-   * Custom style for overriding this component's CSS.
-   */
-  style?: CSSProperties;
 }

--- a/src/components/ButtonSimple/ButtonSimple.stories.args.ts
+++ b/src/components/ButtonSimple/ButtonSimple.stories.args.ts
@@ -31,6 +31,19 @@ const buttonSimpleArgTypes = {
       },
     },
   },
+  useNativeKeyDown: {
+    description:
+      'Use the native onKeyDown event handler to allow `enter` & `space` keypress events fire a onClick (like a native HTML button does). This is necessary since `react-aria` supress that behaviour by design.',
+    control: { type: 'boolean' },
+    table: {
+      type: {
+        summary: 'Boolean',
+      },
+      defaultValue: {
+        summary: 'undefined',
+      },
+    },
+  },
 };
 
 export { buttonSimpleArgTypes };

--- a/src/components/ButtonSimple/ButtonSimple.tsx
+++ b/src/components/ButtonSimple/ButtonSimple.tsx
@@ -10,7 +10,7 @@ import { Props } from './ButtonSimple.types';
  * A simple button component without overhead styling. This is used as an injectable button component for other sibling components.
  */
 const ButtonSimple = forwardRef((props: Props, providedRef: RefObject<HTMLButtonElement>) => {
-  const { children, className, isDisabled, id, style, title } = props;
+  const { children, className, isDisabled, id, style, title, useNativeKeyDown } = props;
   const internalRef = useRef();
   const ref = providedRef || internalRef;
 
@@ -27,6 +27,8 @@ const ButtonSimple = forwardRef((props: Props, providedRef: RefObject<HTMLButton
         title={title}
         {...buttonProps}
         {...hoverProps}
+        // override of onKeyDown to ensure the standard html button behaviour (on enter => onClick) happens
+        onKeyDown={useNativeKeyDown ? props.onKeyDown : buttonProps.onKeyDown}
       >
         {children}
       </button>

--- a/src/components/ButtonSimple/ButtonSimple.types.ts
+++ b/src/components/ButtonSimple/ButtonSimple.types.ts
@@ -27,4 +27,11 @@ export interface Props extends AriaButtonProps, HoverProps {
    * title to use for this component.
    */
   title?: string;
+
+  /**
+   * Use the native onKeyDown event handler to allow `enter` & `space` keypress events fire a onClick (like a native HTML button does)
+   *
+   * This is necessary since `react-aria` supress that behaviour by design.
+   */
+  useNativeKeyDown?: boolean;
 }

--- a/src/components/ButtonSimple/ButtonSimple.unit.test.tsx
+++ b/src/components/ButtonSimple/ButtonSimple.unit.test.tsx
@@ -117,6 +117,8 @@ describe('<ButtonSimple />', () => {
   });
 
   describe('actions', () => {
+    // TODO: add proper unit tests for the button, preferably with React Testing Library
+    // note: the onPress() call in line 129 doesn't ensure that it actually works on the screen
     it('should handle mouse press events', () => {
       expect.assertions(1);
 

--- a/src/components/Popover/Popover.stories.tsx
+++ b/src/components/Popover/Popover.stories.tsx
@@ -37,7 +37,7 @@ Example.args = {
   color: COLORS.PRIMARY,
   delay: [0, 0],
   children: <p>Content Text Content Text</p>,
-  triggerComponent: <ButtonSimple>Click me!</ButtonSimple>,
+  triggerComponent: <ButtonSimple useNativeKeyDown>Click me!</ButtonSimple>,
 };
 
 const InteractiveContent = Template<PopoverProps>(Popover).bind({});

--- a/src/components/Popover/Popover.unit.test.tsx
+++ b/src/components/Popover/Popover.unit.test.tsx
@@ -6,6 +6,7 @@ import '@testing-library/jest-dom';
 import Popover from './';
 import { COLORS, STYLE } from '../ModalContainer/ModalContainer.constants';
 import { PopoverInstance } from './Popover.types';
+import { ButtonSimple } from '..';
 
 describe('<Popover />', () => {
   describe('snapshot', () => {
@@ -126,6 +127,29 @@ describe('<Popover />', () => {
 
       // after another click, popover should be hidden again
       userEvent.click(screen.getByRole('button', { name: /click me!/i }));
+      await waitForElementToBeRemoved(() => screen.queryByText('Content'));
+    });
+
+    it('should show/hide Popover on tab + enter', async () => {
+      expect.assertions(2);
+      render(
+        <Popover triggerComponent={<ButtonSimple useNativeKeyDown>Click Me!</ButtonSimple>}>
+          <p>Content</p>
+        </Popover>
+      );
+
+      // assert no popover on screen
+      const contentBeforeClick = screen.queryByText('Content');
+      expect(contentBeforeClick).not.toBeInTheDocument();
+
+      // after tab and enter, popover should be shown
+      userEvent.tab();
+      userEvent.keyboard('{enter}');
+      const content = await screen.findByText('Content');
+      expect(content).toBeVisible();
+
+      // after hitting space, popover should be hidden again
+      userEvent.keyboard('{space}');
       await waitForElementToBeRemoved(() => screen.queryByText('Content'));
     });
 


### PR DESCRIPTION
# Description

Consuming the ButtonSimple (and its variants) within the Popover led to an issue where the click event was catched correctly as a trigger by the Popover, but tabbing and pressing enter on a ButtonSimple didn't cause a onClick event.

The problem is related to React-aria, where the onKeyDown event on a button results in a onPress and doesn't bubble up the onClick event as you would expect from a normal HTML button element. 

To fix this, we are going to override the onKeyDown coming from react-aria, if we need to (for example when using it on a Popover).

# Links

[React-aria issue](https://github.com/adobe/react-spectrum/issues/2100)
