### PR TITLE
feat(list-item-base): fix overflow, add some examples in docs

### DIFF
--- a/src/components/ListItemBase/ListItemBase.stories.args.ts
+++ b/src/components/ListItemBase/ListItemBase.stories.args.ts
@@ -71,4 +71,17 @@ export default {
       },
     },
   },
+  isPadded: {
+    defaultValue: false,
+    description: 'Determines if the list item is padded (has default padding).',
+    control: { type: 'boolean' },
+    table: {
+      type: {
+        summary: 'boolean',
+      },
+      defaultValue: {
+        summary: false,
+      },
+    },
+  },
 };

--- a/src/components/ListItemBase/ListItemBase.style.scss
+++ b/src/components/ListItemBase/ListItemBase.style.scss
@@ -52,6 +52,15 @@
   & > div[data-position='fill'],
   *[data-position='middle'] {
     width: 100%;
+
+    // trim any type of text inside
+    &,
+    p,
+    span {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
   }
 
   & > div[data-position='end'] {

--- a/src/components/Menu/Menu.stories.tsx
+++ b/src/components/Menu/Menu.stories.tsx
@@ -30,6 +30,7 @@ Example.argTypes = { ...argTypes };
 Example.args = {
   'aria-label': 'Menu component',
   onAction: action('onAction'),
+  selectionMode: 'single',
   children: [
     <Item key="one">One</Item>,
     <Item key="two">Two</Item>,
@@ -50,6 +51,7 @@ Common.args = {
 Common.parameters = {
   variants: [
     {
+      selectionMode: 'single',
       children: [
         <Section key="0" title="Colors">
           <Item>Red</Item>
@@ -63,6 +65,7 @@ Common.parameters = {
       ],
     },
     {
+      selectionMode: 'single',
       disabledKeys: ['$.0.0', '$.0.1'],
       children: [
         // If key is not provided the elements get generated ones
@@ -80,6 +83,7 @@ Common.parameters = {
     },
 
     {
+      selectionMode: 'single',
       itemShape: 'isPilled',
       itemSize: 50,
       children: [

--- a/src/components/MenuTrigger/MenuTrigger.stories.tsx
+++ b/src/components/MenuTrigger/MenuTrigger.stories.tsx
@@ -31,14 +31,14 @@ const Example = Template<MenuTriggerProps>(MenuTrigger).bind({});
 Example.argTypes = { ...argTypes };
 
 Example.args = {
-  closeOnSelect: true,
+  closeOnSelect: false,
   'aria-label': 'Menu trigger',
   children: [
     <ButtonPill key="1">
       <div>Menu</div> <Icon name="arrow-down" weight="bold" autoScale={100} />
     </ButtonPill>,
     <Menu selectionMode="single" key="2">
-      <Item key="one">One</Item>
+      <Item key="one">This is a longer text and should trim nicely...</Item>
       <Item key="two">Two</Item>
       <Item key="three">Three</Item>
       <Item key="four">Four</Item>
@@ -83,7 +83,7 @@ Common.parameters = {
           <Item key="one" textValue="Apps">
             <Flex alignItems="center" xgap="0.875rem">
               <Icon name="accessories" scale={18} weight="bold" />
-              <span>Apps</span>
+              <span>This is a very long option name and should trim.</span>
             </Flex>
           </Item>
           <Item key="two" textValue="Accessories">

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -48,7 +48,7 @@ Example.args = {
   placeholder: 'Select an option',
   onSelectionChange: action('onSelectionChange'),
   children: [
-    <Item key="1">Red</Item>,
+    <Item key="1">This is a very long option and should trim.</Item>,
     <Item key="2">Blue</Item>,
     <Item key="3">Green</Item>,
     <Item key="4">Yellow</Item>,


### PR DESCRIPTION
# Description
Small PR to fix text-overflow in list-item base.
Also updated some docs around select, menu, menu trigger.

# Screenshot
Usage in Select
<img width="349" alt="image" src="https://user-images.githubusercontent.com/14194394/155314654-a0a1f0d2-e6e3-4a7e-a5ae-6104f8f1f029.png">
