### PR TITLE
feat(components/SpaceListItem): add-draft-message-icon-indicator-inside-space-list

### DIFF
--- a/src/components/Icon/Icon.constants.ts
+++ b/src/components/Icon/Icon.constants.ts
@@ -61,6 +61,7 @@ const EXCEPTION_ICONS_LIST = [
   'error-legacy-badge',
   'info-badge',
   'priority-badge',
+  'draft-indicator-small',
 ];
 
 const STYLE = {

--- a/src/components/SpaceListItem/SpaceListItem.stories.args.ts
+++ b/src/components/SpaceListItem/SpaceListItem.stories.args.ts
@@ -53,7 +53,7 @@ export default {
       },
     },
   },
-  hasDraft: {
+  isDraft: {
     description:
       'Determines whether there is a message draft inside the space that has not been sent',
     table: {

--- a/src/components/SpaceListItem/SpaceListItem.stories.args.ts
+++ b/src/components/SpaceListItem/SpaceListItem.stories.args.ts
@@ -65,18 +65,6 @@ export default {
       },
     },
   },
-  isFileStaged: {
-    description:
-      'Determines whether there is a staged files inside the space that has not been sent',
-    table: {
-      type: {
-        summary: 'boolean',
-      },
-      defaultValue: {
-        summary: 'undefined',
-      },
-    },
-  },
   isUnread: {
     description: 'Determines whether there is content inside the space that is not read.',
     control: { type: 'boolean' },

--- a/src/components/SpaceListItem/SpaceListItem.stories.args.ts
+++ b/src/components/SpaceListItem/SpaceListItem.stories.args.ts
@@ -53,14 +53,15 @@ export default {
       },
     },
   },
-  draft: {
-    description: 'Draft Message',
+  hasDraft: {
+    description:
+      'Determines whether there is a message draft inside the space that has not been sent',
     table: {
       type: {
-        summary: 'string',
+        summary: 'boolean',
       },
       defaultValue: {
-        summary: '',
+        summary: 'undefined',
       },
     },
   },

--- a/src/components/SpaceListItem/SpaceListItem.stories.args.ts
+++ b/src/components/SpaceListItem/SpaceListItem.stories.args.ts
@@ -65,6 +65,18 @@ export default {
       },
     },
   },
+  isFileStaged: {
+    description:
+      'Determines whether there is a staged files inside the space that has not been sent',
+    table: {
+      type: {
+        summary: 'boolean',
+      },
+      defaultValue: {
+        summary: 'undefined',
+      },
+    },
+  },
   isUnread: {
     description: 'Determines whether there is content inside the space that is not read.',
     control: { type: 'boolean' },

--- a/src/components/SpaceListItem/SpaceListItem.stories.args.ts
+++ b/src/components/SpaceListItem/SpaceListItem.stories.args.ts
@@ -53,6 +53,17 @@ export default {
       },
     },
   },
+  draft: {
+    description: 'Draft Message',
+    table: {
+      type: {
+        summary: 'string',
+      },
+      defaultValue: {
+        summary: '',
+      },
+    },
+  },
   isUnread: {
     description: 'Determines whether there is content inside the space that is not read.',
     control: { type: 'boolean' },

--- a/src/components/SpaceListItem/SpaceListItem.tsx
+++ b/src/components/SpaceListItem/SpaceListItem.tsx
@@ -18,6 +18,7 @@ const SpaceListItem: FC<Props> = forwardRef(
   (props: Props, providedRef: RefObject<HTMLLIElement>) => {
     const {
       className,
+      draft,
       id,
       style,
       avatar,
@@ -81,6 +82,8 @@ const SpaceListItem: FC<Props> = forwardRef(
         return <Icon fillColor={'var(--listitem-icon)'} name="alert-muted" {...iconProps} />;
       } else if (isAlert) {
         return <Icon fillColor={'var(--listitem-icon)'} name="alert" {...iconProps} />;
+      } else if (!isSelected && draft) {
+        return <Icon name="draft-indicator-small" {...iconProps} weight="filled" />;
       } else if (isError) {
         return (
           <Icon

--- a/src/components/SpaceListItem/SpaceListItem.tsx
+++ b/src/components/SpaceListItem/SpaceListItem.tsx
@@ -19,6 +19,7 @@ const SpaceListItem: FC<Props> = forwardRef(
     const {
       className,
       isDraft,
+      isFileStaged,
       id,
       style,
       avatar,
@@ -82,7 +83,7 @@ const SpaceListItem: FC<Props> = forwardRef(
         return <Icon fillColor={'var(--listitem-icon)'} name="alert-muted" {...iconProps} />;
       } else if (isAlert) {
         return <Icon fillColor={'var(--listitem-icon)'} name="alert" {...iconProps} />;
-      } else if (!isSelected && isDraft) {
+      } else if (!isSelected && (isDraft || isFileStaged)) {
         return <Icon name="draft-indicator-small" {...iconProps} weight="filled" />;
       } else if (isError) {
         return (

--- a/src/components/SpaceListItem/SpaceListItem.tsx
+++ b/src/components/SpaceListItem/SpaceListItem.tsx
@@ -19,7 +19,6 @@ const SpaceListItem: FC<Props> = forwardRef(
     const {
       className,
       isDraft,
-      isFileStaged,
       id,
       style,
       avatar,
@@ -83,7 +82,7 @@ const SpaceListItem: FC<Props> = forwardRef(
         return <Icon fillColor={'var(--listitem-icon)'} name="alert-muted" {...iconProps} />;
       } else if (isAlert) {
         return <Icon fillColor={'var(--listitem-icon)'} name="alert" {...iconProps} />;
-      } else if (!isSelected && (isDraft || isFileStaged)) {
+      } else if (!isSelected && isDraft) {
         return <Icon name="draft-indicator-small" {...iconProps} weight="filled" />;
       } else if (isError) {
         return (

--- a/src/components/SpaceListItem/SpaceListItem.tsx
+++ b/src/components/SpaceListItem/SpaceListItem.tsx
@@ -18,7 +18,7 @@ const SpaceListItem: FC<Props> = forwardRef(
   (props: Props, providedRef: RefObject<HTMLLIElement>) => {
     const {
       className,
-      hasDraft,
+      isDraft,
       id,
       style,
       avatar,
@@ -82,7 +82,7 @@ const SpaceListItem: FC<Props> = forwardRef(
         return <Icon fillColor={'var(--listitem-icon)'} name="alert-muted" {...iconProps} />;
       } else if (isAlert) {
         return <Icon fillColor={'var(--listitem-icon)'} name="alert" {...iconProps} />;
-      } else if (!isSelected && hasDraft) {
+      } else if (!isSelected && isDraft) {
         return <Icon name="draft-indicator-small" {...iconProps} weight="filled" />;
       } else if (isError) {
         return (

--- a/src/components/SpaceListItem/SpaceListItem.tsx
+++ b/src/components/SpaceListItem/SpaceListItem.tsx
@@ -18,7 +18,7 @@ const SpaceListItem: FC<Props> = forwardRef(
   (props: Props, providedRef: RefObject<HTMLLIElement>) => {
     const {
       className,
-      draft,
+      hasDraft,
       id,
       style,
       avatar,
@@ -82,7 +82,7 @@ const SpaceListItem: FC<Props> = forwardRef(
         return <Icon fillColor={'var(--listitem-icon)'} name="alert-muted" {...iconProps} />;
       } else if (isAlert) {
         return <Icon fillColor={'var(--listitem-icon)'} name="alert" {...iconProps} />;
-      } else if (!isSelected && draft) {
+      } else if (!isSelected && hasDraft) {
         return <Icon name="draft-indicator-small" {...iconProps} weight="filled" />;
       } else if (isError) {
         return (

--- a/src/components/SpaceListItem/SpaceListItem.types.ts
+++ b/src/components/SpaceListItem/SpaceListItem.types.ts
@@ -15,6 +15,11 @@ export interface Props extends PressEvents, ContextMenu {
   isDraft?: boolean;
 
   /**
+   * Staged file inside conversation.
+   */
+  isFileStaged?: boolean;
+
+  /**
    * Custom id for overriding this component's CSS.
    */
   id?: string;

--- a/src/components/SpaceListItem/SpaceListItem.types.ts
+++ b/src/components/SpaceListItem/SpaceListItem.types.ts
@@ -12,7 +12,7 @@ export interface Props extends PressEvents, ContextMenu {
   /**
    * Draft text inside conversation.
    */
-  hasDraft?: boolean;
+  isDraft?: boolean;
 
   /**
    * Custom id for overriding this component's CSS.

--- a/src/components/SpaceListItem/SpaceListItem.types.ts
+++ b/src/components/SpaceListItem/SpaceListItem.types.ts
@@ -12,7 +12,7 @@ export interface Props extends PressEvents, ContextMenu {
   /**
    * Draft text inside conversation.
    */
-  draft?: string;
+  hasDraft?: boolean;
 
   /**
    * Custom id for overriding this component's CSS.

--- a/src/components/SpaceListItem/SpaceListItem.types.ts
+++ b/src/components/SpaceListItem/SpaceListItem.types.ts
@@ -10,6 +10,11 @@ export interface Props extends PressEvents, ContextMenu {
   className?: string;
 
   /**
+   * Draft text inside conversation.
+   */
+  draft?: string;
+
+  /**
    * Custom id for overriding this component's CSS.
    */
   id?: string;

--- a/src/components/SpaceListItem/SpaceListItem.types.ts
+++ b/src/components/SpaceListItem/SpaceListItem.types.ts
@@ -15,11 +15,6 @@ export interface Props extends PressEvents, ContextMenu {
   isDraft?: boolean;
 
   /**
-   * Staged file inside conversation.
-   */
-  isFileStaged?: boolean;
-
-  /**
    * Custom id for overriding this component's CSS.
    */
   id?: string;

--- a/src/components/SpaceListItem/SpaceListItem.unit.test.tsx
+++ b/src/components/SpaceListItem/SpaceListItem.unit.test.tsx
@@ -147,6 +147,17 @@ describe('<SpaceListItem />', () => {
       expect(container).toMatchSnapshot();
     });
 
+    it('should match snapshot with isSelected and draft', async () => {
+      expect.assertions(1);
+
+      const isSelected = false;
+      const draft = 'Test Message';
+
+      const container = await mountAndWait(<SpaceListItem draft={draft} isSelected={isSelected} />);
+
+      expect(container).toMatchSnapshot();
+    });
+
     it('should match snapshot with isError', async () => {
       expect.assertions(1);
 

--- a/src/components/SpaceListItem/SpaceListItem.unit.test.tsx
+++ b/src/components/SpaceListItem/SpaceListItem.unit.test.tsx
@@ -151,10 +151,10 @@ describe('<SpaceListItem />', () => {
       expect.assertions(1);
 
       const isSelected = false;
-      const hasDraft = true;
+      const isDraft = true;
 
       const container = await mountAndWait(
-        <SpaceListItem hasDraft={hasDraft} isSelected={isSelected} />
+        <SpaceListItem isDraft={isDraft} isSelected={isSelected} />
       );
 
       expect(container).toMatchSnapshot();
@@ -366,16 +366,17 @@ describe('<SpaceListItem />', () => {
       expect(element).toBeDefined();
     });
 
-    it('should have provided draft icon when hasDraft is provided', async () => {
+    it('should have provided draft icon when isDraft is provided', async () => {
       expect.assertions(1);
 
       const isSelected = false;
-      const hasDraft = true;
+      const isDraft = true;
 
       const element = (
-        await mountAndWait(<SpaceListItem hasDraft={hasDraft} isSelected={isSelected} />)
+        await mountAndWait(<SpaceListItem isDraft={isDraft} isSelected={isSelected} />)
       )
         .find(Icon)
+        .find('svg[data-test="draft-indicator-small"]')
         .getDOMNode();
 
       expect(element).toBeDefined();

--- a/src/components/SpaceListItem/SpaceListItem.unit.test.tsx
+++ b/src/components/SpaceListItem/SpaceListItem.unit.test.tsx
@@ -152,9 +152,10 @@ describe('<SpaceListItem />', () => {
 
       const isSelected = false;
       const isDraft = true;
+      const isFileStaged = true;
 
       const container = await mountAndWait(
-        <SpaceListItem isDraft={isDraft} isSelected={isSelected} />
+        <SpaceListItem isDraft={isDraft} isFileStaged={isFileStaged} isSelected={isSelected} />
       );
 
       expect(container).toMatchSnapshot();
@@ -371,9 +372,12 @@ describe('<SpaceListItem />', () => {
 
       const isSelected = false;
       const isDraft = true;
+      const isFileStaged = true;
 
       const element = (
-        await mountAndWait(<SpaceListItem isDraft={isDraft} isSelected={isSelected} />)
+        await mountAndWait(
+          <SpaceListItem isDraft={isDraft} isFileStaged={isFileStaged} isSelected={isSelected} />
+        )
       )
         .find(Icon)
         .find('svg[data-test="draft-indicator-small"]')

--- a/src/components/SpaceListItem/SpaceListItem.unit.test.tsx
+++ b/src/components/SpaceListItem/SpaceListItem.unit.test.tsx
@@ -151,9 +151,11 @@ describe('<SpaceListItem />', () => {
       expect.assertions(1);
 
       const isSelected = false;
-      const draft = 'Test Message';
+      const hasDraft = true;
 
-      const container = await mountAndWait(<SpaceListItem draft={draft} isSelected={isSelected} />);
+      const container = await mountAndWait(
+        <SpaceListItem hasDraft={hasDraft} isSelected={isSelected} />
+      );
 
       expect(container).toMatchSnapshot();
     });
@@ -358,6 +360,21 @@ describe('<SpaceListItem />', () => {
       const isAlert = true;
 
       const element = (await mountAndWait(<SpaceListItem isAlert={isAlert} />))
+        .find(Icon)
+        .getDOMNode();
+
+      expect(element).toBeDefined();
+    });
+
+    it('should have provided draft icon when hasDraft is provided', async () => {
+      expect.assertions(1);
+
+      const isSelected = false;
+      const hasDraft = true;
+
+      const element = (
+        await mountAndWait(<SpaceListItem hasDraft={hasDraft} isSelected={isSelected} />)
+      )
         .find(Icon)
         .getDOMNode();
 

--- a/src/components/SpaceListItem/SpaceListItem.unit.test.tsx
+++ b/src/components/SpaceListItem/SpaceListItem.unit.test.tsx
@@ -152,10 +152,9 @@ describe('<SpaceListItem />', () => {
 
       const isSelected = false;
       const isDraft = true;
-      const isFileStaged = true;
 
       const container = await mountAndWait(
-        <SpaceListItem isDraft={isDraft} isFileStaged={isFileStaged} isSelected={isSelected} />
+        <SpaceListItem isDraft={isDraft} isSelected={isSelected} />
       );
 
       expect(container).toMatchSnapshot();
@@ -372,12 +371,9 @@ describe('<SpaceListItem />', () => {
 
       const isSelected = false;
       const isDraft = true;
-      const isFileStaged = true;
 
       const element = (
-        await mountAndWait(
-          <SpaceListItem isDraft={isDraft} isFileStaged={isFileStaged} isSelected={isSelected} />
-        )
+        await mountAndWait(<SpaceListItem isDraft={isDraft} isSelected={isSelected} />)
       )
         .find(Icon)
         .find('svg[data-test="draft-indicator-small"]')

--- a/src/components/SpaceListItem/SpaceListItem.unit.test.tsx.snap
+++ b/src/components/SpaceListItem/SpaceListItem.unit.test.tsx.snap
@@ -1252,7 +1252,7 @@ exports[`<SpaceListItem /> snapshot should match snapshot with isSelected 1`] = 
 
 exports[`<SpaceListItem /> snapshot should match snapshot with isSelected and draft 1`] = `
 <SpaceListItem
-  hasDraft={true}
+  isDraft={true}
   isSelected={false}
 >
   <ListItemBase

--- a/src/components/SpaceListItem/SpaceListItem.unit.test.tsx.snap
+++ b/src/components/SpaceListItem/SpaceListItem.unit.test.tsx.snap
@@ -1253,7 +1253,6 @@ exports[`<SpaceListItem /> snapshot should match snapshot with isSelected 1`] = 
 exports[`<SpaceListItem /> snapshot should match snapshot with isSelected and draft 1`] = `
 <SpaceListItem
   isDraft={true}
-  isFileStaged={true}
   isSelected={false}
 >
   <ListItemBase

--- a/src/components/SpaceListItem/SpaceListItem.unit.test.tsx.snap
+++ b/src/components/SpaceListItem/SpaceListItem.unit.test.tsx.snap
@@ -1252,7 +1252,7 @@ exports[`<SpaceListItem /> snapshot should match snapshot with isSelected 1`] = 
 
 exports[`<SpaceListItem /> snapshot should match snapshot with isSelected and draft 1`] = `
 <SpaceListItem
-  draft="Test Message"
+  hasDraft={true}
   isSelected={false}
 >
   <ListItemBase

--- a/src/components/SpaceListItem/SpaceListItem.unit.test.tsx.snap
+++ b/src/components/SpaceListItem/SpaceListItem.unit.test.tsx.snap
@@ -1253,6 +1253,7 @@ exports[`<SpaceListItem /> snapshot should match snapshot with isSelected 1`] = 
 exports[`<SpaceListItem /> snapshot should match snapshot with isSelected and draft 1`] = `
 <SpaceListItem
   isDraft={true}
+  isFileStaged={true}
   isSelected={false}
 >
   <ListItemBase

--- a/src/components/SpaceListItem/SpaceListItem.unit.test.tsx.snap
+++ b/src/components/SpaceListItem/SpaceListItem.unit.test.tsx.snap
@@ -1250,6 +1250,117 @@ exports[`<SpaceListItem /> snapshot should match snapshot with isSelected 1`] = 
 </SpaceListItem>
 `;
 
+exports[`<SpaceListItem /> snapshot should match snapshot with isSelected and draft 1`] = `
+<SpaceListItem
+  draft="Test Message"
+  isSelected={false}
+>
+  <ListItemBase
+    className="md-space-list-item-wrapper"
+    isSelected={false}
+    shape="isPilled"
+    size={50}
+  >
+    <FocusRing
+      isInset={false}
+    >
+      <FocusRing
+        focusClass="md-focus-ring-wrapper children"
+        focusRingClass="md-focus-ring-wrapper children"
+        isInset={false}
+      >
+        <li
+          className="md-space-list-item-wrapper md-list-item-base-wrapper"
+          data-disabled={false}
+          data-interactive={true}
+          data-padded={false}
+          data-shape="isPilled"
+          data-size={50}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onDragStart={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchCancel={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          role="listitem"
+          tabIndex={-1}
+        >
+          <ListItemBaseSection
+            position="start"
+          >
+            <div
+              data-position="start"
+            />
+          </ListItemBaseSection>
+          <ListItemBaseSection
+            className="md-space-list-item-text-wrapper text-column"
+            position="middle"
+          >
+            <div
+              className="md-space-list-item-text-wrapper text-column"
+              data-position="middle"
+            >
+              <Text
+                data-test="list-item-first-line"
+                type="body-primary"
+              >
+                <p
+                  className="md-text-wrapper"
+                  data-test="list-item-first-line"
+                  data-type="body-primary"
+                />
+              </Text>
+            </div>
+          </ListItemBaseSection>
+          <ListItemBaseSection
+            position="end"
+          >
+            <div
+              data-position="end"
+            >
+              <Icon
+                name="draft-indicator-small"
+                scale={14}
+                strokeColor="none"
+                weight="filled"
+              >
+                <div
+                  className="md-icon-wrapper"
+                >
+                  <svg
+                    className=""
+                    data-autoscale={false}
+                    data-scale={14}
+                    data-test="draft-indicator-small"
+                    fill="currentColor"
+                    height="100%"
+                    style={
+                      Object {
+                        "stroke": "none",
+                      }
+                    }
+                    viewBox="0, 0, 14, 14"
+                    width="100%"
+                  />
+                </div>
+              </Icon>
+            </div>
+          </ListItemBaseSection>
+        </li>
+      </FocusRing>
+    </FocusRing>
+  </ListItemBase>
+</SpaceListItem>
+`;
+
 exports[`<SpaceListItem /> snapshot should match snapshot with isUnread 1`] = `
 <SpaceListItem
   isUnread={true}


### PR DESCRIPTION
# IMPORTANT

**Currently, this project is closed to any external contributions. Any pull request made against this project from external sources will likely be closed. If you would like to make changes to this project, please fork this project.**

# Guide

**This "Help" section can be deleted before submitting this pull request.**

*Update the name of this pull request to reflect the following shape:*

```
{type}/{scope?}/{message}
```

* **type** - A [conventional commit type](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional#type-enum) **REQUIRED**
* **scope** - The kabab-case scope of the changes in this request
* **message** - A short, kebab-case statement describing the changes **REQUIRED**

*Provide a general summary of the scope of the changes in this pull request.*

* [Readme](https://github.com/momentum-design/momentum-react-v2/blob/master/README.md)
* [Getting Started Guide](https://github.com/momentum-design/momentum-react-v2/blob/master/GETTING_STARTED.md)
* [Contributing Guide](https://github.com/momentum-design/momentum-react-v2/blob/master/CONTRIBUTING.md)

# Description
 When a user fails/forgets to send a message there is no visible indicator on the space list to notify them that they have a draft .
Here we are adding draft icon indicator which will be shown inside space list for conversation with draft message.


# Links
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-320156

