### PR TITLE
feat(button-circle-toggle-props): fix onChange prop

### DIFF
--- a/src/components/ButtonCircleToggle/ButtonCircleToggle.stories.tsx
+++ b/src/components/ButtonCircleToggle/ButtonCircleToggle.stories.tsx
@@ -8,6 +8,7 @@ import Icon from '../Icon';
 import ButtonCircleToggle, { ButtonCircleToggleProps } from './';
 import argTypes from './ButtonCircleToggle.stories.args';
 import Documentation from './ButtonCircleToggle.stories.docs.mdx';
+import { action } from '@storybook/addon-actions';
 
 export default {
   title: 'Momentum UI/ButtonCircleToggle',
@@ -29,6 +30,8 @@ Example.argTypes = { ...argTypes };
 
 Example.args = {
   children: <Icon name="cancel" autoScale={150} />,
+  onChange: action('onChange'),
+  onPress: action('onPress'),
 };
 
 // Pseudostates will be correctly applied to ButtonCircleToggle once ButtonCircle

--- a/src/components/ButtonCircleToggle/ButtonCircleToggle.tsx
+++ b/src/components/ButtonCircleToggle/ButtonCircleToggle.tsx
@@ -8,7 +8,7 @@ import { DEFAULTS as BUTTON_CIRCLE_DEFAULTS } from '../ButtonCircle/ButtonCircle
 import { Size as ButtonCircleSize } from '../ButtonCircle/ButtonCircle.types';
 import { Props } from './ButtonCircleToggle.types';
 import './ButtonCircleToggle.style.scss';
-import { chain } from 'react-aria';
+import { chain } from '@react-aria/utils';
 
 const ButtonCircleToggle = forwardRef((props: Props, providedRef: RefObject<HTMLButtonElement>) => {
   const {

--- a/src/components/ButtonCircleToggle/ButtonCircleToggle.tsx
+++ b/src/components/ButtonCircleToggle/ButtonCircleToggle.tsx
@@ -2,14 +2,13 @@ import React, { RefObject, forwardRef, useRef } from 'react';
 import classnames from 'classnames';
 import ButtonCircle from '../ButtonCircle';
 import { useToggleState } from '@react-stately/toggle';
-import { useToggleButton } from '@react-aria/button';
 
 import { DEFAULTS, STYLE } from './ButtonCircleToggle.constants';
 import { DEFAULTS as BUTTON_CIRCLE_DEFAULTS } from '../ButtonCircle/ButtonCircle.constants';
 import { Size as ButtonCircleSize } from '../ButtonCircle/ButtonCircle.types';
 import { Props } from './ButtonCircleToggle.types';
 import './ButtonCircleToggle.style.scss';
-import { AriaBaseButtonProps } from '@react-types/button';
+import { chain } from 'react-aria';
 
 const ButtonCircleToggle = forwardRef((props: Props, providedRef: RefObject<HTMLButtonElement>) => {
   const {
@@ -19,26 +18,14 @@ const ButtonCircleToggle = forwardRef((props: Props, providedRef: RefObject<HTML
     outline = DEFAULTS.OUTLINE,
     disabled = DEFAULTS.DISABLED,
     size = BUTTON_CIRCLE_DEFAULTS.SIZE,
+    onPress,
+    ...otherProps
   } = props;
 
   const internalRef = useRef();
   const ref = providedRef || internalRef;
 
   const state = useToggleState(props);
-  const { buttonProps } = useToggleButton(props, state, ref);
-
-  // useToggleButton hook from react-aria has wrong aria button types, so we fix it manually.
-  const filteredProps = {
-    ...buttonProps,
-    color: undefined,
-    'aria-expanded': buttonProps['aria-expanded'] as AriaBaseButtonProps['aria-expanded'],
-    'aria-haspopup': buttonProps['aria-haspopup'] as AriaBaseButtonProps['aria-haspopup'],
-    'aria-pressed': buttonProps['aria-pressed'] as AriaBaseButtonProps['aria-pressed'],
-  };
-
-  // We delete the disabled prop coming from useToggleButton,
-  // so that we use the disabled value passed in props.
-  delete filteredProps.disabled;
 
   if (ghost === false && outline === false) {
     console.warn(
@@ -54,7 +41,10 @@ const ButtonCircleToggle = forwardRef((props: Props, providedRef: RefObject<HTML
       disabled={disabled}
       size={size as ButtonCircleSize}
       data-selected={state.isSelected || DEFAULTS.SELECTED}
-      {...filteredProps}
+      onPress={chain(state.toggle, onPress)}
+      aria-pressed={state.isSelected}
+      {...otherProps}
+      ref={ref}
     >
       {children}
     </ButtonCircle>

--- a/src/components/ButtonCircleToggle/ButtonCircleToggle.unit.test.tsx.snap
+++ b/src/components/ButtonCircleToggle/ButtonCircleToggle.unit.test.tsx.snap
@@ -8,21 +8,8 @@ exports[`<ButtonCircleToggle /> snapshot should match snapshot 1`] = `
     data-selected={false}
     disabled={false}
     ghost={true}
-    onBlur={null}
-    onClick={[Function]}
-    onDragStart={[Function]}
-    onKeyDown={[Function]}
-    onKeyUp={[Function]}
-    onMouseDown={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    onMouseUp={[Function]}
-    onTouchCancel={[Function]}
-    onTouchEnd={[Function]}
-    onTouchMove={[Function]}
-    onTouchStart={[Function]}
+    onPress={[Function]}
     size={40}
-    type="button"
   >
     <ButtonSimple
       aria-pressed={false}
@@ -35,20 +22,7 @@ exports[`<ButtonCircleToggle /> snapshot should match snapshot 1`] = `
       data-selected={false}
       data-size={40}
       isDisabled={false}
-      onBlur={null}
-      onClick={[Function]}
-      onDragStart={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchCancel={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      type="button"
+      onPress={[Function]}
     >
       <FocusRing
         disabled={false}
@@ -102,21 +76,8 @@ exports[`<ButtonCircleToggle /> snapshot should match snapshot with ghost being 
     data-selected={false}
     disabled={false}
     ghost={false}
-    onBlur={null}
-    onClick={[Function]}
-    onDragStart={[Function]}
-    onKeyDown={[Function]}
-    onKeyUp={[Function]}
-    onMouseDown={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    onMouseUp={[Function]}
-    onTouchCancel={[Function]}
-    onTouchEnd={[Function]}
-    onTouchMove={[Function]}
-    onTouchStart={[Function]}
+    onPress={[Function]}
     size={40}
-    type="button"
   >
     <ButtonSimple
       aria-pressed={false}
@@ -129,20 +90,7 @@ exports[`<ButtonCircleToggle /> snapshot should match snapshot with ghost being 
       data-selected={false}
       data-size={40}
       isDisabled={false}
-      onBlur={null}
-      onClick={[Function]}
-      onDragStart={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchCancel={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      type="button"
+      onPress={[Function]}
     >
       <FocusRing
         disabled={false}
@@ -196,21 +144,8 @@ exports[`<ButtonCircleToggle /> snapshot should match snapshot with ghost being 
     data-selected={false}
     disabled={false}
     ghost={true}
-    onBlur={null}
-    onClick={[Function]}
-    onDragStart={[Function]}
-    onKeyDown={[Function]}
-    onKeyUp={[Function]}
-    onMouseDown={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    onMouseUp={[Function]}
-    onTouchCancel={[Function]}
-    onTouchEnd={[Function]}
-    onTouchMove={[Function]}
-    onTouchStart={[Function]}
+    onPress={[Function]}
     size={40}
-    type="button"
   >
     <ButtonSimple
       aria-pressed={false}
@@ -223,20 +158,7 @@ exports[`<ButtonCircleToggle /> snapshot should match snapshot with ghost being 
       data-selected={false}
       data-size={40}
       isDisabled={false}
-      onBlur={null}
-      onClick={[Function]}
-      onDragStart={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchCancel={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      type="button"
+      onPress={[Function]}
     >
       <FocusRing
         disabled={false}
@@ -290,21 +212,9 @@ exports[`<ButtonCircleToggle /> snapshot should match snapshot with isSelected b
     data-selected={false}
     disabled={false}
     ghost={true}
-    onBlur={null}
-    onClick={[Function]}
-    onDragStart={[Function]}
-    onKeyDown={[Function]}
-    onKeyUp={[Function]}
-    onMouseDown={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    onMouseUp={[Function]}
-    onTouchCancel={[Function]}
-    onTouchEnd={[Function]}
-    onTouchMove={[Function]}
-    onTouchStart={[Function]}
+    isSelected={false}
+    onPress={[Function]}
     size={40}
-    type="button"
   >
     <ButtonSimple
       aria-pressed={false}
@@ -317,20 +227,8 @@ exports[`<ButtonCircleToggle /> snapshot should match snapshot with isSelected b
       data-selected={false}
       data-size={40}
       isDisabled={false}
-      onBlur={null}
-      onClick={[Function]}
-      onDragStart={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchCancel={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      type="button"
+      isSelected={false}
+      onPress={[Function]}
     >
       <FocusRing
         disabled={false}
@@ -384,21 +282,9 @@ exports[`<ButtonCircleToggle /> snapshot should match snapshot with isSelected b
     data-selected={true}
     disabled={false}
     ghost={true}
-    onBlur={null}
-    onClick={[Function]}
-    onDragStart={[Function]}
-    onKeyDown={[Function]}
-    onKeyUp={[Function]}
-    onMouseDown={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    onMouseUp={[Function]}
-    onTouchCancel={[Function]}
-    onTouchEnd={[Function]}
-    onTouchMove={[Function]}
-    onTouchStart={[Function]}
+    isSelected={true}
+    onPress={[Function]}
     size={40}
-    type="button"
   >
     <ButtonSimple
       aria-pressed={true}
@@ -411,20 +297,8 @@ exports[`<ButtonCircleToggle /> snapshot should match snapshot with isSelected b
       data-selected={true}
       data-size={40}
       isDisabled={false}
-      onBlur={null}
-      onClick={[Function]}
-      onDragStart={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchCancel={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      type="button"
+      isSelected={true}
+      onPress={[Function]}
     >
       <FocusRing
         disabled={false}
@@ -478,22 +352,9 @@ exports[`<ButtonCircleToggle /> snapshot should match snapshot with outline bein
     data-selected={false}
     disabled={false}
     ghost={true}
-    onBlur={null}
-    onClick={[Function]}
-    onDragStart={[Function]}
-    onKeyDown={[Function]}
-    onKeyUp={[Function]}
-    onMouseDown={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    onMouseUp={[Function]}
-    onTouchCancel={[Function]}
-    onTouchEnd={[Function]}
-    onTouchMove={[Function]}
-    onTouchStart={[Function]}
+    onPress={[Function]}
     outline={false}
     size={40}
-    type="button"
   >
     <ButtonSimple
       aria-pressed={false}
@@ -506,20 +367,7 @@ exports[`<ButtonCircleToggle /> snapshot should match snapshot with outline bein
       data-selected={false}
       data-size={40}
       isDisabled={false}
-      onBlur={null}
-      onClick={[Function]}
-      onDragStart={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchCancel={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      type="button"
+      onPress={[Function]}
     >
       <FocusRing
         disabled={false}
@@ -573,22 +421,9 @@ exports[`<ButtonCircleToggle /> snapshot should match snapshot with outline bein
     data-selected={false}
     disabled={false}
     ghost={true}
-    onBlur={null}
-    onClick={[Function]}
-    onDragStart={[Function]}
-    onKeyDown={[Function]}
-    onKeyUp={[Function]}
-    onMouseDown={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    onMouseUp={[Function]}
-    onTouchCancel={[Function]}
-    onTouchEnd={[Function]}
-    onTouchMove={[Function]}
-    onTouchStart={[Function]}
+    onPress={[Function]}
     outline={true}
     size={40}
-    type="button"
   >
     <ButtonSimple
       aria-pressed={false}
@@ -601,20 +436,7 @@ exports[`<ButtonCircleToggle /> snapshot should match snapshot with outline bein
       data-selected={false}
       data-size={40}
       isDisabled={false}
-      onBlur={null}
-      onClick={[Function]}
-      onDragStart={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchCancel={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      type="button"
+      onPress={[Function]}
     >
       <FocusRing
         disabled={false}


### PR DESCRIPTION
# Description

React Aria's useToggleButton hook was engineered to be used in an html button, meaning it is providing the callback action via the onClick property to the button. We are using this hook in our existent ButtonCircle, which expects onPress as the callback method, not onClick. 

Also, properties passed to ButtonCircleToggle were not passed to ButtonCircle, like the properties to use a Popover triggered by this toggle. 

This PR intends to fix these two things in ButtonCircleToggle.
