### PR TITLE
fix: remove the two characters from line 34

### DIFF
--- a/src/components/Tab/Tab.style.scss
+++ b/src/components/Tab/Tab.style.scss
@@ -31,7 +31,7 @@
 
         .md-text-wrapper,
         .md-icon-wrapper {
-          color: var(--tab-inactive-text-pressed);
+          color: var(--tab-active-text-pressed);
         }
       }
     }


### PR DESCRIPTION
# Description

Literally removing two characters changing the color var name from "inactive" into "active".

# Links

[SPARK-332386](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-332386) Tab active state colour is incorrect