### PR TITLE
Feat/components/coachmark

### DIFF
--- a/src/components/ButtonGroup/ButtonGroup.style.scss
+++ b/src/components/ButtonGroup/ButtonGroup.style.scss
@@ -31,11 +31,13 @@
     &[data-spaced='false'] {
       > * {
         &:first-child {
-          border-radius: 100vh 0 0 100vh;
+          border-top-left-radius: 100vh;
+          border-bottom-left-radius: 100vh;
         }
 
         &:last-child {
-          border-radius: 0 100vh 100vh 0;
+          border-top-right-radius: 100vh;
+          border-bottom-right-radius: 100vh;
         }
       }
     }

--- a/src/components/Coachmark/Coachmark.constants.ts
+++ b/src/components/Coachmark/Coachmark.constants.ts
@@ -1,0 +1,15 @@
+const CLASS_PREFIX = 'md-coachmark';
+
+const DEFAULTS = {};
+
+const STYLE = {
+  container: `${CLASS_PREFIX}-container`,
+  content: `${CLASS_PREFIX}-content`,
+  controls: `${CLASS_PREFIX}-controls`,
+  header: `${CLASS_PREFIX}-header`,
+  image: `${CLASS_PREFIX}-image`,
+  title: `${CLASS_PREFIX}-title`,
+  wrapper: `${CLASS_PREFIX}-wrapper`,
+};
+
+export { CLASS_PREFIX, DEFAULTS, STYLE };

--- a/src/components/Coachmark/Coachmark.stories.args.ts
+++ b/src/components/Coachmark/Coachmark.stories.args.ts
@@ -1,0 +1,110 @@
+import { commonStyles, extendArgTypes } from '../../storybook/helper.stories.argtypes';
+
+import { popoverArgTypes } from '../Popover/Popover.stories.args';
+
+const coachmarkArgTypes = {
+  actions: {
+    description: 'Action buttons to use with this component.',
+    control: { type: 'none' },
+    table: {
+      type: {
+        summary: 'ReactElement<ButtonSimpleProps> | Array<ReactElement<ButtonSimpleProps>>',
+      },
+      defaultValue: {
+        summary: 'undefined',
+      },
+    },
+  },
+  children: {
+    description: 'Content of this component.',
+    control: { type: 'text' },
+    table: {
+      type: {
+        summary: 'ReactNode',
+      },
+      defaultValue: {
+        summary: 'undefined',
+      },
+    },
+  },
+  onDismiss: {
+    description: 'Event handler that is triggered when the user dismisses this component.',
+    control: { type: 'none' },
+    table: {
+      type: {
+        summary: '() => void',
+      },
+      defaultValue: {
+        summary: 'undefined',
+      },
+    },
+  },
+  icon: {
+    description: 'Icon to display to the left of the title.',
+    control: { type: 'text' },
+    table: {
+      type: {
+        summary: 'string',
+      },
+      defaultValue: {
+        summary: 'undefined',
+      },
+    },
+  },
+  image: {
+    description: 'Image to display on this component.',
+    control: { type: 'none' },
+    table: {
+      type: {
+        summary: 'HTMLImageElement',
+      },
+      defaultValue: {
+        summary: 'undefined',
+      },
+    },
+  },
+  isVisible: {
+    description: 'Whether or not this component should be visible.',
+    control: { type: 'boolean' },
+    table: {
+      type: {
+        summary: 'boolean',
+      },
+      defaultValue: {
+        summary: 'undefined',
+      },
+    },
+  },
+  target: {
+    description: 'The element this component should target when rendering its location.',
+    control: { type: 'none' },
+    table: {
+      type: {
+        summary: 'ReactElement',
+      },
+      defaultValue: {
+        summary: 'undefined',
+      },
+    },
+  },
+  title: {
+    description: 'Title to display on this component.',
+    control: { type: 'text' },
+    table: {
+      type: {
+        summary: 'string',
+      },
+      defaultValue: {
+        summary: 'undefined',
+      },
+    },
+  },
+};
+
+export { coachmarkArgTypes };
+
+export default {
+  ...commonStyles,
+  ...extendArgTypes('Popover', popoverArgTypes, ['interactive', 'trigger']),
+  ...coachmarkArgTypes,
+};

--- a/src/components/Coachmark/Coachmark.stories.docs.mdx
+++ b/src/components/Coachmark/Coachmark.stories.docs.mdx
@@ -1,0 +1,3 @@
+The `<Coachmark />` component.
+
+This component should be used with experience-driven flows, such as the "First Time Experience" [FTE] for a feature. The visibility of each `<Coachmark />` must be controlled by the `isVisible` prop, and can be dismissed by changing this prop to `false` or if the user clicks the `dismiss` button. The `dismiss` button triggers the `onDismiss()` event handler.

--- a/src/components/Coachmark/Coachmark.stories.tsx
+++ b/src/components/Coachmark/Coachmark.stories.tsx
@@ -1,0 +1,138 @@
+import React, { useState } from 'react';
+import { Story } from '@storybook/react';
+
+import { DocumentationPage } from '../../storybook/helper.stories.docs';
+import StyleDocs from '../../storybook/docs.stories.style.mdx';
+
+import Coachmark, { CoachmarkProps } from './';
+import ButtonSimple from '../ButtonSimple';
+import ButtonHyperlink from '../ButtonHyperlink';
+import ButtonPill from '../ButtonPill';
+import argTypes from './Coachmark.stories.args';
+import Documentation from './Coachmark.stories.docs.mdx';
+
+export default {
+  title: 'Momentum UI/Coachmark',
+  component: Coachmark,
+  parameters: {
+    expanded: true,
+    docs: {
+      page: DocumentationPage(Documentation, StyleDocs),
+    },
+  },
+};
+
+const Template: Story<CoachmarkProps> = (args: CoachmarkProps) => {
+  return (
+    <>
+      <Coachmark
+        triggerComponent={<div style={{ width: 'fit-content' }}>Target Element</div>}
+        {...args}
+      />
+    </>
+  );
+};
+
+const Example = Template.bind({});
+
+Example.argTypes = { ...argTypes };
+
+Example.args = {
+  children: 'Example',
+};
+
+const TemplateCommon: Story = () => {
+  const [index, setIndex] = useState<number>();
+
+  const next = () => {
+    setIndex(index + 1);
+  };
+
+  const start = () => {
+    setIndex(1);
+  };
+
+  const reset = () => {
+    setIndex(0);
+  };
+
+  interface LocalProps {
+    targetIndex: number;
+    content?: boolean;
+    icon?: boolean;
+    image?: boolean;
+    title?: boolean;
+    trigger: string;
+  }
+
+  const CommonCoachmark = ({ content, icon, image, targetIndex, title, trigger }: LocalProps) => (
+    <Coachmark
+      actions={[
+        <ButtonPill key={0} size={28}>
+          Button
+        </ButtonPill>,
+        <ButtonPill key={1} outline size={28}>
+          Button
+        </ButtonPill>,
+        <ButtonHyperlink key={2}>Hyperlink</ButtonHyperlink>,
+      ]}
+      icon={icon && 'placeholder'}
+      image={
+        image && (
+          <img
+            alt="example"
+            src="https://www.firstbenefits.org/wp-content/uploads/2017/10/placeholder-1024x1024.png"
+          />
+        )
+      }
+      isVisible={index === targetIndex}
+      title={title && 'Example Title'}
+      triggerComponent={<div style={{ width: 'fit-content' }}>{trigger}</div>}
+      onDismiss={next}
+    >
+      {content && (
+        <div>Example Coachmark {targetIndex}. Close this Coachmark to continue the experience.</div>
+      )}
+    </Coachmark>
+  );
+
+  return (
+    <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+      <CommonCoachmark
+        content
+        icon
+        image
+        targetIndex={1}
+        title
+        trigger="[ Content / Icon / Image / Title ]"
+      />
+      <CommonCoachmark content image targetIndex={2} title trigger="[ Content / Image / Title ]" />
+      <CommonCoachmark content icon targetIndex={3} title trigger="[ Content / Icon / Title ]" />
+      <CommonCoachmark content targetIndex={4} title trigger="[ Content / Title ]" />
+      <CommonCoachmark content image targetIndex={5} trigger="[ Content / Image ]" />
+      <CommonCoachmark content targetIndex={6} trigger="[ Content ]" />
+      <CommonCoachmark image targetIndex={7} trigger="[ Image ]" />
+      <CommonCoachmark title targetIndex={8} trigger="[ Title ]" />
+      <CommonCoachmark icon targetIndex={9} title trigger="[ Icon Title ]" />
+      <ButtonSimple onPress={start}>Start Experience</ButtonSimple>
+      <ButtonSimple onPress={reset}>Reset Experience</ButtonSimple>
+    </div>
+  );
+};
+
+const Common = TemplateCommon.bind({});
+
+Common.argTypes = Object.entries({ ...argTypes }).reduce((types, entry) => {
+  const [key, value] = entry;
+  const mutable = { ...types };
+
+  mutable[key] = { ...value };
+
+  mutable[key].control = { type: 'none' };
+
+  return mutable;
+}, {});
+
+Common.args = {};
+
+export { Example, Common };

--- a/src/components/Coachmark/Coachmark.style.scss
+++ b/src/components/Coachmark/Coachmark.style.scss
@@ -1,0 +1,55 @@
+.md-coachmark-wrapper {
+  display: block;
+  width: 19.125rem;
+
+  > .md-coachmark-container {
+    margin: 0.25rem;
+
+    &[data-header='true'] {
+      > :not(:first-child) {
+        margin-top: 0.75rem;
+      }
+
+      > .md-coachmark-header {
+        align-items: center;
+        display: flex;
+        width: 100%;
+
+        > .md-icon-wrapper {
+          height: 2rem;
+          width: 2rem;
+        }
+
+        > .md-coachmark-title {
+          flex-grow: 1;
+        }
+      }
+
+      img {
+        border-radius: 0.5rem;
+        min-height: 4rem;
+        width: 17.625rem;
+      }
+    }
+
+    &[data-header='false'] {
+      > div:first-child {
+        flex-grow: 1;
+        overflow-wrap: break-word;
+
+        > .md-coachmark-content {
+          margin-bottom: 0.5rem;
+          overflow-wrap: break-word;
+        }
+      }
+
+      display: flex;
+      flex-grow: 1;
+
+      > .md-coachmark-controls {
+        justify-self: flex-end;
+        flex-shrink: 0;
+      }
+    }
+  }
+}

--- a/src/components/Coachmark/Coachmark.tsx
+++ b/src/components/Coachmark/Coachmark.tsx
@@ -21,9 +21,7 @@ const Coachmark: FC<Props> = (props: Props) => {
   const handleDismiss = useCallback(() => {
     if (instance?.state?.isVisible) {
       instance.hide();
-      if (onDismiss) {
-        onDismiss();
-      }
+      onDismiss?.();
     }
   }, [instance]);
 

--- a/src/components/Coachmark/Coachmark.tsx
+++ b/src/components/Coachmark/Coachmark.tsx
@@ -1,0 +1,57 @@
+import React, { FC, useCallback, useEffect, useState } from 'react';
+import classnames from 'classnames';
+
+import Popover, { PopoverInstance } from '../Popover';
+
+import WithHeader from './WithHeader';
+import WithoutHeader from './WithoutHeader';
+import { STYLE } from './Coachmark.constants';
+import { Props } from './Coachmark.types';
+import './Coachmark.style.scss';
+
+/**
+ * The Coachmark component.
+ */
+const Coachmark: FC<Props> = (props: Props) => {
+  const { actions, className, children, icon, image, onDismiss, isVisible, title, ...otherProps } =
+    props;
+
+  const [instance, setInstance] = useState<PopoverInstance>(undefined);
+
+  const handleDismiss = useCallback(() => {
+    if (instance?.state?.isVisible) {
+      instance.hide();
+      if (onDismiss) {
+        onDismiss();
+      }
+    }
+  }, [instance]);
+
+  useEffect(() => {
+    if (instance?.show && isVisible) {
+      instance.show();
+    }
+
+    if (instance?.state?.isVisible && !isVisible) {
+      instance.hide();
+    }
+  }, [instance, isVisible]);
+
+  return (
+    <Popover
+      trigger="manual"
+      className={classnames(className, STYLE.wrapper)}
+      interactive={true}
+      setInstance={setInstance}
+      {...otherProps}
+    >
+      {title || image || icon ? (
+        <WithHeader {...{ actions, children, icon, image, onDismiss: handleDismiss, title }} />
+      ) : (
+        <WithoutHeader {...{ actions, children, onDismiss: handleDismiss }} />
+      )}
+    </Popover>
+  );
+};
+
+export default Coachmark;

--- a/src/components/Coachmark/Coachmark.types.ts
+++ b/src/components/Coachmark/Coachmark.types.ts
@@ -1,0 +1,45 @@
+import type { ReactElement, ReactNode } from 'react';
+
+import { ButtonSimpleProps } from '../ButtonSimple';
+import { PopoverProps } from '../Popover';
+
+export interface CoachmarkWithoutHeaderProps {
+  /**
+   * Actions associated with this Coachmark.
+   */
+  actions?: ReactElement<ButtonSimpleProps> | Array<ReactElement<ButtonSimpleProps>>;
+
+  /**
+   * Content to display on this Coachmark.
+   */
+  children: ReactNode;
+
+  /**
+   * Event handler to handle dismissing the Coachmark.
+   */
+  onDismiss?: () => void;
+}
+
+export interface CoachmarkWithHeaderProps extends CoachmarkWithoutHeaderProps {
+  /**
+   * Icon to display to the left of the title.
+   */
+  icon?: string;
+
+  /**
+   * Image associated with this Coachmark.
+   */
+  image?: ReactElement<HTMLImageElement>;
+
+  /**
+   * Title of this Coachmark.
+   */
+  title?: string;
+}
+
+export interface Props extends PopoverProps, CoachmarkWithHeaderProps {
+  /**
+   * Whether or not this Coachmark is to be visible.
+   */
+  isVisible?: boolean;
+}

--- a/src/components/Coachmark/Coachmark.unit.test.tsx
+++ b/src/components/Coachmark/Coachmark.unit.test.tsx
@@ -8,6 +8,9 @@ import ButtonPill from '../ButtonPill';
 import Coachmark from './';
 
 describe('<Coachmark />', () => {
+  const iconName = 'placeholder';
+  const children = 'Children';
+
   describe('snapshot', () => {
     it('should match snapshot without header', async () => {
       expect.assertions(1);
@@ -21,11 +24,11 @@ describe('<Coachmark />', () => {
           isVisible
           triggerComponent={<div />}
         >
-          Children
+          {children}
         </Coachmark>
       );
 
-      await screen.findByText('Children');
+      await screen.findByText(children);
 
       expect(container).toMatchSnapshot();
     });
@@ -39,7 +42,7 @@ describe('<Coachmark />', () => {
             <ButtonPill key={0}>Button A</ButtonPill>,
             <ButtonPill key={1}>Button B</ButtonPill>,
           ]}
-          icon="placeholder"
+          icon={iconName}
           image={
             <img
               alt="example"
@@ -50,11 +53,11 @@ describe('<Coachmark />', () => {
           title="Title"
           triggerComponent={<div />}
         >
-          Children
+          {children}
         </Coachmark>
       );
 
-      await screen.findByText('Children');
+      await screen.findByText(children);
 
       expect(container).toMatchSnapshot();
     });
@@ -76,11 +79,11 @@ describe('<Coachmark />', () => {
           isVisible
           triggerComponent={<div />}
         >
-          Children
+          {children}
         </Coachmark>
       );
 
-      await screen.findByText('Children');
+      await screen.findByText(children);
 
       const button = screen.getByRole('button', { name: 'Button A' });
 
@@ -95,14 +98,14 @@ describe('<Coachmark />', () => {
       expect.assertions(1);
 
       render(
-        <Coachmark isVisible icon="placeholder" triggerComponent={<div />}>
-          Children
+        <Coachmark isVisible icon={iconName} triggerComponent={<div />}>
+          {children}
         </Coachmark>
       );
 
-      await screen.findByText('Children');
+      await screen.findByText(children);
 
-      const icon = screen.getByTestId('placeholder');
+      const icon = screen.getByTestId(iconName);
 
       expect(icon).toBeVisible();
     });
@@ -116,11 +119,11 @@ describe('<Coachmark />', () => {
 
       render(
         <Coachmark isVisible image={<img alt={alt} src={src} />} triggerComponent={<div />}>
-          Children
+          {children}
         </Coachmark>
       );
 
-      await screen.findByText('Children');
+      await screen.findByText(children);
 
       const image = screen.getByAltText<HTMLImageElement>(alt);
 
@@ -135,11 +138,11 @@ describe('<Coachmark />', () => {
 
       render(
         <Coachmark isVisible onDismiss={mockDismiss} triggerComponent={<div />}>
-          Children
+          {children}
         </Coachmark>
       );
 
-      await screen.findByText('Children');
+      await screen.findByText(children);
 
       const dismissButton = screen.getByRole('button', { name: 'dismiss' });
 
@@ -149,7 +152,7 @@ describe('<Coachmark />', () => {
       userEvent.keyboard('{enter}');
 
       await waitFor(() => {
-        expect(screen.queryByText('Children')).not.toBeInTheDocument();
+        expect(screen.queryByText(children)).not.toBeInTheDocument();
       });
 
       expect(mockDismiss).toHaveBeenCalledTimes(1);
@@ -162,11 +165,11 @@ describe('<Coachmark />', () => {
 
       render(
         <Coachmark isVisible onDismiss={mockDismiss} triggerComponent={<div />}>
-          Children
+          {children}
         </Coachmark>
       );
 
-      await screen.findByText('Children');
+      await screen.findByText(children);
 
       const dismissButton = screen.getByRole('button', { name: 'dismiss' });
 
@@ -175,7 +178,7 @@ describe('<Coachmark />', () => {
       userEvent.click(dismissButton);
 
       await waitFor(() => {
-        expect(screen.queryByText('Children')).not.toBeInTheDocument();
+        expect(screen.queryByText(children)).not.toBeInTheDocument();
       });
 
       expect(mockDismiss).toHaveBeenCalledTimes(1);
@@ -186,29 +189,29 @@ describe('<Coachmark />', () => {
 
       const { rerender } = render(
         <Coachmark isVisible triggerComponent={<div />}>
-          Children
+          {children}
         </Coachmark>
       );
 
-      await screen.findByText('Children');
+      await screen.findByText(children);
 
-      expect(screen.getByText('Children')).toBeVisible();
+      expect(screen.getByText(children)).toBeVisible();
 
-      rerender(<Coachmark triggerComponent={<div />}>Children</Coachmark>);
+      rerender(<Coachmark triggerComponent={<div />}>{children}</Coachmark>);
 
       await waitFor(() => {
-        expect(screen.queryByText('Children')).not.toBeInTheDocument();
+        expect(screen.queryByText(children)).not.toBeInTheDocument();
       });
 
       rerender(
         <Coachmark isVisible triggerComponent={<div />}>
-          Children
+          {children}
         </Coachmark>
       );
 
-      await screen.findByText('Children');
+      await screen.findByText(children);
 
-      expect(screen.getByText('Children')).toBeVisible();
+      expect(screen.getByText(children)).toBeVisible();
     });
 
     it('should allow title', async () => {
@@ -218,11 +221,11 @@ describe('<Coachmark />', () => {
 
       render(
         <Coachmark isVisible title={title} triggerComponent={<div />}>
-          Children
+          {children}
         </Coachmark>
       );
 
-      await screen.findByText('Children');
+      await screen.findByText(children);
 
       expect(screen.getByText(title)).toBeVisible();
     });

--- a/src/components/Coachmark/Coachmark.unit.test.tsx
+++ b/src/components/Coachmark/Coachmark.unit.test.tsx
@@ -1,0 +1,230 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+
+import ButtonPill from '../ButtonPill';
+
+import Coachmark from './';
+
+describe('<Coachmark />', () => {
+  describe('snapshot', () => {
+    it('should match snapshot without header', async () => {
+      expect.assertions(1);
+
+      const { container } = render(
+        <Coachmark
+          actions={[
+            <ButtonPill key={0}>Button A</ButtonPill>,
+            <ButtonPill key={1}>Button B</ButtonPill>,
+          ]}
+          isVisible
+          triggerComponent={<div />}
+        >
+          Children
+        </Coachmark>
+      );
+
+      await screen.findByText('Children');
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match snapshot with header', async () => {
+      expect.assertions(1);
+
+      const { container } = render(
+        <Coachmark
+          actions={[
+            <ButtonPill key={0}>Button A</ButtonPill>,
+            <ButtonPill key={1}>Button B</ButtonPill>,
+          ]}
+          icon="placeholder"
+          image={
+            <img
+              alt="example"
+              src="https://www.firstbenefits.org/wp-content/uploads/2017/10/placeholder-1024x1024.png"
+            />
+          }
+          isVisible
+          title="Title"
+          triggerComponent={<div />}
+        >
+          Children
+        </Coachmark>
+      );
+
+      await screen.findByText('Children');
+
+      expect(container).toMatchSnapshot();
+    });
+  });
+
+  describe('attributes', () => {
+    it('should allow actions', async () => {
+      expect.assertions(2);
+
+      const onPressMock = jest.fn();
+
+      render(
+        <Coachmark
+          actions={[
+            <ButtonPill key={0} onPress={onPressMock}>
+              Button A
+            </ButtonPill>,
+          ]}
+          isVisible
+          triggerComponent={<div />}
+        >
+          Children
+        </Coachmark>
+      );
+
+      await screen.findByText('Children');
+
+      const button = screen.getByRole('button', { name: 'Button A' });
+
+      expect(button).toBeVisible();
+
+      userEvent.click(button);
+
+      expect(onPressMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('should allow icon', async () => {
+      expect.assertions(1);
+
+      render(
+        <Coachmark isVisible icon="placeholder" triggerComponent={<div />}>
+          Children
+        </Coachmark>
+      );
+
+      await screen.findByText('Children');
+
+      const icon = screen.getByTestId('placeholder');
+
+      expect(icon).toBeVisible();
+    });
+
+    it('should allow image', async () => {
+      expect.assertions(2);
+
+      const alt = 'example';
+      const src =
+        'https://www.firstbenefits.org/wp-content/uploads/2017/10/placeholder-1024x1024.png';
+
+      render(
+        <Coachmark isVisible image={<img alt={alt} src={src} />} triggerComponent={<div />}>
+          Children
+        </Coachmark>
+      );
+
+      await screen.findByText('Children');
+
+      const image = screen.getByAltText<HTMLImageElement>(alt);
+
+      expect(image).toBeVisible();
+      expect(image.src).toBe(src);
+    });
+
+    it('should allow dismiss via keypress', async () => {
+      expect.assertions(3);
+
+      const mockDismiss = jest.fn();
+
+      render(
+        <Coachmark isVisible onDismiss={mockDismiss} triggerComponent={<div />}>
+          Children
+        </Coachmark>
+      );
+
+      await screen.findByText('Children');
+
+      const dismissButton = screen.getByRole('button', { name: 'dismiss' });
+
+      expect(dismissButton).toBeVisible();
+
+      userEvent.tab();
+      userEvent.keyboard('{enter}');
+
+      await waitFor(() => {
+        expect(screen.queryByText('Children')).not.toBeInTheDocument();
+      });
+
+      expect(mockDismiss).toHaveBeenCalledTimes(1);
+    });
+
+    it('should allow dismiss via click', async () => {
+      expect.assertions(3);
+
+      const mockDismiss = jest.fn();
+
+      render(
+        <Coachmark isVisible onDismiss={mockDismiss} triggerComponent={<div />}>
+          Children
+        </Coachmark>
+      );
+
+      await screen.findByText('Children');
+
+      const dismissButton = screen.getByRole('button', { name: 'dismiss' });
+
+      expect(dismissButton).toBeVisible();
+
+      userEvent.click(dismissButton);
+
+      await waitFor(() => {
+        expect(screen.queryByText('Children')).not.toBeInTheDocument();
+      });
+
+      expect(mockDismiss).toHaveBeenCalledTimes(1);
+    });
+
+    it('should respond to isVisible prop', async () => {
+      expect.assertions(3);
+
+      const { rerender } = render(
+        <Coachmark isVisible triggerComponent={<div />}>
+          Children
+        </Coachmark>
+      );
+
+      await screen.findByText('Children');
+
+      expect(screen.getByText('Children')).toBeVisible();
+
+      rerender(<Coachmark triggerComponent={<div />}>Children</Coachmark>);
+
+      await waitFor(() => {
+        expect(screen.queryByText('Children')).not.toBeInTheDocument();
+      });
+
+      rerender(
+        <Coachmark isVisible triggerComponent={<div />}>
+          Children
+        </Coachmark>
+      );
+
+      await screen.findByText('Children');
+
+      expect(screen.getByText('Children')).toBeVisible();
+    });
+
+    it('should allow title', async () => {
+      expect.assertions(1);
+
+      const title = 'Title';
+
+      render(
+        <Coachmark isVisible title={title} triggerComponent={<div />}>
+          Children
+        </Coachmark>
+      );
+
+      await screen.findByText('Children');
+
+      expect(screen.getByText(title)).toBeVisible();
+    });
+  });
+});

--- a/src/components/Coachmark/Coachmark.unit.test.tsx.snap
+++ b/src/components/Coachmark/Coachmark.unit.test.tsx.snap
@@ -1,0 +1,283 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Coachmark /> snapshot should match snapshot with header 1`] = `
+<div>
+  <div
+    aria-expanded="true"
+  />
+  <div
+    data-tippy-root=""
+    id="tippy-2"
+    style="z-index: 9999; position: absolute; left: 0px; top: 0px; margin: 0px; bottom: 0px; transform: translate(0px, 0px);"
+  >
+    <div
+      class="md-coachmark-wrapper md-modal-container-wrapper"
+      data-arrow-orientation="vertical"
+      data-color="primary"
+      data-elevation="3"
+      data-padded="true"
+      data-placement="top"
+      data-round="50"
+    >
+      <div
+        class="md-coachmark-container"
+        data-header="true"
+      >
+        <div
+          class="md-coachmark-header"
+        >
+          <div
+            class="md-icon-wrapper"
+          >
+            <svg
+              class=""
+              data-autoscale="false"
+              data-scale="18"
+              data-test="placeholder"
+              data-testid="placeholder"
+              fill="currentColor"
+              height="100%"
+              stroke="currentColor"
+              viewBox="0, 0, 32, 32"
+              width="100%"
+            />
+          </div>
+          <h3
+            class="md-text-wrapper md-coachmark-title"
+            data-type="header-primary"
+          >
+            Title
+          </h3>
+          <div
+            class="md-button-group-wrapper"
+            data-round="true"
+            data-spaced="false"
+          >
+            <button
+              aria-label="dismiss"
+              class="md-button-control-wrapper"
+              type="button"
+            >
+              <div
+                class="md-icon-wrapper"
+              >
+                <svg
+                  class=""
+                  data-autoscale="true"
+                  data-scale="false"
+                  data-test="cancel"
+                  fill="currentColor"
+                  height="100%"
+                  stroke="currentColor"
+                  viewBox="0, 0, 32, 32"
+                  width="100%"
+                />
+              </div>
+            </button>
+          </div>
+        </div>
+        <div
+          class="md-coachmark-image"
+        >
+          <img
+            alt="example"
+            src="https://www.firstbenefits.org/wp-content/uploads/2017/10/placeholder-1024x1024.png"
+          />
+        </div>
+        <div
+          class="md-coachmark-content"
+        >
+          Children
+        </div>
+        <div
+          class="md-button-group-wrapper"
+          data-round="true"
+          data-spaced="true"
+        >
+          <button
+            class="md-button-pill-wrapper"
+            data-color="primary"
+            data-disabled="false"
+            data-ghost="false"
+            data-grown="false"
+            data-outline="false"
+            data-size="40"
+            data-solid="false"
+            type="button"
+          >
+            Button A
+          </button>
+          <button
+            class="md-button-pill-wrapper"
+            data-color="primary"
+            data-disabled="false"
+            data-ghost="false"
+            data-grown="false"
+            data-outline="false"
+            data-size="40"
+            data-solid="false"
+            type="button"
+          >
+            Button B
+          </button>
+        </div>
+      </div>
+      <div
+        class="md-modal-container-arrow-wrapper"
+        data-popper-arrow="true"
+        id="arrow"
+        style="position: absolute; left: 0px; transform: translate(5px, 0px);"
+      >
+        <svg
+          class="md-modal-arrow-svg"
+          data-placement="top"
+          height="12"
+          viewBox="0 0 24 12"
+          width="24"
+          xmlns="http://www.w3.org/svg/2000"
+        >
+          <defs>
+            <clippath
+              id="modal-arrow-cut-stroke-top"
+            >
+              <path
+                d="m 24 0 l -10 10 q -2 2 -4 0 l -10 -10"
+              />
+            </clippath>
+          </defs>
+          <path
+            clip-path="url(#modal-arrow-cut-stroke-top)"
+            d="m 24 0 l -10 10 q -2 2 -4 0 l -10 -10"
+            data-color="primary"
+          />
+        </svg>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<Coachmark /> snapshot should match snapshot without header 1`] = `
+<div>
+  <div
+    aria-expanded="true"
+  />
+  <div
+    data-tippy-root=""
+    id="tippy-1"
+    style="z-index: 9999; position: absolute; left: 0px; top: 0px; margin: 0px; bottom: 0px; transform: translate(0px, 0px);"
+  >
+    <div
+      class="md-coachmark-wrapper md-modal-container-wrapper"
+      data-arrow-orientation="vertical"
+      data-color="primary"
+      data-elevation="3"
+      data-padded="true"
+      data-placement="top"
+      data-round="50"
+    >
+      <div
+        class="md-coachmark-container"
+        data-header="false"
+      >
+        <div>
+          <div
+            class="md-coachmark-content"
+          >
+            Children
+          </div>
+          <div
+            class="md-button-group-wrapper"
+            data-round="true"
+            data-spaced="true"
+          >
+            <button
+              class="md-button-pill-wrapper"
+              data-color="primary"
+              data-disabled="false"
+              data-ghost="false"
+              data-grown="false"
+              data-outline="false"
+              data-size="40"
+              data-solid="false"
+              type="button"
+            >
+              Button A
+            </button>
+            <button
+              class="md-button-pill-wrapper"
+              data-color="primary"
+              data-disabled="false"
+              data-ghost="false"
+              data-grown="false"
+              data-outline="false"
+              data-size="40"
+              data-solid="false"
+              type="button"
+            >
+              Button B
+            </button>
+          </div>
+        </div>
+        <div
+          class="md-button-group-wrapper md-coachmark-controls"
+          data-round="true"
+          data-spaced="false"
+        >
+          <button
+            aria-label="dismiss"
+            class="md-button-control-wrapper"
+            type="button"
+          >
+            <div
+              class="md-icon-wrapper"
+            >
+              <svg
+                class=""
+                data-autoscale="true"
+                data-scale="false"
+                data-test="cancel"
+                fill="currentColor"
+                height="100%"
+                stroke="currentColor"
+                viewBox="0, 0, 32, 32"
+                width="100%"
+              />
+            </div>
+          </button>
+        </div>
+      </div>
+      <div
+        class="md-modal-container-arrow-wrapper"
+        data-popper-arrow="true"
+        id="arrow"
+        style="position: absolute; left: 0px; transform: translate(5px, 0px);"
+      >
+        <svg
+          class="md-modal-arrow-svg"
+          data-placement="top"
+          height="12"
+          viewBox="0 0 24 12"
+          width="24"
+          xmlns="http://www.w3.org/svg/2000"
+        >
+          <defs>
+            <clippath
+              id="modal-arrow-cut-stroke-top"
+            >
+              <path
+                d="m 24 0 l -10 10 q -2 2 -4 0 l -10 -10"
+              />
+            </clippath>
+          </defs>
+          <path
+            clip-path="url(#modal-arrow-cut-stroke-top)"
+            d="m 24 0 l -10 10 q -2 2 -4 0 l -10 -10"
+            data-color="primary"
+          />
+        </svg>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/Coachmark/WithHeader.tsx
+++ b/src/components/Coachmark/WithHeader.tsx
@@ -1,0 +1,46 @@
+import React, { FC } from 'react';
+
+import ButtonControl, { BUTTON_CONTROL_CONSTANTS } from '../ButtonControl';
+import ButtonGroup from '../ButtonGroup';
+import Icon, { ICON_CONSTANTS } from '../Icon';
+import Text, { TEXT_CONSTANTS } from '../Text';
+
+import { STYLE } from './Coachmark.constants';
+import { CoachmarkWithHeaderProps } from './Coachmark.types';
+import './Coachmark.style.scss';
+
+/**
+ * The Coachmark content component when displayed with a header.
+ */
+const CoachmarkWithHeader: FC<CoachmarkWithHeaderProps> = (props: CoachmarkWithHeaderProps) => {
+  const { actions, children, icon, image, onDismiss, title } = props;
+
+  return (
+    <div className={STYLE.container} data-header="true">
+      <div className={STYLE.header}>
+        {icon && (
+          <Icon data-testid={icon} name={icon} scale={18} weight={ICON_CONSTANTS.WEIGHTS.BOLD} />
+        )}
+        <Text className={STYLE.title} type={TEXT_CONSTANTS.TYPES.HEADER_PRIMARY}>
+          {title}
+        </Text>
+        <ButtonGroup round>
+          <ButtonControl
+            aria-label="dismiss"
+            control={BUTTON_CONTROL_CONSTANTS.CONTROLS.CLOSE}
+            onPress={onDismiss}
+          />
+        </ButtonGroup>
+      </div>
+      {image && <div className={STYLE.image}>{image}</div>}
+      {children && <div className={STYLE.content}>{children}</div>}
+      {actions && (
+        <ButtonGroup round spaced>
+          {actions}
+        </ButtonGroup>
+      )}
+    </div>
+  );
+};
+
+export default CoachmarkWithHeader;

--- a/src/components/Coachmark/WithoutHeader.tsx
+++ b/src/components/Coachmark/WithoutHeader.tsx
@@ -1,0 +1,41 @@
+import React, { FC } from 'react';
+
+import ButtonControl, { BUTTON_CONTROL_CONSTANTS } from '../ButtonControl';
+import ButtonGroup from '../ButtonGroup';
+
+import { STYLE } from './Coachmark.constants';
+import { CoachmarkWithoutHeaderProps } from './Coachmark.types';
+import './Coachmark.style.scss';
+
+/**
+ * The Coachmark container component when displayed without a header.
+ */
+const CoarchmarkWithoutHeader: FC<CoachmarkWithoutHeaderProps> = (
+  props: CoachmarkWithoutHeaderProps
+) => {
+  const { actions, children, onDismiss } = props;
+
+  return (
+    <>
+      <div className={STYLE.container} data-header="false">
+        <div>
+          {children && <div className={STYLE.content}>{children}</div>}
+          {actions && (
+            <ButtonGroup round spaced>
+              {actions}
+            </ButtonGroup>
+          )}
+        </div>
+        <ButtonGroup className={STYLE.controls} round>
+          <ButtonControl
+            aria-label="dismiss"
+            control={BUTTON_CONTROL_CONSTANTS.CONTROLS.CLOSE}
+            onPress={onDismiss}
+          />
+        </ButtonGroup>
+      </div>
+    </>
+  );
+};
+
+export default CoarchmarkWithoutHeader;

--- a/src/components/Coachmark/index.ts
+++ b/src/components/Coachmark/index.ts
@@ -1,0 +1,9 @@
+import { default as Coachmark } from './Coachmark';
+import * as CONSTANTS from './Coachmark.constants';
+import { Props } from './Coachmark.types';
+
+export { CONSTANTS as COACHMARK_CONSTANTS };
+
+export type CoachmarkProps = Props;
+
+export default Coachmark;

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -16,8 +16,19 @@ import classnames from 'classnames';
  * Icon component that can dynamically display SVG icons with a valid name.
  */
 const Icon: React.FC<Props> = (props: Props) => {
-  const { autoScale, className, color, fillColor, id, name, scale, strokeColor, style, weight } =
-    props;
+  const {
+    autoScale,
+    className,
+    color,
+    fillColor,
+    id,
+    name,
+    scale,
+    strokeColor,
+    style,
+    weight,
+    ...otherProps
+  } = props;
   const { SvgIcon, error } = useDynamicSVGImport(`${name}-${weight || DEFAULTS.WEIGHT}`);
 
   const isColoredIcon = name.indexOf('coloured') > 0;
@@ -85,6 +96,7 @@ const Icon: React.FC<Props> = (props: Props) => {
           height="100%"
           data-scale={!autoScale && (scale || DEFAULTS.SCALE)}
           data-autoscale={autoScale || DEFAULTS.AUTO_SCALE}
+          {...otherProps}
         />
       </div>
     );

--- a/src/components/Popover/Popover.stories.args.ts
+++ b/src/components/Popover/Popover.stories.args.ts
@@ -8,7 +8,7 @@ export default {
   trigger: {
     description: `Determines the events that cause the Popover to show.
     Multiple event names should be separated by spaces. For example to allow both click and hover, use \`click mouseenter\` as the trigger.
-    Possible event names: \`click\`, \`mouseenter\`, \`focusin\`, \`manual\` (to programmatically trigger the popover)`,
+    Possible event names: \`click\`, \`mouseenter\`, \`focusin\`, \`manual\` (to programmatically trigger the popover, this disables the popover-close events on DOM focus change)`,
     control: { type: 'text' },
     table: {
       type: {

--- a/src/components/Popover/Popover.stories.args.ts
+++ b/src/components/Popover/Popover.stories.args.ts
@@ -3,8 +3,7 @@ import { PLACEMENTS } from '../ModalArrow/ModalArrow.constants';
 import { COLORS } from '../ModalContainer/ModalContainer.constants';
 import { DEFAULTS } from './Popover.constants';
 
-export default {
-  ...commonStyles,
+const popoverArgTypes = {
   trigger: {
     description: `Determines the events that cause the Popover to show.
     Multiple event names should be separated by spaces. For example to allow both click and hover, use \`click mouseenter\` as the trigger.
@@ -92,4 +91,11 @@ export default {
       },
     },
   },
+};
+
+export { popoverArgTypes };
+
+export default {
+  ...commonStyles,
+  ...popoverArgTypes,
 };

--- a/src/components/Popover/Popover.stories.docs.mdx
+++ b/src/components/Popover/Popover.stories.docs.mdx
@@ -1,3 +1,3 @@
-The `<Popover />` component allows adding a Popover to whatever provided as
-`triggerComponent`. It will show the Popover after a specific event, which is
-defined by the provided `trigger` prop.
+The `<Popover />` component allows adding a Popover to whatever provided as `triggerComponent`. It will show the Popover after a specific event, which is defined by the provided `trigger` prop.
+
+The `<Popover />` component also supports a manually-triggered appearance using the `manual` value assigned to the `trigger` prop. This allows for external visibility handling.

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -46,6 +46,8 @@ const Popover: FC<Props> = (props: Props) => {
   return (
     <LazyTippy
       ref={tippyRef}
+      /* needed to prevent the popover from closing when the focus is changed via click events */
+      hideOnClick={!trigger.includes('manual')}
       render={(attrs) => (
         <ModalContainer
           id={id}

--- a/src/components/Popover/Popover.types.ts
+++ b/src/components/Popover/Popover.types.ts
@@ -1,4 +1,5 @@
 import type { CSSProperties, ReactElement, ReactNode } from 'react';
+import type { Instance } from 'tippy.js';
 import type { TippyProps } from '@tippyjs/react';
 import type { Color } from '../ModalContainer/ModalContainer.types';
 
@@ -8,10 +9,10 @@ export type VariantType = 'small' | 'medium';
 export type PlacementType = TippyProps['placement'];
 export type TriggerType = TippyProps['trigger'];
 
-export type PopoverInstance = {
-  show: () => void;
-  hide: () => void;
-};
+/**
+ * Popover instance interface abstracted from Tippy.js
+ */
+export type PopoverInstance = Instance;
 
 export interface Props {
   /**

--- a/src/components/Popover/Popover.unit.test.tsx
+++ b/src/components/Popover/Popover.unit.test.tsx
@@ -108,14 +108,6 @@ describe('<Popover />', () => {
     it('should not automatically disappear on focus-change when trigger is manual', async () => {
       expect.assertions(3);
 
-      // Local globals.
-      const trigger = 'manual';
-      const identifiers = {
-        other: 'other-element',
-        popover: 'popover-element',
-        trigger: 'trigger-element',
-      };
-
       // Set up a test component for local state management via hooks.
       const TestComponent: FC = () => {
         const [instance, setInstance] = useState<PopoverInstance>(undefined);
@@ -130,12 +122,10 @@ describe('<Popover />', () => {
 
         return (
           <>
-            <div data-testid={identifiers.other}>Other Element</div>
-            <button data-testid={identifiers.trigger} onClick={toggle}>
-              Trigger Element
-            </button>
-            <Popover setInstance={setInstance} triggerComponent={<div />} trigger={trigger}>
-              <div data-testid={identifiers.popover}>Popover Element</div>
+            <div>Other Element</div>
+            <button onClick={toggle}>Trigger Element</button>
+            <Popover setInstance={setInstance} triggerComponent={<div />} trigger="manual">
+              <div>Popover Element</div>
             </Popover>
           </>
         );
@@ -146,17 +136,17 @@ describe('<Popover />', () => {
 
       let popover: HTMLElement;
 
-      popover = screen.queryByTestId(identifiers.popover);
+      popover = screen.queryByText('Popover Element');
       expect(popover).not.toBeInTheDocument();
 
-      userEvent.click(screen.getByTestId(identifiers.trigger));
+      userEvent.click(screen.getByRole('button', { name: 'Trigger Element' }));
 
-      popover = await screen.findByTestId(identifiers.popover);
+      popover = await screen.findByText('Popover Element');
       expect(popover).toBeVisible();
 
-      userEvent.click(screen.getByTestId(identifiers.other));
+      userEvent.click(screen.getByText('Other Element'));
 
-      popover = await screen.findByTestId(identifiers.popover);
+      popover = await screen.findByText('Popover Element');
       expect(popover).toBeVisible();
     });
   });

--- a/src/components/Popover/index.ts
+++ b/src/components/Popover/index.ts
@@ -1,9 +1,10 @@
 import { default as Popover } from './Popover';
 import * as CONSTANTS from './Popover.constants';
-import type { Props } from './Popover.types';
+import type { Props, PopoverInstance as Instance } from './Popover.types';
 
 export { CONSTANTS as POPOVER_CONSTANTS };
 
 export type PopoverProps = Props;
+export type PopoverInstance = Instance;
 
 export default Popover;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -11,6 +11,7 @@ export { default as ButtonGroup } from './ButtonGroup';
 export { default as ButtonHyperlink } from './ButtonHyperlink';
 export { default as ButtonPill } from './ButtonPill';
 export { default as ButtonSimple } from './ButtonSimple';
+export { default as Coachmark } from './Coachmark';
 export { default as FocusRing } from './FocusRing';
 export { default as NavigationTab } from './NavigationTab';
 export { default as Tab } from './Tab';

--- a/src/index.js
+++ b/src/index.js
@@ -114,6 +114,7 @@ export {
   ButtonHyperlink,
   ButtonPill,
   ButtonSimple,
+  Coachmark as CoachmarkNext,
   CodeInput,
   DividerDot,
   FocusRing,


### PR DESCRIPTION
# Description

The scope of the changes in this pull request are to create the `<Coachmark />` component from the `<Popover />` component. Some minor changes to upstream components has occurred as a part of these changes.j

# Screenshots

![Screen Shot 2022-02-07 at 2 37 44 PM](https://user-images.githubusercontent.com/14828820/152859457-90001bbe-764d-4017-b329-f0e90c59e6e3.png)
![Screen Shot 2022-02-07 at 2 37 57 PM](https://user-images.githubusercontent.com/14828820/152859458-cb49c57e-117d-4c3a-9cf6-a8ca298d8a49.png)
![Screen Shot 2022-02-07 at 2 38 04 PM](https://user-images.githubusercontent.com/14828820/152859459-a166f155-85fa-42d4-b853-c4663ec54e66.png)

# Links

[SPARK-251336](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-251336)
[Figma](https://www.figma.com/file/8DVejsr8rs3puXjTZg7oxL/Components---Web-(WIP)?node-id=26434%3A47214)
