### PR TITLE
feat(toggle-circle-button): implement button circle toggle

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "@momentum-ui/animations": "^1.3.0",
-    "@momentum-ui/design-tokens": "^0.0.50",
+    "@momentum-ui/design-tokens": "^0.0.53",
     "@momentum-ui/icons": "8.28.4",
     "@momentum-ui/icons-rebrand": "^1.39.0",
     "@momentum-ui/tokens": "^1.7.1",
@@ -116,6 +116,7 @@
     "@react-stately/collections": "^3.3.4",
     "@react-stately/data": "^3.4.1",
     "@react-stately/select": "^3.1.3",
+    "@react-stately/toggle": "^3.4.1",
     "@react-stately/tree": "^3.2.0",
     "@react-types/button": "^3.4.0",
     "@react-types/select": "^3.3.1",

--- a/src/components/ButtonCircleToggle/ButtonCircleToggle.constants.ts
+++ b/src/components/ButtonCircleToggle/ButtonCircleToggle.constants.ts
@@ -1,0 +1,16 @@
+import { SIZES } from '../ButtonCircle/ButtonCircle.constants';
+
+const CLASS_PREFIX = 'md-button-circle-toggle';
+
+const DEFAULTS = {
+  SELECTED: false,
+  OUTLINE: undefined,
+  GHOST: true,
+  DISABLED: false,
+};
+
+const STYLE = {
+  wrapper: `${CLASS_PREFIX}-wrapper`,
+};
+
+export { CLASS_PREFIX, DEFAULTS, SIZES, STYLE };

--- a/src/components/ButtonCircleToggle/ButtonCircleToggle.stories.args.ts
+++ b/src/components/ButtonCircleToggle/ButtonCircleToggle.stories.args.ts
@@ -1,0 +1,21 @@
+import { commonStyles, commonAriaButtonToggle } from '../../storybook/helper.stories.argtypes';
+import { BUTTON_CIRCLE_TOGGLE_CONSTANTS as CONSTANTS } from './';
+import { buttonCircleArgTypes } from '../ButtonCircle/ButtonCircle.stories.args';
+
+const buttonCircleToggleArgTypes = {
+  ...buttonCircleArgTypes,
+  ...commonAriaButtonToggle,
+};
+
+delete buttonCircleToggleArgTypes.color;
+
+buttonCircleToggleArgTypes.disabled.table.defaultValue.summary = CONSTANTS.DEFAULTS.DISABLED;
+buttonCircleToggleArgTypes.ghost.table.defaultValue.summary = CONSTANTS.DEFAULTS.GHOST;
+buttonCircleToggleArgTypes.outline.table.defaultValue.summary = CONSTANTS.DEFAULTS.OUTLINE;
+
+export { buttonCircleToggleArgTypes };
+
+export default {
+  ...commonStyles,
+  ...buttonCircleToggleArgTypes,
+};

--- a/src/components/ButtonCircleToggle/ButtonCircleToggle.stories.docs.mdx
+++ b/src/components/ButtonCircleToggle/ButtonCircleToggle.stories.docs.mdx
@@ -1,0 +1,1 @@
+The `<ButtonCircleToggle />` component.

--- a/src/components/ButtonCircleToggle/ButtonCircleToggle.stories.tsx
+++ b/src/components/ButtonCircleToggle/ButtonCircleToggle.stories.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+
+import { MultiTemplateWithPseudoStates, Template } from '../../storybook/helper.stories.templates';
+import { DocumentationPage } from '../../storybook/helper.stories.docs';
+import StyleDocs from '../../storybook/docs.stories.style.mdx';
+
+import Icon from '../Icon';
+import ButtonCircleToggle, { ButtonCircleToggleProps } from './';
+import argTypes from './ButtonCircleToggle.stories.args';
+import Documentation from './ButtonCircleToggle.stories.docs.mdx';
+
+export default {
+  title: 'Momentum UI/ButtonCircleToggle',
+  component: ButtonCircleToggle,
+  parameters: {
+    expanded: true,
+    docs: {
+      page: DocumentationPage(Documentation, StyleDocs),
+    },
+    args: {
+      style: { margin: '0.5rem' },
+    },
+  },
+};
+
+const Example = Template<ButtonCircleToggleProps>(ButtonCircleToggle).bind({});
+
+Example.argTypes = { ...argTypes };
+
+Example.args = {
+  children: <Icon name="cancel" autoScale={150} />,
+};
+
+// Pseudostates will be correctly applied to ButtonCircleToggle once ButtonCircle
+// is fixed to receive these pseudostates.
+
+const Outline = MultiTemplateWithPseudoStates<ButtonCircleToggleProps>(ButtonCircleToggle).bind({});
+
+Outline.argTypes = { ...argTypes };
+delete Outline.argTypes.children;
+delete Outline.argTypes.ghost;
+delete Outline.argTypes.outline;
+delete Outline.argTypes.isSelected;
+
+Outline.args = {
+  children: <Icon name="cancel" autoScale={150} />,
+};
+
+Outline.parameters = {
+  variants: [{ outline: true }, { outline: true, isSelected: true }],
+};
+
+const Ghost = MultiTemplateWithPseudoStates<ButtonCircleToggleProps>(ButtonCircleToggle).bind({});
+
+Ghost.argTypes = { ...argTypes };
+delete Ghost.argTypes.children;
+delete Ghost.argTypes.ghost;
+delete Ghost.argTypes.outline;
+delete Ghost.argTypes.isSelected;
+
+Ghost.args = {
+  children: <Icon name="cancel" autoScale={150} />,
+};
+
+Ghost.parameters = {
+  variants: [{ ghost: true }, { ghost: true, isSelected: true }],
+};
+
+export { Example, Outline, Ghost };

--- a/src/components/ButtonCircleToggle/ButtonCircleToggle.style.scss
+++ b/src/components/ButtonCircleToggle/ButtonCircleToggle.style.scss
@@ -1,0 +1,39 @@
+.md-button-circle-toggle-wrapper {
+  &[data-selected='true'] {
+    &[data-outline='true'], &[data-ghost='true'] {
+      background-color: var(--toggleButton-active-background);
+      color: var(--toggleButton-active-text);
+
+      &:hover {
+        background-color: var(--toggleButton-active-background-hovered);
+        color: var(--toggleButton-active-text-hovered);
+      }
+
+      &:active {
+        background-color: var(--toggleButton-active-background-pressed);
+        color: var(--toggleButton-active-text-pressed);
+      }
+
+      &[data-disabled='true'] {
+        background-color: var(--toggleButton-active-background-disabled);
+        color: var(--toggleButton-active-text-disabled);
+      }
+    }
+
+    &[data-outline='true'] {
+      border-color: var(--toggleButton-active-border-color);
+
+      &:hover {
+        border-color: var(--toggleButton-active-border-color-hovered);
+      }
+
+      &:active {
+        border-color: var(--toggleButton-active-border-color-pressed);
+      }
+
+      &[data-disabled='true'] {
+        border-color: var(--toggleButton-active-border-color-disabled);
+      }
+    }
+  }
+}

--- a/src/components/ButtonCircleToggle/ButtonCircleToggle.tsx
+++ b/src/components/ButtonCircleToggle/ButtonCircleToggle.tsx
@@ -1,0 +1,66 @@
+import React, { RefObject, forwardRef, useRef } from 'react';
+import classnames from 'classnames';
+import ButtonCircle from '../ButtonCircle';
+import { useToggleState } from '@react-stately/toggle';
+import { useToggleButton } from '@react-aria/button';
+
+import { DEFAULTS, STYLE } from './ButtonCircleToggle.constants';
+import { DEFAULTS as BUTTON_CIRCLE_DEFAULTS } from '../ButtonCircle/ButtonCircle.constants';
+import { Size as ButtonCircleSize } from '../ButtonCircle/ButtonCircle.types';
+import { Props } from './ButtonCircleToggle.types';
+import './ButtonCircleToggle.style.scss';
+import { AriaBaseButtonProps } from '@react-types/button';
+
+const ButtonCircleToggle = forwardRef((props: Props, providedRef: RefObject<HTMLButtonElement>) => {
+  const {
+    children,
+    className,
+    ghost = DEFAULTS.GHOST,
+    outline = DEFAULTS.OUTLINE,
+    disabled = DEFAULTS.DISABLED,
+    size = BUTTON_CIRCLE_DEFAULTS.SIZE,
+  } = props;
+
+  const internalRef = useRef();
+  const ref = providedRef || internalRef;
+
+  const state = useToggleState(props);
+  const { buttonProps } = useToggleButton(props, state, ref);
+
+  // useToggleButton hook from react-aria has wrong aria button types, so we fix it manually.
+  const filteredProps = {
+    ...buttonProps,
+    color: undefined,
+    'aria-expanded': buttonProps['aria-expanded'] as AriaBaseButtonProps['aria-expanded'],
+    'aria-haspopup': buttonProps['aria-haspopup'] as AriaBaseButtonProps['aria-haspopup'],
+    'aria-pressed': buttonProps['aria-pressed'] as AriaBaseButtonProps['aria-pressed'],
+  };
+
+  // We delete the disabled prop coming from useToggleButton,
+  // so that we use the disabled value passed in props.
+  delete filteredProps.disabled;
+
+  if (ghost === false && outline === false) {
+    console.warn(
+      'ButtonCircleToggle is only designed for outline or ghost circle buttons. Outline and ghost properties cannot be false at the same time.'
+    );
+  }
+
+  return (
+    <ButtonCircle
+      className={classnames(STYLE.wrapper, className)}
+      outline={outline}
+      ghost={ghost}
+      disabled={disabled}
+      size={size as ButtonCircleSize}
+      data-selected={state.isSelected || DEFAULTS.SELECTED}
+      {...filteredProps}
+    >
+      {children}
+    </ButtonCircle>
+  );
+});
+
+ButtonCircleToggle.displayName = 'ButtonSimpleToggle';
+
+export default ButtonCircleToggle;

--- a/src/components/ButtonCircleToggle/ButtonCircleToggle.types.ts
+++ b/src/components/ButtonCircleToggle/ButtonCircleToggle.types.ts
@@ -1,0 +1,6 @@
+import { ButtonCircleProps } from '../ButtonCircle';
+import { AriaButtonProps, AriaToggleButtonProps } from '@react-types/button';
+
+export interface Props
+  extends Omit<ButtonCircleProps, keyof AriaButtonProps>,
+    AriaToggleButtonProps {}

--- a/src/components/ButtonCircleToggle/ButtonCircleToggle.unit.test.tsx
+++ b/src/components/ButtonCircleToggle/ButtonCircleToggle.unit.test.tsx
@@ -1,0 +1,183 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import ButtonCircleToggle, { BUTTON_CIRCLE_TOGGLE_CONSTANTS as CONSTANTS } from './';
+import { triggerPress } from '../../../test/utils';
+
+describe('<ButtonCircleToggle />', () => {
+  describe('snapshot', () => {
+    it('should match snapshot', () => {
+      expect.assertions(1);
+
+      const container = mount(<ButtonCircleToggle />);
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match snapshot with isSelected being true', () => {
+      expect.assertions(1);
+
+      const isSelected = true;
+
+      const container = mount(<ButtonCircleToggle isSelected={isSelected} />);
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match snapshot with isSelected being false', () => {
+      expect.assertions(1);
+
+      const isSelected = false;
+
+      const container = mount(<ButtonCircleToggle isSelected={isSelected} />);
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match snapshot with ghost being true', () => {
+      expect.assertions(1);
+
+      const ghost = true;
+
+      const container = mount(<ButtonCircleToggle ghost={ghost} />);
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match snapshot with ghost being false', () => {
+      expect.assertions(1);
+
+      const ghost = false;
+
+      const container = mount(<ButtonCircleToggle ghost={ghost} />);
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match snapshot with outline being true', () => {
+      expect.assertions(1);
+
+      const outline = true;
+
+      const container = mount(<ButtonCircleToggle outline={outline} />);
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match snapshot with outline being false', () => {
+      expect.assertions(1);
+
+      const outline = false;
+
+      const container = mount(<ButtonCircleToggle outline={outline} />);
+
+      expect(container).toMatchSnapshot();
+    });
+  });
+
+  describe('attributes', () => {
+    it('should have its wrapper class', () => {
+      expect.assertions(1);
+
+      const element = mount(<ButtonCircleToggle />)
+        .find(ButtonCircleToggle)
+        .getDOMNode();
+
+      expect(element.classList.contains(CONSTANTS.STYLE.wrapper)).toBe(true);
+    });
+
+    it('should have provided outline when outline is provided', () => {
+      expect.assertions(1);
+
+      const outline = true;
+
+      const element = mount(<ButtonCircleToggle outline={outline} />)
+        .find(ButtonCircleToggle)
+        .getDOMNode();
+
+      expect(element.getAttribute('data-outline')).toBe(`${outline}`);
+    });
+
+    it('should have provided ghost when ghost is provided', () => {
+      expect.assertions(1);
+
+      const ghost = true;
+
+      const element = mount(<ButtonCircleToggle ghost={ghost} />)
+        .find(ButtonCircleToggle)
+        .getDOMNode();
+
+      expect(element.getAttribute('data-ghost')).toBe(`${ghost}`);
+    });
+
+    it('should have provided isSelected when isSelected is provided', () => {
+      expect.assertions(1);
+
+      const isSelected = true;
+
+      const element = mount(<ButtonCircleToggle isSelected={isSelected} />)
+        .find(ButtonCircleToggle)
+        .getDOMNode();
+
+      expect(element.getAttribute('data-selected')).toBe(`${isSelected}`);
+    });
+  });
+
+  describe('actions', () => {
+    it('onChange callback is called correctly when provided', () => {
+      expect.assertions(1);
+
+      const mockCallback = jest.fn();
+
+      const initialIsSelected = false;
+
+      const component = mount(<ButtonCircleToggle onChange={mockCallback} />).find(
+        ButtonCircleToggle
+      );
+
+      component.props().onChange(initialIsSelected);
+
+      expect(mockCallback).toBeCalledTimes(1);
+    });
+
+    it('should handle mouse press events', () => {
+      expect.assertions(4);
+
+      const mockCallback = jest.fn();
+
+      const component = mount(<ButtonCircleToggle onChange={mockCallback} />).find(
+        ButtonCircleToggle
+      );
+
+      triggerPress(component);
+
+      expect(mockCallback).toHaveBeenCalledWith(true);
+
+      triggerPress(component);
+
+      expect(mockCallback).toHaveBeenCalledWith(false);
+
+      triggerPress(component);
+
+      expect(mockCallback).toHaveBeenCalledWith(true);
+
+      triggerPress(component);
+
+      expect(mockCallback).toHaveBeenCalledWith(false);
+    });
+
+    it('should handle mouse press event when disabled', () => {
+      expect.assertions(1);
+
+      const mockCallback = jest.fn();
+
+      const component = mount(<ButtonCircleToggle onChange={mockCallback} disabled />).find(
+        ButtonCircleToggle
+      );
+
+      triggerPress(component);
+
+      expect(mockCallback).toBeCalledTimes(0);
+    });
+  });
+});

--- a/src/components/ButtonCircleToggle/ButtonCircleToggle.unit.test.tsx.snap
+++ b/src/components/ButtonCircleToggle/ButtonCircleToggle.unit.test.tsx.snap
@@ -1,0 +1,659 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ButtonCircleToggle /> snapshot should match snapshot 1`] = `
+<ButtonSimpleToggle>
+  <ButtonCircle
+    aria-pressed={false}
+    className="md-button-circle-toggle-wrapper"
+    data-selected={false}
+    disabled={false}
+    ghost={true}
+    onBlur={null}
+    onClick={[Function]}
+    onDragStart={[Function]}
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    onMouseDown={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    onMouseUp={[Function]}
+    onTouchCancel={[Function]}
+    onTouchEnd={[Function]}
+    onTouchMove={[Function]}
+    onTouchStart={[Function]}
+    size={40}
+    type="button"
+  >
+    <ButtonSimple
+      aria-pressed={false}
+      className="md-button-circle-wrapper md-button-circle-toggle-wrapper"
+      data-color="primary"
+      data-disabled={false}
+      data-ghost={true}
+      data-multiple-children={false}
+      data-outline={false}
+      data-selected={false}
+      data-size={40}
+      isDisabled={false}
+      onBlur={null}
+      onClick={[Function]}
+      onDragStart={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchCancel={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      type="button"
+    >
+      <FocusRing
+        disabled={false}
+      >
+        <FocusRing
+          disabled={false}
+          focusClass="md-focus-ring-wrapper children"
+          focusRingClass="md-focus-ring-wrapper children"
+        >
+          <button
+            aria-pressed={false}
+            className="md-button-circle-wrapper md-button-circle-toggle-wrapper md-button-simple-wrapper"
+            data-color="primary"
+            data-disabled={false}
+            data-ghost={true}
+            data-multiple-children={false}
+            data-outline={false}
+            data-selected={false}
+            data-size={40}
+            disabled={false}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onDragStart={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchCancel={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            type="button"
+          />
+        </FocusRing>
+      </FocusRing>
+    </ButtonSimple>
+  </ButtonCircle>
+</ButtonSimpleToggle>
+`;
+
+exports[`<ButtonCircleToggle /> snapshot should match snapshot with ghost being false 1`] = `
+<ButtonSimpleToggle
+  ghost={false}
+>
+  <ButtonCircle
+    aria-pressed={false}
+    className="md-button-circle-toggle-wrapper"
+    data-selected={false}
+    disabled={false}
+    ghost={false}
+    onBlur={null}
+    onClick={[Function]}
+    onDragStart={[Function]}
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    onMouseDown={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    onMouseUp={[Function]}
+    onTouchCancel={[Function]}
+    onTouchEnd={[Function]}
+    onTouchMove={[Function]}
+    onTouchStart={[Function]}
+    size={40}
+    type="button"
+  >
+    <ButtonSimple
+      aria-pressed={false}
+      className="md-button-circle-wrapper md-button-circle-toggle-wrapper"
+      data-color="primary"
+      data-disabled={false}
+      data-ghost={false}
+      data-multiple-children={false}
+      data-outline={false}
+      data-selected={false}
+      data-size={40}
+      isDisabled={false}
+      onBlur={null}
+      onClick={[Function]}
+      onDragStart={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchCancel={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      type="button"
+    >
+      <FocusRing
+        disabled={false}
+      >
+        <FocusRing
+          disabled={false}
+          focusClass="md-focus-ring-wrapper children"
+          focusRingClass="md-focus-ring-wrapper children"
+        >
+          <button
+            aria-pressed={false}
+            className="md-button-circle-wrapper md-button-circle-toggle-wrapper md-button-simple-wrapper"
+            data-color="primary"
+            data-disabled={false}
+            data-ghost={false}
+            data-multiple-children={false}
+            data-outline={false}
+            data-selected={false}
+            data-size={40}
+            disabled={false}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onDragStart={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchCancel={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            type="button"
+          />
+        </FocusRing>
+      </FocusRing>
+    </ButtonSimple>
+  </ButtonCircle>
+</ButtonSimpleToggle>
+`;
+
+exports[`<ButtonCircleToggle /> snapshot should match snapshot with ghost being true 1`] = `
+<ButtonSimpleToggle
+  ghost={true}
+>
+  <ButtonCircle
+    aria-pressed={false}
+    className="md-button-circle-toggle-wrapper"
+    data-selected={false}
+    disabled={false}
+    ghost={true}
+    onBlur={null}
+    onClick={[Function]}
+    onDragStart={[Function]}
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    onMouseDown={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    onMouseUp={[Function]}
+    onTouchCancel={[Function]}
+    onTouchEnd={[Function]}
+    onTouchMove={[Function]}
+    onTouchStart={[Function]}
+    size={40}
+    type="button"
+  >
+    <ButtonSimple
+      aria-pressed={false}
+      className="md-button-circle-wrapper md-button-circle-toggle-wrapper"
+      data-color="primary"
+      data-disabled={false}
+      data-ghost={true}
+      data-multiple-children={false}
+      data-outline={false}
+      data-selected={false}
+      data-size={40}
+      isDisabled={false}
+      onBlur={null}
+      onClick={[Function]}
+      onDragStart={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchCancel={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      type="button"
+    >
+      <FocusRing
+        disabled={false}
+      >
+        <FocusRing
+          disabled={false}
+          focusClass="md-focus-ring-wrapper children"
+          focusRingClass="md-focus-ring-wrapper children"
+        >
+          <button
+            aria-pressed={false}
+            className="md-button-circle-wrapper md-button-circle-toggle-wrapper md-button-simple-wrapper"
+            data-color="primary"
+            data-disabled={false}
+            data-ghost={true}
+            data-multiple-children={false}
+            data-outline={false}
+            data-selected={false}
+            data-size={40}
+            disabled={false}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onDragStart={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchCancel={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            type="button"
+          />
+        </FocusRing>
+      </FocusRing>
+    </ButtonSimple>
+  </ButtonCircle>
+</ButtonSimpleToggle>
+`;
+
+exports[`<ButtonCircleToggle /> snapshot should match snapshot with isSelected being false 1`] = `
+<ButtonSimpleToggle
+  isSelected={false}
+>
+  <ButtonCircle
+    aria-pressed={false}
+    className="md-button-circle-toggle-wrapper"
+    data-selected={false}
+    disabled={false}
+    ghost={true}
+    onBlur={null}
+    onClick={[Function]}
+    onDragStart={[Function]}
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    onMouseDown={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    onMouseUp={[Function]}
+    onTouchCancel={[Function]}
+    onTouchEnd={[Function]}
+    onTouchMove={[Function]}
+    onTouchStart={[Function]}
+    size={40}
+    type="button"
+  >
+    <ButtonSimple
+      aria-pressed={false}
+      className="md-button-circle-wrapper md-button-circle-toggle-wrapper"
+      data-color="primary"
+      data-disabled={false}
+      data-ghost={true}
+      data-multiple-children={false}
+      data-outline={false}
+      data-selected={false}
+      data-size={40}
+      isDisabled={false}
+      onBlur={null}
+      onClick={[Function]}
+      onDragStart={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchCancel={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      type="button"
+    >
+      <FocusRing
+        disabled={false}
+      >
+        <FocusRing
+          disabled={false}
+          focusClass="md-focus-ring-wrapper children"
+          focusRingClass="md-focus-ring-wrapper children"
+        >
+          <button
+            aria-pressed={false}
+            className="md-button-circle-wrapper md-button-circle-toggle-wrapper md-button-simple-wrapper"
+            data-color="primary"
+            data-disabled={false}
+            data-ghost={true}
+            data-multiple-children={false}
+            data-outline={false}
+            data-selected={false}
+            data-size={40}
+            disabled={false}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onDragStart={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchCancel={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            type="button"
+          />
+        </FocusRing>
+      </FocusRing>
+    </ButtonSimple>
+  </ButtonCircle>
+</ButtonSimpleToggle>
+`;
+
+exports[`<ButtonCircleToggle /> snapshot should match snapshot with isSelected being true 1`] = `
+<ButtonSimpleToggle
+  isSelected={true}
+>
+  <ButtonCircle
+    aria-pressed={true}
+    className="md-button-circle-toggle-wrapper"
+    data-selected={true}
+    disabled={false}
+    ghost={true}
+    onBlur={null}
+    onClick={[Function]}
+    onDragStart={[Function]}
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    onMouseDown={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    onMouseUp={[Function]}
+    onTouchCancel={[Function]}
+    onTouchEnd={[Function]}
+    onTouchMove={[Function]}
+    onTouchStart={[Function]}
+    size={40}
+    type="button"
+  >
+    <ButtonSimple
+      aria-pressed={true}
+      className="md-button-circle-wrapper md-button-circle-toggle-wrapper"
+      data-color="primary"
+      data-disabled={false}
+      data-ghost={true}
+      data-multiple-children={false}
+      data-outline={false}
+      data-selected={true}
+      data-size={40}
+      isDisabled={false}
+      onBlur={null}
+      onClick={[Function]}
+      onDragStart={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchCancel={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      type="button"
+    >
+      <FocusRing
+        disabled={false}
+      >
+        <FocusRing
+          disabled={false}
+          focusClass="md-focus-ring-wrapper children"
+          focusRingClass="md-focus-ring-wrapper children"
+        >
+          <button
+            aria-pressed={true}
+            className="md-button-circle-wrapper md-button-circle-toggle-wrapper md-button-simple-wrapper"
+            data-color="primary"
+            data-disabled={false}
+            data-ghost={true}
+            data-multiple-children={false}
+            data-outline={false}
+            data-selected={true}
+            data-size={40}
+            disabled={false}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onDragStart={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchCancel={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            type="button"
+          />
+        </FocusRing>
+      </FocusRing>
+    </ButtonSimple>
+  </ButtonCircle>
+</ButtonSimpleToggle>
+`;
+
+exports[`<ButtonCircleToggle /> snapshot should match snapshot with outline being false 1`] = `
+<ButtonSimpleToggle
+  outline={false}
+>
+  <ButtonCircle
+    aria-pressed={false}
+    className="md-button-circle-toggle-wrapper"
+    data-selected={false}
+    disabled={false}
+    ghost={true}
+    onBlur={null}
+    onClick={[Function]}
+    onDragStart={[Function]}
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    onMouseDown={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    onMouseUp={[Function]}
+    onTouchCancel={[Function]}
+    onTouchEnd={[Function]}
+    onTouchMove={[Function]}
+    onTouchStart={[Function]}
+    outline={false}
+    size={40}
+    type="button"
+  >
+    <ButtonSimple
+      aria-pressed={false}
+      className="md-button-circle-wrapper md-button-circle-toggle-wrapper"
+      data-color="primary"
+      data-disabled={false}
+      data-ghost={true}
+      data-multiple-children={false}
+      data-outline={false}
+      data-selected={false}
+      data-size={40}
+      isDisabled={false}
+      onBlur={null}
+      onClick={[Function]}
+      onDragStart={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchCancel={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      type="button"
+    >
+      <FocusRing
+        disabled={false}
+      >
+        <FocusRing
+          disabled={false}
+          focusClass="md-focus-ring-wrapper children"
+          focusRingClass="md-focus-ring-wrapper children"
+        >
+          <button
+            aria-pressed={false}
+            className="md-button-circle-wrapper md-button-circle-toggle-wrapper md-button-simple-wrapper"
+            data-color="primary"
+            data-disabled={false}
+            data-ghost={true}
+            data-multiple-children={false}
+            data-outline={false}
+            data-selected={false}
+            data-size={40}
+            disabled={false}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onDragStart={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchCancel={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            type="button"
+          />
+        </FocusRing>
+      </FocusRing>
+    </ButtonSimple>
+  </ButtonCircle>
+</ButtonSimpleToggle>
+`;
+
+exports[`<ButtonCircleToggle /> snapshot should match snapshot with outline being true 1`] = `
+<ButtonSimpleToggle
+  outline={true}
+>
+  <ButtonCircle
+    aria-pressed={false}
+    className="md-button-circle-toggle-wrapper"
+    data-selected={false}
+    disabled={false}
+    ghost={true}
+    onBlur={null}
+    onClick={[Function]}
+    onDragStart={[Function]}
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    onMouseDown={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    onMouseUp={[Function]}
+    onTouchCancel={[Function]}
+    onTouchEnd={[Function]}
+    onTouchMove={[Function]}
+    onTouchStart={[Function]}
+    outline={true}
+    size={40}
+    type="button"
+  >
+    <ButtonSimple
+      aria-pressed={false}
+      className="md-button-circle-wrapper md-button-circle-toggle-wrapper"
+      data-color="primary"
+      data-disabled={false}
+      data-ghost={true}
+      data-multiple-children={false}
+      data-outline={true}
+      data-selected={false}
+      data-size={40}
+      isDisabled={false}
+      onBlur={null}
+      onClick={[Function]}
+      onDragStart={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchCancel={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      type="button"
+    >
+      <FocusRing
+        disabled={false}
+      >
+        <FocusRing
+          disabled={false}
+          focusClass="md-focus-ring-wrapper children"
+          focusRingClass="md-focus-ring-wrapper children"
+        >
+          <button
+            aria-pressed={false}
+            className="md-button-circle-wrapper md-button-circle-toggle-wrapper md-button-simple-wrapper"
+            data-color="primary"
+            data-disabled={false}
+            data-ghost={true}
+            data-multiple-children={false}
+            data-outline={true}
+            data-selected={false}
+            data-size={40}
+            disabled={false}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onDragStart={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchCancel={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            type="button"
+          />
+        </FocusRing>
+      </FocusRing>
+    </ButtonSimple>
+  </ButtonCircle>
+</ButtonSimpleToggle>
+`;

--- a/src/components/ButtonCircleToggle/index.ts
+++ b/src/components/ButtonCircleToggle/index.ts
@@ -1,0 +1,9 @@
+import { default as ButtonCircleToggle } from './ButtonCircleToggle';
+import * as CONSTANTS from './ButtonCircleToggle.constants';
+import { Props } from './ButtonCircleToggle.types';
+
+export { CONSTANTS as BUTTON_CIRCLE_TOGGLE_CONSTANTS };
+
+export type ButtonCircleToggleProps = Props;
+
+export default ButtonCircleToggle;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -5,6 +5,7 @@ export { default as AvatarCompact } from './AvatarCompact';
 export { default as Badge } from './Badge';
 export { default as Banner } from './Banner';
 export { default as ButtonCircle } from './ButtonCircle';
+export { default as ButtonCircleToggle } from './ButtonCircle';
 export { default as ButtonControl } from './ButtonControl';
 export { default as ButtonDialpad } from './ButtonDialpad';
 export { default as ButtonGroup } from './ButtonGroup';

--- a/src/index.js
+++ b/src/index.js
@@ -107,6 +107,7 @@ export {
   Avatar as AvatarNext,
   PresenceType,
   ButtonCircle,
+  ButtonCircleToggle,
   AvatarCompact as AvatarCompactNext,
   ButtonControl,
   ButtonDialpad,

--- a/src/storybook/helper.stories.argtypes.ts
+++ b/src/storybook/helper.stories.argtypes.ts
@@ -668,6 +668,48 @@ const commonAriaButton = {
   },
 };
 
+const commonAriaButtonToggle = {
+  isSelected: {
+    description: 'Whether the element should be selected (controlled).',
+    options: [true, false],
+    control: { type: 'boolean' },
+    table: {
+      type: {
+        summary: 'boolean',
+      },
+      defaultValue: {
+        summary: 'undefined',
+      },
+    },
+  },
+  defaultSelected: {
+    description: 'Whether the element should be selected (uncontrolled).',
+    options: [true, false],
+    control: { type: 'boolean' },
+    table: {
+      type: {
+        summary: 'boolean',
+      },
+      defaultValue: {
+        summary: 'undefined',
+      },
+    },
+  },
+  onChange: {
+    action: 'onPress',
+    description: "Handler that is called when the element's selection state chnges.",
+    table: {
+      category: 'React Aria - ButtonToggle',
+      type: {
+        summary: '(isSelected: boolean) => void',
+      },
+      defaultValue: {
+        summary: 'undefined',
+      },
+    },
+  },
+};
+
 const commonStyles = {
   className: {
     description: "If present, this value will be added to the rendered element's `class` attribute",
@@ -731,6 +773,7 @@ const commonHTMLAttributes = {
 
 export {
   commonAriaButton,
+  commonAriaButtonToggle,
   commonAriaDialog,
   commonAriaFocusScope,
   commonAriaHover,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1827,10 +1827,10 @@
   resolved "https://registry.yarnpkg.com/@momentum-ui/animations/-/animations-1.3.0.tgz#1aeb51679a4019afff1381eb8627fe143befff1c"
   integrity sha512-lUKggfh1PjJ949HFxZdY23lSIIN0FTUyoNLOSSbU0L9bQI0ryx6FYTrJMiS2e/DS/gyUk306++OXxRnNSq3Kjw==
 
-"@momentum-ui/design-tokens@^0.0.50":
-  version "0.0.50"
-  resolved "https://registry.yarnpkg.com/@momentum-ui/design-tokens/-/design-tokens-0.0.50.tgz#ca24b61a9bd55d233f1210101c84a351e5e26e62"
-  integrity sha512-vQsXKzsgMuYCK27/TBa938Xg+LQV37lXyahTts26uL2UqR77Wq/W3rHbRHwsVA8C8R35NAah7fZpJG8B0aJdvQ==
+"@momentum-ui/design-tokens@^0.0.53":
+  version "0.0.53"
+  resolved "https://registry.yarnpkg.com/@momentum-ui/design-tokens/-/design-tokens-0.0.53.tgz#26b5987685048ca6b6b1fa88fffa1d43494034a0"
+  integrity sha512-uWjWGt0Tqy54ffg9j6l+gnScHulSpAiZs+rZxqpdxEC9zVstxAeNjrzfjqLOVoJ29MnBBboBib3G++HZBGEJiA==
 
 "@momentum-ui/icons-rebrand@^1.39.0":
   version "1.39.0"
@@ -3341,6 +3341,16 @@
     "@react-types/checkbox" "^3.3.1"
     "@react-types/shared" "^3.13.1"
 
+"@react-stately/toggle@^3.4.1":
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/@react-stately/toggle/-/toggle-3.4.1.tgz#65ffc1063ccaa9e77e012f46a15fcf41411c0be7"
+  integrity sha512-Dlg7M9W52n0K+Op/H5ywdSCORW70ry6syPSahh+RXQKKdky9bckqmrpO24A92dL7Rci2H4fTsBgZGVla9b/wNQ==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    "@react-stately/utils" "^3.5.1"
+    "@react-types/checkbox" "^3.3.3"
+    "@react-types/shared" "^3.14.1"
+
 "@react-stately/tooltip@^3.0.5":
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/@react-stately/tooltip/-/tooltip-3.0.5.tgz#0cb716791ef3242acd810794162d651b1c47a328"
@@ -3380,6 +3390,13 @@
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/@react-stately/utils/-/utils-3.5.0.tgz#e76231cfc93042814dcc5d96436e50c807c1d905"
   integrity sha512-WzzwlQtJrf7egaN+lt02/f/wkFKbcscsbinmXs9pL7QyYm+BCQ9xXj01w0juzt93piZgB/kfIYJqInEdpudh1A==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+
+"@react-stately/utils@^3.5.1":
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/@react-stately/utils/-/utils-3.5.1.tgz#502de762e5d33e892347c5f58053674e06d3bc92"
+  integrity sha512-INeQ5Er2Jm+db8Py4upKBtgfzp3UYgwXYmbU/XJn49Xw27ktuimH9e37qP3bgHaReb5L3g8IrGs38tJUpnGPHA==
   dependencies:
     "@babel/runtime" "^7.6.2"
 
@@ -3433,6 +3450,13 @@
   integrity sha512-6PlyvfqisuObrltmJdBx88t143NaQ/ibkvuDdsEaiMlJbHKU4m0dbxaYNhGNQ0Jm4AK/x9Rig0tbpMeXjBXaDA==
   dependencies:
     "@react-types/shared" "^3.13.1"
+
+"@react-types/checkbox@^3.3.3":
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/@react-types/checkbox/-/checkbox-3.3.3.tgz#a8f24b8396005ff2c77571c645efe873c477eb51"
+  integrity sha512-GkhC+y4g7Dga9Ck5MNvvX11hnn9S4b9Rx1+cdFMzBczJPJZhDxO69+CPQnoFAkVQSIYEC5bh/2u34sWyF6uq6g==
+  dependencies:
+    "@react-types/shared" "^3.14.1"
 
 "@react-types/combobox@^3.0.1", "@react-types/combobox@^3.1.0":
   version "3.1.0"
@@ -3559,6 +3583,11 @@
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/@react-types/shared/-/shared-3.13.1.tgz#eda5e3744971606f753baf7879136bf8e3f707ab"
   integrity sha512-EHQqILDJeDvnloy5VV9lnnEjpCMwH1ghptCfa/lz9Ht9nwco3qGCvUABkWyND7yU1Adt3A/1oJxhpRUu3eTlyg==
+
+"@react-types/shared@^3.14.1":
+  version "3.14.1"
+  resolved "https://registry.yarnpkg.com/@react-types/shared/-/shared-3.14.1.tgz#8fe25f729426e8043054e442eb5392364200e028"
+  integrity sha512-yPPgVRWWanXqbdxFTgJmVwx0JlcnEK3dqkKDIbVk6mxAHvEESI9+oDnHvO8IMHqF+GbrTCzVtAs0zwhYI/uHJA==
 
 "@react-types/shared@^3.7.1", "@react-types/shared@^3.8.0", "@react-types/shared@^3.9.0":
   version "3.9.0"


### PR DESCRIPTION
# Description

PR to implement the buttonCircleToggle component. This is a component that is based on ButtonCircle and adds toggle hooks to it to make it toggable/selectable. 

As for now, only the outline and ghost buttons have a toggable version designed in the component library, which only cover these button colour types in the scope.

<img width="283" alt="image" src="https://user-images.githubusercontent.com/56999622/189151168-4b0d311d-a213-4333-aad0-a48de20bc0e3.png">
<img width="293" alt="image" src="https://user-images.githubusercontent.com/56999622/189151218-a8599bc1-a052-4b50-908a-bb6b63cb2f06.png">

# Links

[*Links to relevent resources.*](https://www.figma.com/file/vdL18BATeJAIq2JvGAjRPD/Components---Web?node-id=4445%3A5884)
