### PR TITLE
fix(expose-boundary): expose Tippy overflow boundary prop

### DIFF
--- a/src/components/Popover/Popover.constants.ts
+++ b/src/components/Popover/Popover.constants.ts
@@ -6,7 +6,7 @@ const CLASS_PREFIX = 'md-popover';
 const BOUNDARIES = {
   VIEWPORT: 'viewport',
   WINDOW: 'window',
-  PARENT: 'parent',
+  PARENT: 'scrollParent',
 };
 
 const DEFAULTS = {

--- a/src/components/Popover/Popover.constants.ts
+++ b/src/components/Popover/Popover.constants.ts
@@ -3,6 +3,12 @@ import { COLORS } from '../ModalContainer/ModalContainer.constants';
 
 const CLASS_PREFIX = 'md-popover';
 
+const BOUNDARIES = {
+  VIEWPORT: 'viewport',
+  WINDOW: 'window',
+  PARENT: 'parent',
+};
+
 const DEFAULTS = {
   VARIANT: 'small',
   TRIGGER: 'click',
@@ -10,6 +16,7 @@ const DEFAULTS = {
   SHOW_ARROW: true,
   INTERACTIVE: false,
   COLOR: COLORS.PRIMARY,
+  BOUNDARY: BOUNDARIES.PARENT,
 };
 
 const STYLE = {
@@ -23,4 +30,4 @@ const OFFSET = 5;
 // padding between the edge of the popover and the arrow, to ensure the arrow doesn't get pushed outside
 const ARROW_PADDING = 5;
 
-export { CLASS_PREFIX, DEFAULTS, STYLE, OFFSET, ARROW_PADDING };
+export { CLASS_PREFIX, DEFAULTS, STYLE, OFFSET, ARROW_PADDING, BOUNDARIES };

--- a/src/components/Popover/Popover.stories.args.ts
+++ b/src/components/Popover/Popover.stories.args.ts
@@ -1,7 +1,7 @@
 import { commonStyles } from '../../storybook/helper.stories.argtypes';
 import { PLACEMENTS } from '../ModalArrow/ModalArrow.constants';
 import { COLORS } from '../ModalContainer/ModalContainer.constants';
-import { DEFAULTS } from './Popover.constants';
+import { DEFAULTS, BOUNDARIES } from './Popover.constants';
 
 const popoverArgTypes = {
   trigger: {
@@ -88,6 +88,19 @@ const popoverArgTypes = {
       },
       defaultValue: {
         summary: DEFAULTS.COLOR,
+      },
+    },
+  },
+  boundary: {
+    description: 'The overflow boundary of the popover element.',
+    control: { type: 'select' },
+    options: [...Object.values(BOUNDARIES)],
+    table: {
+      type: {
+        summary: 'string',
+      },
+      defaultValue: {
+        summary: DEFAULTS.BOUNDARY,
       },
     },
   },

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -32,7 +32,7 @@ const Popover: FC<Props> = (props: Props) => {
     id,
     style,
     onClickOutside,
-    boundary,
+    boundary = DEFAULTS.BOUNDARY,
     ...rest
   } = props;
 

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -32,6 +32,7 @@ const Popover: FC<Props> = (props: Props) => {
     id,
     style,
     onClickOutside,
+    boundary,
     ...rest
   } = props;
 
@@ -86,6 +87,7 @@ const Popover: FC<Props> = (props: Props) => {
             name: 'preventOverflow',
             options: {
               altAxis: true,
+              boundariesElement: boundary,
             },
           },
         ],

--- a/src/components/Popover/Popover.types.ts
+++ b/src/components/Popover/Popover.types.ts
@@ -57,7 +57,7 @@ export type PopoverCommonStyleProps = {
   /**
    * overflow Boundary of Popover
    *
-   * Possible values: `parent`, `viewport`, `window`, or any `HTMLElement`
+   * Possible values: `scrollParent`, `viewport`, `window`, or any `HTMLElement`
    *
    * @default `parent`
    */

--- a/src/components/Popover/Popover.types.ts
+++ b/src/components/Popover/Popover.types.ts
@@ -5,6 +5,7 @@ import type { Color } from '../ModalContainer/ModalContainer.types';
 
 // variant - based on Figma mockups:
 export type VariantType = 'small' | 'medium';
+export type BoundaryType = 'parent' | 'viewport' | 'window' | HTMLElement;
 
 export type PlacementType = TippyProps['placement'];
 export type TriggerType = TippyProps['trigger'];
@@ -52,6 +53,15 @@ export type PopoverCommonStyleProps = {
    * @default `bottom`
    */
   placement?: PlacementType;
+
+  /**
+   * overflow Boundary of Popover
+   *
+   * Possible values: `parent`, `viewport`, `window`, or any `HTMLElement`
+   *
+   * @default `parent`
+   */
+  boundary?: BoundaryType;
 };
 
 export interface Props extends PopoverCommonStyleProps {

--- a/src/components/Popover/Popover.types.ts
+++ b/src/components/Popover/Popover.types.ts
@@ -59,7 +59,7 @@ export type PopoverCommonStyleProps = {
    *
    * Possible values: `scrollParent`, `viewport`, `window`, or any `HTMLElement`
    *
-   * @default `parent`
+   * @default `scollParent`
    */
   boundary?: BoundaryType;
 };


### PR DESCRIPTION
# Description
Exposes overflow boundary prop for Tippy, currently overflow boundary will default to scrollParent 
*The full description of the changes made in this request.*
Added boundary to types, stories, constants and in component. 
# Links
https://popper.js.org/docs/v1/#modifiers..preventOverflow.boundariesElement

https://atomiks.github.io/tippyjs/v5/all-props/

[Related ticket](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-224523)

*Links to relevent resources.*
