### PR TITLE
fix(sass): missing semicolon

### DIFF
--- a/scss/components/link/module.scss
+++ b/scss/components/link/module.scss
@@ -17,7 +17,7 @@
 @import "../../generic/global";
 
 // Typography
-@include brand-font-face-regular
+@include brand-font-face-regular;
 
 // Component Specific
 @import 'mixins';


### PR DESCRIPTION
# Description
trying to convert from node-sass to sass encountered this error. missing semi-colon
