### PR TITLE
feat(popover): add close btn and focusBackOnTrigger

### DIFF
--- a/src/components/MenuTrigger/MenuTrigger.unit.test.tsx.snap
+++ b/src/components/MenuTrigger/MenuTrigger.unit.test.tsx.snap
@@ -47,6 +47,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot 1`] = `
         ]
       }
       onClickOutside={[Function]}
+      onHide={[Function]}
       placement="bottom-start"
       popperOptions={
         Object {
@@ -84,6 +85,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot 1`] = `
           ]
         }
         onClickOutside={[Function]}
+        onHide={[Function]}
         placement="bottom-start"
         plugins={
           Array [
@@ -128,6 +130,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot 1`] = `
             ]
           }
           onClickOutside={[Function]}
+          onHide={[Function]}
           placement="bottom-start"
           plugins={
             Array [
@@ -2236,6 +2239,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with className 
         ]
       }
       onClickOutside={[Function]}
+      onHide={[Function]}
       placement="bottom-start"
       popperOptions={
         Object {
@@ -2273,6 +2277,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with className 
           ]
         }
         onClickOutside={[Function]}
+        onHide={[Function]}
         placement="bottom-start"
         plugins={
           Array [
@@ -2317,6 +2322,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with className 
             ]
           }
           onClickOutside={[Function]}
+          onHide={[Function]}
           placement="bottom-start"
           plugins={
             Array [
@@ -4425,6 +4431,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with color 1`] 
         ]
       }
       onClickOutside={[Function]}
+      onHide={[Function]}
       placement="bottom-start"
       popperOptions={
         Object {
@@ -4462,6 +4469,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with color 1`] 
           ]
         }
         onClickOutside={[Function]}
+        onHide={[Function]}
         placement="bottom-start"
         plugins={
           Array [
@@ -4506,6 +4514,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with color 1`] 
             ]
           }
           onClickOutside={[Function]}
+          onHide={[Function]}
           placement="bottom-start"
           plugins={
             Array [
@@ -6615,6 +6624,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with id 1`] = `
         ]
       }
       onClickOutside={[Function]}
+      onHide={[Function]}
       placement="bottom-start"
       popperOptions={
         Object {
@@ -6652,6 +6662,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with id 1`] = `
           ]
         }
         onClickOutside={[Function]}
+        onHide={[Function]}
         placement="bottom-start"
         plugins={
           Array [
@@ -6696,6 +6707,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with id 1`] = `
             ]
           }
           onClickOutside={[Function]}
+          onHide={[Function]}
           placement="bottom-start"
           plugins={
             Array [
@@ -8807,6 +8819,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with placement 
         ]
       }
       onClickOutside={[Function]}
+      onHide={[Function]}
       placement="top"
       popperOptions={
         Object {
@@ -8844,6 +8857,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with placement 
           ]
         }
         onClickOutside={[Function]}
+        onHide={[Function]}
         placement="top"
         plugins={
           Array [
@@ -8888,6 +8902,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with placement 
             ]
           }
           onClickOutside={[Function]}
+          onHide={[Function]}
           placement="top"
           plugins={
             Array [
@@ -10996,6 +11011,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with showArrow 
         ]
       }
       onClickOutside={[Function]}
+      onHide={[Function]}
       placement="bottom-start"
       popperOptions={
         Object {
@@ -11033,6 +11049,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with showArrow 
           ]
         }
         onClickOutside={[Function]}
+        onHide={[Function]}
         placement="bottom-start"
         plugins={
           Array [
@@ -11077,6 +11094,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with showArrow 
             ]
           }
           onClickOutside={[Function]}
+          onHide={[Function]}
           placement="bottom-start"
           plugins={
             Array [
@@ -13258,6 +13276,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with style 1`] 
         ]
       }
       onClickOutside={[Function]}
+      onHide={[Function]}
       placement="bottom-start"
       popperOptions={
         Object {
@@ -13295,6 +13314,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with style 1`] 
           ]
         }
         onClickOutside={[Function]}
+        onHide={[Function]}
         placement="bottom-start"
         plugins={
           Array [
@@ -13339,6 +13359,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with style 1`] 
             ]
           }
           onClickOutside={[Function]}
+          onHide={[Function]}
           placement="bottom-start"
           plugins={
             Array [
@@ -15458,6 +15479,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with variant 1`
         ]
       }
       onClickOutside={[Function]}
+      onHide={[Function]}
       placement="bottom-start"
       popperOptions={
         Object {
@@ -15495,6 +15517,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with variant 1`
           ]
         }
         onClickOutside={[Function]}
+        onHide={[Function]}
         placement="bottom-start"
         plugins={
           Array [
@@ -15539,6 +15562,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with variant 1`
             ]
           }
           onClickOutside={[Function]}
+          onHide={[Function]}
           placement="bottom-start"
           plugins={
             Array [

--- a/src/components/Popover/Popover.constants.ts
+++ b/src/components/Popover/Popover.constants.ts
@@ -9,6 +9,12 @@ const BOUNDARIES = {
   PARENT: 'scrollParent',
 };
 
+const CLOSE_BUTTON_PLACEMENTS: Record<string, string> = {
+  TOP_LEFT: 'top-left',
+  TOP_RIGHT: 'top-right',
+  NONE: 'none',
+};
+
 const DEFAULTS = {
   VARIANT: 'small',
   TRIGGER: 'click',
@@ -18,11 +24,14 @@ const DEFAULTS = {
   COLOR: COLORS.PRIMARY,
   BOUNDARY: BOUNDARIES.PARENT,
   HIDE_ON_ESC: true,
+  CLOSE_BUTTON_PLACEMENT: CLOSE_BUTTON_PLACEMENTS.NONE,
+  FOCUS_BACK_ON_TRIGGER_COMPONENT: false,
 };
 
 const STYLE = {
   wrapper: `${CLASS_PREFIX}-wrapper`,
   arrowWrapper: `${CLASS_PREFIX}-arrow-wrapper`,
+  closeButton: `${CLASS_PREFIX}-close-button`,
 };
 
 // default offset between popover and trigger component:
@@ -31,4 +40,12 @@ const OFFSET = 5;
 // padding between the edge of the popover and the arrow, to ensure the arrow doesn't get pushed outside
 const ARROW_PADDING = 5;
 
-export { CLASS_PREFIX, DEFAULTS, STYLE, OFFSET, ARROW_PADDING, BOUNDARIES };
+export {
+  CLASS_PREFIX,
+  DEFAULTS,
+  STYLE,
+  OFFSET,
+  ARROW_PADDING,
+  BOUNDARIES,
+  CLOSE_BUTTON_PLACEMENTS,
+};

--- a/src/components/Popover/Popover.constants.ts
+++ b/src/components/Popover/Popover.constants.ts
@@ -9,7 +9,7 @@ const BOUNDARIES = {
   PARENT: 'scrollParent',
 };
 
-const CLOSE_BUTTON_PLACEMENTS: Record<string, string> = {
+const CLOSE_BUTTON_PLACEMENTS = {
   TOP_LEFT: 'top-left',
   TOP_RIGHT: 'top-right',
   NONE: 'none',

--- a/src/components/Popover/Popover.stories.args.ts
+++ b/src/components/Popover/Popover.stories.args.ts
@@ -106,7 +106,7 @@ const popoverArgTypes = {
   },
   closeButtonPlacement: {
     description: `Placement of the close button relative to the container of the popover`,
-    options: [...Object.values(CLOSE_BUTTON_PLACEMENTS as Record<string, string>)],
+    options: [...Object.values(CLOSE_BUTTON_PLACEMENTS)],
     control: { type: 'select' },
     table: {
       type: {

--- a/src/components/Popover/Popover.stories.args.ts
+++ b/src/components/Popover/Popover.stories.args.ts
@@ -1,7 +1,7 @@
 import { commonStyles } from '../../storybook/helper.stories.argtypes';
 import { PLACEMENTS } from '../ModalArrow/ModalArrow.constants';
 import { COLORS } from '../ModalContainer/ModalContainer.constants';
-import { DEFAULTS, BOUNDARIES } from './Popover.constants';
+import { DEFAULTS, BOUNDARIES, CLOSE_BUTTON_PLACEMENTS } from './Popover.constants';
 
 const popoverArgTypes = {
   trigger: {
@@ -101,6 +101,31 @@ const popoverArgTypes = {
       },
       defaultValue: {
         summary: DEFAULTS.BOUNDARY,
+      },
+    },
+  },
+  closeButtonPlacement: {
+    description: `Placement of the close button relative to the container of the popover`,
+    options: [...Object.values(CLOSE_BUTTON_PLACEMENTS as Record<string, string>)],
+    control: { type: 'select' },
+    table: {
+      type: {
+        summary: 'string',
+      },
+      defaultValue: {
+        summary: DEFAULTS.CLOSE_BUTTON_PLACEMENT,
+      },
+    },
+  },
+  focusBackOnTrigger: {
+    description: `Determines wether the focus should return to the trigger element when the popover is closed`,
+    control: { type: 'boolean' },
+    table: {
+      type: {
+        summary: 'boolean',
+      },
+      defaultValue: {
+        summary: DEFAULTS.FOCUS_BACK_ON_TRIGGER_COMPONENT,
       },
     },
   },

--- a/src/components/Popover/Popover.stories.tsx
+++ b/src/components/Popover/Popover.stories.tsx
@@ -4,7 +4,7 @@ import { DocumentationPage } from '../../storybook/helper.stories.docs';
 import StyleDocs from '../../storybook/docs.stories.style.mdx';
 import Documentation from './Popover.stories.docs.mdx';
 import { Item } from '@react-stately/collections';
-
+import Text from '../Text';
 import Popover, { PopoverProps } from './';
 import ButtonPill from '../ButtonPill';
 import ButtonSimple from '../ButtonSimple';
@@ -12,6 +12,7 @@ import Menu from '../Menu';
 import { COLORS } from '../ModalContainer/ModalContainer.constants';
 import argTypes from './Popover.stories.args';
 import { PLACEMENTS } from '../ModalArrow/ModalArrow.constants';
+import Flex from '../Flex';
 
 export default {
   title: 'Momentum UI/Popover',
@@ -71,6 +72,30 @@ InteractiveContent.args = {
   ),
 };
 
+const WithCloseButton = Template<PopoverProps>(Popover).bind({});
+
+WithCloseButton.argTypes = { ...argTypes };
+
+WithCloseButton.args = {
+  trigger: 'click',
+  placement: PLACEMENTS.BOTTOM,
+  showArrow: true,
+  interactive: true,
+  variant: 'small',
+  closeButtonPlacement: 'top-right',
+  focusBackOnTrigger: true,
+  color: COLORS.TERTIARY,
+  delay: [0, 0],
+  triggerComponent: (
+    <ButtonPill style={{ margin: '10rem auto', display: 'flex' }}>Click me!</ButtonPill>
+  ),
+  children: (
+    <Flex style={{ width: '10rem', height: '10rem' }} justifyContent="center" alignItems="center">
+      <Text type="display">🏖</Text>
+    </Flex>
+  ),
+};
+
 const Common = MultiTemplate<PopoverProps>(Popover).bind({});
 
 Common.argTypes = { ...argTypes };
@@ -124,4 +149,4 @@ Common.parameters = {
   ],
 };
 
-export { Example, InteractiveContent, Common };
+export { Example, InteractiveContent, WithCloseButton, Common };

--- a/src/components/Popover/Popover.style.scss
+++ b/src/components/Popover/Popover.style.scss
@@ -5,3 +5,17 @@
 .tippy-content {
   padding: 0;
 }
+
+.md-popover-close-button {
+  position: absolute;
+  z-index: 1000;
+  top: 0.5rem;
+
+  &[data-placement='top-left'] {
+    left: 0.5rem;
+  }
+
+  &[data-placement='top-right'] {
+    right: 0.5rem;
+  }
+}

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback } from 'react';
+import React, { FC, useCallback, forwardRef } from 'react';
 import './Popover.style.scss';
 import ModalContainer from '../ModalContainer';
 import ButtonCircle from '../ButtonCircle';
@@ -56,7 +56,6 @@ const Popover: FC<Props> = (props: Props) => {
   } = props;
 
   const tippyRef = React.useRef(null);
-  const triggerRef = React.useRef(null);
 
   const handleOnCloseButtonClick = useCallback(() => {
     tippyRef?.current?._tippy?.hide();
@@ -64,9 +63,9 @@ const Popover: FC<Props> = (props: Props) => {
 
   const handleOnPopoverHide = useCallback(() => {
     if (focusBackOnTrigger) {
-      triggerRef?.current?.focus();
+      tippyRef?.current?._tippy?.reference?.focus();
     }
-  }, [triggerComponent, triggerRef, focusBackOnTrigger]);
+  }, [triggerComponent, tippyRef, focusBackOnTrigger]);
 
   React.useEffect(() => {
     if (tippyRef?.current?._tippy) {
@@ -158,7 +157,9 @@ const Popover: FC<Props> = (props: Props) => {
         }
       }}
     >
-      {React.cloneElement(triggerComponent, { useNativeKeyDown: true, ref: triggerRef })}
+      {React.cloneElement(triggerComponent, {
+        useNativeKeyDown: true,
+      })}
     </LazyTippy>
   );
 };

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback, forwardRef } from 'react';
+import React, { FC, useCallback } from 'react';
 import './Popover.style.scss';
 import ModalContainer from '../ModalContainer';
 import ButtonCircle from '../ButtonCircle';

--- a/src/components/Popover/Popover.types.ts
+++ b/src/components/Popover/Popover.types.ts
@@ -2,10 +2,12 @@ import type { CSSProperties, ReactElement, ReactNode } from 'react';
 import type { Instance, LifecycleHooks } from 'tippy.js';
 import type { TippyProps } from '@tippyjs/react';
 import type { Color } from '../ModalContainer/ModalContainer.types';
+import { ButtonCircleProps } from '../ButtonCircle';
 
 // variant - based on Figma mockups:
 export type VariantType = 'small' | 'medium';
 export type BoundaryType = 'parent' | 'viewport' | 'window' | HTMLElement;
+export type CloseButtonPlacement = 'top-left' | 'top-right' | 'none';
 
 export type PlacementType = TippyProps['placement'];
 export type TriggerType = TippyProps['trigger'];
@@ -124,4 +126,21 @@ export interface Props extends PopoverCommonStyleProps, Partial<LifecycleHooks> 
    * Custom style for overriding this component's CSS.
    */
   style?: CSSProperties;
+
+  /**
+   * Position of the close button
+   * @default `none`
+   */
+  closeButtonPlacement?: CloseButtonPlacement;
+
+  /**
+   * Props that are passed down to the close button.
+   */
+  closeButtonProps?: ButtonCircleProps;
+
+  /**
+   * Determines if the component will focus back on the trigger when the Popover is hidden.
+   * @default `false`
+   */
+  focusBackOnTrigger?: boolean;
 }

--- a/src/components/Popover/Popover.unit.test.tsx
+++ b/src/components/Popover/Popover.unit.test.tsx
@@ -10,9 +10,22 @@ import { COLORS, STYLE } from '../ModalContainer/ModalContainer.constants';
 import { PopoverInstance } from './Popover.types';
 
 describe('<Popover />', () => {
+  /**
+   * Opens the popover by clicking on the trigger component, waits until
+   * content gets displayed, expects it to be visible and returns the content.
+   * expect() statements count: 1
+   * @returns {HTMLElement}
+   */
+  const openPopoverByClickingOnTriggerAndCheckContent = async (name = /click me!/i) => {
+    userEvent.click(screen.getByRole('button', { name }));
+    const content = await screen.findByText('Content');
+    expect(content).toBeVisible();
+    return content;
+  };
+
   describe('snapshot', () => {
-    it('should match snapshot', () => {
-      expect.assertions(1);
+    it('should match snapshot', async () => {
+      expect.assertions(3);
 
       const { container } = render(
         <Popover triggerComponent={<button>Click Me!</button>}>
@@ -21,10 +34,14 @@ describe('<Popover />', () => {
       );
 
       expect(container).toMatchSnapshot();
+
+      await openPopoverByClickingOnTriggerAndCheckContent();
+
+      expect(container).toMatchSnapshot();
     });
 
-    it('should match snapshot with className', () => {
-      expect.assertions(1);
+    it('should match snapshot with className', async () => {
+      expect.assertions(3);
 
       const className = 'example-class';
 
@@ -35,10 +52,14 @@ describe('<Popover />', () => {
       );
 
       expect(container).toMatchSnapshot();
+
+      await openPopoverByClickingOnTriggerAndCheckContent();
+
+      expect(container).toMatchSnapshot();
     });
 
-    it('should match snapshot with id', () => {
-      expect.assertions(1);
+    it('should match snapshot with id', async () => {
+      expect.assertions(3);
 
       const id = 'example-id';
 
@@ -49,10 +70,14 @@ describe('<Popover />', () => {
       );
 
       expect(container).toMatchSnapshot();
+
+      await openPopoverByClickingOnTriggerAndCheckContent();
+
+      expect(container).toMatchSnapshot();
     });
 
-    it('should match snapshot with style', () => {
-      expect.assertions(1);
+    it('should match snapshot with style', async () => {
+      expect.assertions(3);
 
       const style = { color: 'pink' };
 
@@ -63,10 +88,14 @@ describe('<Popover />', () => {
       );
 
       expect(container).toMatchSnapshot();
+
+      await openPopoverByClickingOnTriggerAndCheckContent();
+
+      expect(container).toMatchSnapshot();
     });
 
-    it('should match snapshot with color', () => {
-      expect.assertions(1);
+    it('should match snapshot with color', async () => {
+      expect.assertions(3);
 
       const { container } = render(
         <Popover triggerComponent={<button>Click Me!</button>} color={COLORS.TERTIARY}>
@@ -75,12 +104,32 @@ describe('<Popover />', () => {
       );
 
       expect(container).toMatchSnapshot();
+
+      await openPopoverByClickingOnTriggerAndCheckContent();
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match snapshot with closeButtonPlacement', async () => {
+      expect.assertions(3);
+
+      const { container } = render(
+        <Popover triggerComponent={<button>Click Me!</button>} closeButtonPlacement="top-right">
+          <p>Content</p>
+        </Popover>
+      );
+
+      expect(container).toMatchSnapshot();
+
+      await openPopoverByClickingOnTriggerAndCheckContent();
+
+      expect(container).toMatchSnapshot();
     });
   });
 
   describe('attributes', () => {
     it('should have provided attributes when attributes are provided', async () => {
-      expect.assertions(5);
+      expect.assertions(6);
       const className = 'example-class';
       const style = { color: 'pink' };
       const styleString = 'color: pink;';
@@ -97,8 +146,7 @@ describe('<Popover />', () => {
           <p>Content</p>
         </Popover>
       );
-      userEvent.click(screen.getByRole('button', { name: /click me!/i }));
-      const content = await screen.findByText('Content');
+      const content = await openPopoverByClickingOnTriggerAndCheckContent();
 
       expect(content.parentElement.classList.contains(STYLE.wrapper)).toBe(true);
       expect(content.parentElement.classList.contains(className)).toBe(true);
@@ -151,6 +199,32 @@ describe('<Popover />', () => {
       popover = await screen.findByText('Popover Element');
       expect(popover).toBeVisible();
     });
+
+    it('should render the close button if provided', async () => {
+      expect.assertions(4);
+
+      render(
+        <Popover
+          triggerComponent={<button>Click Me!</button>}
+          interactive
+          closeButtonPlacement="top-right"
+          closeButtonProps={{ 'aria-label': 'Close' }}
+        >
+          <p>Content</p>
+        </Popover>
+      );
+
+      // assert no popover on screen
+      const contentBeforeClick = screen.queryByText('Content');
+      expect(contentBeforeClick).not.toBeInTheDocument();
+
+      // after click, popover should be shown
+      await openPopoverByClickingOnTriggerAndCheckContent();
+
+      const closeButton = await screen.findByRole('button', { name: 'Close' });
+      expect(closeButton).toBeVisible();
+      expect(closeButton.getAttribute('aria-label')).toBe('Close');
+    });
   });
 
   describe('actions', () => {
@@ -189,9 +263,7 @@ describe('<Popover />', () => {
       expect(contentBeforeClick).not.toBeInTheDocument();
 
       // after click, popover should be shown
-      userEvent.click(screen.getByRole('button', { name: /click me!/i }));
-      const content = await screen.findByText('Content');
-      expect(content).toBeVisible();
+      await openPopoverByClickingOnTriggerAndCheckContent();
 
       expect(props.onMount).toBeCalled();
       expect(props.onShow).toBeCalled();
@@ -320,9 +392,7 @@ describe('<Popover />', () => {
       render(<ParentComponent />);
 
       // show popover from the parent component
-      userEvent.click(screen.getByRole('button', { name: /show/i }));
-      const content = await screen.findByText('Content');
-      expect(content).toBeVisible();
+      await openPopoverByClickingOnTriggerAndCheckContent(/show/i);
 
       // hide popover from the parent component
       userEvent.click(screen.getByRole('button', { name: /hide/i }));
@@ -345,9 +415,7 @@ describe('<Popover />', () => {
       expect(contentBeforeClick).not.toBeInTheDocument();
 
       // after click, popover should be shown
-      userEvent.click(screen.getByRole('button', { name: /click me!/i }));
-      const content = await screen.findByText('Content');
-      expect(content).toBeVisible();
+      await openPopoverByClickingOnTriggerAndCheckContent();
 
       userEvent.keyboard('{Escape}');
 
@@ -371,15 +439,88 @@ describe('<Popover />', () => {
       expect(contentBeforeClick).not.toBeInTheDocument();
 
       // after click, popover should be shown
-      userEvent.click(screen.getByRole('button', { name: /click me!/i }));
-      const content = await screen.findByText('Content');
-      expect(content).toBeVisible();
+      await openPopoverByClickingOnTriggerAndCheckContent();
 
       userEvent.keyboard('{Escape}');
 
       // content should still be visible
       const contentAfterEsc = await screen.findByText('Content');
       expect(contentAfterEsc).toBeVisible();
+    });
+
+    it('it should close the Popover if closeButtonPlacement is not none', async () => {
+      expect.assertions(3);
+
+      render(
+        <Popover
+          closeButtonProps={{ 'aria-label': 'Close' }}
+          triggerComponent={<button>Click Me!</button>}
+          interactive
+          closeButtonPlacement="top-right"
+          trigger="click"
+          hideOnEsc={false}
+        >
+          <p>Content</p>
+        </Popover>
+      );
+
+      // assert no popover on screen
+      const contentBeforeClick = screen.queryByText('Content');
+      expect(contentBeforeClick).not.toBeInTheDocument();
+
+      // after click, popover should be shown
+      await openPopoverByClickingOnTriggerAndCheckContent();
+
+      // click the close button
+      userEvent.click(screen.getByRole('button', { name: 'Close' }));
+
+      // content should be hidden
+      await waitFor(() => {
+        expect(screen.queryByText('Content')).not.toBeInTheDocument();
+      });
+    });
+
+    it('it should focus on the trigger component when focusBackOnTrigger= = true and popover gets closed', async () => {
+      expect.assertions(5);
+
+      render(
+        <Popover
+          closeButtonProps={{ 'aria-label': 'Close' }}
+          triggerComponent={<button>Click Me!</button>}
+          interactive
+          closeButtonPlacement="top-right"
+          trigger="click"
+          hideOnEsc={false}
+          focusBackOnTrigger
+        >
+          <p>Content</p>
+        </Popover>
+      );
+
+      // assert no popover on screen
+      const contentBeforeClick = screen.queryByText('Content');
+      expect(contentBeforeClick).not.toBeInTheDocument();
+
+      // after click, popover should be shown
+
+      await openPopoverByClickingOnTriggerAndCheckContent();
+
+      const closeButton = screen.getByRole('button', { name: 'Close' });
+
+      userEvent.tab();
+      // click the close button
+
+      expect(document.activeElement).toEqual(closeButton);
+
+      userEvent.click(closeButton);
+
+      // content should be hidden
+      await waitFor(() => {
+        expect(screen.queryByText('Content')).not.toBeInTheDocument();
+      });
+
+      const triggerComponent = screen.getByRole('button', { name: /click me!/i });
+      expect(document.activeElement).toEqual(triggerComponent);
     });
   });
 });

--- a/src/components/Popover/Popover.unit.test.tsx.snap
+++ b/src/components/Popover/Popover.unit.test.tsx.snap
@@ -8,11 +8,222 @@ exports[`<Popover /> snapshot should match snapshot 1`] = `
 </div>
 `;
 
+exports[`<Popover /> snapshot should match snapshot 2`] = `
+<div>
+  <button
+    aria-describedby="tippy-1"
+  >
+    Click Me!
+  </button>
+  <div
+    data-tippy-root=""
+    id="tippy-1"
+    style="pointer-events: none; z-index: 9999; position: absolute; left: 0px; top: 0px; margin: 0px; bottom: 0px; transform: translate(0px, 0px);"
+  >
+    <div
+      class="md-modal-container-wrapper"
+      data-arrow-orientation="vertical"
+      data-color="primary"
+      data-elevation="3"
+      data-padded="true"
+      data-placement="top"
+      data-round="50"
+    >
+      <p>
+        Content
+      </p>
+      <div
+        class="md-modal-container-arrow-wrapper"
+        data-popper-arrow="true"
+        id="arrow"
+        style="position: absolute; left: 0px; transform: translate(5px, 0px);"
+      >
+        <svg
+          class="md-modal-arrow-svg"
+          data-placement="top"
+          height="12"
+          viewBox="0 0 24 12"
+          width="24"
+          xmlns="http://www.w3.org/svg/2000"
+        >
+          <defs>
+            <clippath
+              id="modal-arrow-cut-stroke-top"
+            >
+              <path
+                d="m 24 0 l -10 10 q -2 2 -4 0 l -10 -10"
+              />
+            </clippath>
+          </defs>
+          <path
+            clip-path="url(#modal-arrow-cut-stroke-top)"
+            d="m 24 0 l -10 10 q -2 2 -4 0 l -10 -10"
+            data-color="primary"
+          />
+        </svg>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`<Popover /> snapshot should match snapshot with className 1`] = `
 <div>
   <button>
     Click Me!
   </button>
+</div>
+`;
+
+exports[`<Popover /> snapshot should match snapshot with className 2`] = `
+<div>
+  <button
+    aria-describedby="tippy-2"
+  >
+    Click Me!
+  </button>
+  <div
+    data-tippy-root=""
+    id="tippy-2"
+    style="pointer-events: none; z-index: 9999; position: absolute; left: 0px; top: 0px; margin: 0px; bottom: 0px; transform: translate(0px, 0px);"
+  >
+    <div
+      class="example-class md-modal-container-wrapper"
+      data-arrow-orientation="vertical"
+      data-color="primary"
+      data-elevation="3"
+      data-padded="true"
+      data-placement="top"
+      data-round="50"
+    >
+      <p>
+        Content
+      </p>
+      <div
+        class="md-modal-container-arrow-wrapper"
+        data-popper-arrow="true"
+        id="arrow"
+        style="position: absolute; left: 0px; transform: translate(5px, 0px);"
+      >
+        <svg
+          class="md-modal-arrow-svg"
+          data-placement="top"
+          height="12"
+          viewBox="0 0 24 12"
+          width="24"
+          xmlns="http://www.w3.org/svg/2000"
+        >
+          <defs>
+            <clippath
+              id="modal-arrow-cut-stroke-top"
+            >
+              <path
+                d="m 24 0 l -10 10 q -2 2 -4 0 l -10 -10"
+              />
+            </clippath>
+          </defs>
+          <path
+            clip-path="url(#modal-arrow-cut-stroke-top)"
+            d="m 24 0 l -10 10 q -2 2 -4 0 l -10 -10"
+            data-color="primary"
+          />
+        </svg>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<Popover /> snapshot should match snapshot with closeButtonPlacement 1`] = `
+<div>
+  <button>
+    Click Me!
+  </button>
+</div>
+`;
+
+exports[`<Popover /> snapshot should match snapshot with closeButtonPlacement 2`] = `
+<div>
+  <button
+    aria-describedby="tippy-6"
+  >
+    Click Me!
+  </button>
+  <div
+    data-tippy-root=""
+    id="tippy-6"
+    style="pointer-events: none; z-index: 9999; position: absolute; left: 0px; top: 0px; margin: 0px; bottom: 0px; transform: translate(0px, 0px);"
+  >
+    <div
+      class="md-modal-container-wrapper"
+      data-arrow-orientation="vertical"
+      data-color="primary"
+      data-elevation="3"
+      data-padded="true"
+      data-placement="top"
+      data-round="50"
+    >
+      <button
+        class="md-button-circle-wrapper md-popover-close-button md-button-simple-wrapper"
+        data-color="primary"
+        data-disabled="false"
+        data-ghost="true"
+        data-multiple-children="false"
+        data-outline="false"
+        data-placement="top-right"
+        data-size="20"
+        type="button"
+      >
+        <div
+          class="md-icon-wrapper"
+        >
+          <svg
+            class=""
+            data-autoscale="false"
+            data-scale="16"
+            data-test="cancel"
+            fill="currentColor"
+            height="100%"
+            viewBox="0, 0, 32, 32"
+            width="100%"
+          />
+        </div>
+      </button>
+      <p>
+        Content
+      </p>
+      <div
+        class="md-modal-container-arrow-wrapper"
+        data-popper-arrow="true"
+        id="arrow"
+        style="position: absolute; left: 0px; transform: translate(5px, 0px);"
+      >
+        <svg
+          class="md-modal-arrow-svg"
+          data-placement="top"
+          height="12"
+          viewBox="0 0 24 12"
+          width="24"
+          xmlns="http://www.w3.org/svg/2000"
+        >
+          <defs>
+            <clippath
+              id="modal-arrow-cut-stroke-top"
+            >
+              <path
+                d="m 24 0 l -10 10 q -2 2 -4 0 l -10 -10"
+              />
+            </clippath>
+          </defs>
+          <path
+            clip-path="url(#modal-arrow-cut-stroke-top)"
+            d="m 24 0 l -10 10 q -2 2 -4 0 l -10 -10"
+            data-color="primary"
+          />
+        </svg>
+      </div>
+    </div>
+  </div>
 </div>
 `;
 
@@ -24,6 +235,65 @@ exports[`<Popover /> snapshot should match snapshot with color 1`] = `
 </div>
 `;
 
+exports[`<Popover /> snapshot should match snapshot with color 2`] = `
+<div>
+  <button
+    aria-describedby="tippy-5"
+  >
+    Click Me!
+  </button>
+  <div
+    data-tippy-root=""
+    id="tippy-5"
+    style="pointer-events: none; z-index: 9999; position: absolute; left: 0px; top: 0px; margin: 0px; bottom: 0px; transform: translate(0px, 0px);"
+  >
+    <div
+      class="md-modal-container-wrapper"
+      data-arrow-orientation="vertical"
+      data-color="tertiary"
+      data-elevation="3"
+      data-padded="true"
+      data-placement="top"
+      data-round="50"
+    >
+      <p>
+        Content
+      </p>
+      <div
+        class="md-modal-container-arrow-wrapper"
+        data-popper-arrow="true"
+        id="arrow"
+        style="position: absolute; left: 0px; transform: translate(5px, 0px);"
+      >
+        <svg
+          class="md-modal-arrow-svg"
+          data-placement="top"
+          height="12"
+          viewBox="0 0 24 12"
+          width="24"
+          xmlns="http://www.w3.org/svg/2000"
+        >
+          <defs>
+            <clippath
+              id="modal-arrow-cut-stroke-top"
+            >
+              <path
+                d="m 24 0 l -10 10 q -2 2 -4 0 l -10 -10"
+              />
+            </clippath>
+          </defs>
+          <path
+            clip-path="url(#modal-arrow-cut-stroke-top)"
+            d="m 24 0 l -10 10 q -2 2 -4 0 l -10 -10"
+            data-color="tertiary"
+          />
+        </svg>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`<Popover /> snapshot should match snapshot with id 1`] = `
 <div>
   <button>
@@ -32,10 +302,130 @@ exports[`<Popover /> snapshot should match snapshot with id 1`] = `
 </div>
 `;
 
+exports[`<Popover /> snapshot should match snapshot with id 2`] = `
+<div>
+  <button
+    aria-describedby="tippy-3"
+  >
+    Click Me!
+  </button>
+  <div
+    data-tippy-root=""
+    id="tippy-3"
+    style="pointer-events: none; z-index: 9999; position: absolute; left: 0px; top: 0px; margin: 0px; bottom: 0px; transform: translate(0px, 0px);"
+  >
+    <div
+      class="md-modal-container-wrapper"
+      data-arrow-orientation="vertical"
+      data-color="primary"
+      data-elevation="3"
+      data-padded="true"
+      data-placement="top"
+      data-round="50"
+      id="example-id"
+    >
+      <p>
+        Content
+      </p>
+      <div
+        class="md-modal-container-arrow-wrapper"
+        data-popper-arrow="true"
+        id="arrow"
+        style="position: absolute; left: 0px; transform: translate(5px, 0px);"
+      >
+        <svg
+          class="md-modal-arrow-svg"
+          data-placement="top"
+          height="12"
+          viewBox="0 0 24 12"
+          width="24"
+          xmlns="http://www.w3.org/svg/2000"
+        >
+          <defs>
+            <clippath
+              id="modal-arrow-cut-stroke-top"
+            >
+              <path
+                d="m 24 0 l -10 10 q -2 2 -4 0 l -10 -10"
+              />
+            </clippath>
+          </defs>
+          <path
+            clip-path="url(#modal-arrow-cut-stroke-top)"
+            d="m 24 0 l -10 10 q -2 2 -4 0 l -10 -10"
+            data-color="primary"
+          />
+        </svg>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`<Popover /> snapshot should match snapshot with style 1`] = `
 <div>
   <button>
     Click Me!
   </button>
+</div>
+`;
+
+exports[`<Popover /> snapshot should match snapshot with style 2`] = `
+<div>
+  <button
+    aria-describedby="tippy-4"
+  >
+    Click Me!
+  </button>
+  <div
+    data-tippy-root=""
+    id="tippy-4"
+    style="pointer-events: none; z-index: 9999; position: absolute; left: 0px; top: 0px; margin: 0px; bottom: 0px; transform: translate(0px, 0px);"
+  >
+    <div
+      class="md-modal-container-wrapper"
+      data-arrow-orientation="vertical"
+      data-color="primary"
+      data-elevation="3"
+      data-padded="true"
+      data-placement="top"
+      data-round="50"
+      style="color: pink;"
+    >
+      <p>
+        Content
+      </p>
+      <div
+        class="md-modal-container-arrow-wrapper"
+        data-popper-arrow="true"
+        id="arrow"
+        style="position: absolute; left: 0px; transform: translate(5px, 0px);"
+      >
+        <svg
+          class="md-modal-arrow-svg"
+          data-placement="top"
+          height="12"
+          viewBox="0 0 24 12"
+          width="24"
+          xmlns="http://www.w3.org/svg/2000"
+        >
+          <defs>
+            <clippath
+              id="modal-arrow-cut-stroke-top"
+            >
+              <path
+                d="m 24 0 l -10 10 q -2 2 -4 0 l -10 -10"
+              />
+            </clippath>
+          </defs>
+          <path
+            clip-path="url(#modal-arrow-cut-stroke-top)"
+            d="m 24 0 l -10 10 q -2 2 -4 0 l -10 -10"
+            data-color="primary"
+          />
+        </svg>
+      </div>
+    </div>
+  </div>
 </div>
 `;


### PR DESCRIPTION
# Description
- Added `closeButtonPlacement` to configure the popover to have a close button (`top-left' | 'top-right' | 'none'`)
- Added `focusBackOnTrigger` to configure the popover to focus back on trigger on close
- Added `closeButtonProps` to support the `closeButtonPlacement` and give flexibility to add accessibility props on the close button (aria label, title, translation etc)

# Screenshots
<img width="326" alt="image" src="https://user-images.githubusercontent.com/14194394/178725498-70ee9f07-e80e-4ed5-a5d3-b1aa9c5bbafd.png">
<img width="324" alt="image" src="https://user-images.githubusercontent.com/14194394/178725536-e05b465a-e9c1-482c-aaa3-b7f9a7038e38.png">

