### PR TITLE
fix(reaction): css fix for reaction count alignment

### DIFF
--- a/src/components/ReactionBadge/ReactionBadge.style.scss
+++ b/src/components/ReactionBadge/ReactionBadge.style.scss
@@ -11,6 +11,7 @@
   color: var(--reaction-badge-primary-unreacted-text);
 
   .reaction-badge-count {
+    height: 1rem;
     margin-left: 0.25rem;
   }
 


### PR DESCRIPTION
# Description

Small CSS fix for reaction count's vertical alignment. [As per the figma](https://www.figma.com/file/NaNrfXjygZtRgMfHAFHjsp/Components---Windows?node-id=5585%3A13026) the height for the div/span should've been 16px/1rem

![image](https://user-images.githubusercontent.com/50709949/168379199-bd42ecef-1412-4ad4-a3fe-f800ca6bcf82.png)

Left: with CSS fix | Right: current view

# Links

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-224533
https://www.figma.com/file/NaNrfXjygZtRgMfHAFHjsp/Components---Windows?node-id=5585%3A13026

*Links to relevent resources.*
