### PR TITLE
fix: added hideOnEsc on Popover

### DIFF
--- a/src/components/MenuTrigger/MenuTrigger.tsx
+++ b/src/components/MenuTrigger/MenuTrigger.tsx
@@ -122,6 +122,7 @@ const MenuTrigger: FC<Props> = (props: Props) => {
       color={color}
       onClickOutside={state.close}
       setInstance={setPopoverInstance}
+      hideOnEsc={false}
       {...(keyboardProps as Omit<React.HTMLAttributes<HTMLElement>, 'color'>)}
     >
       <FocusScope restoreFocus contain>

--- a/src/components/MenuTrigger/MenuTrigger.unit.test.tsx
+++ b/src/components/MenuTrigger/MenuTrigger.unit.test.tsx
@@ -249,7 +249,7 @@ describe('<MenuTrigger /> - React Testing Library', () => {
       expect(onOpenChangeMock).toHaveBeenCalledTimes(1);
       onOpenChangeMock.mockClear();
 
-      userEvent.keyboard('{escape}');
+      userEvent.keyboard('{Escape}');
 
       expect(onOpenChangeMock).toHaveBeenCalledWith(false);
       expect(onOpenChangeMock).toHaveBeenCalledTimes(1);
@@ -333,7 +333,7 @@ describe('<MenuTrigger /> - React Testing Library', () => {
       const menu = await screen.findByRole('menu', { name: 'Single Menu' });
       expect(menu).toBeVisible();
 
-      userEvent.keyboard('{escape}');
+      userEvent.keyboard('{Escape}');
 
       await waitFor(() => {
         expect(screen.queryByRole('menu', { name: 'Single Menu' })).not.toBeInTheDocument();

--- a/src/components/MenuTrigger/MenuTrigger.unit.test.tsx.snap
+++ b/src/components/MenuTrigger/MenuTrigger.unit.test.tsx.snap
@@ -13,6 +13,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot 1`] = `
   <Popover
     className="md-menu-trigger-wrapper"
     color="primary"
+    hideOnEsc={false}
     interactive={true}
     onClickOutside={[Function]}
     onKeyDown={[Function]}
@@ -2201,6 +2202,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with className 
   <Popover
     className="example-class md-menu-trigger-wrapper"
     color="primary"
+    hideOnEsc={false}
     interactive={true}
     onClickOutside={[Function]}
     onKeyDown={[Function]}
@@ -4389,6 +4391,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with color 1`] 
   <Popover
     className="md-menu-trigger-wrapper"
     color="secondary"
+    hideOnEsc={false}
     interactive={true}
     onClickOutside={[Function]}
     onKeyDown={[Function]}
@@ -6577,6 +6580,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with id 1`] = `
   <Popover
     className="md-menu-trigger-wrapper"
     color="primary"
+    hideOnEsc={false}
     id="example-id"
     interactive={true}
     onClickOutside={[Function]}
@@ -8769,6 +8773,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with placement 
   <Popover
     className="md-menu-trigger-wrapper"
     color="primary"
+    hideOnEsc={false}
     interactive={true}
     onClickOutside={[Function]}
     onKeyDown={[Function]}
@@ -10957,6 +10962,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with showArrow 
   <Popover
     className="md-menu-trigger-wrapper"
     color="primary"
+    hideOnEsc={false}
     interactive={true}
     onClickOutside={[Function]}
     onKeyDown={[Function]}
@@ -13213,6 +13219,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with style 1`] 
   <Popover
     className="md-menu-trigger-wrapper"
     color="primary"
+    hideOnEsc={false}
     interactive={true}
     onClickOutside={[Function]}
     onKeyDown={[Function]}
@@ -15417,6 +15424,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with variant 1`
   <Popover
     className="md-menu-trigger-wrapper"
     color="primary"
+    hideOnEsc={false}
     interactive={true}
     onClickOutside={[Function]}
     onKeyDown={[Function]}

--- a/src/components/Popover/Popover.constants.ts
+++ b/src/components/Popover/Popover.constants.ts
@@ -17,6 +17,7 @@ const DEFAULTS = {
   INTERACTIVE: false,
   COLOR: COLORS.PRIMARY,
   BOUNDARY: BOUNDARIES.PARENT,
+  HIDE_ON_ESC: true,
 };
 
 const STYLE = {

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -7,6 +7,7 @@ import { ARROW_PADDING, DEFAULTS, OFFSET } from './Popover.constants';
 import { ARROW_HEIGHT } from '../ModalArrow/ModalArrow.constants';
 import type { Props } from './Popover.types';
 import type { PlacementType } from '../ModalArrow/ModalArrow.types';
+import { hideOnEscPlugin } from './tippyPlugins';
 
 /**
  * The Popover component allows adding a Popover to whatever provided
@@ -33,6 +34,7 @@ const Popover: FC<Props> = (props: Props) => {
     style,
     onClickOutside,
     boundary = DEFAULTS.BOUNDARY,
+    hideOnEsc = DEFAULTS.HIDE_ON_ESC,
     ...rest
   } = props;
 
@@ -94,6 +96,7 @@ const Popover: FC<Props> = (props: Props) => {
       }}
       animation={false}
       delay={delay}
+      plugins={hideOnEsc ? [hideOnEscPlugin] : undefined}
       // add arrow height to default offset if arrow is shown:
       offset={[0, showArrow ? ARROW_HEIGHT + OFFSET : OFFSET]}
     >

--- a/src/components/Popover/Popover.types.ts
+++ b/src/components/Popover/Popover.types.ts
@@ -62,6 +62,13 @@ export type PopoverCommonStyleProps = {
    * @default `scollParent`
    */
   boundary?: BoundaryType;
+
+  /**
+   * Whether the popover should hide when Esc is pressed
+   *
+   * @default true
+   */
+  hideOnEsc?: boolean;
 };
 
 export interface Props extends PopoverCommonStyleProps {

--- a/src/components/Popover/Popover.unit.test.tsx
+++ b/src/components/Popover/Popover.unit.test.tsx
@@ -291,5 +291,56 @@ describe('<Popover />', () => {
         expect(screen.queryByText('Content')).not.toBeInTheDocument();
       });
     });
+
+    it('should hide Popover after pressing Esc by default', async () => {
+      expect.assertions(3);
+
+      render(
+        <Popover triggerComponent={<button>Click Me!</button>} trigger="click">
+          <p>Content</p>
+        </Popover>
+      );
+
+      // assert no popover on screen
+      const contentBeforeClick = screen.queryByText('Content');
+      expect(contentBeforeClick).not.toBeInTheDocument();
+
+      // after click, popover should be shown
+      userEvent.click(screen.getByRole('button', { name: /click me!/i }));
+      const content = await screen.findByText('Content');
+      expect(content).toBeVisible();
+
+      userEvent.keyboard('{Escape}');
+
+      // content should be hidden
+      await waitFor(() => {
+        expect(screen.queryByText('Content')).not.toBeInTheDocument();
+      });
+    });
+
+    it('should not hide Popover after pressing Esc when hideOnEsc is false', async () => {
+      expect.assertions(3);
+
+      render(
+        <Popover triggerComponent={<button>Click Me!</button>} trigger="click" hideOnEsc={false}>
+          <p>Content</p>
+        </Popover>
+      );
+
+      // assert no popover on screen
+      const contentBeforeClick = screen.queryByText('Content');
+      expect(contentBeforeClick).not.toBeInTheDocument();
+
+      // after click, popover should be shown
+      userEvent.click(screen.getByRole('button', { name: /click me!/i }));
+      const content = await screen.findByText('Content');
+      expect(content).toBeVisible();
+
+      userEvent.keyboard('{Escape}');
+
+      // content should still be visible
+      const contentAfterEsc = await screen.findByText('Content');
+      expect(contentAfterEsc).toBeVisible();
+    });
   });
 });

--- a/src/components/Popover/tippyPlugins.test.ts
+++ b/src/components/Popover/tippyPlugins.test.ts
@@ -1,0 +1,13 @@
+import { hideOnEscPlugin } from './tippyPlugins';
+
+describe('tippyPlugins', () => {
+  describe('hideOnEscPlugin', () => {
+    it('should return plugin correctly', () => {
+      expect(hideOnEscPlugin).toStrictEqual({
+        name: 'hideOnEsc',
+        defaultValue: true,
+        fn: expect.any(Function),
+      });
+    });
+  });
+});

--- a/src/components/Popover/tippyPlugins.ts
+++ b/src/components/Popover/tippyPlugins.ts
@@ -1,10 +1,10 @@
-/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+import type { Plugin } from 'tippy.js';
 
 // Tippy plugin to add hiding on Esc to Popover:
-export const hideOnEscPlugin = {
+export const hideOnEscPlugin: Plugin = {
   name: 'hideOnEsc',
   defaultValue: true,
-  fn({ hide }: { hide: () => void }) {
+  fn({ hide }) {
     // hide popover when Escape key is pressed
     function onKeyDown(event: KeyboardEvent) {
       if (event.key === 'Escape') {

--- a/src/components/Popover/tippyPlugins.ts
+++ b/src/components/Popover/tippyPlugins.ts
@@ -1,0 +1,24 @@
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+
+// Tippy plugin to add hiding on Esc to Popover:
+export const hideOnEscPlugin = {
+  name: 'hideOnEsc',
+  defaultValue: true,
+  fn({ hide }: { hide: () => void }) {
+    // hide popover when Escape key is pressed
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        hide();
+      }
+    }
+
+    return {
+      onShow() {
+        document.addEventListener('keydown', onKeyDown);
+      },
+      onHide() {
+        document.removeEventListener('keydown', onKeyDown);
+      },
+    };
+  },
+};


### PR DESCRIPTION
# Description

- Added a plugin to Popover to fix the hideOnEsc (hideOnEsc is turned on by default)
- Added unit tests for it
- Set hideOnEsc to false in MenuTrigger component (Escape is handled separately there).

Side Note: noticed Bug in MenuTrigger, which could be fixed with this new hideOnEsc Popover functionality:
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-342208

# Links

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-342004
