### PR TITLE
Revert "refactor: removed old checkbox and depednants"

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,6 +42,7 @@ export {
   Icon,
   Input,
   InputMessage,
+  InputHelper,
   InputSearch,
   InputSection,
   Label,

--- a/src/legacy/InputHelper/examples/Default.js
+++ b/src/legacy/InputHelper/examples/Default.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Checkbox, InputHelper } from '@momentum-ui/react-collaboration';
+
+export default function InputHelperDefault() {
+  return (
+    <div className="row">
+      <Checkbox value="us" label="us" htmlId="inputHelper1" onChange={() => {}}>
+        <InputHelper message={"I'm here to help"} />
+      </Checkbox>
+    </div>
+  );
+}

--- a/src/legacy/InputHelper/examples/KitchenSink.js
+++ b/src/legacy/InputHelper/examples/KitchenSink.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { InputHelperDefault } from './index';
+
+export default class InputHelperKitchenSink extends React.Component {
+  render() {
+    return (
+      <React.Fragment>
+        <InputHelperDefault />
+      </React.Fragment>
+    );
+  }
+}

--- a/src/legacy/InputHelper/examples/KitchenSink.stories.tsx
+++ b/src/legacy/InputHelper/examples/KitchenSink.stories.tsx
@@ -1,0 +1,12 @@
+import LegacyKitchenSink from './KitchenSink';
+import React from 'react';
+
+export default {
+  title: 'Legacy/InputHelper',
+  component: LegacyKitchenSink,
+};
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+const Legacy = () => <LegacyKitchenSink />;
+
+export { Legacy };

--- a/src/legacy/InputHelper/examples/index.js
+++ b/src/legacy/InputHelper/examples/index.js
@@ -1,0 +1,2 @@
+export { default as InputHelperDefault } from './Default';
+export { default as InputHelperKitchenSink } from './KitchenSink';

--- a/src/legacy/InputHelper/index.js
+++ b/src/legacy/InputHelper/index.js
@@ -1,0 +1,28 @@
+/** @component input */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const InputHelper = ({ message, className, ...props }) => {
+  return (
+    <div className={`md-input__help-text` + `${(className && ` ${className}`) || ''}`} {...props}>
+      {message}
+    </div>
+  );
+};
+
+InputHelper.propTypes = {
+  /** @prop Optional css class name | '' */
+  className: PropTypes.string,
+  /** @prop Input help message for parent Input | null */
+  message: PropTypes.string.isRequired,
+};
+
+InputHelper.defaultProps = {
+  className: '',
+  message: null,
+};
+
+InputHelper.displayName = 'InputHelper';
+
+export default InputHelper;

--- a/src/legacy/InputHelper/tests/index.cy.js
+++ b/src/legacy/InputHelper/tests/index.cy.js
@@ -1,0 +1,10 @@
+import { prefix } from '../../utils/index';
+
+describe('@momentum-ui/react-collaboration', () => {
+  it('snapshot of input-helper', () => {
+    cy.visit(`${Cypress.env('BASE_URL')}/input-helper`)
+      .get(`.${prefix}-input__help-text`)
+      .should('be.visible')
+      .percySnapshot();
+  });
+});

--- a/src/legacy/InputHelper/tests/index.spec.js
+++ b/src/legacy/InputHelper/tests/index.spec.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import { shallow, mount } from 'enzyme';
+import { InputHelper } from '@momentum-ui/react-collaboration';
+
+describe('tests for <InputHelper />', () => {
+  it('should match text SnapShot', () => {
+    const container = mount(<InputHelper message="test" />);
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should render className if prop is passed', () => {
+    const container = shallow(<InputHelper className="class-test" message="test" />);
+
+    expect(container.find('.class-test').exists()).toEqual(true);
+  });
+
+  it('should render input help with correct class', () => {
+    const container = shallow(<InputHelper message="test" />);
+
+    expect(container.find('div').hasClass('md-input__help-text')).toEqual(true);
+  });
+
+  it('should render message', () => {
+    const container = shallow(<InputHelper message="test" />);
+
+    expect(container.find('div').text()).toEqual('test');
+  });
+
+  it('should pass otherProps to container', () => {
+    const container = shallow(<InputHelper message="test" id="testid" />);
+
+    expect(container.find('#testid').exists()).toEqual(true);
+  });
+});

--- a/src/legacy/InputHelper/tests/index.spec.js.snap
+++ b/src/legacy/InputHelper/tests/index.spec.js.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`tests for <InputHelper /> should match text SnapShot 1`] = `
+<InputHelper
+  className=""
+  message="test"
+>
+  <div
+    className="md-input__help-text"
+  >
+    test
+  </div>
+</InputHelper>
+`;

--- a/src/legacy/List/examples/ListWithEventBubbling.js
+++ b/src/legacy/List/examples/ListWithEventBubbling.js
@@ -1,15 +1,15 @@
 /* eslint-disable no-console */
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 import React from 'react';
-import { CheckboxNext, List, ListItem } from '@momentum-ui/react-collaboration';
+import { Checkbox, List, ListItem } from '@momentum-ui/react-collaboration';
 
 export default class ListWithEventBubbling extends React.PureComponent {
   state = {
     enableBubbling: true,
   };
 
-  onChange = (isSelected) => {
-    this.setState({ enableBubbling: isSelected });
+  onChange = (e) => {
+    this.setState({ enableBubbling: e.target.checked });
   };
 
   bubbledEventHandler = (e) => {
@@ -27,11 +27,11 @@ export default class ListWithEventBubbling extends React.PureComponent {
             <ListItem label="List Item 4" />
           </List>
         </div>
-        <CheckboxNext
-          isSelected={this.state.enableBubbling}
+        <Checkbox
+          checked={this.state.enableBubbling}
           onChange={this.onChange}
           label="Enable Event Bubbling (See Console)"
-          id={`checkbox-for-event-bubbling`}
+          htmlId={`checkbox-for-event-bubbling`}
         />
       </div>
     );

--- a/src/legacy/SelectOption/index.js
+++ b/src/legacy/SelectOption/index.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
-import { CheckboxNext, Icon, ListItem, ListItemSection } from '@momentum-ui/react-collaboration';
+import { Checkbox, Icon, ListItem, ListItemSection } from '@momentum-ui/react-collaboration';
 import SelectContext from '../SelectContext';
 import ListContext from '../ListContext';
 import { UIDConsumer } from 'react-uid';
@@ -14,7 +14,12 @@ class SelectOption extends React.Component {
 
     const separateChildren = (isMulti, cxtActive, uniqueId) => {
       return isMulti ? (
-        <CheckboxNext id={`${uniqueId}__checkbox`} label={label} isSelected={cxtActive || false} />
+        <Checkbox
+          htmlId={`${uniqueId}__checkbox`}
+          label={label}
+          checked={cxtActive || false}
+          onChange={() => {}}
+        />
       ) : (
         [
           <ListItemSection key="child-0" position="center">

--- a/src/legacy/SelectOption/tests/index.spec.js
+++ b/src/legacy/SelectOption/tests/index.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import { Select, SelectOption, CheckboxNext } from '@momentum-ui/react-collaboration';
+import { Select, SelectOption } from '@momentum-ui/react-collaboration';
 
 describe('tests for <SelectOption />', () => {
   it('should match SnapShot', () => {
@@ -54,7 +54,7 @@ describe('tests for <SelectOption />', () => {
     );
 
     container.find('button').simulate('click');
-    expect(container.find(CheckboxNext).props().isSelected).toEqual(true);
+    expect(container.find('Checkbox').props().checked).toEqual(true);
   });
 
   it('should pass props to ListItem', () => {

--- a/src/legacy/index.js
+++ b/src/legacy/index.js
@@ -41,6 +41,7 @@ export { default as FormSubSection } from './FormSubSection';
 export { default as Icon } from './Icon';
 export { default as Input } from './Input';
 export { default as InputMessage } from './InputMessage';
+export { default as InputHelper } from './InputHelper';
 export { default as InputSearch } from './InputSearch';
 export { default as InputSection } from './InputSection';
 export { default as Label } from './Label';


### PR DESCRIPTION
This reverts commit ad326226b928b87a0cce27471ef4449522a92433.

InputHelper was still in use by the legacy Input