### PR TITLE
fix(components/button-group): fix right border if MenuTrigger is child

### DIFF
--- a/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -4,6 +4,9 @@ import { MultiTemplate, Template } from '../../storybook/helper.stories.template
 import { DocumentationPage } from '../../storybook/helper.stories.docs';
 import StyleDocs from '../../storybook/docs.stories.style.mdx';
 
+import MenuTrigger from '../MenuTrigger';
+import Menu from '../Menu';
+import { Item } from '@react-stately/collections';
 import ButtonPill from '../ButtonPill';
 import ButtonCircle from '../ButtonCircle';
 import Icon from '../Icon';
@@ -89,9 +92,21 @@ AudioVideoControls.parameters = {
             Mute
           </div>
         </ButtonPill>,
-        <ButtonCircle outline ghost key="1" size={40}>
-          <Icon name="arrow-down-optical" autoScale={100} />
-        </ButtonCircle>,
+        <MenuTrigger
+          key="2"
+          placement="top-end"
+          triggerComponent={
+            <ButtonCircle outline ghost key="1" size={40}>
+              <Icon name="arrow-down-optical" autoScale={100} />
+            </ButtonCircle>
+          }
+          children={[
+            <Menu key="0" selectionMode="single">
+              <Item>Item 1</Item>
+              <Item>Item 2</Item>
+            </Menu>,
+          ]}
+        />,
       ],
       round: true,
       compressed: true,

--- a/src/components/ButtonGroup/ButtonGroup.style.scss
+++ b/src/components/ButtonGroup/ButtonGroup.style.scss
@@ -29,26 +29,26 @@
     border-radius: 100vh;
 
     &[data-spaced='false'] {
-      > * {
-        &:first-child {
+      > button {
+        &:first-of-type {
           border-top-left-radius: 100vh;
           border-bottom-left-radius: 100vh;
         }
 
-        &:last-child {
+        &:last-of-type {
           border-top-right-radius: 100vh;
           border-bottom-right-radius: 100vh;
         }
       }
 
       &[data-compressed='true'] {
-        > * {
-          &:not(:first-child) {
+        > button {
+          &:not(:first-of-type) {
             border-left: none;
             padding-left: 0.2rem;
           }
 
-          &:not(:last-child) {
+          &:not(:last-of-type) {
             border-right: none;
             padding-right: 0.2rem;
           }
@@ -59,12 +59,12 @@
 
   &[data-round='false'] {
     &[data-compressed='true'] {
-      > * {
-        &:not(:first-child) {
+      > button {
+        &:not(:first-of-type) {
           border-left: none;
         }
 
-        &:not(:last-child) {
+        &:not(:last-of-type) {
           border-right: none;
         }
       }


### PR DESCRIPTION
*Provide a general summary of the scope of the changes in this pull request.*

Fix the left and right borders of ButtonGroup when a non-button is included in the children (e.g. MenuTrigger).

(second attempt because first ran into rebase problems)

# Description

Added a MenuTrigger to the Audio Video Controls story as a test. Updated the .scss to select button last/first-of-type when adding begin/end border and border-radius.
