### PR TITLE
Fix svgr dynamic loading

### DIFF
--- a/config/typescript/tsconfig.cjs.json
+++ b/config/typescript/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "module": "CommonJS",
+    "module": "es2020",
     "outDir": "../../dist/cjs",
   },
   "extends": "./tsconfig.build.json"

--- a/config/typescript/tsconfig.esm.json
+++ b/config/typescript/tsconfig.esm.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "module": "ES6",
+    "module": "es2020",
     "outDir": "../../dist/esm",
   },
   "extends": "./tsconfig.build.json"

--- a/jest.config.js
+++ b/jest.config.js
@@ -18,7 +18,8 @@ module.exports = {
     '\\.(jpg|jpeg|png|gif|eot|otf|webp|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
       '<rootDir>/tools/assetsTransformer.js',
     '\\.(scss|css|less)$': '<rootDir>/tools/assetsTransformer.js',
-    '\\.svg$': '<rootDir>/tools/svgMock.js',
+    '\\.svg\\?svgr$': '<rootDir>/tools/svgMock.js',
+    '\\/reactions/.*\\.json\\?lottie$': '<rootDir>/tools/reactionMock.js',
     ...moduleMaps,
   },
 };

--- a/src/components/Icon/Icon.unit.test.tsx
+++ b/src/components/Icon/Icon.unit.test.tsx
@@ -114,12 +114,18 @@ describe('<Icon />', () => {
 
     it('should match snapshot with invalid name', async () => {
       expect.assertions(1);
-      jest.setMock('@momentum-ui/icons-rebrand/svg/invalid_icon_name.svg', undefined);
+      jest.mock(
+        '@momentum-ui/icons-rebrand/svg/invalid_icon_name.svg?svgr',
+        () => {
+          throw new Error('error');
+        },
+        { virtual: true }
+      );
 
       container = await mountAndWait(<Icon name="invalid_icon_name" />);
 
       expect(container).toMatchSnapshot();
-      jest.dontMock('@momentum-ui/icons-rebrand/svg/invalid_icon_name.svg');
+      jest.dontMock('@momentum-ui/icons-rebrand/svg/invalid_icon_name.svg?svgr');
     });
 
     it('should match snapshot with small icons', async () => {

--- a/src/hooks/useDynamicJSONImport.test.ts
+++ b/src/hooks/useDynamicJSONImport.test.ts
@@ -10,7 +10,7 @@ describe('SVG', () => {
     const onErrorMock = jest.fn();
     const mockSVG = 'JSON_CONTENT';
     jest.mock(
-      '@momentum-ui/animations/lottie/reactions/test_json-regular.json',
+      '@momentum-ui/animations/lottie/reactions/test_json-regular.json?lottie',
       () => {
         return mockSVG;
       },
@@ -39,11 +39,12 @@ describe('SVG', () => {
     const name = 'bad_icon';
     const onCompleteMock = jest.fn();
     const onErrorMock = jest.fn();
+    const expectedError = new Error('error');
 
     jest.mock(
-      '@momentum-ui/animations/lottie/reactions/test_json-regular.json',
+      '@momentum-ui/animations/lottie/reactions/bad_icon.json?lottie',
       () => {
-        return undefined;
+        throw expectedError;
       },
       { virtual: true }
     );
@@ -55,9 +56,12 @@ describe('SVG', () => {
       })
     );
 
+    await hook.waitForNextUpdate();
+
     expect(onCompleteMock).not.toBeCalled();
 
     expect(onErrorMock).toBeCalled();
+    expect(onErrorMock).toBeCalledWith(expectedError);
     expect(hook.result.current.animationData).toEqual(undefined);
     expect(hook.result.current.error).toBeTruthy();
     expect(hook.result.current.loading).toBe(false);

--- a/src/hooks/useDynamicJSONImport.ts
+++ b/src/hooks/useDynamicJSONImport.ts
@@ -38,8 +38,9 @@ function useDynamicJSONImport(
       try {
         setError(undefined);
         setError(undefined);
-        ImportedJSONRef.current =
-          await require(`@momentum-ui/animations/lottie/reactions/${name}.json`);
+        ImportedJSONRef.current = (
+          await import(`@momentum-ui/animations/lottie/reactions/${name}.json?lottie`)
+        ).default;
         if (isMounted()) {
           onCompleted?.(name, ImportedJSONRef.current);
         }

--- a/src/hooks/useDynamicSVGImport.test.ts
+++ b/src/hooks/useDynamicSVGImport.test.ts
@@ -9,9 +9,13 @@ describe('Icon', () => {
     const onCompleteMock = jest.fn();
     const onErrorMock = jest.fn();
     const mockSVG = 'SVG_CONTENT';
-    jest.mock('@momentum-ui/icons-rebrand/svg/test_icon-regular.svg', () => {
-      return { ReactComponent: mockSVG };
-    });
+    jest.mock(
+      '@momentum-ui/icons-rebrand/svg/test_icon-regular.svg?svgr',
+      () => {
+        return { ReactComponent: mockSVG };
+      },
+      { virtual: true }
+    );
 
     const hook = renderHook(() =>
       useDynamicSVGImport(name, {
@@ -35,9 +39,15 @@ describe('Icon', () => {
     const name = 'bad_icon';
     const onCompleteMock = jest.fn();
     const onErrorMock = jest.fn();
-    const expectedError = new TypeError("Cannot read property 'ReactComponent' of undefined");
+    const expectedError = new Error('error');
 
-    jest.setMock('@momentum-ui/icons-rebrand/svg/bad_icon-regular.svg', undefined);
+    jest.mock(
+      '@momentum-ui/icons-rebrand/svg/bad_icon.svg?svgr',
+      () => {
+        throw expectedError;
+      },
+      { virtual: true }
+    );
 
     const hook = renderHook(() =>
       useDynamicSVGImport(name, {

--- a/src/hooks/useDynamicSVGImport.ts
+++ b/src/hooks/useDynamicSVGImport.ts
@@ -38,7 +38,7 @@ function useDynamicSVGImport(
       try {
         setError(undefined);
         ImportedIconRef.current = (
-          await require(`@momentum-ui/icons-rebrand/svg/${name}.svg`)
+          await import(`@momentum-ui/icons-rebrand/svg/${name}.svg?svgr`)
         ).ReactComponent;
         if (isMounted()) {
           onCompleted?.(name, ImportedIconRef.current);

--- a/tools/reactionMock.js
+++ b/tools/reactionMock.js
@@ -1,0 +1,2 @@
+import * as React from 'react';
+export default JSON.stringify({});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "module": "ES2020",
     "allowJs": true,
     "allowSyntheticDefaultImports": true,
     "alwaysStrict": true,


### PR DESCRIPTION
# Description

Update the module for both cjs and esm to es2020. This is necessary for SVGs to be dynamically loaded.
The reaction animations work the same way so I also fixed those as well.

A way to test this is working on the storybook is to pop out the Icon story page as a separate window. Open the network tab and refresh the page. There should be a separate request for the icon chunk (it will be a js bundle)

This will break downstream projects that require less than es2020 support. They should push momentum through babel if that support is required.

# Links

*Links to relevent resources.*
