### PR TITLE
Fix: MenuTrigger separator width 

### DIFF
--- a/src/components/MenuTrigger/MenuTrigger.style.scss
+++ b/src/components/MenuTrigger/MenuTrigger.style.scss
@@ -10,3 +10,7 @@
     width: 18rem;
   }
 }
+
+.md-content-separator-wrapper {
+  width: 100%;
+}

--- a/src/components/Tab/Tab.style.scss
+++ b/src/components/Tab/Tab.style.scss
@@ -31,7 +31,7 @@
 
         .md-text-wrapper,
         .md-icon-wrapper {
-          color: var(--tab-inactive-text-pressed);
+          color: var(--tab-active-text-pressed);
         }
       }
     }


### PR DESCRIPTION
# Description

defines the width of the separator as being 100% of its parent element (it was 0 before)

# Links

[SPARK-332388](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-332388)
Separator for MenuTrigger with multiple menus doesn't get displayed