### PR TITLE
fix(search-input): fix styling to align with figma

### DIFF
--- a/src/components/SearchInput/SearchInput.constants.ts
+++ b/src/components/SearchInput/SearchInput.constants.ts
@@ -5,7 +5,7 @@ const CLASS_PREFIX = 'md-search-input';
 
 const HEIGHTS = [28, 32] as const;
 
-const SEARCH_ICON_HEIGHT_MAPPING: Record<SearchFieldHeight, IconScale> = {
+const ICON_HEIGHT_MAPPING: Record<SearchFieldHeight, IconScale> = {
   28: 12,
   32: 16,
 };
@@ -22,4 +22,4 @@ const STYLE = {
   clear: `${CLASS_PREFIX}-clear`,
 };
 
-export { CLASS_PREFIX, HEIGHTS, SEARCH_ICON_HEIGHT_MAPPING, DEFAULTS, STYLE };
+export { CLASS_PREFIX, HEIGHTS, ICON_HEIGHT_MAPPING, DEFAULTS, STYLE };

--- a/src/components/SearchInput/SearchInput.constants.ts
+++ b/src/components/SearchInput/SearchInput.constants.ts
@@ -1,20 +1,18 @@
 import { IconScale } from '../Icon';
+import { SearchFieldHeight } from './SearchInput.types';
 
 const CLASS_PREFIX = 'md-search-input';
 
-const HEIGHTS = {
-  28: 28,
-  32: 32,
-};
+const HEIGHTS = [28, 32] as const;
 
-const SEARCH_ICON_HEIGHT_MAPPING: Record<number, IconScale> = {
+const SEARCH_ICON_HEIGHT_MAPPING: Record<SearchFieldHeight, IconScale> = {
   28: 12,
   32: 16,
 };
 
 const DEFAULTS = {
-  HEIGHT: HEIGHTS[32],
-};
+  HEIGHT: 32,
+} as const;
 
 const STYLE = {
   wrapper: `${CLASS_PREFIX}-wrapper`,

--- a/src/components/SearchInput/SearchInput.constants.ts
+++ b/src/components/SearchInput/SearchInput.constants.ts
@@ -1,6 +1,20 @@
+import { IconScale } from '../Icon';
+
 const CLASS_PREFIX = 'md-search-input';
 
-const DEFAULTS = {};
+const HEIGHTS = {
+  28: 28,
+  32: 32,
+};
+
+const SEARCH_ICON_HEIGHT_MAPPING: Record<number, IconScale> = {
+  28: 12,
+  32: 16,
+};
+
+const DEFAULTS = {
+  HEIGHT: HEIGHTS[32],
+};
 
 const STYLE = {
   wrapper: `${CLASS_PREFIX}-wrapper`,
@@ -10,4 +24,4 @@ const STYLE = {
   clear: `${CLASS_PREFIX}-clear`,
 };
 
-export { CLASS_PREFIX, DEFAULTS, STYLE };
+export { CLASS_PREFIX, HEIGHTS, SEARCH_ICON_HEIGHT_MAPPING, DEFAULTS, STYLE };

--- a/src/components/SearchInput/SearchInput.constants.ts
+++ b/src/components/SearchInput/SearchInput.constants.ts
@@ -6,6 +6,7 @@ const STYLE = {
   wrapper: `${CLASS_PREFIX}-wrapper`,
   container: `${CLASS_PREFIX}-container`,
   search: `${CLASS_PREFIX}-search`,
+  searching: `${CLASS_PREFIX}-searching`,
   clear: `${CLASS_PREFIX}-clear`,
 };
 

--- a/src/components/SearchInput/SearchInput.stories.args.ts
+++ b/src/components/SearchInput/SearchInput.stories.args.ts
@@ -29,7 +29,7 @@ export default {
   },
   height: {
     description: 'Changes the height of the component',
-    options: [...Object.values(HEIGHTS)],
+    options: HEIGHTS,
     control: { type: 'select' },
     defaultValue: DEFAULTS.HEIGHT,
     table: {

--- a/src/components/SearchInput/SearchInput.stories.args.ts
+++ b/src/components/SearchInput/SearchInput.stories.args.ts
@@ -1,4 +1,5 @@
 import { commonStyles } from '../../storybook/helper.stories.argtypes';
+import { DEFAULTS, HEIGHTS } from './SearchInput.constants';
 
 export default {
   ...commonStyles,
@@ -22,6 +23,15 @@ export default {
   },
   searching: {
     description: 'Triggers the display of the spinner when true',
+    table: {
+      category: 'Props',
+    },
+  },
+  height: {
+    description: 'Changes the height of the SearchInput component',
+    options: [...Object.values(HEIGHTS)],
+    control: { type: 'select' },
+    defaultValue: DEFAULTS.HEIGHT,
     table: {
       category: 'Props',
     },

--- a/src/components/SearchInput/SearchInput.stories.args.ts
+++ b/src/components/SearchInput/SearchInput.stories.args.ts
@@ -28,7 +28,7 @@ export default {
     },
   },
   height: {
-    description: 'Changes the height of the SearchInput component',
+    description: 'Changes the height of the component',
     options: [...Object.values(HEIGHTS)],
     control: { type: 'select' },
     defaultValue: DEFAULTS.HEIGHT,

--- a/src/components/SearchInput/SearchInput.stories.docs.mdx
+++ b/src/components/SearchInput/SearchInput.stories.docs.mdx
@@ -1,10 +1,1 @@
-The `<GlobalSearchInput />` component.
-
-This component uses the react-aria useSearchField. See
-https://react-spectrum.adobe.com/react-aria/useSearchField.html
-
-This component takes an array of active filters and informs the parent component of changes made by
-the user using `onFiltersChange` alongside the standard `onChange` method
-
-Each filter contains a translations object which has the necessary strings for describing the
-current filter and its add/removal.
+The `<SearchInput />` component.

--- a/src/components/SearchInput/SearchInput.stories.tsx
+++ b/src/components/SearchInput/SearchInput.stories.tsx
@@ -129,9 +129,14 @@ Example.argTypes = { ...argTypes };
 
 const PaddedExample: FC<SearchInputProps> = (props: SearchInputProps) => {
   return (
-    <div style={{ margin: '1rem' }}>
-      <SearchInput {...props} />
-    </div>
+    <>
+      <div style={{ margin: '1rem' }}>
+        <SearchInput style={{ height: 32 }} {...props} />
+      </div>
+      <div style={{ margin: '1rem' }}>
+        <SearchInput style={{ height: 28 }} {...props} />
+      </div>
+    </>
   );
 };
 

--- a/src/components/SearchInput/SearchInput.stories.tsx
+++ b/src/components/SearchInput/SearchInput.stories.tsx
@@ -131,7 +131,7 @@ delete Example.argTypes.searching;
 const PaddedExample: FC<SearchInputProps> = (props: SearchInputProps) => {
   return (
     <div style={{ margin: '1rem' }}>
-      <SearchInput height={32} {...props} />
+      <SearchInput {...props} />
     </div>
   );
 };

--- a/src/components/SearchInput/SearchInput.stories.tsx
+++ b/src/components/SearchInput/SearchInput.stories.tsx
@@ -72,7 +72,7 @@ const BetterExample: FC<SearchInputExampleProps> = (props: SearchInputExamplePro
     setSearching(true);
     setTimeout(() => {
       setSearching(false);
-    }, 500);
+    }, 1500);
     if (e.toLowerCase().startsWith('from:')) {
       setFilters([
         {
@@ -122,6 +122,7 @@ const BetterExample: FC<SearchInputExampleProps> = (props: SearchInputExamplePro
 const Example = Template<SearchInputExampleProps>(BetterExample).bind({});
 
 Example.argTypes = { ...argTypes };
+delete Example.argTypes.searching;
 
 /**
  * Common variants story. This renders multiple variants of a single component.
@@ -131,10 +132,7 @@ const PaddedExample: FC<SearchInputProps> = (props: SearchInputProps) => {
   return (
     <>
       <div style={{ margin: '1rem' }}>
-        <SearchInput style={{ height: 32 }} {...props} />
-      </div>
-      <div style={{ margin: '1rem' }}>
-        <SearchInput style={{ height: 28 }} {...props} />
+        <SearchInput height={32} {...props} />
       </div>
     </>
   );

--- a/src/components/SearchInput/SearchInput.stories.tsx
+++ b/src/components/SearchInput/SearchInput.stories.tsx
@@ -130,7 +130,7 @@ Example.argTypes = { ...argTypes };
 const PaddedExample: FC<SearchInputProps> = (props: SearchInputProps) => {
   return (
     <div style={{ margin: '1rem' }}>
-      <SearchInput style={{ width: '20rem' }} {...props} />
+      <SearchInput {...props} />
     </div>
   );
 };

--- a/src/components/SearchInput/SearchInput.stories.tsx
+++ b/src/components/SearchInput/SearchInput.stories.tsx
@@ -130,11 +130,9 @@ delete Example.argTypes.searching;
 
 const PaddedExample: FC<SearchInputProps> = (props: SearchInputProps) => {
   return (
-    <>
-      <div style={{ margin: '1rem' }}>
-        <SearchInput height={32} {...props} />
-      </div>
-    </>
+    <div style={{ margin: '1rem' }}>
+      <SearchInput height={32} {...props} />
+    </div>
   );
 };
 

--- a/src/components/SearchInput/SearchInput.style.scss
+++ b/src/components/SearchInput/SearchInput.style.scss
@@ -1,16 +1,13 @@
 @use "sass:math";
 
 .md-search-input-wrapper {
-  $search-width: 16.25rem;
-  $search-height: 2rem;
-
   position: relative;
   border-radius: 0.5rem;
   background-color: var(--textinput-background);
   border: 0.0625rem solid var(--textinput-border-color);
   box-sizing: border-box;
-  height: $search-height;
-  width: $search-width;
+  height: 2rem;
+  width: 16.25rem;
   display: flex;
   align-content: center;
   justify-content: center;
@@ -18,6 +15,10 @@
 
   &[data-focus='true'] {
     box-shadow: var(--md-globals-focus-ring-box-shadow);
+  }
+
+  &[data-height='28'] {
+    height: 1.75rem;
   }
 
   &:hover {
@@ -68,27 +69,12 @@
     }
   }
 
-  .md-search-input-search {
-    $icon-height: math.div($search-height, 2);
-
-    // margin-top: 0px;
-    width: 1rem;
-    height: 1rem;
+  .md-search-input-search,
+  .md-search-input-searching {
     margin-left: 0.375rem;
     margin-right: 0.375rem;
     align-content: center;
-    // flex-grow: 0;
-  }
-
-  .md-search-input-searching {
-    $icon-height: math.div($search-height, 2);
-
-    // margin-top: 0px;
-    scale: math.div(2, 3);
-    margin-left: 0.2rem;
-    margin-right: 0.15rem;
-    align-content: center;
-    // flex-grow: 0;
+    flex-grow: 0;
   }
 
   .md-search-input-clear {

--- a/src/components/SearchInput/SearchInput.style.scss
+++ b/src/components/SearchInput/SearchInput.style.scss
@@ -14,6 +14,8 @@
   width: $search-width;
   display: flex;
   align-content: center;
+  justify-content: center;
+  align-items: center;
 
   &[data-focus='true'] {
     box-shadow: var(--md-globals-focus-ring-box-shadow);
@@ -71,9 +73,9 @@
   .md-search-input-searching {
     $icon-height: math.div($search-height, 2);
 
-    margin-top: 0px;
-    margin-left: 0px;
-    margin-bottom: 8px;
+    // margin-top: 0px;
+    margin-left: 0.375rem;
+    margin-right: 0.375rem;
     align-content: center;
     // flex-grow: 0;
   }

--- a/src/components/SearchInput/SearchInput.style.scss
+++ b/src/components/SearchInput/SearchInput.style.scss
@@ -1,10 +1,17 @@
+@use "sass:math";
+
 .md-search-input-wrapper {
+  $search-width: 16.25rem;
+  $search-height: 2rem;
+  $search-border-radius: math.div($search-height, 4);
+
   position: relative;
-  border-radius: 0.5rem;
+  border-radius: $search-border-radius;
   background-color: var(--textinput-background);
   border: 0.0625rem solid var(--textinput-border-color);
   box-sizing: border-box;
-  height: 1.75rem;
+  height: $search-height;
+  width: $search-width;
   display: flex;
   align-content: center;
 
@@ -48,7 +55,6 @@
     color: var(--textinput-text);
     font-family: var(--md-globals-font-default);
     font-size: 0.875rem;
-    height: 1.75rem;
     display: inline-block;
     flex: 1;
 
@@ -61,12 +67,15 @@
     }
   }
 
-  .md-search-input-search {
-    margin-left: 0.5625rem;
-    margin-right: 0.5625rem;
-    height: 1.625rem;
+  .md-search-input-search,
+  .md-search-input-searching {
+    $icon-height: math.div($search-height, 2);
+
+    margin-top: 0px;
+    margin-left: 0px;
+    margin-bottom: 8px;
     align-content: center;
-    flex-grow: 0;
+    // flex-grow: 0;
   }
 
   .md-search-input-clear {

--- a/src/components/SearchInput/SearchInput.style.scss
+++ b/src/components/SearchInput/SearchInput.style.scss
@@ -73,12 +73,12 @@
   .md-search-input-searching {
     margin-left: 0.375rem;
     margin-right: 0.375rem;
-    align-content: center;
-    flex-grow: 0;
   }
 
   .md-search-input-clear {
     border: 0;
+    padding: 0;
+    margin-right: 0.5rem;
     background-color: transparent;
     cursor: pointer;
     color: var(--globalHeader-buttonIcon-icon);

--- a/src/components/SearchInput/SearchInput.style.scss
+++ b/src/components/SearchInput/SearchInput.style.scss
@@ -9,8 +9,6 @@
   height: 2rem;
   width: 16.25rem;
   display: flex;
-  align-content: center;
-  justify-content: center;
   align-items: center;
 
   &[data-focus='true'] {

--- a/src/components/SearchInput/SearchInput.style.scss
+++ b/src/components/SearchInput/SearchInput.style.scss
@@ -3,10 +3,9 @@
 .md-search-input-wrapper {
   $search-width: 16.25rem;
   $search-height: 2rem;
-  $search-border-radius: math.div($search-height, 4);
 
   position: relative;
-  border-radius: $search-border-radius;
+  border-radius: 0.5rem;
   background-color: var(--textinput-background);
   border: 0.0625rem solid var(--textinput-border-color);
   box-sizing: border-box;
@@ -69,13 +68,25 @@
     }
   }
 
-  .md-search-input-search,
+  .md-search-input-search {
+    $icon-height: math.div($search-height, 2);
+
+    // margin-top: 0px;
+    width: 1rem;
+    height: 1rem;
+    margin-left: 0.375rem;
+    margin-right: 0.375rem;
+    align-content: center;
+    // flex-grow: 0;
+  }
+
   .md-search-input-searching {
     $icon-height: math.div($search-height, 2);
 
     // margin-top: 0px;
-    margin-left: 0.375rem;
-    margin-right: 0.375rem;
+    scale: math.div(2, 3);
+    margin-left: 0.2rem;
+    margin-right: 0.15rem;
     align-content: center;
     // flex-grow: 0;
   }

--- a/src/components/SearchInput/SearchInput.tsx
+++ b/src/components/SearchInput/SearchInput.tsx
@@ -13,6 +13,7 @@ import InputMessage from '../InputMessage';
 import { useFocusState } from '../../hooks/useFocusState';
 
 import Icon from '../Icon';
+import LoadingSpinner from '../LoadingSpinner';
 
 /**
  *  Search input
@@ -47,12 +48,11 @@ const SearchInput = (props: Props, ref: RefObject<HTMLInputElement>): ReactEleme
         </label>
       )}
       <div>
-        <Icon
-          weight="light"
-          scale={18}
-          className={STYLE.search}
-          name={searching ? 'spinner' : 'search'}
-        />
+        {searching ? (
+          <LoadingSpinner scale={16} className={STYLE.searching} />
+        ) : (
+          <Icon weight="bold" scale={16} className={STYLE.search} name={'search'} />
+        )}
       </div>
       <div className={STYLE.container}>
         <input {...inputProps} {...focusProps} ref={inputRef} />

--- a/src/components/SearchInput/SearchInput.tsx
+++ b/src/components/SearchInput/SearchInput.tsx
@@ -4,7 +4,7 @@ import React, { ReactElement, useRef, RefObject, forwardRef } from 'react';
 import classnames from 'classnames';
 
 import ButtonSimple from '../ButtonSimple';
-import { STYLE, DEFAULTS, SEARCH_ICON_HEIGHT_MAPPING } from './SearchInput.constants';
+import { STYLE, DEFAULTS, ICON_HEIGHT_MAPPING } from './SearchInput.constants';
 import { Props } from './SearchInput.types';
 import './SearchInput.style.scss';
 import { useSearchField } from '@react-aria/searchfield';
@@ -59,11 +59,11 @@ const SearchInput = (props: Props, ref: RefObject<HTMLInputElement>): ReactEleme
       )}
       <div>
         {searching ? (
-          <LoadingSpinner scale={SEARCH_ICON_HEIGHT_MAPPING[height]} className={STYLE.searching} />
+          <LoadingSpinner scale={ICON_HEIGHT_MAPPING[height]} className={STYLE.searching} />
         ) : (
           <Icon
             weight="bold"
-            scale={SEARCH_ICON_HEIGHT_MAPPING[height]}
+            scale={ICON_HEIGHT_MAPPING[height]}
             className={STYLE.search}
             name={'search'}
           />
@@ -78,7 +78,7 @@ const SearchInput = (props: Props, ref: RefObject<HTMLInputElement>): ReactEleme
           {...clearButtonProps}
           aria-label={clearButtonAriaLabel}
         >
-          <Icon weight="bold" scale={SEARCH_ICON_HEIGHT_MAPPING[height]} name="cancel" />
+          <Icon weight="bold" scale={ICON_HEIGHT_MAPPING[height]} name="cancel" />
         </ButtonSimple>
       )}
       <InputMessage />

--- a/src/components/SearchInput/SearchInput.tsx
+++ b/src/components/SearchInput/SearchInput.tsx
@@ -49,9 +49,9 @@ const SearchInput = (props: Props, ref: RefObject<HTMLInputElement>): ReactEleme
       )}
       <div>
         {searching ? (
-          <LoadingSpinner scale={16} className={STYLE.searching} />
+          <LoadingSpinner className={STYLE.searching} />
         ) : (
-          <Icon weight="bold" scale={16} className={STYLE.search} name={'search'} />
+          <Icon weight="bold" className={STYLE.search} name={'search'} />
         )}
       </div>
       <div className={STYLE.container}>

--- a/src/components/SearchInput/SearchInput.tsx
+++ b/src/components/SearchInput/SearchInput.tsx
@@ -4,7 +4,7 @@ import React, { ReactElement, useRef, RefObject, forwardRef } from 'react';
 import classnames from 'classnames';
 
 import ButtonSimple from '../ButtonSimple';
-import { STYLE } from './SearchInput.constants';
+import { STYLE, DEFAULTS, SEARCH_ICON_HEIGHT_MAPPING } from './SearchInput.constants';
 import { Props } from './SearchInput.types';
 import './SearchInput.style.scss';
 import { useSearchField } from '@react-aria/searchfield';
@@ -19,7 +19,16 @@ import LoadingSpinner from '../LoadingSpinner';
  *  Search input
  */
 const SearchInput = (props: Props, ref: RefObject<HTMLInputElement>): ReactElement => {
-  const { className, id, style, searching, clearButtonAriaLabel, label, isDisabled } = props;
+  const {
+    className,
+    id,
+    style,
+    searching,
+    clearButtonAriaLabel,
+    label,
+    isDisabled,
+    height = DEFAULTS.HEIGHT,
+  } = props;
   const state = useSearchFieldState(props);
   const componentRef = useRef(null);
   const inputRef = ref || componentRef;
@@ -41,6 +50,7 @@ const SearchInput = (props: Props, ref: RefObject<HTMLInputElement>): ReactEleme
       style={style}
       data-disabled={isDisabled}
       data-focus={isFocused}
+      data-height={height}
     >
       {label && (
         <label htmlFor={labelProps.htmlFor} {...labelProps}>
@@ -49,9 +59,14 @@ const SearchInput = (props: Props, ref: RefObject<HTMLInputElement>): ReactEleme
       )}
       <div>
         {searching ? (
-          <LoadingSpinner className={STYLE.searching} />
+          <LoadingSpinner scale={SEARCH_ICON_HEIGHT_MAPPING[height]} className={STYLE.searching} />
         ) : (
-          <Icon weight="bold" className={STYLE.search} name={'search'} />
+          <Icon
+            weight="bold"
+            scale={SEARCH_ICON_HEIGHT_MAPPING[height]}
+            className={STYLE.search}
+            name={'search'}
+          />
         )}
       </div>
       <div className={STYLE.container}>
@@ -63,7 +78,7 @@ const SearchInput = (props: Props, ref: RefObject<HTMLInputElement>): ReactEleme
           {...clearButtonProps}
           aria-label={clearButtonAriaLabel}
         >
-          <Icon scale={18} name="cancel" />
+          <Icon weight="bold" scale={SEARCH_ICON_HEIGHT_MAPPING[height]} name="cancel" />
         </ButtonSimple>
       )}
       <InputMessage />

--- a/src/components/SearchInput/SearchInput.types.ts
+++ b/src/components/SearchInput/SearchInput.types.ts
@@ -1,6 +1,8 @@
 import { CSSProperties } from 'react';
 import { AriaSearchFieldProps } from '@react-types/searchfield';
 
+export type SearchFieldHeight = 28 | 32;
+
 export interface SearchFilterTranslations {
   /**
    * The text shown in the filter bubble
@@ -81,4 +83,10 @@ export interface Props extends AriaSearchFieldProps {
    * Initial text for accessible label
    */
   initialLabel?: string;
+
+  /**
+   * Height of the search field
+   * @default 32
+   */
+  height?: SearchFieldHeight;
 }

--- a/src/components/SearchInput/SearchInput.types.ts
+++ b/src/components/SearchInput/SearchInput.types.ts
@@ -1,7 +1,8 @@
 import { CSSProperties } from 'react';
 import { AriaSearchFieldProps } from '@react-types/searchfield';
+import { HEIGHTS } from './SearchInput.constants';
 
-export type SearchFieldHeight = 28 | 32;
+export type SearchFieldHeight = typeof HEIGHTS[number];
 
 export interface SearchFilterTranslations {
   /**

--- a/src/components/SearchInput/SearchInput.unit.test.tsx
+++ b/src/components/SearchInput/SearchInput.unit.test.tsx
@@ -77,6 +77,14 @@ describe('<SearchInput />', () => {
       expect(container).toMatchSnapshot();
     });
 
+    it('should match snapshot with height', async () => {
+      expect.assertions(1);
+
+      const container = await mountComponent(<SearchInput aria-label="search" height={28} />);
+
+      expect(container).toMatchSnapshot();
+    });
+
     it('should match snapshot when filters are set', async () => {
       expect.assertions(1);
 
@@ -151,6 +159,26 @@ describe('<SearchInput />', () => {
         .getDOMNode();
 
       expect(element.getAttribute('style')).toBe(styleString);
+    });
+
+    it('should have provided height when height is provided', async () => {
+      expect.assertions(1);
+
+      const element = (await mountAndWait(<SearchInput aria-label="search" height={28} />))
+        .find(SearchInput)
+        .getDOMNode();
+
+      expect(element.getAttribute('data-height')).toBe('28');
+    });
+
+    it('should have default height when height is not provided', async () => {
+      expect.assertions(1);
+
+      const element = (await mountAndWait(<SearchInput aria-label="search" />))
+        .find(SearchInput)
+        .getDOMNode();
+
+      expect(element.getAttribute('data-height')).toBe('32');
     });
 
     it('should pass the aria label to the input', async () => {

--- a/src/components/SearchInput/SearchInput.unit.test.tsx.snap
+++ b/src/components/SearchInput/SearchInput.unit.test.tsx.snap
@@ -508,6 +508,84 @@ exports[`<SearchInput /> snapshot should match snapshot with className 1`] = `
 </SSRProvider>
 `;
 
+exports[`<SearchInput /> snapshot should match snapshot with height 1`] = `
+<SSRProvider>
+  <SearchInput
+    aria-label="search"
+    height={28}
+  >
+    <div
+      className="md-search-input-wrapper"
+      data-focus={false}
+      data-height={28}
+      onClick={[Function]}
+    >
+      <div>
+        <Icon
+          className="md-search-input-search"
+          name="search"
+          scale={12}
+          weight="bold"
+        >
+          <div
+            className="md-icon-wrapper md-search-input-search"
+          >
+            <svg
+              className=""
+              data-autoscale={false}
+              data-scale={12}
+              data-test="search"
+              fill="currentColor"
+              height="100%"
+              style={Object {}}
+              viewBox="0, 0, 32, 32"
+              width="100%"
+            />
+          </div>
+        </Icon>
+      </div>
+      <div
+        className="md-search-input-container"
+      >
+        <input
+          aria-label="search"
+          disabled={false}
+          id="test-ID"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          readOnly={false}
+          type="search"
+          value=""
+        />
+      </div>
+      <InputMessage>
+        <div
+          className="md-input-message-wrapper"
+        >
+          <div
+            className="md-input-message-message"
+            message-level="none"
+            role="alert"
+          >
+            <Text
+              className="md-input-message--text"
+              type="body-secondary"
+            >
+              <small
+                className="md-text-wrapper md-input-message--text"
+                data-type="body-secondary"
+              />
+            </Text>
+          </div>
+        </div>
+      </InputMessage>
+    </div>
+  </SearchInput>
+</SSRProvider>
+`;
+
 exports[`<SearchInput /> snapshot should match snapshot with id 1`] = `
 <SSRProvider>
   <SearchInput

--- a/src/components/SearchInput/SearchInput.unit.test.tsx.snap
+++ b/src/components/SearchInput/SearchInput.unit.test.tsx.snap
@@ -8,14 +8,15 @@ exports[`<SearchInput /> snapshot should match snapshot 1`] = `
     <div
       className="md-search-input-wrapper"
       data-focus={false}
+      data-height={32}
       onClick={[Function]}
     >
       <div>
         <Icon
           className="md-search-input-search"
           name="search"
-          scale={18}
-          weight="light"
+          scale={16}
+          weight="bold"
         >
           <div
             className="md-icon-wrapper md-search-input-search"
@@ -23,7 +24,7 @@ exports[`<SearchInput /> snapshot should match snapshot 1`] = `
             <svg
               className=""
               data-autoscale={false}
-              data-scale={18}
+              data-scale={16}
               data-test="search"
               fill="currentColor"
               height="100%"
@@ -111,14 +112,15 @@ exports[`<SearchInput /> snapshot should match snapshot when filters are set 1`]
     <div
       className="md-search-input-wrapper"
       data-focus={false}
+      data-height={32}
       onClick={[Function]}
     >
       <div>
         <Icon
           className="md-search-input-search"
           name="search"
-          scale={18}
-          weight="light"
+          scale={16}
+          weight="bold"
         >
           <div
             className="md-icon-wrapper md-search-input-search"
@@ -126,7 +128,7 @@ exports[`<SearchInput /> snapshot should match snapshot when filters are set 1`]
             <svg
               className=""
               data-autoscale={false}
-              data-scale={18}
+              data-scale={16}
               data-test="search"
               fill="currentColor"
               height="100%"
@@ -186,7 +188,8 @@ exports[`<SearchInput /> snapshot should match snapshot when filters are set 1`]
             >
               <Icon
                 name="cancel"
-                scale={18}
+                scale={16}
+                weight="bold"
               >
                 <div
                   className="md-icon-wrapper"
@@ -194,7 +197,7 @@ exports[`<SearchInput /> snapshot should match snapshot when filters are set 1`]
                   <svg
                     className=""
                     data-autoscale={false}
-                    data-scale={18}
+                    data-scale={16}
                     data-test="cancel"
                     fill="currentColor"
                     height="100%"
@@ -243,31 +246,62 @@ exports[`<SearchInput /> snapshot should match snapshot when searching 1`] = `
     <div
       className="md-search-input-wrapper"
       data-focus={false}
+      data-height={32}
       onClick={[Function]}
     >
       <div>
-        <Icon
-          className="md-search-input-search"
-          name="spinner"
-          scale={18}
-          weight="light"
+        <LoadingSpinner
+          className="md-search-input-searching"
+          scale={16}
         >
           <div
-            className="md-icon-wrapper md-search-input-search"
+            className="md-search-input-searching md-loading-spinner-wrapper"
           >
-            <svg
-              className=""
-              data-autoscale={false}
-              data-scale={18}
-              data-test="spinner"
-              fill="currentColor"
-              height="100%"
-              style={Object {}}
-              viewBox="0, 0, 32, 32"
-              width="100%"
-            />
+            <Icon
+              name="spinner"
+              scale={16}
+              weight="regular"
+            >
+              <div
+                className="md-icon-wrapper"
+              >
+                <svg
+                  className=""
+                  data-autoscale={false}
+                  data-scale={16}
+                  data-test="spinner"
+                  fill="currentColor"
+                  height="100%"
+                  style={Object {}}
+                  viewBox="0, 0, 32, 32"
+                  width="100%"
+                />
+              </div>
+            </Icon>
+            <Icon
+              className="md-loading-spinner-arch"
+              name="spinner-partial"
+              scale={16}
+              weight="regular"
+            >
+              <div
+                className="md-icon-wrapper md-loading-spinner-arch"
+              >
+                <svg
+                  className=""
+                  data-autoscale={false}
+                  data-scale={16}
+                  data-test="spinner-partial"
+                  fill="currentColor"
+                  height="100%"
+                  style={Object {}}
+                  viewBox="0, 0, 32, 32"
+                  width="100%"
+                />
+              </div>
+            </Icon>
           </div>
-        </Icon>
+        </LoadingSpinner>
       </div>
       <div
         className="md-search-input-container"
@@ -320,6 +354,7 @@ exports[`<SearchInput /> snapshot should match snapshot with a label 1`] = `
     <div
       className="md-search-input-wrapper"
       data-focus={false}
+      data-height={32}
       onClick={[Function]}
     >
       <label
@@ -332,8 +367,8 @@ exports[`<SearchInput /> snapshot should match snapshot with a label 1`] = `
         <Icon
           className="md-search-input-search"
           name="search"
-          scale={18}
-          weight="light"
+          scale={16}
+          weight="bold"
         >
           <div
             className="md-icon-wrapper md-search-input-search"
@@ -341,7 +376,7 @@ exports[`<SearchInput /> snapshot should match snapshot with a label 1`] = `
             <svg
               className=""
               data-autoscale={false}
-              data-scale={18}
+              data-scale={16}
               data-test="search"
               fill="currentColor"
               height="100%"
@@ -404,14 +439,15 @@ exports[`<SearchInput /> snapshot should match snapshot with className 1`] = `
     <div
       className="example-class md-search-input-wrapper"
       data-focus={false}
+      data-height={32}
       onClick={[Function]}
     >
       <div>
         <Icon
           className="md-search-input-search"
           name="search"
-          scale={18}
-          weight="light"
+          scale={16}
+          weight="bold"
         >
           <div
             className="md-icon-wrapper md-search-input-search"
@@ -419,7 +455,7 @@ exports[`<SearchInput /> snapshot should match snapshot with className 1`] = `
             <svg
               className=""
               data-autoscale={false}
-              data-scale={18}
+              data-scale={16}
               data-test="search"
               fill="currentColor"
               height="100%"
@@ -481,6 +517,7 @@ exports[`<SearchInput /> snapshot should match snapshot with id 1`] = `
     <div
       className="md-search-input-wrapper"
       data-focus={false}
+      data-height={32}
       id="example-id"
       onClick={[Function]}
     >
@@ -488,8 +525,8 @@ exports[`<SearchInput /> snapshot should match snapshot with id 1`] = `
         <Icon
           className="md-search-input-search"
           name="search"
-          scale={18}
-          weight="light"
+          scale={16}
+          weight="bold"
         >
           <div
             className="md-icon-wrapper md-search-input-search"
@@ -497,7 +534,7 @@ exports[`<SearchInput /> snapshot should match snapshot with id 1`] = `
             <svg
               className=""
               data-autoscale={false}
-              data-scale={18}
+              data-scale={16}
               data-test="search"
               fill="currentColor"
               height="100%"
@@ -563,6 +600,7 @@ exports[`<SearchInput /> snapshot should match snapshot with style 1`] = `
     <div
       className="md-search-input-wrapper"
       data-focus={false}
+      data-height={32}
       onClick={[Function]}
       style={
         Object {
@@ -574,8 +612,8 @@ exports[`<SearchInput /> snapshot should match snapshot with style 1`] = `
         <Icon
           className="md-search-input-search"
           name="search"
-          scale={18}
-          weight="light"
+          scale={16}
+          weight="bold"
         >
           <div
             className="md-icon-wrapper md-search-input-search"
@@ -583,7 +621,7 @@ exports[`<SearchInput /> snapshot should match snapshot with style 1`] = `
             <svg
               className=""
               data-autoscale={false}
-              data-scale={18}
+              data-scale={16}
               data-test="search"
               fill="currentColor"
               height="100%"


### PR DESCRIPTION
# Description

This PR fixes some of the styling in the SearchInput component:

- Changes weight of icons to "bold"
- Centres the icons and text within the wrapper div 
- Moves the icons closer to the sides of the wrapper
- Adds the two height variations as seen in the Figma and adds a default width
- Replaces the old 'searching' icon with the LoadingSpinner component

I had a look at why the 'searching' icon doesn't seem to work and it's to do with how it's being used in Cantina - the boolean 'searching' prop isn't being used and so the component never changes the icons.

# Links

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-356975

https://www.figma.com/file/vdL18BATeJAIq2JvGAjRPD/Components---Web?node-id=25054%3A38561

Before: 
![Screenshot 2022-09-23 at 15 31 49](https://user-images.githubusercontent.com/86778628/191984824-97ffde11-53c6-4f7c-ae80-51e108e9139a.png)

After: 
![Screenshot 2022-09-23 at 15 31 58](https://user-images.githubusercontent.com/86778628/191984855-8e9d6315-474f-4d3e-a4f2-00d4a507f500.png)