### PR TITLE
feat(icons): add warning-badge as exception

### DIFF
--- a/src/components/Icon/Icon.constants.ts
+++ b/src/components/Icon/Icon.constants.ts
@@ -62,6 +62,7 @@ const EXCEPTION_ICONS_LIST = [
   'info-badge',
   'priority-badge',
   'draft-indicator-small',
+  'warning-badge',
 ];
 
 const STYLE = {


### PR DESCRIPTION
# Description
Add `warning-badge` as small icon exception.
There's a small issue with the icon itself, it was designed at 16x16 instead of 14x14 like the rest of the exception icons.
[I've left a comment in the figma](https://www.figma.com/file/SXK8Gb5tMlN9xiG2cC4OBu?node-id=9091:12274#230785156) -- this will probabbly automatically get fixed when they fix it on their end.