### PR TITLE
fix: another two characters that should be deleted 'inactive'->'active'

### DIFF
--- a/src/components/Tab/Tab.style.scss
+++ b/src/components/Tab/Tab.style.scss
@@ -27,7 +27,7 @@
       }
 
       &:active {
-        background-color: var(--tab-inactive-background-pressed);
+        background-color: var(--tab-active-background-pressed);
 
         .md-text-wrapper,
         .md-icon-wrapper {


### PR DESCRIPTION
# Description
I had forgotten to do the same modifications to a line below as well.

# Links

Does what should have been done from this PR:
https://github.com/momentum-design/momentum-react-v2/commit/7578ceb5918f6fd644f919acdda7d87bb46a63a3

[SPARK-332386](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-332386) Tab active state colour is incorrect