### PR TITLE
fix(tag): pointer cursor on pressable tag

### DIFF
--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -8,7 +8,6 @@ import CardStatus from './CardStatus';
 import { DEFAULTS, STYLE } from './Card.constants';
 import type { Props } from './Card.types';
 import './Card.style.scss';
-import { isDisabled } from '@testing-library/user-event/dist/utils';
 
 /**
  * The Card component.

--- a/src/components/Tag/Tag.constants.ts
+++ b/src/components/Tag/Tag.constants.ts
@@ -30,6 +30,7 @@ const DEFAULTS = {
 
 const STYLE = {
   wrapper: `${CLASS_PREFIX}-wrapper`,
+  pressable: `${CLASS_PREFIX}-pressable`,
 };
 
 export { CLASS_PREFIX, COLORS, DEFAULTS, STYLE, FORMATS, FORMATS_DISABLED };

--- a/src/components/Tag/Tag.stories.tsx
+++ b/src/components/Tag/Tag.stories.tsx
@@ -23,6 +23,7 @@ Example.argTypes = { ...argTypes };
 
 Example.args = {
   children: 'Example',
+  onPress: () => alert('Pressed'),
 };
 
 const Colors = MultiTemplate<TagProps>(Tag).bind({});

--- a/src/components/Tag/Tag.style.scss
+++ b/src/components/Tag/Tag.style.scss
@@ -113,6 +113,10 @@
   border-color: var(--local-border-color);
   color: var(--local-text-color);
 
+  &.md-tag-pressable {
+    cursor: pointer;
+  }
+
   &:hover {
     background-color: var(--local-background-hover);
   }

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -30,7 +30,7 @@ const Tag: FC<Props> = (props: Props) => {
   return (
     <ButtonSimple
       className={classnames(STYLE.wrapper, className, {
-         [STYLE.pressable]: props.onPress && !disabled
+         [STYLE.pressable]: props.onPress && !disabled,
       })}
       data-color={disabled ? DEFAULTS.COLOR : color}
       data-format={format}

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -30,7 +30,7 @@ const Tag: FC<Props> = (props: Props) => {
   return (
     <ButtonSimple
       className={classnames(STYLE.wrapper, className, {
-         [STYLE.pressable]: props.onPress && !disabled,
+        [STYLE.pressable]: props.onPress && !disabled,
       })}
       data-color={disabled ? DEFAULTS.COLOR : color}
       data-format={format}

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -29,7 +29,9 @@ const Tag: FC<Props> = (props: Props) => {
 
   return (
     <ButtonSimple
-      className={classnames(...clsNames)}
+      className={classnames(STYLE.wrapper, className, {
+         [STYLE.pressable]: props.onPress && !disabled
+      })}
       data-color={disabled ? DEFAULTS.COLOR : color}
       data-format={format}
       isDisabled={disabled}

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -22,10 +22,14 @@ const Tag: FC<Props> = (props: Props) => {
   } = props;
 
   const disabled = isDisabled || FORMATS_DISABLED.includes(format);
+  const clsNames = [STYLE.wrapper, className];
+  if (props.onPress && !disabled) {
+    clsNames.push(STYLE.pressable);
+  }
 
   return (
     <ButtonSimple
-      className={classnames(STYLE.wrapper, className)}
+      className={classnames(...clsNames)}
       data-color={disabled ? DEFAULTS.COLOR : color}
       data-format={format}
       isDisabled={disabled}

--- a/src/components/Tag/Tag.types.ts
+++ b/src/components/Tag/Tag.types.ts
@@ -28,4 +28,10 @@ export interface Props extends ButtonSimpleProps {
    * Special type for this component.
    */
   format?: Format;
+
+  /**
+   * Determines if this component is disabled
+   * @default false
+   */
+  isDisabled?: boolean;
 }

--- a/src/components/Tag/Tag.unit.test.tsx
+++ b/src/components/Tag/Tag.unit.test.tsx
@@ -200,6 +200,40 @@ describe('<Tag />', () => {
 
       expect(component.getAttribute(attribute)).toBe(CONSTANTS.DEFAULTS.COLOR);
     });
+
+    it('should have pressable class when onPress is provided', async () => {
+      expect.assertions(1);
+
+      const spy = jest.fn();
+
+      render(<Tag data-testid={testid} onPress={spy} />);
+
+      const component = await screen.findByTestId(testid);
+
+      expect(component.classList.contains('md-tag-pressable')).toBe(true);
+    });
+
+    it('should not have pressable class when onPress is not provided', async () => {
+      expect.assertions(1);
+
+      render(<Tag data-testid={testid} />);
+
+      const component = await screen.findByTestId(testid);
+
+      expect(component.classList.contains('md-tag-pressable')).toBe(false);
+    });
+
+    it('should not have pressable class when disabled', async () => {
+      expect.assertions(1);
+
+      const spy = jest.fn();
+
+      render(<Tag data-testid={testid} onPress={spy} isDisabled />);
+
+      const component = await screen.findByTestId(testid);
+
+      expect(component.classList.contains('md-tag-pressable')).toBe(false);
+    });
   });
 
   describe('actions', () => {


### PR DESCRIPTION
When a tag is "pressable" (used as a button), the cursor should be set to the pointer (to match our other buttons).

# Description

* Updated Tag component to add an 'md-tag-pressable' css class that has a 'cursor: pointer' style.
* Added tests for pressable/not-pressable, etc
* Added the missing isDisabled type
* removed an unused line of code in Card.tsx (unrelated to this change)

# Links

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-336426
