### PR TITLE
fix(autofill-colours): remove yellow autofill box and styling fixes

### DIFF
--- a/src/components/TextInput/TextInput.stories.tsx
+++ b/src/components/TextInput/TextInput.stories.tsx
@@ -103,14 +103,16 @@ const FormExample: FC<FormProps> = (props: FormProps) => {
       }}
     >
       {displayName && (
-        <TextInput
+        <BetterExample
+          initialValue=""
           placeholder={'Display Name'}
           type="name"
           style={{ marginTop: '1rem', marginBottom: '1rem', width: '16.25rem' }}
         />
       )}
       {emailAddress && (
-        <TextInput
+        <BetterExample
+          initialValue=""
           placeholder={'Email address'}
           type="email"
           style={{
@@ -121,7 +123,8 @@ const FormExample: FC<FormProps> = (props: FormProps) => {
         />
       )}
       {password && (
-        <TextInput
+        <BetterExample
+          initialValue=""
           type="password"
           placeholder={'Password'}
           style={{ marginBottom: '1rem', width: '16.25rem' }}

--- a/src/components/TextInput/TextInput.stories.tsx
+++ b/src/components/TextInput/TextInput.stories.tsx
@@ -1,5 +1,6 @@
 import React, { useState, FC, useRef } from 'react';
 import { MultiTemplate, Template } from '../../storybook/helper.stories.templates';
+import ButtonPill from '../ButtonPill';
 
 import TextInput, { TextInputProps } from './';
 
@@ -59,6 +60,12 @@ interface StoryProps extends TextInputProps {
   initialValue: string;
 }
 
+interface FormProps extends TextInputProps {
+  displayName?: boolean;
+  emailAddress?: boolean;
+  password?: boolean;
+}
+
 const PaddedExample: FC<TextInputProps> = (props: TextInputProps) => {
   return (
     <div style={{ margin: '1rem' }}>
@@ -85,9 +92,63 @@ const BetterExample: FC<StoryProps> = (props: StoryProps) => {
   return <TextInput {...mutatedProps} value={value} ref={ref} onChange={onChange} />;
 };
 
+const FormExample: FC<FormProps> = (props: FormProps) => {
+  const { displayName = false, emailAddress = false, password = false } = props;
+
+  return (
+    <>
+      <form>
+        {displayName && (
+          <TextInput
+            placeholder={'Display Name'}
+            type="name"
+            style={{ marginTop: '1rem', marginBottom: '1rem', width: '16.25rem' }}
+          />
+        )}
+        {emailAddress && (
+          <TextInput
+            placeholder={'Email address'}
+            type="email"
+            style={{
+              marginTop: !displayName ? '1rem' : '0',
+              marginBottom: '1rem',
+              width: '16.25rem',
+            }}
+          />
+        )}
+        {password && (
+          <TextInput
+            type="password"
+            placeholder={'Password'}
+            style={{ marginBottom: '1rem', width: '16.25rem' }}
+          />
+        )}
+        <ButtonPill size={32} grown style={{ marginBottom: '1rem', width: '16.25rem' }}>
+          Next
+        </ButtonPill>
+      </form>
+    </>
+  );
+};
+
 const Example = Template<StoryProps>(BetterExample).bind({});
 
 Example.args = {};
+
+const Forms = Template<FormProps>(() => {
+  return (
+    <>
+      These stories allow for testing of the behaviour and styling of autofill in browers. The first
+      form is to test the autofill of contact information, such as a Display Name.
+      <FormExample displayName={true} emailAddress={true} />
+      The second form is to test the autofill of log-on credentials and, when available in browser,
+      a password suggestion.
+      <FormExample emailAddress={true} password={true} />
+    </>
+  );
+});
+
+Forms.args = {};
 
 const Common = MultiTemplate<TextInputProps>(PaddedExample).bind({});
 Common.args = {};
@@ -113,4 +174,4 @@ Common.parameters = {
   ],
 };
 
-export { Example, Common };
+export { Example, Forms, Common };

--- a/src/components/TextInput/TextInput.stories.tsx
+++ b/src/components/TextInput/TextInput.stories.tsx
@@ -96,38 +96,41 @@ const FormExample: FC<FormProps> = (props: FormProps) => {
   const { displayName = false, emailAddress = false, password = false } = props;
 
   return (
-    <>
-      <form>
-        {displayName && (
-          <TextInput
-            placeholder={'Display Name'}
-            type="name"
-            style={{ marginTop: '1rem', marginBottom: '1rem', width: '16.25rem' }}
-          />
-        )}
-        {emailAddress && (
-          <TextInput
-            placeholder={'Email address'}
-            type="email"
-            style={{
-              marginTop: !displayName ? '1rem' : '0',
-              marginBottom: '1rem',
-              width: '16.25rem',
-            }}
-          />
-        )}
-        {password && (
-          <TextInput
-            type="password"
-            placeholder={'Password'}
-            style={{ marginBottom: '1rem', width: '16.25rem' }}
-          />
-        )}
-        <ButtonPill size={32} grown style={{ marginBottom: '1rem', width: '16.25rem' }}>
-          Next
-        </ButtonPill>
-      </form>
-    </>
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        location.reload();
+      }}
+    >
+      {displayName && (
+        <TextInput
+          placeholder={'Display Name'}
+          type="name"
+          style={{ marginTop: '1rem', marginBottom: '1rem', width: '16.25rem' }}
+        />
+      )}
+      {emailAddress && (
+        <TextInput
+          placeholder={'Email address'}
+          type="email"
+          style={{
+            marginTop: !displayName ? '1rem' : '0',
+            marginBottom: '1rem',
+            width: '16.25rem',
+          }}
+        />
+      )}
+      {password && (
+        <TextInput
+          type="password"
+          placeholder={'Password'}
+          style={{ marginBottom: '1rem', width: '16.25rem' }}
+        />
+      )}
+      <ButtonPill type="submit" size={32} grown style={{ marginBottom: '1rem', width: '16.25rem' }}>
+        Submit
+      </ButtonPill>
+    </form>
   );
 };
 
@@ -137,14 +140,14 @@ Example.args = {};
 
 const Forms = Template<FormProps>(() => {
   return (
-    <>
+    <div>
       These stories allow for testing of the behaviour and styling of autofill in browers. The first
       form is to test the autofill of contact information, such as a Display Name.
       <FormExample displayName={true} emailAddress={true} />
       The second form is to test the autofill of log-on credentials and, when available in browser,
       a password suggestion.
       <FormExample emailAddress={true} password={true} />
-    </>
+    </div>
   );
 });
 

--- a/src/components/TextInput/TextInput.style.scss
+++ b/src/components/TextInput/TextInput.style.scss
@@ -39,6 +39,48 @@
     &::placeholder {
       color: var(--textinput-placeholder-text);
     }
+
+    &::-webkit-contacts-auto-fill-button {
+      background-color: var(--theme-text-secondary-normal);
+
+      &:hover {
+        background-color: var(--theme-text-primary-normal);
+      }
+
+      &:active {
+        background-color: var(--theme-text-secondary-normal);
+      }
+    }
+
+    &:-webkit-autofill,
+    &:-webkit-autofill:hover,
+    &:-webkit-autofill:focus,
+    &:-webkit-autofill:active {
+      -webkit-animation: autofill 0s forwards;
+      animation: autofill 0s forwards;
+    }
+
+    @keyframes autofill {
+      100% {
+        background: transparent;
+        color: inherit;
+      }
+    }
+
+    @-webkit-keyframes autofill {
+      100% {
+        background: transparent;
+        color: inherit;
+      }
+    }
+
+    &:-webkit-autofill-strong-password {
+      margin-top: 0.0625rem;
+      margin-left: 0.0625rem;
+      -webkit-box-shadow: 0 0 0 3.75rem #f9ffbd inset;
+      box-shadow: 0 0 0 3.75rem #f9ffbd inset;
+      border-radius: 0.375rem 0 0 0.375rem;
+    }
   }
 
   &[data-level='error'] {

--- a/src/components/TextInput/TextInput.style.scss
+++ b/src/components/TextInput/TextInput.style.scss
@@ -58,6 +58,7 @@
     &:-webkit-autofill:active {
       -webkit-animation: autofill 0s forwards;
       animation: autofill 0s forwards;
+      border-radius: 0.438rem 0 0 0.438rem;
     }
 
     @keyframes autofill {


### PR DESCRIPTION
# Description

This PR styles the autofill icon in Safari so that it is visible in our dark theming - the same changes as made in https://sqbu-github.cisco.com/WebExSquared/webex-web-client/pull/3032 but generalising them to the momentum component. It also removes the yellow autofill box on Safari (except in the case of a suggested password) and Firefox, making it transparent. In the case of a suggested password in Safari the yellow box is restyled to have a border radius which aligns with that of the TextInput.

# Links
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-362673

Safari ->
Before
![SAFARI-BEFORE](https://user-images.githubusercontent.com/86778628/191272800-b835367b-ad39-4472-a2e0-e5ba2368b4e5.png)
After 
![SAFARI_AFTER](https://user-images.githubusercontent.com/86778628/191272837-7e709fd3-699a-4bac-8002-d527e05c2ce9.png)

Firefox -> 
Before
<img width="534" alt="FIREFOX-BEFORE" src="https://user-images.githubusercontent.com/86778628/191272902-f4406eb2-d1b8-4e65-bd5e-e57e9b9dc032.png">
After
<img width="549" alt="FIREFOX-AFTER" src="https://user-images.githubusercontent.com/86778628/191272928-59edebfd-a995-47d2-958f-addbc6158743.png">
