### PR TITLE
feat(menu-item): fix toggle accessibility issue

### DIFF
--- a/src/legacy/Menu/examples/CustomMenuItems.js
+++ b/src/legacy/Menu/examples/CustomMenuItems.js
@@ -8,6 +8,8 @@ import {
   MenuItem,
   MenuOverlay,
 } from '@momentum-ui/react-collaboration';
+import Toggle from '../../../components/Toggle';
+
 export default class CustomMenuItems extends React.PureComponent {
   onClick(event, value) {
     alert(`${value} clicked`);
@@ -20,15 +22,18 @@ export default class CustomMenuItems extends React.PureComponent {
             Show Customized MenuItems
           </Button>
         }
-        direction="top-center"
+        direction="bottom-center"
       >
         <MenuContent>Content</MenuContent>
         <Menu>
-          <MenuItem>
+          <MenuItem keepMenuOpen>
             <ListItemSection position="left">
               <Icon name="edit_20" />
             </ListItemSection>
-            <ListItemSection position="center">Edit space settings</ListItemSection>
+            <ListItemSection position="center">Dark mode</ListItemSection>
+            <ListItemSection position="right">
+              <Toggle />
+            </ListItemSection>
           </MenuItem>
           <MenuItem keepMenuOpen>
             <ListItemSection position="left">

--- a/src/legacy/MenuItem/index.js
+++ b/src/legacy/MenuItem/index.js
@@ -35,6 +35,10 @@ class MenuItem extends React.Component {
     const { onClick, parentKeyDown, parentOnSelect } = this.props;
     const { eventKey } = opts;
 
+    if (!e.target?.classList?.contains(`${prefix}-list-item`)) {
+      return;
+    }
+
     if (e.which === 32 || e.which === 13 || e.charCode === 32 || e.charCode === 13) {
       onClick && onClick(e);
       parentOnSelect && parentOnSelect(e, { eventKey, element: this });

--- a/src/legacy/MenuItem/tests/index.spec.js
+++ b/src/legacy/MenuItem/tests/index.spec.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import { MenuItem } from '@momentum-ui/react-collaboration';
 import SelectableContext from '../../SelectableContext';
-
+import { Icon, ListItemSection, MenuItem } from '@momentum-ui/react-collaboration';
+import Toggle from '../../../components/Toggle';
 beforeEach(() => {
   jest.resetModules();
   jest.clearAllMocks();
@@ -47,6 +47,38 @@ describe('tests for <MenuItem />', () => {
     listItem.simulate('click');
     expect(context.parentOnSelect.mock.calls.length).toBe(1);
     expect(onClick.mock.calls[0][1].value).toBe('test');
+  });
+
+  it('should not call e.preventDefault if target is not md-list-item', () => {
+    const onClick = jest.fn();
+
+    const wrapper = mount(
+      <SelectableContext.Provider value={context}>
+        <MenuItem onClick={onClick} label="one" value="test">
+          <ListItemSection position="left">
+            <Icon name="edit_20" />
+          </ListItemSection>
+          <ListItemSection position="center">Dark mode</ListItemSection>
+          <ListItemSection position="right">
+            <Toggle aria-label="toggle" />
+          </ListItemSection>
+        </MenuItem>
+      </SelectableContext.Provider>
+    );
+
+    const toggle = wrapper.find(Toggle);
+
+    const mockEvent = {
+      preventDefault: jest.fn(),
+      keyCode: 32,
+      target: toggle.getDOMNode(),
+    };
+
+    const listItem = wrapper.find(Toggle);
+    listItem.simulate('keydown', mockEvent);
+    expect(onClick).not.toBeCalled();
+    expect(context.parentKeyDown).not.toBeCalled();
+    expect(mockEvent.preventDefault).not.toBeCalled();
   });
 
   it('should call handleKeyDown function of context when keyDown is fired on ListItem', () => {


### PR DESCRIPTION
# Description
Legacy Menu Items were preventDefaulting events when a toggle is provided as children causing keyboard accessibility on the toggle to break. This PR makes sure the events for menu-item are only handled when the event target is the menu-item itself.  