### PR TITLE
Revert "Remove legacy checkbox"

### DIFF
--- a/src/examples/data/components.js
+++ b/src/examples/data/components.js
@@ -12,6 +12,7 @@ export { default as ButtonGroup } from '../../legacy/ButtonGroup/examples/Kitche
 export { default as CallControl } from '../../legacy/CallControl/examples/KitchenSink';
 export { default as Card } from '../../legacy/Card/examples/KitchenSink';
 export { default as CardSection } from '../../legacy/CardSection/examples/KitchenSink';
+export { default as Checkbox } from '../../legacy/Checkbox/examples/KitchenSink';
 export { default as Coachmark } from '../../legacy/Coachmark/examples/KitchenSink';
 export { default as CollapseButton } from '../../legacy/CollapseButton/examples/KitchenSink';
 export { default as ComboBox } from '../../legacy/ComboBox/examples/KitchenSink';
@@ -24,6 +25,7 @@ export { default as FormSection } from '../../legacy/FormSection/examples/Kitche
 export { default as FormSubSection } from '../../legacy/FormSubSection/examples/KitchenSink';
 export { default as Icon } from '../../legacy/Icon/examples/KitchenSink';
 export { default as Input } from '../../legacy/Input/examples/KitchenSink';
+export { default as InputHelper } from '../../legacy/InputHelper/examples/KitchenSink';
 export { default as InputSearch } from '../../legacy/InputSearch/examples/KitchenSink';
 export { default as Label } from '../../legacy/Label/examples/KitchenSink';
 export { default as Lightbox } from '../../legacy/Lightbox/examples/KitchenSink';

--- a/src/index.js
+++ b/src/index.js
@@ -42,6 +42,7 @@ export {
   Icon,
   Input,
   InputMessage,
+  InputHelper,
   InputSearch,
   InputSection,
   Label,

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,8 @@ export {
   CallControl,
   Card,
   CardSection,
+  Checkbox,
+  CheckboxGroup,
   Chip,
   CloseIcon,
   CloseWrapper,

--- a/src/legacy/Checkbox/examples/Default.js
+++ b/src/legacy/Checkbox/examples/Default.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import { Checkbox, CheckboxGroup } from '@momentum-ui/react-collaboration';
+export default function CheckboxDefault() {
+  return (
+    <CheckboxGroup name="CheckboxGroup1">
+      <Checkbox value="me" label="me" htmlId="testCheckbox1" onChange={() => {}} />
+    </CheckboxGroup>
+  );
+}

--- a/src/legacy/Checkbox/examples/Disabled.js
+++ b/src/legacy/Checkbox/examples/Disabled.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Checkbox } from '@momentum-ui/react-collaboration';
+export default function CheckboxDisabled() {
+  return (
+    <Checkbox
+      value="disabledChecked"
+      label="Disabled Checkbox"
+      htmlId="disabledCheckbox"
+      disabled
+      onChange={() => {}}
+    />
+  );
+}

--- a/src/legacy/Checkbox/examples/Group.js
+++ b/src/legacy/Checkbox/examples/Group.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import { Checkbox, CheckboxGroup } from '@momentum-ui/react-collaboration';
+export default function CheckboxGroupExample() {
+  return (
+    <CheckboxGroup name="CheckboxGroup1">
+      <Checkbox value="me" label="me" htmlId="testCheckbox1" onChange={() => {}} />
+      <Checkbox value="you" label="you" htmlId="testCheckbox2" onChange={() => {}} />
+      <Checkbox value="us" label="us" htmlId="testCheckbox3" onChange={() => {}} />
+    </CheckboxGroup>
+  );
+}

--- a/src/legacy/Checkbox/examples/Indeterminate.js
+++ b/src/legacy/Checkbox/examples/Indeterminate.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Checkbox } from '@momentum-ui/react-collaboration';
+export default function CheckboxIndeterminate() {
+  return (
+    <Checkbox
+      value="indeterminate"
+      label="Indeterminate Checkbox"
+      htmlId="indeterminateCheckbox"
+      onChange={() => {}}
+      indeterminate
+    />
+  );
+}

--- a/src/legacy/Checkbox/examples/KitchenSink.js
+++ b/src/legacy/Checkbox/examples/KitchenSink.js
@@ -1,0 +1,210 @@
+import React from 'react';
+import { Checkbox, InputHelper } from '@momentum-ui/react-collaboration';
+
+export default class CheckboxKitchenSink extends React.PureComponent {
+  state = {
+    checkboxChecked: true,
+    checkboxCheckedDisabled: true,
+    checkboxCheckedReadonly: true,
+  };
+  render() {
+    const checkboxes = (value) => (
+      <>
+        <Checkbox
+          name={`checkbox${value}`}
+          label="Checkbox Example"
+          htmlId={`checkbox${value}`}
+          checked={this.state.checkbox}
+          onChange={() => this.setState({ checkbox: !this.state.checkbox })}
+          key={`checkbox${value}`}
+        />
+        <Checkbox
+          name={`checkboxChecked${value}`}
+          label="Checkbox Checked Example"
+          htmlId={`checkboxChecked${value}`}
+          checked={this.state.checkboxChecked}
+          onChange={() => this.setState({ checkboxChecked: !this.state.checkboxChecked })}
+          key={`checkboxChecked${value}`}
+        />
+        <Checkbox
+          name={`checkboxIndeterminate${value}`}
+          label="Checkbox Indeterminate Example"
+          htmlId={`checkboxIndeterminate${value}`}
+          checked={this.state.checkboxIndeterminate}
+          onChange={() =>
+            this.setState({
+              checkboxIndeterminate: !this.state.checkboxIndeterminate,
+            })
+          }
+          key={`checkboxIndeterminate${value}`}
+          indeterminate
+        />
+        <Checkbox
+          name={`checkboxHelp${value}`}
+          label="Checkbox Example with help text"
+          htmlId={`checkboxHelp${value}`}
+          checked={this.state.checkboxHelp}
+          onChange={() => this.setState({ checkboxHelp: !this.state.checkboxHelp })}
+          key={`checkboxHelp${value}`}
+        >
+          <InputHelper message="This is help text for the Checkbox component" />
+        </Checkbox>
+
+        <Checkbox
+          name={`checkboxDisabled${value}`}
+          label="Disabled Checkbox Example"
+          htmlId={`checkboxDisabled${value}`}
+          checked={this.state.checkboxDisabled}
+          onChange={() => this.setState({ checkbox: !this.state.checkboxDisabled })}
+          key={`checkboxDisabled${value}`}
+          disabled
+        />
+        <Checkbox
+          name={`checkboxCheckedDisabled${value}`}
+          label="Disabled Checkbox Checked Example"
+          htmlId={`checkboxCheckedDisabled${value}`}
+          checked={this.state.checkboxCheckedDisabled}
+          onChange={() =>
+            this.setState({
+              checkboxCheckedDisabled: !this.state.checkboxCheckedDisabled,
+            })
+          }
+          key={`checkboxCheckedDisabled${value}`}
+          disabled
+        />
+        <Checkbox
+          name={`checkboxIndeterminateDisabled${value}`}
+          label="Disabled Checkbox Indeterminate Example"
+          htmlId={`checkboxIndeterminateDisabled${value}`}
+          checked={this.state.checkboxIndeterminateDisabled}
+          onChange={() =>
+            this.setState({
+              checkboxIndeterminateDisabled: !this.state.checkboxIndeterminateDisabled,
+            })
+          }
+          key={`checkboxIndeterminateDisabled${value}`}
+          indeterminate
+          disabled
+        />
+        <Checkbox
+          name={`checkboxHelpDisabled${value}`}
+          label="Disabled Checkbox Example with help text"
+          htmlId={`checkboxHelpDisabled${value}`}
+          checked={this.state.checkboxHelpDisabled}
+          onChange={() => this.setState({ checkboxHelpDisabled: !this.state.checkboxHelpDisabled })}
+          key={`checkboxHelpDisabled${value}`}
+          disabled
+        >
+          <InputHelper message="This is help text for the Checkbox component" />
+        </Checkbox>
+
+        <Checkbox
+          name={`checkboxReadonly${value}`}
+          label="Readonly Checkbox Example"
+          htmlId={`checkboxReadonly${value}`}
+          checked={this.state.checkboxReadonly}
+          onChange={() => this.setState({ checkbox: !this.state.checkboxReadonly })}
+          key={`checkboxReadonly${value}`}
+          readOnly
+        />
+        <Checkbox
+          name={`checkboxCheckedReadonly${value}`}
+          label="Readonly Checkbox Checked Example"
+          htmlId={`checkboxCheckedReadonly${value}`}
+          checked={this.state.checkboxCheckedReadonly}
+          onChange={() =>
+            this.setState({
+              checkboxCheckedReadonly: !this.state.checkboxCheckedReadonly,
+            })
+          }
+          key={`checkboxCheckedReadonly${value}`}
+          readOnly
+        />
+        <Checkbox
+          name={`checkboxIndeterminateReadonly${value}`}
+          label="Readonly Checkbox Indeterminate Example"
+          htmlId={`checkboxIndeterminateReadonly${value}`}
+          checked={this.state.checkboxIndeterminateReadonly}
+          onChange={() =>
+            this.setState({
+              checkboxIndeterminateReadonly: !this.state.checkboxIndeterminateReadonly,
+            })
+          }
+          key={`checkboxIndeterminateReadonly${value}`}
+          indeterminate
+          readOnly
+        />
+        <Checkbox
+          name={`checkboxHelpReadonly${value}`}
+          label="Readonly Checkbox Example with help text"
+          htmlId={`checkboxHelpReadonly${value}`}
+          checked={this.state.checkboxHelpReadonly}
+          onChange={() => this.setState({ checkboxHelpReadonly: !this.state.checkboxHelpReadonly })}
+          key={`checkboxHelpReadonly${value}`}
+          readOnly
+        >
+          <InputHelper message="This is help text for the Checkbox component" />
+        </Checkbox>
+
+        <Checkbox
+          name={`checkboxNested0${value}`}
+          label="Nested Checkbox Example Level 0"
+          htmlId={`checkboxNested0${value}`}
+          checked={this.state.checkboxNested0}
+          onChange={() => this.setState({ checkboxNested0: !this.state.checkboxNested0 })}
+          key={`checkboxNested0${value}`}
+          nestedLevel={0}
+        />
+        <Checkbox
+          name={`checkboxNested1${value}`}
+          label="Nested Checkbox Example Level 1"
+          htmlId={`checkboxNested1${value}`}
+          checked={this.state.checkboxNested1}
+          onChange={() => this.setState({ checkboxNested1: !this.state.checkboxNested1 })}
+          key={`checkboxNested1${value}`}
+          nestedLevel={1}
+        />
+        <Checkbox
+          name={`checkboxNestedHelp2${value}`}
+          label="Nested Checkbox Example Level 2"
+          htmlId={`checkboxNestedHelp2${value}`}
+          checked={this.state.checkboxNestedHelp2}
+          onChange={() => this.setState({ checkboxNestedHelp2: !this.state.checkboxNestedHelp2 })}
+          key={`checkboxNestedHelp2${value}`}
+          nestedLevel={2}
+        >
+          <InputHelper message="This is help text for the nested Checkbox component" />
+        </Checkbox>
+        <Checkbox
+          name={`checkboxNestedHelp3${value}`}
+          label="Nested Checkbox Example Level 3"
+          htmlId={`checkboxNestedHelp3${value}`}
+          checked={this.state.checkboxNestedHelp3}
+          onChange={() => this.setState({ checkboxNestedHelp3: !this.state.checkboxNestedHelp3 })}
+          key={`checkboxNestedHelp3${value}`}
+          nestedLevel={3}
+        >
+          <InputHelper message="This is help text for the nested Checkbox component" />
+        </Checkbox>
+      </>
+    );
+    return (
+      <>
+        <div className="row" style={{ padding: '1rem' }}>
+          {checkboxes(1)}
+        </div>
+        <div className="md--dark row" style={{ backgroundColor: 'black', padding: '1rem' }}>
+          {checkboxes(2)}
+        </div>
+        <div className="md--contrast">
+          <div className="row" style={{ padding: '1rem' }}>
+            {checkboxes(3)}
+          </div>
+          <div className="md--dark row" style={{ backgroundColor: 'black', padding: '1rem' }}>
+            {checkboxes(4)}
+          </div>
+        </div>
+      </>
+    );
+  }
+}

--- a/src/legacy/Checkbox/examples/KitchenSink.stories.tsx
+++ b/src/legacy/Checkbox/examples/KitchenSink.stories.tsx
@@ -1,0 +1,12 @@
+import LegacyKitchenSink from './KitchenSink';
+import React from 'react';
+
+export default {
+  title: 'Legacy/Checkbox',
+  component: LegacyKitchenSink,
+};
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+const Legacy = () => <LegacyKitchenSink />;
+
+export { Legacy };

--- a/src/legacy/Checkbox/examples/Nested.js
+++ b/src/legacy/Checkbox/examples/Nested.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import { Checkbox } from '@momentum-ui/react-collaboration';
+export default class CheckboxNested extends React.PureComponent {
+  state = {
+    parent: false,
+    child1: false,
+    child2: false,
+    child3: false,
+  };
+  render() {
+    return (
+      <span>
+        <Checkbox
+          value="parent"
+          label="Parent Checkbox Example"
+          htmlId="parentCheckbox"
+          checked={this.state.parent}
+          onChange={() => this.setState({ parent: !this.state.parent })}
+          key="child-0"
+        />
+        <Checkbox
+          value="child1"
+          label="Child Checkbox Nested 1 Level"
+          htmlId="childCheckbox1"
+          nestedLevel={1}
+          checked={this.state.child1}
+          onChange={() => this.setState({ child1: !this.state.child1 })}
+          key="child-1"
+        />
+        <Checkbox
+          value="child2"
+          label="Child Checkbox Nested 2 Levels"
+          htmlId="childCheckbox2"
+          nestedLevel={2}
+          checked={this.state.child2}
+          onChange={() => this.setState({ child2: !this.state.child2 })}
+          key="child-2"
+        />
+        <Checkbox
+          value="child3"
+          label="Child Checkbox Nested 3 Levels"
+          htmlId="childCheckbox3"
+          nestedLevel={3}
+          checked={this.state.child3}
+          onChange={() => this.setState({ child3: !this.state.child3 })}
+          key="child-3"
+        />
+      </span>
+    );
+  }
+}

--- a/src/legacy/Checkbox/examples/index.js
+++ b/src/legacy/Checkbox/examples/index.js
@@ -1,0 +1,6 @@
+export { default as CheckboxDefault } from './Default';
+export { default as CheckboxDisabled } from './Disabled';
+export { default as CheckboxGroup } from './Group';
+export { default as CheckboxIndeterminate } from './Indeterminate';
+export { default as CheckboxNested } from './Nested';
+export { default as CheckboxKitchenSink } from './KitchenSink';

--- a/src/legacy/Checkbox/index.js
+++ b/src/legacy/Checkbox/index.js
@@ -1,0 +1,100 @@
+/** @component checkbox */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import { Label } from '@momentum-ui/react-collaboration';
+
+const Checkbox = (props) => {
+  const {
+    checked,
+    children,
+    className,
+    disabled,
+    htmlId,
+    indeterminate,
+    inputRef,
+    label,
+    name,
+    nestedLevel,
+    onChange,
+    required,
+    value,
+    ...otherProps
+  } = props;
+
+  return (
+    <div
+      className={
+        'md-input-container md-checkbox' +
+        `${(nestedLevel && ` md-input--nested-${nestedLevel}`) || ''}` +
+        ` ${className}`
+      }
+    >
+      <input
+        aria-checked={checked}
+        className={`md-input md-checkbox__input` + `${(indeterminate && ' indeterminate') || ''}`}
+        type="checkbox"
+        ref={inputRef}
+        disabled={disabled}
+        checked={checked}
+        required={required}
+        name={name}
+        value={value}
+        onChange={onChange}
+        tabIndex={0}
+        id={htmlId}
+        {...otherProps}
+      />
+      <Label className="md-checkbox__label" label={label} htmlFor={htmlId} />
+      {children}
+    </div>
+  );
+};
+
+Checkbox.propTypes = {
+  /** @prop Sets Checkbox status as checked | false */
+  checked: PropTypes.bool,
+  /** @prop Child component to display next to the input | null */
+  children: PropTypes.node,
+  /** @prop Optional css class string | ''  */
+  className: PropTypes.string,
+  /** @prop Sets the attribute disabled to the Checkbox | false */
+  disabled: PropTypes.bool,
+  /** @prop Unique HTML ID. Used for tying label to HTML input. Handy hook for automated testing */
+  htmlId: PropTypes.string.isRequired,
+  /** @prop Optional indeterminate capabilities of checkbox | false */
+  indeterminate: PropTypes.bool,
+  /** @prop optional ref attribute for Checkbox input element | null */
+  inputRef: PropTypes.func,
+  /** @prop Required label string for Checkbox */
+  label: PropTypes.string.isRequired,
+  /** @prop Sets the attribute name to the Checkbox input element | '' */
+  name: PropTypes.string,
+  /** @prop Set the level of nested checkboxes | 0 */
+  nestedLevel: PropTypes.number,
+  /** @prop Optional onChange handler invoked when user makes a change within the Checkbox input element | null */
+  onChange: PropTypes.func,
+  /** @prop Optional required setting for Checkbox input | false */
+  required: PropTypes.bool,
+  /** @prop sets value of the Checkbox input element | '' */
+  value: PropTypes.string,
+};
+
+Checkbox.defaultProps = {
+  autoFocus: false,
+  checked: false,
+  className: '',
+  disabled: false,
+  indeterminate: false,
+  inputRef: null,
+  label: '',
+  name: '',
+  nestedLevel: 0,
+  onChange: () => {},
+  required: false,
+  value: '',
+};
+
+Checkbox.displayName = 'Checkbox';
+
+export default Checkbox;

--- a/src/legacy/Checkbox/tests/index.cy.js
+++ b/src/legacy/Checkbox/tests/index.cy.js
@@ -1,0 +1,10 @@
+import { prefix } from '../../utils/index';
+
+describe('@momentum-ui/react-collaboration', () => {
+  it('snapshot of checkbox', () => {
+    cy.visit(`${Cypress.env('BASE_URL')}/checkbox`)
+      .get(`.${prefix}-checkbox`)
+      .should('be.visible')
+      .percySnapshot();
+  });
+});

--- a/src/legacy/Checkbox/tests/index.spec.js
+++ b/src/legacy/Checkbox/tests/index.spec.js
@@ -1,0 +1,83 @@
+import React from 'react';
+import { shallow, mount } from 'enzyme';
+import { Checkbox, Label, InputHelper } from '@momentum-ui/react-collaboration';
+
+describe('tests for <Checkbox />', () => {
+  it('should match SnapShot', () => {
+    const container = mount(<Checkbox htmlId="test123" />);
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should render one Checkbox', () => {
+    const container = shallow(<Checkbox htmlId="test123" />);
+
+    expect(container.find('input').length).toEqual(1);
+    expect(container.children().length).toEqual(2);
+  });
+
+  it('should render Label', () => {
+    const container = shallow(<Checkbox htmlId="test123" label="test" />);
+
+    expect(
+      container.contains(<Label className="md-checkbox__label" htmlFor="test123" label="test" />)
+    ).toEqual(true);
+  });
+
+  it('should pass class based on indeterminate prop', () => {
+    const container = shallow(<Checkbox htmlId="test123" indeterminate />);
+
+    expect(container.find('input').hasClass('indeterminate')).toEqual(true);
+  });
+
+  it('should pass class based on nesting', () => {
+    const container = shallow(<Checkbox htmlId="test123" nestedLevel={1} />);
+
+    expect(container.hasClass('md-input--nested-1')).toEqual(true);
+  });
+
+  it('should handle disabled state', () => {
+    const container = shallow(<Checkbox htmlId="test123" disabled />);
+
+    expect(container.find('input').props().disabled).toEqual(true);
+  });
+
+  it('should render children', () => {
+    const container = shallow(
+      <Checkbox htmlId="test123">
+        <InputHelper message={"I'm here to help"} />
+      </Checkbox>
+    );
+
+    expect(container.children().length).toEqual(3);
+  });
+
+  it('should handle other DOM events if passed', () => {
+    let count = 0;
+    const countUp = () => count++;
+    const container = shallow(<Checkbox htmlId="test" onFocus={countUp} />);
+
+    container.find('input').simulate('focus');
+    expect(count).toEqual(1);
+  });
+
+  it('should handle onChange event', () => {
+    let count = 0;
+    const countUp = () => count++;
+    const container = shallow(<Checkbox htmlId="test" onChange={countUp} />);
+
+    container.find('input').simulate('change');
+    expect(count).toEqual(1);
+  });
+
+  it('should support input ref', () => {
+    class Container extends React.Component {
+      render() {
+        return <Checkbox htmlId="test123" inputRef={(ref) => (this.input = ref)} />;
+      }
+    }
+    const instance = mount(<Container />).instance();
+
+    expect(instance.input.tagName).toEqual('INPUT');
+  });
+});

--- a/src/legacy/Checkbox/tests/index.spec.js.snap
+++ b/src/legacy/Checkbox/tests/index.spec.js.snap
@@ -1,0 +1,49 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`tests for <Checkbox /> should match SnapShot 1`] = `
+<Checkbox
+  autoFocus={false}
+  checked={false}
+  className=""
+  disabled={false}
+  htmlId="test123"
+  indeterminate={false}
+  inputRef={null}
+  label=""
+  name=""
+  nestedLevel={0}
+  onChange={[Function]}
+  required={false}
+  value=""
+>
+  <div
+    className="md-input-container md-checkbox "
+  >
+    <input
+      aria-checked={false}
+      autoFocus={false}
+      checked={false}
+      className="md-input md-checkbox__input"
+      disabled={false}
+      id="test123"
+      name=""
+      onChange={[Function]}
+      required={false}
+      tabIndex={0}
+      type="checkbox"
+      value=""
+    />
+    <Label
+      className="md-checkbox__label"
+      htmlFor="test123"
+      label=""
+      theme=""
+    >
+      <label
+        className="md-label md-checkbox__label"
+        htmlFor="test123"
+      />
+    </Label>
+  </div>
+</Checkbox>
+`;

--- a/src/legacy/CheckboxGroup/index.js
+++ b/src/legacy/CheckboxGroup/index.js
@@ -1,0 +1,72 @@
+/** @component checkbox */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+class CheckboxGroup extends React.Component {
+  static displayName = 'CheckboxGroup';
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      values: props.values || [],
+    };
+  }
+
+  handleToggle = (value) => {
+    let newValues;
+    const { onChange } = this.props;
+    const { values } = this.state;
+    const isActive = values.includes(value);
+
+    if (isActive) {
+      newValues = values.filter((v) => v !== value);
+      onChange(this.props.values.filter((n) => n !== value));
+    } else {
+      newValues = values.concat(value);
+      onChange([...this.props.values, value]);
+    }
+
+    this.setState({
+      values: newValues,
+    });
+  };
+
+  render() {
+    const { children, name } = this.props;
+    const { values } = this.state;
+
+    const addHandlersToChildren = () => {
+      return React.Children.map(children, (child) => {
+        const { value } = child.props;
+        return React.cloneElement(child, {
+          name: name,
+          checked: values.includes(value),
+          'aria-checked': values.includes(value),
+          onChange: () => this.handleToggle(value),
+        });
+      });
+    };
+
+    return <div className={`md-checkbox-group`}>{addHandlersToChildren()}</div>;
+  }
+}
+
+CheckboxGroup.propTypes = {
+  /** @prop Children nodes to render inside Accordion | null */
+  children: PropTypes.node,
+  /** @prop Callback fired with the value or array of active values when the user presses a button | null */
+  onChange: PropTypes.func,
+  /** @prop An array of values, of the active (pressed) buttons | () => {} */
+  values: PropTypes.array,
+  /** @prop An HTML `<input>` name for each child button | '' */
+  name: PropTypes.string,
+};
+
+CheckboxGroup.defaultProps = {
+  values: [],
+  onChange: () => {},
+  name: '',
+};
+
+export default CheckboxGroup;

--- a/src/legacy/CheckboxGroup/tests/index.spec.js
+++ b/src/legacy/CheckboxGroup/tests/index.spec.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import { shallow, mount } from 'enzyme';
+import { Checkbox, CheckboxGroup } from '@momentum-ui/react-collaboration';
+
+describe('tests for <CheckboxGroup />', () => {
+  it('should match SnapShot', () => {
+    const container = mount(<CheckboxGroup />);
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should render one CheckboxGroup', () => {
+    const container = shallow(<CheckboxGroup />);
+
+    expect(container.find('div').length).toEqual(1);
+  });
+
+  it('should handle default true Values', () => {
+    const container = mount(
+      <CheckboxGroup values={['me']}>
+        <Checkbox value="me" label="me" htmlId="testCheckbox1" onChange={() => {}} />
+        <Checkbox value="you" label="you" htmlId="testCheckbox2" onChange={() => {}} />
+        <Checkbox value="us" label="us" htmlId="testCheckbox3" onChange={() => {}} />
+      </CheckboxGroup>
+    );
+
+    expect(container.find('#testCheckbox1').props().checked).toEqual(true);
+    expect(container.find('#testCheckbox2').props().checked).toEqual(false);
+  });
+
+  it('should handle Change Events', () => {
+    class Container extends React.Component {
+      render() {
+        return (
+          <CheckboxGroup>
+            <Checkbox value="me" label="me" htmlId="testCheckbox1" />
+            <Checkbox value="you" label="you" htmlId="testCheckbox2" />
+            <Checkbox value="us" label="us" htmlId="testCheckbox3" />
+          </CheckboxGroup>
+        );
+      }
+    }
+    const instance = mount(<Container />);
+    instance.find('#testCheckbox1').simulate('change', { target: { value: 'me' } });
+
+    expect(instance.find('#testCheckbox1').props().checked).toEqual(true);
+    expect(instance.find('#testCheckbox2').props().checked).toEqual(false);
+  });
+});

--- a/src/legacy/CheckboxGroup/tests/index.spec.js.snap
+++ b/src/legacy/CheckboxGroup/tests/index.spec.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`tests for <CheckboxGroup /> should match SnapShot 1`] = `
+<CheckboxGroup
+  name=""
+  onChange={[Function]}
+  values={Array []}
+>
+  <div
+    className="md-checkbox-group"
+  />
+</CheckboxGroup>
+`;

--- a/src/legacy/InputHelper/examples/Default.js
+++ b/src/legacy/InputHelper/examples/Default.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Checkbox, InputHelper } from '@momentum-ui/react-collaboration';
+
+export default function InputHelperDefault() {
+  return (
+    <div className="row">
+      <Checkbox value="us" label="us" htmlId="inputHelper1" onChange={() => {}}>
+        <InputHelper message={"I'm here to help"} />
+      </Checkbox>
+    </div>
+  );
+}

--- a/src/legacy/InputHelper/examples/KitchenSink.js
+++ b/src/legacy/InputHelper/examples/KitchenSink.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { InputHelperDefault } from './index';
+
+export default class InputHelperKitchenSink extends React.Component {
+  render() {
+    return (
+      <React.Fragment>
+        <InputHelperDefault />
+      </React.Fragment>
+    );
+  }
+}

--- a/src/legacy/InputHelper/examples/KitchenSink.stories.tsx
+++ b/src/legacy/InputHelper/examples/KitchenSink.stories.tsx
@@ -1,0 +1,12 @@
+import LegacyKitchenSink from './KitchenSink';
+import React from 'react';
+
+export default {
+  title: 'Legacy/InputHelper',
+  component: LegacyKitchenSink,
+};
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+const Legacy = () => <LegacyKitchenSink />;
+
+export { Legacy };

--- a/src/legacy/InputHelper/examples/index.js
+++ b/src/legacy/InputHelper/examples/index.js
@@ -1,0 +1,2 @@
+export { default as InputHelperDefault } from './Default';
+export { default as InputHelperKitchenSink } from './KitchenSink';

--- a/src/legacy/InputHelper/index.js
+++ b/src/legacy/InputHelper/index.js
@@ -1,0 +1,28 @@
+/** @component input */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const InputHelper = ({ message, className, ...props }) => {
+  return (
+    <div className={`md-input__help-text` + `${(className && ` ${className}`) || ''}`} {...props}>
+      {message}
+    </div>
+  );
+};
+
+InputHelper.propTypes = {
+  /** @prop Optional css class name | '' */
+  className: PropTypes.string,
+  /** @prop Input help message for parent Input | null */
+  message: PropTypes.string.isRequired,
+};
+
+InputHelper.defaultProps = {
+  className: '',
+  message: null,
+};
+
+InputHelper.displayName = 'InputHelper';
+
+export default InputHelper;

--- a/src/legacy/InputHelper/tests/index.cy.js
+++ b/src/legacy/InputHelper/tests/index.cy.js
@@ -1,0 +1,10 @@
+import { prefix } from '../../utils/index';
+
+describe('@momentum-ui/react-collaboration', () => {
+  it('snapshot of input-helper', () => {
+    cy.visit(`${Cypress.env('BASE_URL')}/input-helper`)
+      .get(`.${prefix}-input__help-text`)
+      .should('be.visible')
+      .percySnapshot();
+  });
+});

--- a/src/legacy/InputHelper/tests/index.spec.js
+++ b/src/legacy/InputHelper/tests/index.spec.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import { shallow, mount } from 'enzyme';
+import { InputHelper } from '@momentum-ui/react-collaboration';
+
+describe('tests for <InputHelper />', () => {
+  it('should match text SnapShot', () => {
+    const container = mount(<InputHelper message="test" />);
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should render className if prop is passed', () => {
+    const container = shallow(<InputHelper className="class-test" message="test" />);
+
+    expect(container.find('.class-test').exists()).toEqual(true);
+  });
+
+  it('should render input help with correct class', () => {
+    const container = shallow(<InputHelper message="test" />);
+
+    expect(container.find('div').hasClass('md-input__help-text')).toEqual(true);
+  });
+
+  it('should render message', () => {
+    const container = shallow(<InputHelper message="test" />);
+
+    expect(container.find('div').text()).toEqual('test');
+  });
+
+  it('should pass otherProps to container', () => {
+    const container = shallow(<InputHelper message="test" id="testid" />);
+
+    expect(container.find('#testid').exists()).toEqual(true);
+  });
+});

--- a/src/legacy/InputHelper/tests/index.spec.js.snap
+++ b/src/legacy/InputHelper/tests/index.spec.js.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`tests for <InputHelper /> should match text SnapShot 1`] = `
+<InputHelper
+  className=""
+  message="test"
+>
+  <div
+    className="md-input__help-text"
+  >
+    test
+  </div>
+</InputHelper>
+`;

--- a/src/legacy/List/examples/ListWithEventBubbling.js
+++ b/src/legacy/List/examples/ListWithEventBubbling.js
@@ -1,15 +1,15 @@
 /* eslint-disable no-console */
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 import React from 'react';
-import { CheckboxNext, List, ListItem } from '@momentum-ui/react-collaboration';
+import { Checkbox, List, ListItem } from '@momentum-ui/react-collaboration';
 
 export default class ListWithEventBubbling extends React.PureComponent {
   state = {
     enableBubbling: true,
   };
 
-  onChange = (isSelected) => {
-    this.setState({ enableBubbling: isSelected });
+  onChange = (e) => {
+    this.setState({ enableBubbling: e.target.checked });
   };
 
   bubbledEventHandler = (e) => {
@@ -27,11 +27,11 @@ export default class ListWithEventBubbling extends React.PureComponent {
             <ListItem label="List Item 4" />
           </List>
         </div>
-        <CheckboxNext
-          isSelected={this.state.enableBubbling}
+        <Checkbox
+          checked={this.state.enableBubbling}
           onChange={this.onChange}
           label="Enable Event Bubbling (See Console)"
-          id={`checkbox-for-event-bubbling`}
+          htmlId={`checkbox-for-event-bubbling`}
         />
       </div>
     );

--- a/src/legacy/SelectOption/index.js
+++ b/src/legacy/SelectOption/index.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
-import { CheckboxNext, Icon, ListItem, ListItemSection } from '@momentum-ui/react-collaboration';
+import { Checkbox, Icon, ListItem, ListItemSection } from '@momentum-ui/react-collaboration';
 import SelectContext from '../SelectContext';
 import ListContext from '../ListContext';
 import { UIDConsumer } from 'react-uid';
@@ -14,7 +14,12 @@ class SelectOption extends React.Component {
 
     const separateChildren = (isMulti, cxtActive, uniqueId) => {
       return isMulti ? (
-        <CheckboxNext id={`${uniqueId}__checkbox`} label={label} isSelected={cxtActive || false} />
+        <Checkbox
+          htmlId={`${uniqueId}__checkbox`}
+          label={label}
+          checked={cxtActive || false}
+          onChange={() => {}}
+        />
       ) : (
         [
           <ListItemSection key="child-0" position="center">

--- a/src/legacy/SelectOption/tests/index.spec.js
+++ b/src/legacy/SelectOption/tests/index.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import { Select, SelectOption, CheckboxNext } from '@momentum-ui/react-collaboration';
+import { Select, SelectOption } from '@momentum-ui/react-collaboration';
 
 describe('tests for <SelectOption />', () => {
   it('should match SnapShot', () => {
@@ -54,7 +54,7 @@ describe('tests for <SelectOption />', () => {
     );
 
     container.find('button').simulate('click');
-    expect(container.find(CheckboxNext).props().isSelected).toEqual(true);
+    expect(container.find('Checkbox').props().checked).toEqual(true);
   });
 
   it('should pass props to ListItem', () => {

--- a/src/legacy/index.js
+++ b/src/legacy/index.js
@@ -20,6 +20,8 @@ export { default as ButtonGroup } from './ButtonGroup';
 export { default as CallControl } from './CallControl';
 export { default as Card } from './Card';
 export { default as CardSection } from './CardSection';
+export { default as Checkbox } from './Checkbox';
+export { default as CheckboxGroup } from './CheckboxGroup';
 export { default as Chip } from './Chip';
 export { default as CloseIcon } from './CloseIcon';
 export { default as CloseWrapper } from './CloseWrapper';

--- a/src/legacy/index.js
+++ b/src/legacy/index.js
@@ -41,6 +41,7 @@ export { default as FormSubSection } from './FormSubSection';
 export { default as Icon } from './Icon';
 export { default as Input } from './Input';
 export { default as InputMessage } from './InputMessage';
+export { default as InputHelper } from './InputHelper';
 export { default as InputSearch } from './InputSearch';
 export { default as InputSection } from './InputSection';
 export { default as Label } from './Label';


### PR DESCRIPTION
Reverts momentum-design/momentum-react-v2#281

PR 281 removed InputHelper, but Input was actually still using it