### PR TITLE
feat(button-pill-toggle): implement button pill toggle

### DIFF
--- a/src/components/ButtonCircleToggle/ButtonCircleToggle.tsx
+++ b/src/components/ButtonCircleToggle/ButtonCircleToggle.tsx
@@ -61,6 +61,6 @@ const ButtonCircleToggle = forwardRef((props: Props, providedRef: RefObject<HTML
   );
 });
 
-ButtonCircleToggle.displayName = 'ButtonSimpleToggle';
+ButtonCircleToggle.displayName = 'ButtonCircleToggle';
 
 export default ButtonCircleToggle;

--- a/src/components/ButtonCircleToggle/ButtonCircleToggle.unit.test.tsx.snap
+++ b/src/components/ButtonCircleToggle/ButtonCircleToggle.unit.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<ButtonCircleToggle /> snapshot should match snapshot 1`] = `
-<ButtonSimpleToggle>
+<ButtonCircleToggle>
   <ButtonCircle
     aria-pressed={false}
     className="md-button-circle-toggle-wrapper"
@@ -63,11 +63,11 @@ exports[`<ButtonCircleToggle /> snapshot should match snapshot 1`] = `
       </FocusRing>
     </ButtonSimple>
   </ButtonCircle>
-</ButtonSimpleToggle>
+</ButtonCircleToggle>
 `;
 
 exports[`<ButtonCircleToggle /> snapshot should match snapshot with ghost being false 1`] = `
-<ButtonSimpleToggle
+<ButtonCircleToggle
   ghost={false}
 >
   <ButtonCircle
@@ -131,11 +131,11 @@ exports[`<ButtonCircleToggle /> snapshot should match snapshot with ghost being 
       </FocusRing>
     </ButtonSimple>
   </ButtonCircle>
-</ButtonSimpleToggle>
+</ButtonCircleToggle>
 `;
 
 exports[`<ButtonCircleToggle /> snapshot should match snapshot with ghost being true 1`] = `
-<ButtonSimpleToggle
+<ButtonCircleToggle
   ghost={true}
 >
   <ButtonCircle
@@ -199,11 +199,11 @@ exports[`<ButtonCircleToggle /> snapshot should match snapshot with ghost being 
       </FocusRing>
     </ButtonSimple>
   </ButtonCircle>
-</ButtonSimpleToggle>
+</ButtonCircleToggle>
 `;
 
 exports[`<ButtonCircleToggle /> snapshot should match snapshot with isSelected being false 1`] = `
-<ButtonSimpleToggle
+<ButtonCircleToggle
   isSelected={false}
 >
   <ButtonCircle
@@ -269,11 +269,11 @@ exports[`<ButtonCircleToggle /> snapshot should match snapshot with isSelected b
       </FocusRing>
     </ButtonSimple>
   </ButtonCircle>
-</ButtonSimpleToggle>
+</ButtonCircleToggle>
 `;
 
 exports[`<ButtonCircleToggle /> snapshot should match snapshot with isSelected being true 1`] = `
-<ButtonSimpleToggle
+<ButtonCircleToggle
   isSelected={true}
 >
   <ButtonCircle
@@ -339,11 +339,11 @@ exports[`<ButtonCircleToggle /> snapshot should match snapshot with isSelected b
       </FocusRing>
     </ButtonSimple>
   </ButtonCircle>
-</ButtonSimpleToggle>
+</ButtonCircleToggle>
 `;
 
 exports[`<ButtonCircleToggle /> snapshot should match snapshot with outline being false 1`] = `
-<ButtonSimpleToggle
+<ButtonCircleToggle
   outline={false}
 >
   <ButtonCircle
@@ -408,11 +408,11 @@ exports[`<ButtonCircleToggle /> snapshot should match snapshot with outline bein
       </FocusRing>
     </ButtonSimple>
   </ButtonCircle>
-</ButtonSimpleToggle>
+</ButtonCircleToggle>
 `;
 
 exports[`<ButtonCircleToggle /> snapshot should match snapshot with outline being true 1`] = `
-<ButtonSimpleToggle
+<ButtonCircleToggle
   outline={true}
 >
   <ButtonCircle
@@ -477,5 +477,5 @@ exports[`<ButtonCircleToggle /> snapshot should match snapshot with outline bein
       </FocusRing>
     </ButtonSimple>
   </ButtonCircle>
-</ButtonSimpleToggle>
+</ButtonCircleToggle>
 `;

--- a/src/components/ButtonPill/ButtonPill.style.scss
+++ b/src/components/ButtonPill/ButtonPill.style.scss
@@ -14,14 +14,16 @@
   color: rgba(255, 255, 255, 0.95); // IEFIX
   color: var(--button-primary-text);
 
-  &:hover {
+  &:hover,
+  &.hover {
     background-color: rgba(0, 0, 0, 0.8); // IEFIX
     background-color: var(--button-primary-background-hovered);
     color: rgba(255, 255, 255, 0.95); // IEFIX
     color: var(--button-primary-text-hovered);
   }
 
-  &:active {
+  &:active,
+  &.active {
     background-color: rgba(0, 0, 0, 0.7); // IEFIX
     background-color: var(--button-primary-background-pressed);
     color: rgba(255, 255, 255, 0.95); // IEFIX
@@ -33,7 +35,8 @@
     border-color: var(--videoSupport-controls-button-border-color);
     color: var(--videoSupport-controls-button-text);
 
-    &:hover {
+    &:hover,
+    &.hover {
       background-color: rgba(0, 0, 0, 0.07); // IEFIX
       background-color: var(--button-secondary-background-hovered);
       border-color: rgba(0, 0, 0, 0.3); // IEFIX
@@ -42,7 +45,8 @@
       color: var(--button-secondary-text-hovered);
     }
 
-    &:active {
+    &:active,
+    &.active {
       background-color: rgba(0, 0, 0, 0.2); // IEFIX
       background-color: var(--button-secondary-background-pressed);
       border-color: rgba(0, 0, 0, 0.3); // IEFIX
@@ -56,13 +60,15 @@
       border-color: var(--videoSupport-controls-button-border-color);
       color: var(--videoSupport-controls-button-text);
 
-      &:hover {
+      &:hover,
+      &.hover {
         background-color: var(--videoSupport-controls-button-background-hovered);
         border-color: var(--videoSupport-controls-button-border-color-hovered);
         color: var(--videoSupport-controls-button-text-hovered);
       }
 
-      &:active {
+      &:active,
+      &.active {
         background-color: var(--videoSupport-controls-button-background-pressed);
         border-color: var(--videoSupport-controls-button-border-color-pressed);
         color: var(--videoSupport-controls-button-text-pressed);
@@ -76,14 +82,16 @@
     color: rgba(255, 255, 255, 0.95); // IEFIX
     color: var(--button-join-fill-text);
 
-    &:hover {
+    &:hover,
+    &.hover {
       background-color: rgba(24, 94, 70, 1); // IEFIX
       background-color: var(--button-join-fill-background-hovered);
       color: rgba(255, 255, 255, 0.95); // IEFIX
       color: var(--button-join-fill-text-hovered);
     }
 
-    &:active {
+    &:active,
+    &.active {
       background-color: rgba(19, 66, 49, 1); // IEFIX
       background-color: var(--button-join-fill-background-pressed);
       color: rgba(255, 255, 255, 0.95); // IEFIX
@@ -98,7 +106,8 @@
       color: rgba(24, 94, 70, 1); // IEFIX
       color: var(--button-join-outline-text);
 
-      &:hover {
+      &:hover,
+      &.hover {
         background-color: rgba(24, 94, 70, 1); // IEFIX
         background-color: var(--button-join-outline-background-hovered);
         border-color: rgba(0, 0, 0, 0);
@@ -106,7 +115,8 @@
         color: var(--button-join-outline-text-hovered);
       }
 
-      &:active {
+      &:active,
+      &.active {
         background-color: rgba(19, 66, 49, 1); // IEFIX
         background-color: var(--button-join-outline-background-pressed);
         border-color: rgba(0, 0, 0, 0);
@@ -114,7 +124,8 @@
         color: var(--button-join-outline-text-pressed);
       }
 
-      &[data-disabled='true'] {
+      &[data-disabled='true'],
+      &.disable {
         background-color: rgba(0, 0, 0, 0); // IEFIX
         background-color: var(--button-secondary-background-disabled);
         border-color: rgba(0, 0, 0, 0.2); // IEFIX
@@ -131,14 +142,16 @@
     color: rgba(255, 255, 255, 0.95); // IEFIX
     color: var(--button-cancel-fill-text);
 
-    &:hover {
+    &:hover,
+    &.hover {
       background-color: rgba(171, 10, 21, 1); // IEFIX
       background-color: var(--button-cancel-fill-background-hovered);
       color: rgba(255, 255, 255, 0.95); // IEFIX
       color: var(--button-cancel-fill-text-hovered);
     }
 
-    &:active {
+    &:active,
+    &.active {
       background-color: rgba(120, 13, 19, 1); // IEFIX
       background-color: var(--button-cancel-fill-background-pressed);
       color: rgba(255, 255, 255, 0.95); // IEFIX
@@ -153,7 +166,8 @@
       color: rgba(171, 10, 21, 1); // IEFIX
       color: var(--button-cancel-outline-text);
 
-      &:hover {
+      &:hover,
+      &.hover {
         background-color: rgba(171, 10, 21, 1); // IEFIX
         background-color: var(--button-cancel-outline-background-hovered);
         border-color: rgba(0, 0, 0, 0);
@@ -161,7 +175,8 @@
         color: var(--button-cancel-outline-text-hovered);
       }
 
-      &:active {
+      &:active,
+      &.active {
         background-color: rgba(120, 13, 19, 1); // IEFIX
         background-color: var(--button-cancel-outline-background-pressed);
         border-color: rgba(0, 0, 0, 0);
@@ -177,14 +192,16 @@
     color: rgba(255, 255, 255, 0.95); // IEFIX
     color: var(--button-message-fill-text);
 
-    &:hover {
+    &:hover,
+    &.hover {
       background-color: rgba(3, 83, 168, 1); // IEFIX
       background-color: var(--button-message-fill-background-hovered);
       color: rgba(255, 255, 255, 0.95); // IEFIX
       color: var(--button-message-fill-text-hovered);
     }
 
-    &:active {
+    &:active,
+    &.active {
       background-color: rgba(6, 58, 117, 1); // IEFIX
       background-color: var(--button-message-fill-background-pressed);
       color: rgba(255, 255, 255, 0.95); // IEFIX
@@ -203,30 +220,40 @@
     color: rgba(0, 0, 0, 0.95); // IEFIX
     color: var(--button-ghost-text);
 
-    &:hover {
+    &:hover,
+    &.hover {
       background-color: rgba(0, 0, 0, 0.07); // IEFIX
       background-color: var(--button-ghost-background-hovered);
       color: rgba(0, 0, 0, 0.95); // IEFIX
       color: var(--button-ghost-text-hovered);
     }
 
-    &:active {
+    &:active,
+    &.active {
       background-color: rgba(0, 0, 0, 0.2); // IEFIX
       background-color: var(--button-secondary-background-pressed);
       color: rgba(0, 0, 0, 0.95); // IEFIX
       color: var(--button-secondary-text-pressed);
     }
 
+    &[data-disabled='true'],
+    &.disable {
+      background-color: var(--button-ghost-background-disabled);
+      color: var(--button-ghost-text-disabled);
+    }
+
     &[data-color='cancel'][data-disabled='false'] {
       color: rgba(171, 10, 21, 1); // IEFIX
       color: var(--button-cancel-ghost-text);
 
-      &:hover {
+      &:hover,
+      &.hover {
         color: rgba(171, 10, 21, 1); // IEFIX
         color: var(--button-cancel-ghost-text-hovered);
       }
 
-      &:active {
+      &:active,
+      &.active {
         color: rgba(171, 10, 21, 1); // IEFIX
         color: var(--button-cancel-ghost-text-pressed);
       }
@@ -236,12 +263,14 @@
       color: rgba(3, 83, 168, 1); // IEFIX
       color: var(--button-message-ghost-text);
 
-      &:hover {
+      &:hover,
+      &.hover {
         color: rgba(3, 83, 168, 1); // IEFIX
         color: var(--button-message-ghost-text-hovered);
       }
 
-      &:active {
+      &:active,
+      &.active {
         color: rgba(3, 83, 168, 1); // IEFIX
         color: var(--button-message-ghost-text-pressed);
       }
@@ -255,14 +284,16 @@
       color: rgba(0, 0, 0, 0.95); // IEFIX
       color: var(--button-ghost-text);
 
-      &:hover {
+      &:hover,
+      &.hover {
         background-color: rgba(0, 0, 0, 0.07); // IEFIX
         background-color: var(--button-ghost-background-hovered);
         color: rgba(0, 0, 0, 0.95); // IEFIX
         color: var(--button-ghost-text-hovered);
       }
 
-      &:active {
+      &:active,
+      &.active {
         background-color: rgba(0, 0, 0, 0.2); // IEFIX
         background-color: var(--button-secondary-background-pressed);
         color: rgba(0, 0, 0, 0.95); // IEFIX
@@ -271,21 +302,24 @@
     }
   }
 
-  &[data-disabled='true'] {
+  &[data-disabled='true'],
+  &.disable {
     background-color: rgba(0, 0, 0, 0.2); // IEFIX
     background-color: var(--button-primary-background-disabled);
     color: rgba(0, 0, 0, 0.4); // IEFIX
     color: var(--button-primary-text-disabled);
     cursor: auto;
 
-    &:hover {
+    &:hover,
+    &.hover {
       background-color: rgba(0, 0, 0, 0.2); // IEFIX
       background-color: var(--button-primary-background-disabled);
       color: rgba(0, 0, 0, 0.4); // IEFIX
       color: var(--button-primary-text-disabled);
     }
 
-    &:active {
+    &:active,
+    &.active {
       background-color: rgba(0, 0, 0, 0.2); // IEFIX
       background-color: var(--button-primary-background-disabled);
       color: rgba(0, 0, 0, 0.4); // IEFIX
@@ -301,7 +335,8 @@
       color: var(--button-secondary-text-disabled);
       cursor: auto;
 
-      &:hover {
+      &:hover,
+      &.hover {
         background-color: rgba(0, 0, 0, 0); // IEFIX
         background-color: var(--button-secondary-background-disabled);
         border-color: rgba(0, 0, 0, 0.2); // IEFIX
@@ -310,7 +345,8 @@
         color: var(--button-secondary-text-disabled);
       }
 
-      &:active {
+      &:active,
+      &.active {
         background-color: rgba(0, 0, 0, 0); // IEFIX
         background-color: var(--button-secondary-background-disabled);
         border-color: rgba(0, 0, 0, 0.2); // IEFIX
@@ -324,13 +360,15 @@
         border-color: var(--videoSupport-controls-button-border-color-disabled);
         color: var(--videoSupport-controls-button-text-disabled);
 
-        &:hover {
+        &:hover,
+        &.hover {
           background-color: var(--videoSupport-controls-button-background-disabled);
           border-color: var(--videoSupport-controls-button-border-color-disabled);
           color: var(--videoSupport-controls-button-text-disabled);
         }
 
-        &:active {
+        &:active,
+        &.active {
           background-color: var(--videoSupport-controls-button-background-disabled);
           border-color: var(--videoSupport-controls-button-border-color-disabled);
           color: var(--videoSupport-controls-button-text-disabled);

--- a/src/components/ButtonPillToggle/ButtonPillToggle.constants.ts
+++ b/src/components/ButtonPillToggle/ButtonPillToggle.constants.ts
@@ -1,0 +1,16 @@
+import { SIZES } from '../ButtonPill/ButtonPill.constants';
+
+const CLASS_PREFIX = 'md-button-pill-toggle';
+
+const DEFAULTS = {
+  SELECTED: false,
+  OUTLINE: undefined,
+  GHOST: true,
+  DISABLED: false,
+};
+
+const STYLE = {
+  wrapper: `${CLASS_PREFIX}-wrapper`,
+};
+
+export { CLASS_PREFIX, DEFAULTS, SIZES, STYLE };

--- a/src/components/ButtonPillToggle/ButtonPillToggle.stories.args.ts
+++ b/src/components/ButtonPillToggle/ButtonPillToggle.stories.args.ts
@@ -1,0 +1,21 @@
+import { commonStyles, commonAriaButtonToggle } from '../../storybook/helper.stories.argtypes';
+import { BUTTON_PILL_TOGGLE_CONSTANTS as CONSTANTS } from './';
+import buttonPillArgTypes from '../ButtonPill/ButtonPill.stories.args';
+
+const buttonPillToggleArgTypes = {
+  ...buttonPillArgTypes,
+  ...commonAriaButtonToggle,
+};
+
+delete buttonPillToggleArgTypes.color;
+
+buttonPillToggleArgTypes.disabled.table.defaultValue.summary = CONSTANTS.DEFAULTS.DISABLED;
+buttonPillToggleArgTypes.ghost.table.defaultValue.summary = CONSTANTS.DEFAULTS.GHOST;
+buttonPillToggleArgTypes.outline.table.defaultValue.summary = CONSTANTS.DEFAULTS.OUTLINE;
+
+export { buttonPillToggleArgTypes };
+
+export default {
+  ...commonStyles,
+  ...buttonPillToggleArgTypes,
+};

--- a/src/components/ButtonPillToggle/ButtonPillToggle.stories.docs.mdx
+++ b/src/components/ButtonPillToggle/ButtonPillToggle.stories.docs.mdx
@@ -1,0 +1,1 @@
+The `<ButtonPillToggle />` component.

--- a/src/components/ButtonPillToggle/ButtonPillToggle.stories.tsx
+++ b/src/components/ButtonPillToggle/ButtonPillToggle.stories.tsx
@@ -28,9 +28,6 @@ Example.args = {
   children: 'Example text',
 };
 
-// Pseudostates will be correctly applied to ButtonPillToggle once ButtonPill
-// is fixed to receive these pseudostates.
-
 const Outline = MultiTemplateWithPseudoStates<ButtonPillToggleProps>(ButtonPillToggle).bind({});
 
 Outline.argTypes = { ...argTypes };
@@ -39,12 +36,15 @@ delete Outline.argTypes.ghost;
 delete Outline.argTypes.outline;
 delete Outline.argTypes.isSelected;
 
-Outline.args = {
-  children: 'Example text',
-};
-
 Outline.parameters = {
-  variants: [{ outline: true }, { outline: true, isSelected: true }],
+  variants: [
+    ...[false, true].map((isSelected) => ({
+      isSelected,
+      outline: true,
+      label: `isSelected: ${isSelected}`,
+      children: 'Example text',
+    })),
+  ],
 };
 
 const Ghost = MultiTemplateWithPseudoStates<ButtonPillToggleProps>(ButtonPillToggle).bind({});
@@ -55,12 +55,15 @@ delete Ghost.argTypes.ghost;
 delete Ghost.argTypes.outline;
 delete Ghost.argTypes.isSelected;
 
-Ghost.args = {
-  children: 'Example text',
-};
-
 Ghost.parameters = {
-  variants: [{ ghost: true }, { ghost: true, isSelected: true }],
+  variants: [
+    ...[false, true].map((isSelected) => ({
+      isSelected,
+      ghost: true,
+      label: `isSelected: ${isSelected}`,
+      children: 'Example text',
+    })),
+  ],
 };
 
 export { Example, Outline, Ghost };

--- a/src/components/ButtonPillToggle/ButtonPillToggle.stories.tsx
+++ b/src/components/ButtonPillToggle/ButtonPillToggle.stories.tsx
@@ -1,0 +1,66 @@
+import { MultiTemplateWithPseudoStates, Template } from '../../storybook/helper.stories.templates';
+import { DocumentationPage } from '../../storybook/helper.stories.docs';
+import StyleDocs from '../../storybook/docs.stories.style.mdx';
+
+import ButtonPillToggle, { ButtonPillToggleProps } from './';
+import argTypes from './ButtonPillToggle.stories.args';
+import Documentation from './ButtonPillToggle.stories.docs.mdx';
+
+export default {
+  title: 'Momentum UI/ButtonPillToggle',
+  component: ButtonPillToggle,
+  parameters: {
+    expanded: true,
+    docs: {
+      page: DocumentationPage(Documentation, StyleDocs),
+    },
+    args: {
+      style: { margin: '0.5rem' },
+    },
+  },
+};
+
+const Example = Template<ButtonPillToggleProps>(ButtonPillToggle).bind({});
+
+Example.argTypes = { ...argTypes };
+
+Example.args = {
+  children: 'Example text',
+};
+
+// Pseudostates will be correctly applied to ButtonPillToggle once ButtonPill
+// is fixed to receive these pseudostates.
+
+const Outline = MultiTemplateWithPseudoStates<ButtonPillToggleProps>(ButtonPillToggle).bind({});
+
+Outline.argTypes = { ...argTypes };
+delete Outline.argTypes.children;
+delete Outline.argTypes.ghost;
+delete Outline.argTypes.outline;
+delete Outline.argTypes.isSelected;
+
+Outline.args = {
+  children: 'Example text',
+};
+
+Outline.parameters = {
+  variants: [{ outline: true }, { outline: true, isSelected: true }],
+};
+
+const Ghost = MultiTemplateWithPseudoStates<ButtonPillToggleProps>(ButtonPillToggle).bind({});
+
+Ghost.argTypes = { ...argTypes };
+delete Ghost.argTypes.children;
+delete Ghost.argTypes.ghost;
+delete Ghost.argTypes.outline;
+delete Ghost.argTypes.isSelected;
+
+Ghost.args = {
+  children: 'Example text',
+};
+
+Ghost.parameters = {
+  variants: [{ ghost: true }, { ghost: true, isSelected: true }],
+};
+
+export { Example, Outline, Ghost };

--- a/src/components/ButtonPillToggle/ButtonPillToggle.style.scss
+++ b/src/components/ButtonPillToggle/ButtonPillToggle.style.scss
@@ -5,17 +5,20 @@
       background-color: var(--toggleButton-active-background);
       color: var(--toggleButton-active-text);
 
-      &:hover {
+      &:hover,
+      &.hover {
         background-color: var(--toggleButton-active-background-hovered);
         color: var(--toggleButton-active-text-hovered);
       }
 
-      &:active {
+      &:active,
+      &.active {
         background-color: var(--toggleButton-active-background-pressed);
         color: var(--toggleButton-active-text-pressed);
       }
 
-      &[data-disabled='true'] {
+      &[data-disabled='true'],
+      &.disable {
         background-color: var(--toggleButton-active-background-disabled);
         color: var(--toggleButton-active-text-disabled);
       }
@@ -24,15 +27,18 @@
     &[data-outline='true'] {
       border-color: var(--toggleButton-active-border-color);
 
-      &:hover {
+      &:hover,
+      &.hover {
         border-color: var(--toggleButton-active-border-color-hovered);
       }
 
-      &:active {
+      &:active,
+      &.active {
         border-color: var(--toggleButton-active-border-color-pressed);
       }
 
-      &[data-disabled='true'] {
+      &[data-disabled='true'],
+      &.disable {
         border-color: var(--toggleButton-active-border-color-disabled);
       }
     }

--- a/src/components/ButtonPillToggle/ButtonPillToggle.style.scss
+++ b/src/components/ButtonPillToggle/ButtonPillToggle.style.scss
@@ -1,0 +1,40 @@
+.md-button-pill-toggle-wrapper {
+  &[data-selected='true'] {
+    &[data-outline='true'],
+    &[data-ghost='true'] {
+      background-color: var(--toggleButton-active-background);
+      color: var(--toggleButton-active-text);
+
+      &:hover {
+        background-color: var(--toggleButton-active-background-hovered);
+        color: var(--toggleButton-active-text-hovered);
+      }
+
+      &:active {
+        background-color: var(--toggleButton-active-background-pressed);
+        color: var(--toggleButton-active-text-pressed);
+      }
+
+      &[data-disabled='true'] {
+        background-color: var(--toggleButton-active-background-disabled);
+        color: var(--toggleButton-active-text-disabled);
+      }
+    }
+
+    &[data-outline='true'] {
+      border-color: var(--toggleButton-active-border-color);
+
+      &:hover {
+        border-color: var(--toggleButton-active-border-color-hovered);
+      }
+
+      &:active {
+        border-color: var(--toggleButton-active-border-color-pressed);
+      }
+
+      &[data-disabled='true'] {
+        border-color: var(--toggleButton-active-border-color-disabled);
+      }
+    }
+  }
+}

--- a/src/components/ButtonPillToggle/ButtonPillToggle.tsx
+++ b/src/components/ButtonPillToggle/ButtonPillToggle.tsx
@@ -1,0 +1,55 @@
+import React, { RefObject, forwardRef, useRef } from 'react';
+import classnames from 'classnames';
+import ButtonPill from '../ButtonPill';
+import { useToggleState } from '@react-stately/toggle';
+
+import { DEFAULTS, STYLE } from './ButtonPillToggle.constants';
+import { DEFAULTS as BUTTON_PILL_DEFAULTS } from '../ButtonPill/ButtonPill.constants';
+import { Props } from './ButtonPillToggle.types';
+import './ButtonPillToggle.style.scss';
+import { chain } from '@react-aria/utils';
+
+const ButtonPillToggle = forwardRef((props: Props, providedRef: RefObject<HTMLButtonElement>) => {
+  const {
+    children,
+    className,
+    ghost = DEFAULTS.GHOST,
+    outline = DEFAULTS.OUTLINE,
+    disabled = DEFAULTS.DISABLED,
+    size = BUTTON_PILL_DEFAULTS.SIZE,
+    onPress,
+    ...otherProps
+  } = props;
+
+  const internalRef = useRef();
+  const ref = providedRef || internalRef;
+
+  const state = useToggleState(props);
+
+  if (ghost === false && outline === false) {
+    console.warn(
+      'ButtonPillToggle is only designed for outline or ghost pill buttons. Outline and ghost properties cannot be false at the same time.'
+    );
+  }
+
+  return (
+    <ButtonPill
+      className={classnames(STYLE.wrapper, className)}
+      outline={outline}
+      ghost={ghost}
+      disabled={disabled}
+      size={size}
+      data-selected={state.isSelected || DEFAULTS.SELECTED}
+      onPress={chain(state.toggle, onPress)}
+      aria-pressed={state.isSelected}
+      {...otherProps}
+      ref={ref}
+    >
+      {children}
+    </ButtonPill>
+  );
+});
+
+ButtonPillToggle.displayName = 'ButtonPillToggle';
+
+export default ButtonPillToggle;

--- a/src/components/ButtonPillToggle/ButtonPillToggle.types.ts
+++ b/src/components/ButtonPillToggle/ButtonPillToggle.types.ts
@@ -1,0 +1,6 @@
+import { ButtonPillProps } from '../ButtonPill';
+import { AriaButtonProps, AriaToggleButtonProps } from '@react-types/button';
+
+export interface Props
+  extends Omit<ButtonPillProps, keyof AriaButtonProps>,
+    AriaToggleButtonProps {}

--- a/src/components/ButtonPillToggle/ButtonPillToggle.unit.test.tsx
+++ b/src/components/ButtonPillToggle/ButtonPillToggle.unit.test.tsx
@@ -1,0 +1,179 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import ButtonPillToggle, { BUTTON_PILL_TOGGLE_CONSTANTS as CONSTANTS } from './';
+import { triggerPress } from '../../../test/utils';
+
+describe('<ButtonPillToggle />', () => {
+  describe('snapshot', () => {
+    it('should match snapshot', () => {
+      expect.assertions(1);
+
+      const container = mount(<ButtonPillToggle />);
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match snapshot with isSelected being true', () => {
+      expect.assertions(1);
+
+      const isSelected = true;
+
+      const container = mount(<ButtonPillToggle isSelected={isSelected} />);
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match snapshot with isSelected being false', () => {
+      expect.assertions(1);
+
+      const isSelected = false;
+
+      const container = mount(<ButtonPillToggle isSelected={isSelected} />);
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match snapshot with ghost being true', () => {
+      expect.assertions(1);
+
+      const ghost = true;
+
+      const container = mount(<ButtonPillToggle ghost={ghost} />);
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match snapshot with ghost being false', () => {
+      expect.assertions(1);
+
+      const ghost = false;
+
+      const container = mount(<ButtonPillToggle ghost={ghost} />);
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match snapshot with outline being true', () => {
+      expect.assertions(1);
+
+      const outline = true;
+
+      const container = mount(<ButtonPillToggle outline={outline} />);
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match snapshot with outline being false', () => {
+      expect.assertions(1);
+
+      const outline = false;
+
+      const container = mount(<ButtonPillToggle outline={outline} />);
+
+      expect(container).toMatchSnapshot();
+    });
+  });
+
+  describe('attributes', () => {
+    it('should have its wrapper class', () => {
+      expect.assertions(1);
+
+      const element = mount(<ButtonPillToggle />)
+        .find(ButtonPillToggle)
+        .getDOMNode();
+
+      expect(element.classList.contains(CONSTANTS.STYLE.wrapper)).toBe(true);
+    });
+
+    it('should have provided outline when outline is provided', () => {
+      expect.assertions(1);
+
+      const outline = true;
+
+      const element = mount(<ButtonPillToggle outline={outline} />)
+        .find(ButtonPillToggle)
+        .getDOMNode();
+
+      expect(element.getAttribute('data-outline')).toBe(`${outline}`);
+    });
+
+    it('should have provided ghost when ghost is provided', () => {
+      expect.assertions(1);
+
+      const ghost = true;
+
+      const element = mount(<ButtonPillToggle ghost={ghost} />)
+        .find(ButtonPillToggle)
+        .getDOMNode();
+
+      expect(element.getAttribute('data-ghost')).toBe(`${ghost}`);
+    });
+
+    it('should have provided isSelected when isSelected is provided', () => {
+      expect.assertions(1);
+
+      const isSelected = true;
+
+      const element = mount(<ButtonPillToggle isSelected={isSelected} />)
+        .find(ButtonPillToggle)
+        .getDOMNode();
+
+      expect(element.getAttribute('data-selected')).toBe(`${isSelected}`);
+    });
+  });
+
+  describe('actions', () => {
+    it('onChange callback is called correctly when provided', () => {
+      expect.assertions(1);
+
+      const mockCallback = jest.fn();
+
+      const initialIsSelected = false;
+
+      const component = mount(<ButtonPillToggle onChange={mockCallback} />).find(ButtonPillToggle);
+
+      component.props().onChange(initialIsSelected);
+
+      expect(mockCallback).toBeCalledTimes(1);
+    });
+
+    it('should handle mouse press events', () => {
+      expect.assertions(4);
+
+      const mockCallback = jest.fn();
+
+      const component = mount(<ButtonPillToggle onChange={mockCallback} />).find(ButtonPillToggle);
+
+      triggerPress(component);
+
+      expect(mockCallback).toHaveBeenCalledWith(true);
+
+      triggerPress(component);
+
+      expect(mockCallback).toHaveBeenCalledWith(false);
+
+      triggerPress(component);
+
+      expect(mockCallback).toHaveBeenCalledWith(true);
+
+      triggerPress(component);
+
+      expect(mockCallback).toHaveBeenCalledWith(false);
+    });
+
+    it('should handle mouse press event when disabled', () => {
+      expect.assertions(1);
+
+      const mockCallback = jest.fn();
+
+      const component = mount(<ButtonPillToggle onChange={mockCallback} disabled />).find(
+        ButtonPillToggle
+      );
+
+      triggerPress(component);
+
+      expect(mockCallback).toBeCalledTimes(0);
+    });
+  });
+});

--- a/src/components/ButtonPillToggle/ButtonPillToggle.unit.test.tsx.snap
+++ b/src/components/ButtonPillToggle/ButtonPillToggle.unit.test.tsx.snap
@@ -1,0 +1,495 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ButtonPillToggle /> snapshot should match snapshot 1`] = `
+<ButtonPillToggle>
+  <ButtonPill
+    aria-pressed={false}
+    className="md-button-pill-toggle-wrapper"
+    data-selected={false}
+    disabled={false}
+    ghost={true}
+    onPress={[Function]}
+    size={40}
+  >
+    <ButtonSimple
+      aria-pressed={false}
+      className="md-button-pill-wrapper md-button-pill-toggle-wrapper"
+      data-color="primary"
+      data-disabled={false}
+      data-ghost={true}
+      data-grown={false}
+      data-outline={false}
+      data-selected={false}
+      data-size={40}
+      data-solid={false}
+      isDisabled={false}
+      onPress={[Function]}
+    >
+      <FocusRing
+        disabled={false}
+      >
+        <FocusRing
+          disabled={false}
+          focusClass="md-focus-ring-wrapper children"
+          focusRingClass="md-focus-ring-wrapper children"
+        >
+          <button
+            aria-pressed={false}
+            className="md-button-pill-wrapper md-button-pill-toggle-wrapper md-button-simple-wrapper"
+            data-color="primary"
+            data-disabled={false}
+            data-ghost={true}
+            data-grown={false}
+            data-outline={false}
+            data-selected={false}
+            data-size={40}
+            data-solid={false}
+            disabled={false}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onDragStart={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchCancel={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            type="button"
+          />
+        </FocusRing>
+      </FocusRing>
+    </ButtonSimple>
+  </ButtonPill>
+</ButtonPillToggle>
+`;
+
+exports[`<ButtonPillToggle /> snapshot should match snapshot with ghost being false 1`] = `
+<ButtonPillToggle
+  ghost={false}
+>
+  <ButtonPill
+    aria-pressed={false}
+    className="md-button-pill-toggle-wrapper"
+    data-selected={false}
+    disabled={false}
+    ghost={false}
+    onPress={[Function]}
+    size={40}
+  >
+    <ButtonSimple
+      aria-pressed={false}
+      className="md-button-pill-wrapper md-button-pill-toggle-wrapper"
+      data-color="primary"
+      data-disabled={false}
+      data-ghost={false}
+      data-grown={false}
+      data-outline={false}
+      data-selected={false}
+      data-size={40}
+      data-solid={false}
+      isDisabled={false}
+      onPress={[Function]}
+    >
+      <FocusRing
+        disabled={false}
+      >
+        <FocusRing
+          disabled={false}
+          focusClass="md-focus-ring-wrapper children"
+          focusRingClass="md-focus-ring-wrapper children"
+        >
+          <button
+            aria-pressed={false}
+            className="md-button-pill-wrapper md-button-pill-toggle-wrapper md-button-simple-wrapper"
+            data-color="primary"
+            data-disabled={false}
+            data-ghost={false}
+            data-grown={false}
+            data-outline={false}
+            data-selected={false}
+            data-size={40}
+            data-solid={false}
+            disabled={false}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onDragStart={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchCancel={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            type="button"
+          />
+        </FocusRing>
+      </FocusRing>
+    </ButtonSimple>
+  </ButtonPill>
+</ButtonPillToggle>
+`;
+
+exports[`<ButtonPillToggle /> snapshot should match snapshot with ghost being true 1`] = `
+<ButtonPillToggle
+  ghost={true}
+>
+  <ButtonPill
+    aria-pressed={false}
+    className="md-button-pill-toggle-wrapper"
+    data-selected={false}
+    disabled={false}
+    ghost={true}
+    onPress={[Function]}
+    size={40}
+  >
+    <ButtonSimple
+      aria-pressed={false}
+      className="md-button-pill-wrapper md-button-pill-toggle-wrapper"
+      data-color="primary"
+      data-disabled={false}
+      data-ghost={true}
+      data-grown={false}
+      data-outline={false}
+      data-selected={false}
+      data-size={40}
+      data-solid={false}
+      isDisabled={false}
+      onPress={[Function]}
+    >
+      <FocusRing
+        disabled={false}
+      >
+        <FocusRing
+          disabled={false}
+          focusClass="md-focus-ring-wrapper children"
+          focusRingClass="md-focus-ring-wrapper children"
+        >
+          <button
+            aria-pressed={false}
+            className="md-button-pill-wrapper md-button-pill-toggle-wrapper md-button-simple-wrapper"
+            data-color="primary"
+            data-disabled={false}
+            data-ghost={true}
+            data-grown={false}
+            data-outline={false}
+            data-selected={false}
+            data-size={40}
+            data-solid={false}
+            disabled={false}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onDragStart={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchCancel={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            type="button"
+          />
+        </FocusRing>
+      </FocusRing>
+    </ButtonSimple>
+  </ButtonPill>
+</ButtonPillToggle>
+`;
+
+exports[`<ButtonPillToggle /> snapshot should match snapshot with isSelected being false 1`] = `
+<ButtonPillToggle
+  isSelected={false}
+>
+  <ButtonPill
+    aria-pressed={false}
+    className="md-button-pill-toggle-wrapper"
+    data-selected={false}
+    disabled={false}
+    ghost={true}
+    isSelected={false}
+    onPress={[Function]}
+    size={40}
+  >
+    <ButtonSimple
+      aria-pressed={false}
+      className="md-button-pill-wrapper md-button-pill-toggle-wrapper"
+      data-color="primary"
+      data-disabled={false}
+      data-ghost={true}
+      data-grown={false}
+      data-outline={false}
+      data-selected={false}
+      data-size={40}
+      data-solid={false}
+      isDisabled={false}
+      isSelected={false}
+      onPress={[Function]}
+    >
+      <FocusRing
+        disabled={false}
+      >
+        <FocusRing
+          disabled={false}
+          focusClass="md-focus-ring-wrapper children"
+          focusRingClass="md-focus-ring-wrapper children"
+        >
+          <button
+            aria-pressed={false}
+            className="md-button-pill-wrapper md-button-pill-toggle-wrapper md-button-simple-wrapper"
+            data-color="primary"
+            data-disabled={false}
+            data-ghost={true}
+            data-grown={false}
+            data-outline={false}
+            data-selected={false}
+            data-size={40}
+            data-solid={false}
+            disabled={false}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onDragStart={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchCancel={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            type="button"
+          />
+        </FocusRing>
+      </FocusRing>
+    </ButtonSimple>
+  </ButtonPill>
+</ButtonPillToggle>
+`;
+
+exports[`<ButtonPillToggle /> snapshot should match snapshot with isSelected being true 1`] = `
+<ButtonPillToggle
+  isSelected={true}
+>
+  <ButtonPill
+    aria-pressed={true}
+    className="md-button-pill-toggle-wrapper"
+    data-selected={true}
+    disabled={false}
+    ghost={true}
+    isSelected={true}
+    onPress={[Function]}
+    size={40}
+  >
+    <ButtonSimple
+      aria-pressed={true}
+      className="md-button-pill-wrapper md-button-pill-toggle-wrapper"
+      data-color="primary"
+      data-disabled={false}
+      data-ghost={true}
+      data-grown={false}
+      data-outline={false}
+      data-selected={true}
+      data-size={40}
+      data-solid={false}
+      isDisabled={false}
+      isSelected={true}
+      onPress={[Function]}
+    >
+      <FocusRing
+        disabled={false}
+      >
+        <FocusRing
+          disabled={false}
+          focusClass="md-focus-ring-wrapper children"
+          focusRingClass="md-focus-ring-wrapper children"
+        >
+          <button
+            aria-pressed={true}
+            className="md-button-pill-wrapper md-button-pill-toggle-wrapper md-button-simple-wrapper"
+            data-color="primary"
+            data-disabled={false}
+            data-ghost={true}
+            data-grown={false}
+            data-outline={false}
+            data-selected={true}
+            data-size={40}
+            data-solid={false}
+            disabled={false}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onDragStart={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchCancel={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            type="button"
+          />
+        </FocusRing>
+      </FocusRing>
+    </ButtonSimple>
+  </ButtonPill>
+</ButtonPillToggle>
+`;
+
+exports[`<ButtonPillToggle /> snapshot should match snapshot with outline being false 1`] = `
+<ButtonPillToggle
+  outline={false}
+>
+  <ButtonPill
+    aria-pressed={false}
+    className="md-button-pill-toggle-wrapper"
+    data-selected={false}
+    disabled={false}
+    ghost={true}
+    onPress={[Function]}
+    outline={false}
+    size={40}
+  >
+    <ButtonSimple
+      aria-pressed={false}
+      className="md-button-pill-wrapper md-button-pill-toggle-wrapper"
+      data-color="primary"
+      data-disabled={false}
+      data-ghost={true}
+      data-grown={false}
+      data-outline={false}
+      data-selected={false}
+      data-size={40}
+      data-solid={false}
+      isDisabled={false}
+      onPress={[Function]}
+    >
+      <FocusRing
+        disabled={false}
+      >
+        <FocusRing
+          disabled={false}
+          focusClass="md-focus-ring-wrapper children"
+          focusRingClass="md-focus-ring-wrapper children"
+        >
+          <button
+            aria-pressed={false}
+            className="md-button-pill-wrapper md-button-pill-toggle-wrapper md-button-simple-wrapper"
+            data-color="primary"
+            data-disabled={false}
+            data-ghost={true}
+            data-grown={false}
+            data-outline={false}
+            data-selected={false}
+            data-size={40}
+            data-solid={false}
+            disabled={false}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onDragStart={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchCancel={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            type="button"
+          />
+        </FocusRing>
+      </FocusRing>
+    </ButtonSimple>
+  </ButtonPill>
+</ButtonPillToggle>
+`;
+
+exports[`<ButtonPillToggle /> snapshot should match snapshot with outline being true 1`] = `
+<ButtonPillToggle
+  outline={true}
+>
+  <ButtonPill
+    aria-pressed={false}
+    className="md-button-pill-toggle-wrapper"
+    data-selected={false}
+    disabled={false}
+    ghost={true}
+    onPress={[Function]}
+    outline={true}
+    size={40}
+  >
+    <ButtonSimple
+      aria-pressed={false}
+      className="md-button-pill-wrapper md-button-pill-toggle-wrapper"
+      data-color="primary"
+      data-disabled={false}
+      data-ghost={true}
+      data-grown={false}
+      data-outline={true}
+      data-selected={false}
+      data-size={40}
+      data-solid={false}
+      isDisabled={false}
+      onPress={[Function]}
+    >
+      <FocusRing
+        disabled={false}
+      >
+        <FocusRing
+          disabled={false}
+          focusClass="md-focus-ring-wrapper children"
+          focusRingClass="md-focus-ring-wrapper children"
+        >
+          <button
+            aria-pressed={false}
+            className="md-button-pill-wrapper md-button-pill-toggle-wrapper md-button-simple-wrapper"
+            data-color="primary"
+            data-disabled={false}
+            data-ghost={true}
+            data-grown={false}
+            data-outline={true}
+            data-selected={false}
+            data-size={40}
+            data-solid={false}
+            disabled={false}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onDragStart={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchCancel={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            type="button"
+          />
+        </FocusRing>
+      </FocusRing>
+    </ButtonSimple>
+  </ButtonPill>
+</ButtonPillToggle>
+`;

--- a/src/components/ButtonPillToggle/index.ts
+++ b/src/components/ButtonPillToggle/index.ts
@@ -1,0 +1,9 @@
+import { default as ButtonPillToggle } from './ButtonPillToggle';
+import * as CONSTANTS from './ButtonPillToggle.constants';
+import { Props } from './ButtonPillToggle.types';
+
+export { CONSTANTS as BUTTON_PILL_TOGGLE_CONSTANTS };
+
+export type ButtonPillToggleProps = Props;
+
+export default ButtonPillToggle;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -11,6 +11,7 @@ export { default as ButtonDialpad } from './ButtonDialpad';
 export { default as ButtonGroup } from './ButtonGroup';
 export { default as ButtonHyperlink } from './ButtonHyperlink';
 export { default as ButtonPill } from './ButtonPill';
+export { default as ButtonPillToggle } from './ButtonPillToggle';
 export { default as ButtonSimple } from './ButtonSimple';
 export { default as Coachmark } from './Coachmark';
 export { default as FocusRing } from './FocusRing';

--- a/src/index.js
+++ b/src/index.js
@@ -114,6 +114,7 @@ export {
   ButtonGroup as ButtonGroupNext,
   ButtonHyperlink,
   ButtonPill,
+  ButtonPillToggle,
   ButtonSimple,
   Checkbox as CheckboxNext,
   Coachmark as CoachmarkNext,


### PR DESCRIPTION
# Description

PR to implement the buttonPillToggle component. This is a component that is based on ButtonPill and adds toggle hooks to it to make it toggable/selectable. 

As for now, only the outline and ghost buttons have a toggable version designed in the component library, which only cover these button colour types in the scope.

![image](https://user-images.githubusercontent.com/56999622/190428423-3423c8e0-e41a-4442-8225-4f38705f8339.png)
![image](https://user-images.githubusercontent.com/56999622/190428469-7e0566db-ebb4-408b-b914-0465bef4449e.png)

# Links

[*Links to relevent resources.*](https://www.figma.com/file/vdL18BATeJAIq2JvGAjRPD/Components---Web?node-id=4445%3A5884)