### PR TITLE
feat(component-variant/solid-button): adding styles for circle and pill solid outline button

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "@momentum-ui/animations": "^1.3.0",
-    "@momentum-ui/design-tokens": "^0.0.28",
+    "@momentum-ui/design-tokens": "^0.0.34",
     "@momentum-ui/icons": "8.27.0",
     "@momentum-ui/icons-rebrand": "^1.22.0",
     "@momentum-ui/tokens": "^1.7.1",

--- a/src/components/Avatar/Avatar.style.scss
+++ b/src/components/Avatar/Avatar.style.scss
@@ -181,7 +181,7 @@
 .md-avatar-animation-wrapper {
   width: 100%;
   height: 100%;
-  background: var(--overlayFade-secondary-background);
+  background: var(--overlayFade-secondary-background-normal);
   position: absolute;
   display: flex;
   justify-content: center;

--- a/src/components/ButtonCircle/ButtonCircle.style.scss
+++ b/src/components/ButtonCircle/ButtonCircle.style.scss
@@ -111,7 +111,7 @@
     }
   }
 
-  &[data-outline='true'][data-ghost='false'] {
+  &[data-outline='true'][data-ghost='true'] {
     background-color: rgba(0, 0, 0, 0); // IEFIX
     background-color: var(--button-secondary-background);
     border-color: rgba(0, 0, 0, 0.3); // IEFIX
@@ -212,6 +212,43 @@
         border-color: var(--button-secondary-border-color-disabled);
         color: rgba(0, 0, 0, 0.4); // IEFIX
         color: var(--button-secondary-text-disabled);
+      }
+    }
+  }
+
+  &[data-outline='true'][data-ghost='false'] {
+    background-color: var(--videoSupport-controls-button-background);
+    border-color: var(--videoSupport-controls-button-border-color);
+    color: var(--videoSupport-controls-button-text);
+
+    &:hover {
+      background-color: var(--videoSupport-controls-button-background-hovered);
+      border-color: var(--videoSupport-controls-button-border-color-hovered);
+      color: var(--videoSupport-controls-button-text-hovered);
+    }
+
+    &:active {
+      background-color: var(--videoSupport-controls-button-background-pressed);
+      border-color: var(--videoSupport-controls-button-border-color-pressed);
+      color: var(--videoSupport-controls-button-text-pressed);
+    }
+
+    &[data-disabled='true'] {
+      background-color: var(--videoSupport-controls-button-background-disabled);
+      border-color: var(--videoSupport-controls-button-border-color-disabled);
+      color: var(--videoSupport-controls-button-text-disabled);
+      cursor: auto;
+
+      &:hover {
+        background-color: var(--videoSupport-controls-button-background-disabled);
+        border-color: var(--videoSupport-controls-button-border-color-disabled);
+        color: var(--videoSupport-controls-button-text-disabled);
+      }
+
+      &:active {
+        background-color: var(--videoSupport-controls-button-background-disabled);
+        border-color: var(--videoSupport-controls-button-border-color-disabled);
+        color: var(--videoSupport-controls-button-text-disabled);
       }
     }
   }

--- a/src/components/ButtonPill/ButtonPill.style.scss
+++ b/src/components/ButtonPill/ButtonPill.style.scss
@@ -55,17 +55,20 @@
     }
 
     &[data-solid='true'] {
-      background-color: rgba(255, 255, 255, 1); // IEFIX
-      background-color: var(--theme-button-inverted-normal);
+      background-color: var(--videoSupport-controls-button-background);
+      border-color: var(--videoSupport-controls-button-border-color);
+      color: var(--videoSupport-controls-button-text);
 
       &:hover {
-        background-color: rgba(237, 237, 237, 1); // IEFIX
-        background-color: var(--theme-button-inverted-hover);
+        background-color: var(--videoSupport-controls-button-background-hovered);
+        border-color: var(--videoSupport-controls-button-border-color-hovered);
+        color: var(--videoSupport-controls-button-text-hovered);
       }
 
       &:active {
-        background-color: rgba(222, 222, 222, 1); // IEFIX
-        background-color: var(--theme-button-inverted-pressed);
+        background-color: var(--videoSupport-controls-button-background-pressed);
+        border-color: var(--videoSupport-controls-button-border-color-pressed);
+        color: var(--videoSupport-controls-button-text-pressed);
       }
     }
   }
@@ -316,6 +319,24 @@
         border-color: var(--button-secondary-border-color-disabled);
         color: rgba(0, 0, 0, 0.4); // IEFIX
         color: var(--button-secondary-text-disabled);
+      }
+
+      &[data-solid='true'] {
+        background-color: var(--videoSupport-controls-button-background-disabled);
+        border-color: var(--videoSupport-controls-button-border-color-disabled);
+        color: var(--videoSupport-controls-button-text-disabled);
+
+        &:hover {
+          background-color: var(--videoSupport-controls-button-background-disabled);
+          border-color: var(--videoSupport-controls-button-border-color-disabled);
+          color: var(--videoSupport-controls-button-text-disabled);
+        }
+
+        &:active {
+          background-color: var(--videoSupport-controls-button-background-disabled);
+          border-color: var(--videoSupport-controls-button-border-color-disabled);
+          color: var(--videoSupport-controls-button-text-disabled);
+        }
       }
     }
   }

--- a/src/components/Overlay/Overlay.style.scss
+++ b/src/components/Overlay/Overlay.style.scss
@@ -19,10 +19,10 @@
   }
 
   &[data-color='primary'] {
-    background-color: var(--overlayFade-primary-background);
+    background-color: var(--overlayFade-primary-background-normal);
   }
 
   &[data-color='secondary'] {
-    background-color: var(--overlayFade-secondary-background);
+    background-color: var(--overlayFade-secondary-background-normal);
   }
 }

--- a/src/components/ThemeProvider/ThemeProvider.style.scss
+++ b/src/components/ThemeProvider/ThemeProvider.style.scss
@@ -132,7 +132,7 @@
 .md-theme-provider-globals {
   --md-globals-border-clear: 0rem solid rgba(0, 0, 0, 0);
   --md-globals-focus-ring-box-shadow: 0 0 0 0.25rem rgba(100, 180, 250, 0.3),
-    0 0 0 0.125rem var(--theme-outline-focus-normal);
+    0 0 0 0.125rem var(--theme-outline-theme-normal);
   --md-globals-focus-ring-box-shadow-inset: var(--md-globals-focus-ring-box-shadow) inset;
   --md-globals-elevation-0: 0 0 0 rgba(0, 0, 0, 0.2), 0 0 0.0625rem rgba(0, 0, 0, 0.11);
   --md-globals-elevation-1: 0 0.25rem 0.5rem rgba(0, 0, 0, 0.2), 0 0 0.0625rem rgba(0, 0, 0, 0.11);
@@ -160,7 +160,7 @@
 
   &.md-theme-lightWebex {
     --md-globals-focus-ring-box-shadow: 0 0 0 0.25rem rgba(17, 112, 207, 0.3),
-      0 0 0 0.125rem var(--theme-outline-focus-normal);
+      0 0 0 0.125rem var(--theme-outline-theme-normal);
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1817,10 +1817,10 @@
   resolved "https://registry.yarnpkg.com/@momentum-ui/animations/-/animations-1.3.0.tgz#1aeb51679a4019afff1381eb8627fe143befff1c"
   integrity sha512-lUKggfh1PjJ949HFxZdY23lSIIN0FTUyoNLOSSbU0L9bQI0ryx6FYTrJMiS2e/DS/gyUk306++OXxRnNSq3Kjw==
 
-"@momentum-ui/design-tokens@^0.0.28":
-  version "0.0.28"
-  resolved "https://registry.yarnpkg.com/@momentum-ui/design-tokens/-/design-tokens-0.0.28.tgz#ab6ca4f6070789366656d163a3bd8ff3c93a50e4"
-  integrity sha512-y8RQjmQV74tUxHCLEOakZZt5azdsvmA+Uhcza6mA7vlOLKZ4mK1gR539TXQAN9zxwABm9+CAAYTcoszpAZDlmg==
+"@momentum-ui/design-tokens@^0.0.34":
+  version "0.0.34"
+  resolved "https://registry.yarnpkg.com/@momentum-ui/design-tokens/-/design-tokens-0.0.34.tgz#4c2aa3409dc5098ea29c99be61eb56223500e664"
+  integrity sha512-A52/Dd+P4W7IEFpjSUkaBMsUR6vSZYFI2GZNpAG6OUeyD+xrQnoOP2O4XiOGWap0LTo4VXEfj8Sea5IWr2XjJg==
 
 "@momentum-ui/icons-rebrand@^1.22.0":
   version "1.22.0"


### PR DESCRIPTION
# Description

PR to add the variant of outline circle and pill buttons with non-ghost or solid background, as specified here:
<img width="896" alt="image" src="https://user-images.githubusercontent.com/56999622/155545280-ce2e6482-0876-4971-9104-4a237196a7c2.png">

# Links

[*Links to relevent resources.*](https://www.figma.com/file/vdL18BATeJAIq2JvGAjRPD/Components---Web?node-id=6361%3A0)
