### PR TITLE
feat(menu-trigger): bug fixes

### DIFF
--- a/src/components/MenuTrigger/MenuTrigger.stories.docs.mdx
+++ b/src/components/MenuTrigger/MenuTrigger.stories.docs.mdx
@@ -5,11 +5,61 @@ The `<MenuTrigger />` component. Implemented using [useMenuTrigger](https://reac
 The `<Menu />` element follows the [Collection Components API](https://react-spectrum.adobe.com/react-stately/collections.html) from the `@react-stately` library, accepting both static and dynamic collections. `<Menu />` accepts `<Item />` elements as children, each with a key prop. Basic usage of `<Menu />`, seen in the example below, shows multiple options populated with a string.
 Simple element with simple options as text.
 
+## Important!
+
+The `<Menu />` components provided to the `<MenuTrigger />` need to be separated and not grouped together!
+For example, if you have a wrapper component that groups together 2 Menus related to each other, and you render
+that component inside the `<MenuTrigger />` as one single child, the MenuTrigger will not identify the Menus
+correctly and will break accessibility.
+
+Therefore you need to pass 2 children (one per `<Menu />`).
+
+### Don't
+
+```js
+const Menus = (<Menu key="1"/><Menu  key="2"/><Menu  key="3"/>);
+...
+return (
+  <MenuTrigger>
+   <Menus/> // donn't do this!
+  </MenuTrigger>
+);
+```
+
+### Do
+
+```js
+return (
+  <MenuTrigger>
+    <Menu key="1" /> // do this
+    <Menu key="2" />
+    <Menu key="3" />
+  </MenuTrigger>
+);
+```
+
+The type of each child doesn't necessarily need to be `Menu`, as long as the leaf component of the child resolves to `Menu`.
+Exmaple
+
+```js
+const WrappedSettingsMenu = (
+  <WrappedSettingsContainer>
+    <Menu/>
+  </WrappedSettingsContainer>
+);
+const WrappeedShareMenu = (<Menu/>);
+...
+return (
+  <MenuTrigger>
+    <WrappedSettingsMenu/>
+    <WrappeedShareMenu />
+  </MenuTrigger>
+);
+```
+
 ## Children Structure
 
 ```
-+-------------------------+
-| Target Button Component |
 +-------------------------+
 | Menu Component 1        |
 +-------------------------+
@@ -22,10 +72,14 @@ Simple element with simple options as text.
 ## Simple example
 
 ```js
-<MenuTrigger closeOnSelect={true}>
-  <ButtonPill key="1">
-    <div>Menu</div> <Icon name="arrow-down" weight="bold" autoScale={100} />
-  </ButtonPill>
+<MenuTrigger
+  closeOnSelect={true}
+  triggerComponent={
+    <ButtonPill key="1">
+      <div>Menu</div> <Icon name="arrow-down" weight="bold" autoScale={100} />
+    </ButtonPill>
+  }
+>
   <Menu selectionMode="single" key="2">
     <Item key="one">One</Item>
     <Item key="two">Two</Item>
@@ -42,10 +96,14 @@ Simple element with simple options as text.
 This is a more complex example showing how to build a menu trigger with multiple selection modes
 
 ```js
-<MenuTrigger closeOnSelect={false}>
-  <ButtonPill key="1">
-    <div>Mixed Selection</div> <Icon name="arrow-down" weight="bold" autoScale={100} />
-  </ButtonPill>
+<MenuTrigger
+  closeOnSelect={false}
+  triggerComponent={
+    <ButtonPill key="1">
+      <div>Mixed Selection</div> <Icon name="arrow-down" weight="bold" autoScale={100} />
+    </ButtonPill>
+  }
+>
   <Menu selectionMode="single" key="2">
     <Item key="one">One</Item>
     <Item key="two">Two</Item>

--- a/src/components/MenuTrigger/MenuTrigger.tsx
+++ b/src/components/MenuTrigger/MenuTrigger.tsx
@@ -76,7 +76,6 @@ const MenuTrigger: FC<Props> = (props: Props) => {
         popoverInstance.show();
       } else {
         popoverInstance.hide();
-        state.close();
       }
     }
   }, [isOpen, popoverInstance]);

--- a/src/components/MenuTrigger/MenuTrigger.tsx
+++ b/src/components/MenuTrigger/MenuTrigger.tsx
@@ -6,9 +6,8 @@ import { Props } from './MenuTrigger.types';
 import './MenuTrigger.style.scss';
 import { useMenuTriggerState } from '@react-stately/menu';
 import { useMenuTrigger } from '@react-aria/menu';
-import Menu, { MenuContext } from '../Menu';
+import { MenuContext } from '../Menu';
 import { DismissButton } from '@react-aria/overlays';
-import { verifyTypes } from '../../helpers/verifyTypes';
 import { FocusScope } from '@react-aria/focus';
 import { useKeyboard } from '@react-aria/interactions';
 import ContentSeparator from '../ContentSeparator';
@@ -42,10 +41,6 @@ const MenuTrigger: FC<Props> = (props: Props) => {
   const [...menus] = Children.toArray(children);
 
   const { menuTriggerProps, menuProps } = useMenuTrigger({ type: 'menu' }, state, buttonRef);
-
-  if (!verifyTypes(menus, Menu)) {
-    console.warn('MenuTrigger: All children must be a Menu component.');
-  }
 
   /**
    * For some reason restoreFocus prop on <FocusScope> doesn't
@@ -81,6 +76,7 @@ const MenuTrigger: FC<Props> = (props: Props) => {
         popoverInstance.show();
       } else {
         popoverInstance.hide();
+        state.close();
       }
     }
   }, [isOpen, popoverInstance]);
@@ -125,6 +121,7 @@ const MenuTrigger: FC<Props> = (props: Props) => {
       variant={variant as VariantType}
       delay={delay}
       color={color}
+      onClickOutside={state.close}
       setInstance={setPopoverInstance}
       {...(keyboardProps as Omit<React.HTMLAttributes<HTMLElement>, 'color'>)}
     >

--- a/src/components/MenuTrigger/MenuTrigger.types.ts
+++ b/src/components/MenuTrigger/MenuTrigger.types.ts
@@ -1,4 +1,4 @@
-import { CSSProperties, ReactElement } from 'react';
+import { CSSProperties, ReactElement, ReactNode } from 'react';
 import { MenuTriggerProps } from '@react-types/menu';
 import type { PopoverCommonStyleProps, PlacementType } from '../Popover/Popover.types';
 
@@ -8,7 +8,7 @@ export interface Props
   /**
    * Child components of this Popover (what will be shown within the Popover)
    */
-  children: ReactElement[];
+  children: ReactNode;
 
   /**
    * Custom class for overriding this component's CSS.

--- a/src/components/MenuTrigger/MenuTrigger.types.ts
+++ b/src/components/MenuTrigger/MenuTrigger.types.ts
@@ -1,5 +1,5 @@
-import { CSSProperties, ReactElement, ReactNode } from 'react';
-import { MenuTriggerProps } from '@react-types/menu';
+import type { CSSProperties, ReactElement, ReactNode } from 'react';
+import type { MenuTriggerProps } from '@react-types/menu';
 import type { PopoverCommonStyleProps, PlacementType } from '../Popover/Popover.types';
 
 export interface Props

--- a/src/components/MenuTrigger/MenuTrigger.unit.test.tsx.snap
+++ b/src/components/MenuTrigger/MenuTrigger.unit.test.tsx.snap
@@ -14,6 +14,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot 1`] = `
     className="md-menu-trigger-wrapper"
     color="primary"
     interactive={true}
+    onClickOutside={[Function]}
     onKeyDown={[Function]}
     placement="bottom-start"
     setInstance={[Function]}
@@ -44,6 +45,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot 1`] = `
           5,
         ]
       }
+      onClickOutside={[Function]}
       placement="bottom-start"
       popperOptions={
         Object {
@@ -79,6 +81,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot 1`] = `
             5,
           ]
         }
+        onClickOutside={[Function]}
         placement="bottom-start"
         plugins={
           Array [
@@ -121,6 +124,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot 1`] = `
               5,
             ]
           }
+          onClickOutside={[Function]}
           placement="bottom-start"
           plugins={
             Array [
@@ -2193,6 +2197,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with className 
     className="example-class md-menu-trigger-wrapper"
     color="primary"
     interactive={true}
+    onClickOutside={[Function]}
     onKeyDown={[Function]}
     placement="bottom-start"
     setInstance={[Function]}
@@ -2223,6 +2228,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with className 
           5,
         ]
       }
+      onClickOutside={[Function]}
       placement="bottom-start"
       popperOptions={
         Object {
@@ -2258,6 +2264,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with className 
             5,
           ]
         }
+        onClickOutside={[Function]}
         placement="bottom-start"
         plugins={
           Array [
@@ -2300,6 +2307,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with className 
               5,
             ]
           }
+          onClickOutside={[Function]}
           placement="bottom-start"
           plugins={
             Array [
@@ -4372,6 +4380,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with color 1`] 
     className="md-menu-trigger-wrapper"
     color="secondary"
     interactive={true}
+    onClickOutside={[Function]}
     onKeyDown={[Function]}
     placement="bottom-start"
     setInstance={[Function]}
@@ -4402,6 +4411,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with color 1`] 
           5,
         ]
       }
+      onClickOutside={[Function]}
       placement="bottom-start"
       popperOptions={
         Object {
@@ -4437,6 +4447,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with color 1`] 
             5,
           ]
         }
+        onClickOutside={[Function]}
         placement="bottom-start"
         plugins={
           Array [
@@ -4479,6 +4490,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with color 1`] 
               5,
             ]
           }
+          onClickOutside={[Function]}
           placement="bottom-start"
           plugins={
             Array [
@@ -6552,6 +6564,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with id 1`] = `
     color="primary"
     id="example-id"
     interactive={true}
+    onClickOutside={[Function]}
     onKeyDown={[Function]}
     placement="bottom-start"
     setInstance={[Function]}
@@ -6582,6 +6595,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with id 1`] = `
           5,
         ]
       }
+      onClickOutside={[Function]}
       placement="bottom-start"
       popperOptions={
         Object {
@@ -6617,6 +6631,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with id 1`] = `
             5,
           ]
         }
+        onClickOutside={[Function]}
         placement="bottom-start"
         plugins={
           Array [
@@ -6659,6 +6674,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with id 1`] = `
               5,
             ]
           }
+          onClickOutside={[Function]}
           placement="bottom-start"
           plugins={
             Array [
@@ -8734,6 +8750,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with placement 
     className="md-menu-trigger-wrapper"
     color="primary"
     interactive={true}
+    onClickOutside={[Function]}
     onKeyDown={[Function]}
     placement="top"
     setInstance={[Function]}
@@ -8764,6 +8781,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with placement 
           5,
         ]
       }
+      onClickOutside={[Function]}
       placement="top"
       popperOptions={
         Object {
@@ -8799,6 +8817,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with placement 
             5,
           ]
         }
+        onClickOutside={[Function]}
         placement="top"
         plugins={
           Array [
@@ -8841,6 +8860,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with placement 
               5,
             ]
           }
+          onClickOutside={[Function]}
           placement="top"
           plugins={
             Array [
@@ -10913,6 +10933,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with showArrow 
     className="md-menu-trigger-wrapper"
     color="primary"
     interactive={true}
+    onClickOutside={[Function]}
     onKeyDown={[Function]}
     placement="bottom-start"
     setInstance={[Function]}
@@ -10943,6 +10964,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with showArrow 
           17,
         ]
       }
+      onClickOutside={[Function]}
       placement="bottom-start"
       popperOptions={
         Object {
@@ -10978,6 +11000,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with showArrow 
             17,
           ]
         }
+        onClickOutside={[Function]}
         placement="bottom-start"
         plugins={
           Array [
@@ -11020,6 +11043,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with showArrow 
               17,
             ]
           }
+          onClickOutside={[Function]}
           placement="bottom-start"
           plugins={
             Array [
@@ -13160,6 +13184,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with style 1`] 
     className="md-menu-trigger-wrapper"
     color="primary"
     interactive={true}
+    onClickOutside={[Function]}
     onKeyDown={[Function]}
     placement="bottom-start"
     setInstance={[Function]}
@@ -13195,6 +13220,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with style 1`] 
           5,
         ]
       }
+      onClickOutside={[Function]}
       placement="bottom-start"
       popperOptions={
         Object {
@@ -13230,6 +13256,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with style 1`] 
             5,
           ]
         }
+        onClickOutside={[Function]}
         placement="bottom-start"
         plugins={
           Array [
@@ -13272,6 +13299,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with style 1`] 
               5,
             ]
           }
+          onClickOutside={[Function]}
           placement="bottom-start"
           plugins={
             Array [
@@ -15355,6 +15383,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with variant 1`
     className="md-menu-trigger-wrapper"
     color="primary"
     interactive={true}
+    onClickOutside={[Function]}
     onKeyDown={[Function]}
     placement="bottom-start"
     setInstance={[Function]}
@@ -15385,6 +15414,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with variant 1`
           5,
         ]
       }
+      onClickOutside={[Function]}
       placement="bottom-start"
       popperOptions={
         Object {
@@ -15420,6 +15450,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with variant 1`
             5,
           ]
         }
+        onClickOutside={[Function]}
         placement="bottom-start"
         plugins={
           Array [
@@ -15462,6 +15493,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with variant 1`
               5,
             ]
           }
+          onClickOutside={[Function]}
           placement="bottom-start"
           plugins={
             Array [

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -31,6 +31,7 @@ const Popover: FC<Props> = (props: Props) => {
     className,
     id,
     style,
+    onClickOutside,
     ...rest
   } = props;
 
@@ -70,6 +71,7 @@ const Popover: FC<Props> = (props: Props) => {
       trigger={trigger === 'mouseenter' ? 'mouseenter focusin' : trigger}
       interactive={interactive}
       appendTo="parent"
+      onClickOutside={onClickOutside}
       popperOptions={{
         modifiers: [
           {

--- a/src/components/Popover/Popover.types.ts
+++ b/src/components/Popover/Popover.types.ts
@@ -107,4 +107,9 @@ export interface Props extends PopoverCommonStyleProps {
    * Custom style for overriding this component's CSS.
    */
   style?: CSSProperties;
+
+  /**
+   * Callback when user clicks outside the target.
+   */
+  onClickOutside?: (instance: Instance, event: Event) => void;
 }


### PR DESCRIPTION
# Description
- the internal state of the menuTrigger doesn't reflect correctly when popover was closed via click outside
- warnings about type of children in MenuTrigger, removed
- children type for MenuTrigger is `ReactElement[]` which is wrong, it's supposed to be `ReactNode`. 
- updated docs for MenuTrigger