### PR TITLE
Feat/popover/add add flex-shrink:0 to svg in close button

### DIFF
--- a/src/components/Popover/Popover.style.scss
+++ b/src/components/Popover/Popover.style.scss
@@ -18,4 +18,8 @@
   &[data-placement='top-right'] {
     right: 0.5rem;
   }
+
+  svg {
+    flex-shrink: 0;
+  }
 }

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback } from 'react';
+import React, { FC, useCallback, forwardRef } from 'react';
 import './Popover.style.scss';
 import ModalContainer from '../ModalContainer';
 import ButtonCircle from '../ButtonCircle';

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback, forwardRef } from 'react';
+import React, { FC, useCallback } from 'react';
 import './Popover.style.scss';
 import ModalContainer from '../ModalContainer';
 import ButtonCircle from '../ButtonCircle';


### PR DESCRIPTION
# Description
Cheeky little flex-shrink to avoid random resizing of the icon inside the close button. It currently doesn't look good in Cantina because we have this snippet in the _base.scss 
```
* {
min-width: 0;
min-width: 0;
}
```

This will make sure the icon will always look ok.