### PR TITLE
feat(icons): tooltips for space list icons

### DIFF
--- a/src/components/Icon/Icon.constants.ts
+++ b/src/components/Icon/Icon.constants.ts
@@ -61,7 +61,6 @@ const EXCEPTION_ICONS_LIST = [
   'error-legacy-badge',
   'info-badge',
   'priority-badge',
-  'draft-indicator-small',
 ];
 
 const STYLE = {

--- a/src/components/Icon/Icon.constants.ts
+++ b/src/components/Icon/Icon.constants.ts
@@ -61,6 +61,7 @@ const EXCEPTION_ICONS_LIST = [
   'error-legacy-badge',
   'info-badge',
   'priority-badge',
+  'draft-indicator-small',
 ];
 
 const STYLE = {

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -26,6 +26,7 @@ const Icon: React.FC<Props> = (props: Props) => {
     scale,
     strokeColor,
     style,
+    title,
     weight,
     ...otherProps
   } = props;
@@ -78,7 +79,7 @@ const Icon: React.FC<Props> = (props: Props) => {
 
   if (SvgIcon) {
     return (
-      <div className={classnames(STYLE.wrapper, className)} id={id} style={style}>
+      <div className={classnames(STYLE.wrapper, className)} id={id} style={style} title={title}>
         <SvgIcon
           // coloured class is added to avoid theming the fixed colours inside coloured icons
           data-test={name}

--- a/src/components/Icon/Icon.types.ts
+++ b/src/components/Icon/Icon.types.ts
@@ -76,6 +76,11 @@ export interface Props {
   style?: CSSProperties;
 
   /**
+   * Custom title string on the icon hover.
+   */
+  title?: string;
+
+  /**
    * Represents the style of the icon.
    *
    * @remarks

--- a/src/components/Icon/Icon.types.ts
+++ b/src/components/Icon/Icon.types.ts
@@ -76,7 +76,7 @@ export interface Props {
   style?: CSSProperties;
 
   /**
-   * Custom title string on the icon hover.
+   * Provides accessibility label when icon is hovered
    */
   title?: string;
 

--- a/src/components/Icon/Icon.unit.test.tsx
+++ b/src/components/Icon/Icon.unit.test.tsx
@@ -46,6 +46,16 @@ describe('<Icon />', () => {
       expect(container).toMatchSnapshot();
     });
 
+    it('should match snapshot with title', async () => {
+      expect.assertions(1);
+
+      const title = 'You have a draft message';
+
+      container = await mountAndWait(<Icon name="draft-indicator-bold" title={title} />);
+
+      expect(container).toMatchSnapshot();
+    });
+
     it('should match snapshot with scale', async () => {
       expect.assertions(1);
 
@@ -161,6 +171,17 @@ describe('<Icon />', () => {
       const element = wrapper.find(Icon).getDOMNode();
 
       expect(element.getAttribute('style')).toBe(styleString);
+    });
+
+    it('should have provided title when title is provided', async () => {
+      expect.assertions(1);
+
+      const title = 'You have a draft message';
+
+      const wrapper = await mountAndWait(<Icon name="draft-indicator-bold" title={title} />);
+      const element = wrapper.find(Icon).getDOMNode();
+
+      expect(element.getAttribute('title')).toBe(title);
     });
 
     it('should pass scale prop', async () => {

--- a/src/components/Icon/Icon.unit.test.tsx.snap
+++ b/src/components/Icon/Icon.unit.test.tsx.snap
@@ -291,6 +291,30 @@ exports[`<Icon /> snapshot should match snapshot with style 1`] = `
 </Icon>
 `;
 
+exports[`<Icon /> snapshot should match snapshot with title 1`] = `
+<Icon
+  name="draft-indicator-bold"
+  title="You have a draft message"
+>
+  <div
+    className="md-icon-wrapper"
+    title="You have a draft message"
+  >
+    <svg
+      className=""
+      data-autoscale={false}
+      data-scale={32}
+      data-test="draft-indicator-bold"
+      fill="currentColor"
+      height="100%"
+      style={Object {}}
+      viewBox="0, 0, 32, 32"
+      width="100%"
+    />
+  </div>
+</Icon>
+`;
+
 exports[`<Icon /> snapshot should match snapshot with weight 1`] = `
 <Icon
   name="accessibility"

--- a/src/components/SpaceListItem/SpaceListItem.tsx
+++ b/src/components/SpaceListItem/SpaceListItem.tsx
@@ -74,64 +74,29 @@ const SpaceListItem: FC<Props> = forwardRef(
         weight: 'bold' as const,
         scale: 14 as const,
         strokeColor: 'none',
+        title: rightIconTooltip,
       };
       if (isMention) {
-        return (
-          <Icon
-            fillColor={'var(--listitem-tick)'}
-            name="mention"
-            {...iconProps}
-            title={rightIconTooltip}
-          />
-        );
+        return <Icon fillColor={'var(--listitem-tick)'} name="mention" {...iconProps} />;
       } else if (isEnterRoom) {
-        return (
-          <Icon
-            fillColor={'var(--listitem-tick)'}
-            name="enter-room"
-            {...iconProps}
-            title={rightIconTooltip}
-          />
-        );
+        return <Icon fillColor={'var(--listitem-tick)'} name="enter-room" {...iconProps} />;
       } else if (isAlertMuted) {
-        return (
-          <Icon
-            fillColor={'var(--listitem-icon)'}
-            name="alert-muted"
-            {...iconProps}
-            title={rightIconTooltip}
-          />
-        );
+        return <Icon fillColor={'var(--listitem-icon)'} name="alert-muted" {...iconProps} />;
       } else if (isAlert) {
-        return (
-          <Icon
-            fillColor={'var(--listitem-icon)'}
-            name="alert"
-            {...iconProps}
-            title={rightIconTooltip}
-          />
-        );
+        return <Icon fillColor={'var(--listitem-icon)'} name="alert" {...iconProps} />;
       } else if (!isSelected && isDraft) {
-        return <Icon name="draft-indicator" {...iconProps} title={rightIconTooltip} />;
+        return <Icon name="draft-indicator" {...iconProps} />;
       } else if (isError) {
         return (
           <Icon
             fillColor={'var(--label-error-text)'}
             name="priority-circle"
-            title={rightIconTooltip}
             {...iconProps}
             weight="filled"
           />
         );
       } else if (isUnread) {
-        return (
-          <Icon
-            name="unread"
-            fillColor={'var(--listitem-tick)'}
-            title={rightIconTooltip}
-            {...iconProps}
-          />
-        );
+        return <Icon name="unread" fillColor={'var(--listitem-tick)'} {...iconProps} />;
       } else if (action) {
         return <>{action}</>;
       } else return null;

--- a/src/components/SpaceListItem/SpaceListItem.tsx
+++ b/src/components/SpaceListItem/SpaceListItem.tsx
@@ -36,6 +36,7 @@ const SpaceListItem: FC<Props> = forwardRef(
       isSelected,
       isCompact = false,
       itemIndex,
+      rightIconTooltip,
       ...rest
     } = props;
 
@@ -75,26 +76,62 @@ const SpaceListItem: FC<Props> = forwardRef(
         strokeColor: 'none',
       };
       if (isMention) {
-        return <Icon fillColor={'var(--listitem-tick)'} name="mention" {...iconProps} />;
+        return (
+          <Icon
+            fillColor={'var(--listitem-tick)'}
+            name="mention"
+            {...iconProps}
+            title={rightIconTooltip}
+          />
+        );
       } else if (isEnterRoom) {
-        return <Icon fillColor={'var(--listitem-tick)'} name="enter-room" {...iconProps} />;
+        return (
+          <Icon
+            fillColor={'var(--listitem-tick)'}
+            name="enter-room"
+            {...iconProps}
+            title={rightIconTooltip}
+          />
+        );
       } else if (isAlertMuted) {
-        return <Icon fillColor={'var(--listitem-icon)'} name="alert-muted" {...iconProps} />;
+        return (
+          <Icon
+            fillColor={'var(--listitem-icon)'}
+            name="alert-muted"
+            {...iconProps}
+            title={rightIconTooltip}
+          />
+        );
       } else if (isAlert) {
-        return <Icon fillColor={'var(--listitem-icon)'} name="alert" {...iconProps} />;
+        return (
+          <Icon
+            fillColor={'var(--listitem-icon)'}
+            name="alert"
+            {...iconProps}
+            title={rightIconTooltip}
+          />
+        );
       } else if (!isSelected && isDraft) {
-        return <Icon name="draft-indicator" {...iconProps} />;
+        return <Icon name="draft-indicator" {...iconProps} title={rightIconTooltip} />;
       } else if (isError) {
         return (
           <Icon
             fillColor={'var(--label-error-text)'}
             name="priority-circle"
+            title={rightIconTooltip}
             {...iconProps}
             weight="filled"
           />
         );
       } else if (isUnread) {
-        return <Icon name="unread" fillColor={'var(--listitem-tick)'} {...iconProps} />;
+        return (
+          <Icon
+            name="unread"
+            fillColor={'var(--listitem-tick)'}
+            title={rightIconTooltip}
+            {...iconProps}
+          />
+        );
       } else if (action) {
         return <>{action}</>;
       } else return null;

--- a/src/components/SpaceListItem/SpaceListItem.types.ts
+++ b/src/components/SpaceListItem/SpaceListItem.types.ts
@@ -100,7 +100,7 @@ export interface Props extends PressEvents, ContextMenu {
   itemIndex?: number;
 
   /**
-   * Right icon tooltip shown on hover
+   * Right icon tooltip shown on hover.
    */
   rightIconTooltip?: string;
 }

--- a/src/components/SpaceListItem/SpaceListItem.types.ts
+++ b/src/components/SpaceListItem/SpaceListItem.types.ts
@@ -98,4 +98,9 @@ export interface Props extends PressEvents, ContextMenu {
    * Used to manage focus when this is used inside a list.
    */
   itemIndex?: number;
+
+  /**
+   * Right icon tooltip shown on hover
+   */
+  rightIconTooltip?: string;
 }


### PR DESCRIPTION
# Description
Currently we do not provide users with tooltip information regarding space list icons on Web. Tooltips are needed for most icons as it is not obvious to the user what they are. This was highlighted after the introduction of the draft indicator.

**OLD IMPLEMENTATION (without tooltip)** 
![tooltip-old](https://user-images.githubusercontent.com/25443019/165300028-59d42699-c64c-4be8-b19c-b82179dce702.gif)

**NEW IMPLEMENTATION (with tooltip)**
![tooltip-new](https://user-images.githubusercontent.com/25443019/165300019-4608f8d9-d677-4483-b64d-6c22e27105a1.gif)

# Links

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-323707
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-323825
https://www.figma.com/file/IyTViwqLFPjlbmX84QeQd8/SPARK-320154%3A-Tooltips-for-space-list-icons?node-id=2%3A3)

PR on web-webex-client
https://sqbu-github.cisco.com/WebExSquared/webex-web-client/pull/2594