### PR TITLE
fix(Popover): fix top arrow

### DIFF
--- a/src/components/ModalContainer/ModalContainer.style.scss
+++ b/src/components/ModalContainer/ModalContainer.style.scss
@@ -11,7 +11,7 @@
 
   /* Arrow placement (svg arrow size is 12px, that's why the following offsets are set like that) */
   &[data-placement^='top'] > .md-modal-container-arrow-wrapper {
-    top: 12px;
+    top: 40px;
   }
 
   &[data-placement^='right'] > .md-modal-container-arrow-wrapper {

--- a/src/components/Popover/Popover.stories.tsx
+++ b/src/components/Popover/Popover.stories.tsx
@@ -37,7 +37,11 @@ Example.args = {
   color: COLORS.PRIMARY,
   delay: [0, 0],
   children: <p>Content Text Content Text</p>,
-  triggerComponent: <ButtonSimple useNativeKeyDown>Click me!</ButtonSimple>,
+  triggerComponent: (
+    <ButtonSimple style={{ margin: '10rem auto', display: 'flex' }} useNativeKeyDown>
+      Click me!
+    </ButtonSimple>
+  ),
 };
 
 const InteractiveContent = Template<PopoverProps>(Popover).bind({});
@@ -52,7 +56,9 @@ InteractiveContent.args = {
   variant: 'small',
   color: COLORS.TERTIARY,
   delay: [0, 0],
-  triggerComponent: <ButtonPill>Click me!</ButtonPill>,
+  triggerComponent: (
+    <ButtonPill style={{ margin: '10rem auto', display: 'flex' }}>Click me!</ButtonPill>
+  ),
   children: (
     <Menu selectionMode="single" key="2" style={{ width: '200px' }}>
       <Item key="one">One</Item>
@@ -76,7 +82,9 @@ Common.parameters = {
       children: <p>Non-interactive Content on TERTIARY color, variant medium</p>,
       trigger: 'click',
       triggerComponent: (
-        <ButtonSimple style={{ height: '50px', width: '100px', marginRight: '10px' }}>
+        <ButtonSimple
+          style={{ height: '50px', width: '100px', margin: '10rem auto', display: 'flex' }}
+        >
           Click me!
         </ButtonSimple>
       ),
@@ -89,7 +97,9 @@ Common.parameters = {
       children: <p>Non-interactive Content on PRIMARY color, variant small, without arrow</p>,
       trigger: 'mouseenter',
       triggerComponent: (
-        <ButtonSimple style={{ height: '50px', width: '100px', marginRight: '10px' }}>
+        <ButtonSimple
+          style={{ height: '50px', width: '100px', margin: '10rem auto', display: 'flex' }}
+        >
           Hover me!
         </ButtonSimple>
       ),


### PR DESCRIPTION

# Description

Popover when set to top placement, messes up with the arrow.

*The full description of the changes made in this request.*
<img width="402" alt="image" src="https://user-images.githubusercontent.com/104304483/173536945-5104925b-9246-4261-baa6-a2c7d117fb1f.png">
<img width="381" alt="image" src="https://user-images.githubusercontent.com/104304483/173536993-2463063f-bf7f-456b-a6da-9d985f33b874.png">

# Links

*Links to relevent resources.*
