### PR TITLE
task(components/button-group): button-group update to ease use in audio/video controls

### DIFF
--- a/src/components/Banner/Banner.unit.test.tsx.snap
+++ b/src/components/Banner/Banner.unit.test.tsx.snap
@@ -103,6 +103,7 @@ exports[`<Banner /> snapshot should match a complex snapshot 1`] = `
       >
         <div
           className="md-button-group-wrapper"
+          data-compressed={false}
           data-round={false}
           data-spaced={true}
         >
@@ -358,6 +359,7 @@ exports[`<Banner /> snapshot should match snapshot with actions 1`] = `
       >
         <div
           className="md-button-group-wrapper"
+          data-compressed={false}
           data-round={false}
           data-spaced={true}
         >

--- a/src/components/ButtonCircle/ButtonCircle.style.scss
+++ b/src/components/ButtonCircle/ButtonCircle.style.scss
@@ -367,3 +367,32 @@
     }
   }
 }
+
+[data-compressed='true'] {
+  > .md-button-circle-wrapper {
+    &[data-size='64'] {
+      width: 3.2rem;
+    }
+
+    &[data-size='52'] {
+      width: 2.6rem;
+    }
+
+    &[data-size='40'] {
+      width: 1.875rem;
+    }
+
+    &[data-size='32'] {
+      width: 1.5rem;
+    }
+
+    &[data-size='28'] {
+      width: 1.31rem;
+    }
+
+    // this size is ONLY for AddReactionButton
+    &[data-size='20'] {
+      width: 1.2rem;
+    }
+  }
+}

--- a/src/components/ButtonGroup/ButtonGroup.constants.ts
+++ b/src/components/ButtonGroup/ButtonGroup.constants.ts
@@ -2,8 +2,8 @@ const CLASS_PREFIX = 'md-button-group';
 
 const DEFAULTS = {
   ROUND: false,
-  SEPARATION: 'none',
   SPACED: false,
+  COMPRESSED: false,
 };
 
 const STYLE = {

--- a/src/components/ButtonGroup/ButtonGroup.stories.args.ts
+++ b/src/components/ButtonGroup/ButtonGroup.stories.args.ts
@@ -33,6 +33,20 @@ export default {
       },
     },
   },
+  compressed: {
+    defaultValue: CONSTANTS.DEFAULTS.SPACED,
+    description: 'Whether to compress horizontal space and remove inner borders around ChildNodes.',
+    options: [true, false],
+    control: { type: 'boolean' },
+    table: {
+      type: {
+        summary: 'boolean',
+      },
+      defaultValue: {
+        summary: CONSTANTS.DEFAULTS.SPACED,
+      },
+    },
+  },
   round: {
     defaultValue: CONSTANTS.DEFAULTS.ROUND,
     description: 'Whether this `<ButtonGroup />` is rounded.',

--- a/src/components/ButtonGroup/ButtonGroup.stories.args.ts
+++ b/src/components/ButtonGroup/ButtonGroup.stories.args.ts
@@ -34,7 +34,7 @@ export default {
     },
   },
   compressed: {
-    defaultValue: CONSTANTS.DEFAULTS.SPACED,
+    defaultValue: CONSTANTS.DEFAULTS.COMPRESSED,
     description: 'Whether to compress horizontal space and remove inner borders around ChildNodes.',
     options: [true, false],
     control: { type: 'boolean' },

--- a/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -34,8 +34,6 @@ const commonChildren = [
   </ButtonCircle>,
 ];
 
-// Example
-
 const Example = Template<ButtonGroupProps>(ButtonGroup).bind({});
 
 Example.args = {
@@ -43,8 +41,6 @@ Example.args = {
 };
 
 Example.argTypes = { ...argTypes };
-
-// Rounding
 
 const Rounding = MultiTemplate<ButtonGroupProps>(ButtonGroup).bind({});
 
@@ -59,8 +55,6 @@ Rounding.parameters = {
 Rounding.argTypes = { ...argTypes };
 delete Rounding.argTypes.round;
 
-// Spacing
-
 const Spacing = MultiTemplate<ButtonGroupProps>(ButtonGroup).bind({});
 
 Spacing.args = {
@@ -73,60 +67,6 @@ Spacing.parameters = {
 
 Spacing.argTypes = { ...argTypes };
 delete Spacing.argTypes.spaced;
-
-// Compressed
-
-const Compressed = MultiTemplate<ButtonGroupProps>(ButtonGroup).bind({});
-Compressed.argTypes = { ...argTypes };
-delete Compressed.argTypes.compressed;
-
-const compressedVariant = (size) => {
-  return {
-    children: [
-      <ButtonCircle key="0" ghost size={size}>
-        <Icon name="camera-presence" autoScale={150} />
-      </ButtonCircle>,
-      <ButtonCircle key="1" ghost size={size}>
-        <Icon name="meetings-presence" autoScale={150} />
-      </ButtonCircle>,
-      <ButtonCircle key="2" ghost size={size}>
-        <Icon name="arrow-down-optical" autoScale={100} />
-      </ButtonCircle>,
-      <ButtonCircle key="3" ghost size={size}>
-        <Icon name="pto-presence" autoScale={150} />
-      </ButtonCircle>,
-    ],
-    compressed: true,
-    style: {
-      backgroundColor: 'var(--button-message-fill-background)',
-    },
-  };
-};
-
-Compressed.parameters = {
-  variants: [
-    compressedVariant(20),
-    compressedVariant(28),
-    compressedVariant(32),
-    compressedVariant(40),
-    compressedVariant(52),
-    compressedVariant(64),
-    {
-      children: [
-        <ButtonPill outline key="0" size={40}>
-          <Icon key="0" name="camera-muted" strokeColor="#FC8B98" autoScale={125} />
-          <div key="1">Start Video</div>
-        </ButtonPill>,
-        <ButtonCircle outline key="1" size={40}>
-          <Icon name="arrow-down-optical" autoScale={100} />
-        </ButtonCircle>,
-      ],
-      compressed: true,
-    },
-  ],
-};
-
-// Audio Video Controls
 
 const AudioVideoControls = MultiTemplate<ButtonGroupProps>(ButtonGroup).bind({});
 AudioVideoControls.argTypes = { ...argTypes };
@@ -220,8 +160,6 @@ AudioVideoControls.parameters = {
     },
   ],
 };
-
-// Common
 
 const Common = MultiTemplate<ButtonGroupProps>(ButtonGroup).bind({});
 
@@ -328,4 +266,4 @@ Common.parameters = {
   ],
 };
 
-export { Example, Spacing, Compressed, AudioVideoControls, Common };
+export { Example, Spacing, AudioVideoControls, Common };

--- a/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -34,6 +34,8 @@ const commonChildren = [
   </ButtonCircle>,
 ];
 
+// Example
+
 const Example = Template<ButtonGroupProps>(ButtonGroup).bind({});
 
 Example.args = {
@@ -41,6 +43,8 @@ Example.args = {
 };
 
 Example.argTypes = { ...argTypes };
+
+// Rounding
 
 const Rounding = MultiTemplate<ButtonGroupProps>(ButtonGroup).bind({});
 
@@ -55,6 +59,8 @@ Rounding.parameters = {
 Rounding.argTypes = { ...argTypes };
 delete Rounding.argTypes.round;
 
+// Spacing
+
 const Spacing = MultiTemplate<ButtonGroupProps>(ButtonGroup).bind({});
 
 Spacing.args = {
@@ -68,11 +74,160 @@ Spacing.parameters = {
 Spacing.argTypes = { ...argTypes };
 delete Spacing.argTypes.spaced;
 
+// Compressed
+
+const Compressed = MultiTemplate<ButtonGroupProps>(ButtonGroup).bind({});
+Compressed.argTypes = { ...argTypes };
+delete Compressed.argTypes.compressed;
+
+const compressedVariant = (size) => {
+  return {
+    children: [
+      <ButtonCircle key="0" ghost size={size}>
+        <Icon name="camera-presence" autoScale={150} />
+      </ButtonCircle>,
+      <ButtonCircle key="1" ghost size={size}>
+        <Icon name="meetings-presence" autoScale={150} />
+      </ButtonCircle>,
+      <ButtonCircle key="2" ghost size={size}>
+        <Icon name="arrow-down-optical" autoScale={100} />
+      </ButtonCircle>,
+      <ButtonCircle key="3" ghost size={size}>
+        <Icon name="pto-presence" autoScale={150} />
+      </ButtonCircle>,
+    ],
+    compressed: true,
+
+    style: {
+      backgroundColor: 'var(--button-message-fill-background)',
+    },
+  };
+};
+
+Compressed.parameters = {
+  variants: [
+    compressedVariant(20),
+    compressedVariant(28),
+    compressedVariant(32),
+    compressedVariant(40),
+    compressedVariant(52),
+    compressedVariant(64),
+    {
+      children: [
+        <ButtonPill outline key="0" size={40}>
+          <Icon key="0" name="camera-muted" strokeColor="#FC8B98" autoScale={125} />
+          <div key="1">Start Video</div>
+        </ButtonPill>,
+        <ButtonCircle outline key="1" size={40}>
+          <Icon name="arrow-down-optical" autoScale={100} />
+        </ButtonCircle>,
+      ],
+      compressed: true,
+    },
+  ],
+};
+
+// Audio Video Controls
+
+const AudioVideoControls = MultiTemplate<ButtonGroupProps>(ButtonGroup).bind({});
+AudioVideoControls.argTypes = { ...argTypes };
+delete AudioVideoControls.argTypes.round;
+delete AudioVideoControls.argTypes.spaced;
+delete AudioVideoControls.argTypes.compressed;
+
+AudioVideoControls.parameters = {
+  variants: [
+    {
+      children: [
+        <ButtonPill outline ghost key="0" size={40} style={{ minWidth: '6.8rem' }}>
+          <Icon
+            key="0"
+            name="audio-microphone-on-colored"
+            autoScale={125}
+            style={{ marginLeft: 'auto' }}
+          />
+          <div key="1" style={{ marginRight: 'auto' }}>
+            Mute
+          </div>
+        </ButtonPill>,
+        <ButtonCircle outline ghost key="1" size={40}>
+          <Icon name="arrow-down-optical" autoScale={100} />
+        </ButtonCircle>,
+      ],
+      round: true,
+      compressed: true,
+    },
+    {
+      children: [
+        <ButtonPill outline ghost key="0" size={40} style={{ minWidth: '6.8rem' }}>
+          <Icon
+            key="0"
+            name="microphone-muted"
+            strokeColor="#FC8B98"
+            autoScale={125}
+            style={{ marginLeft: 'auto' }}
+          />
+          <div key="1" style={{ marginRight: 'auto' }}>
+            Unmute
+          </div>
+        </ButtonPill>,
+        <ButtonCircle outline ghost key="1" size={40}>
+          <Icon name="arrow-down-optical" autoScale={100} />
+        </ButtonCircle>,
+      ],
+      round: true,
+      compressed: true,
+    },
+    {
+      children: [
+        <ButtonPill outline ghost key="0" size={40} style={{ minWidth: '8.3rem' }}>
+          <Icon key="0" name="camera-on-colored" autoScale={125} style={{ marginLeft: 'auto' }} />
+          <div key="1" style={{ marginRight: 'auto' }}>
+            Stop Video
+          </div>
+        </ButtonPill>,
+        <ButtonCircle outline ghost key="1" size={40}>
+          <Icon name="arrow-down-optical" autoScale={100} />
+        </ButtonCircle>,
+      ],
+      round: true,
+      compressed: true,
+    },
+    {
+      children: [
+        <ButtonPill outline ghost key="0" size={40} style={{ minWidth: '8.3rem' }}>
+          <Icon key="0" name="camera-muted" strokeColor="#FC8B98" autoScale={125} />
+          <div key="1">Start Video</div>
+        </ButtonPill>,
+        <ButtonCircle outline ghost key="1" size={40}>
+          <Icon name="arrow-down-optical" autoScale={100} />
+        </ButtonCircle>,
+      ],
+      round: true,
+      compressed: true,
+    },
+    {
+      children: [
+        <ButtonPill outline ghost key="0" size={40} style={{ minWidth: '8.3rem' }}>
+          <Icon key="0" name="camera-muted" strokeColor="#FC8B98" autoScale={125} />
+          <div key="1">Long Label Possibly German</div>
+        </ButtonPill>,
+        <ButtonCircle outline ghost key="1" size={40}>
+          <Icon name="arrow-down-optical" autoScale={100} />
+        </ButtonCircle>,
+      ],
+      round: true,
+      compressed: true,
+    },
+  ],
+};
+
+// Common
+
 const Common = MultiTemplate<ButtonGroupProps>(ButtonGroup).bind({});
 
 Common.argTypes = { ...argTypes };
 delete Common.argTypes.children;
-delete Common.argTypes.separation;
 delete Common.argTypes.spaced;
 delete Common.argTypes.round;
 
@@ -174,4 +329,4 @@ Common.parameters = {
   ],
 };
 
-export { Example, Rounding, Spacing, Common };
+export { Example, Spacing, Compressed, AudioVideoControls, Common };

--- a/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -97,7 +97,6 @@ const compressedVariant = (size) => {
       </ButtonCircle>,
     ],
     compressed: true,
-
     style: {
       backgroundColor: 'var(--button-message-fill-background)',
     },

--- a/src/components/ButtonGroup/ButtonGroup.style.scss
+++ b/src/components/ButtonGroup/ButtonGroup.style.scss
@@ -40,6 +40,41 @@
           border-bottom-right-radius: 100vh;
         }
       }
+
+      &[data-compressed='true'] {
+        > * {
+          &:not(:first-child) {
+            border-left: none;
+            padding-left: 0.2rem;
+          }
+
+          &:not(:last-child) {
+            border-right: none;
+            padding-right: 0.2rem;
+          }
+        }
+      }
+    }
+  }
+
+  &[data-round='false'] {
+    &[data-compressed='true'] {
+      > * {
+        &:not(:first-child) {
+          border-left: none;
+        }
+
+        &:not(:last-child) {
+          border-right: none;
+        }
+      }
+
+      &[data-spaced='false'] {
+        > * {
+          padding-left: 0.2rem;
+          padding-right: 0.2rem;
+        }
+      }
     }
   }
 }

--- a/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.tsx
@@ -6,13 +6,14 @@ import { Props } from './ButtonGroup.types';
 import './ButtonGroup.style.scss';
 
 const ButtonGroup: FC<Props> = (props: Props) => {
-  const { children, className, id, round, spaced, style } = props;
+  const { children, className, id, round, spaced, compressed, style } = props;
 
   return (
     <div
       className={classNames(STYLE.wrapper, className)}
       data-round={round || DEFAULTS.ROUND}
       data-spaced={spaced || DEFAULTS.SPACED}
+      data-compressed={compressed || DEFAULTS.COMPRESSED}
       id={id}
       style={style}
     >

--- a/src/components/ButtonGroup/ButtonGroup.types.ts
+++ b/src/components/ButtonGroup/ButtonGroup.types.ts
@@ -32,6 +32,11 @@ export interface Props {
   spaced?: boolean;
 
   /**
+   * Whether to compress horizontal space and remove inner borders between <SupportedComponents />.
+   */
+  compressed?: boolean;
+
+  /**
    * Custom style for overriding this component's CSS.
    */
   style?: CSSProperties;

--- a/src/components/ButtonGroup/ButtonGroup.unit.test.tsx.snap
+++ b/src/components/ButtonGroup/ButtonGroup.unit.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`<ButtonPill /> snapshot should match snapshot 1`] = `
 <ButtonGroup>
   <div
     className="md-button-group-wrapper"
+    data-compressed={false}
     data-round={false}
     data-spaced={false}
   >
@@ -113,6 +114,7 @@ exports[`<ButtonPill /> snapshot should match snapshot when spaced 1`] = `
 >
   <div
     className="md-button-group-wrapper"
+    data-compressed={false}
     data-round={false}
     data-spaced={true}
   >
@@ -320,6 +322,7 @@ exports[`<ButtonPill /> snapshot should match snapshot with round 1`] = `
 >
   <div
     className="md-button-group-wrapper"
+    data-compressed={false}
     data-round={true}
     data-spaced={false}
   >

--- a/src/components/ButtonPill/ButtonPill.style.scss
+++ b/src/components/ButtonPill/ButtonPill.style.scss
@@ -29,12 +29,9 @@
   }
 
   &[data-outline='true'] {
-    background-color: rgba(0, 0, 0, 0); // IEFIX
-    background-color: var(--button-secondary-background);
-    border-color: rgba(0, 0, 0, 0.3); // IEFIX
-    border-color: var(--button-secondary-border-color);
-    color: rgba(0, 0, 0, 0.95); // IEFIX
-    color: var(--button-secondary-text);
+    background-color: var(--videoSupport-controls-button-background);
+    border-color: var(--videoSupport-controls-button-border-color);
+    color: var(--videoSupport-controls-button-text);
 
     &:hover {
       background-color: rgba(0, 0, 0, 0.07); // IEFIX
@@ -253,7 +250,8 @@
     &[data-outline='true'] {
       background-color: rgba(0, 0, 0, 0); // IEFIX
       background-color: var(--button-ghost-background);
-      border-color: rgba(0, 0, 0, 0);
+      border-color: rgba(0, 0, 0, 0.3); // IEFIX
+      border-color: var(--button-secondary-border-color);
       color: rgba(0, 0, 0, 0.95); // IEFIX
       color: var(--button-ghost-text);
 
@@ -390,5 +388,11 @@
 
   > *:not(:first-child) {
     margin-left: 0.5em;
+  }
+}
+
+[data-compressed='true'][data-spaced='true'] {
+  > .md-button-pill-wrapper {
+    padding: 0 1rem;
   }
 }

--- a/src/components/Coachmark/Coachmark.unit.test.tsx.snap
+++ b/src/components/Coachmark/Coachmark.unit.test.tsx.snap
@@ -49,6 +49,7 @@ exports[`<Coachmark /> snapshot should match snapshot with header 1`] = `
           </h3>
           <div
             class="md-button-group-wrapper"
+            data-compressed="false"
             data-round="true"
             data-spaced="false"
           >
@@ -89,6 +90,7 @@ exports[`<Coachmark /> snapshot should match snapshot with header 1`] = `
         </div>
         <div
           class="md-button-group-wrapper"
+          data-compressed="false"
           data-round="true"
           data-spaced="true"
         >
@@ -186,6 +188,7 @@ exports[`<Coachmark /> snapshot should match snapshot without header 1`] = `
           </div>
           <div
             class="md-button-group-wrapper"
+            data-compressed="false"
             data-round="true"
             data-spaced="true"
           >
@@ -219,6 +222,7 @@ exports[`<Coachmark /> snapshot should match snapshot without header 1`] = `
         </div>
         <div
           class="md-button-group-wrapper md-coachmark-controls"
+          data-compressed="false"
           data-round="true"
           data-spaced="false"
         >

--- a/src/components/MeetingListItem/MeetingListItem.unit.test.tsx.snap
+++ b/src/components/MeetingListItem/MeetingListItem.unit.test.tsx.snap
@@ -148,6 +148,7 @@ exports[`<MeetingListItem /> snapshot should match snapshot with buttonGroup 1`]
               <ButtonGroup>
                 <div
                   className="md-button-group-wrapper"
+                  data-compressed={false}
                   data-round={false}
                   data-spaced={false}
                 />

--- a/src/components/ReactionPicker/ReactionPicker.unit.test.tsx.snap
+++ b/src/components/ReactionPicker/ReactionPicker.unit.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`<ReactionPicker /> snapshot should match snapshot 1`] = `
   >
     <div
       className="md-button-group-wrapper md-reaction-picker-wrapper"
+      data-compressed={false}
       data-round={true}
       data-spaced={false}
     />
@@ -23,6 +24,7 @@ exports[`<ReactionPicker /> snapshot should match snapshot with children 1`] = `
   >
     <div
       className="md-button-group-wrapper md-reaction-picker-wrapper"
+      data-compressed={false}
       data-round={true}
       data-spaced={false}
     >
@@ -92,6 +94,7 @@ exports[`<ReactionPicker /> snapshot should match snapshot with className 1`] = 
   >
     <div
       className="md-button-group-wrapper example-class md-reaction-picker-wrapper"
+      data-compressed={false}
       data-round={true}
       data-spaced={false}
     />
@@ -110,6 +113,7 @@ exports[`<ReactionPicker /> snapshot should match snapshot with id 1`] = `
   >
     <div
       className="md-button-group-wrapper md-reaction-picker-wrapper"
+      data-compressed={false}
       data-round={true}
       data-spaced={false}
       id="example-id"
@@ -137,6 +141,7 @@ exports[`<ReactionPicker /> snapshot should match snapshot with style 1`] = `
   >
     <div
       className="md-button-group-wrapper md-reaction-picker-wrapper"
+      data-compressed={false}
       data-round={true}
       data-spaced={false}
       style={

--- a/src/components/Toast/Toast.unit.test.tsx.snap
+++ b/src/components/Toast/Toast.unit.test.tsx.snap
@@ -390,6 +390,7 @@ exports[`<Toast /> snapshot should match snapshot 1`] = `
         >
           <div
             className="md-button-group-wrapper md-toast-content-actions"
+            data-compressed={false}
             data-round={false}
             data-spaced={true}
           >
@@ -1010,6 +1011,7 @@ exports[`<Toast /> snapshot should match snapshot with className 1`] = `
         >
           <div
             className="md-button-group-wrapper md-toast-content-actions"
+            data-compressed={false}
             data-round={false}
             data-spaced={true}
           >
@@ -1587,6 +1589,7 @@ exports[`<Toast /> snapshot should match snapshot with content children and deta
         >
           <div
             className="md-button-group-wrapper md-toast-content-actions"
+            data-compressed={false}
             data-round={false}
             data-spaced={true}
           >
@@ -2151,6 +2154,7 @@ exports[`<Toast /> snapshot should match snapshot with details and content child
         >
           <div
             className="md-button-group-wrapper md-toast-content-actions"
+            data-compressed={false}
             data-round={false}
             data-spaced={true}
           >
@@ -2757,6 +2761,7 @@ exports[`<Toast /> snapshot should match snapshot with details children and cont
         >
           <div
             className="md-button-group-wrapper md-toast-content-actions"
+            data-compressed={false}
             data-round={false}
             data-spaced={true}
           >
@@ -3378,6 +3383,7 @@ exports[`<Toast /> snapshot should match snapshot with id 1`] = `
         >
           <div
             className="md-button-group-wrapper md-toast-content-actions"
+            data-compressed={false}
             data-round={false}
             data-spaced={true}
           >
@@ -4007,6 +4013,7 @@ exports[`<Toast /> snapshot should match snapshot with style 1`] = `
         >
           <div
             className="md-button-group-wrapper md-toast-content-actions"
+            data-compressed={false}
             data-round={false}
             data-spaced={true}
           >
@@ -4614,6 +4621,7 @@ exports[`<Toast /> snapshot should match snapshot with title 1`] = `
         >
           <div
             className="md-button-group-wrapper md-toast-content-actions"
+            data-compressed={false}
             data-round={false}
             data-spaced={true}
           >

--- a/src/components/ToastContent/ToastContent.unit.test.tsx.snap
+++ b/src/components/ToastContent/ToastContent.unit.test.tsx.snap
@@ -159,6 +159,7 @@ exports[`<ToastContent /> snapshot should match snapshot with complex props 1`] 
     >
       <div
         className="md-button-group-wrapper md-toast-content-actions"
+        data-compressed={false}
         data-round={false}
         data-spaced={true}
       >


### PR DESCRIPTION
# Description

Updates were made to the ButtonGroup component to make it easier to use it with the audio/video controls design.
* Added a "compressed" property to compress horizontal space and remove inner borders around ChildNodes
* Added new Compressed and Audio Video Controls stories.
* Updated snaps of components that used ButtonGroup since it added data-compressed={false} to all of them.

# Links

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-303422

![image](https://user-images.githubusercontent.com/15893389/160640633-8fab8845-1b64-466e-a824-b6525a14fd71.png)
![image](https://user-images.githubusercontent.com/15893389/160641917-22787e0d-3571-42d6-9ccb-84afba22e013.png)

