### PR TITLE
fix(avatar): add size 64 and change shape of presence icon 

### DIFF
--- a/src/components/Avatar/Avatar.constants.ts
+++ b/src/components/Avatar/Avatar.constants.ts
@@ -17,12 +17,12 @@ const SIZES = {
 };
 
 const AVATAR_PRESENCE_ICON_SIZE_MAPPING: Record<number, IconScale> = {
-  24: 8,
-  32: 12,
-  48: 14,
-  72: 16,
-  88: 20,
-  124: 28,
+  24: 10,
+  32: 14,
+  48: 16,
+  72: 20,
+  88: 28,
+  124: 40,
 };
 
 const AVATAR_ICON_SIZE_MAPPING: Record<number, { scale: IconScale; weight: IconWeight }> = {

--- a/src/components/Avatar/Avatar.constants.ts
+++ b/src/components/Avatar/Avatar.constants.ts
@@ -7,28 +7,23 @@ const CLASS_PREFIX = 'md-avatar';
 const MAX_INITIALS_SPACE = 1;
 const MAX_INITIALS_PERSON = 2;
 
-const SIZES = {
-  24: 24,
-  32: 32,
-  48: 48,
-  72: 72,
-  88: 88,
-  124: 124,
-};
+const SIZES = [24, 32, 48, 64, 72, 88, 124] as const;
 
 const AVATAR_PRESENCE_ICON_SIZE_MAPPING: Record<number, IconScale> = {
-  24: 10,
+  24: 14,
   32: 14,
   48: 16,
+  64: 18,
   72: 20,
   88: 28,
-  124: 40,
+  124: 36,
 };
 
 const AVATAR_ICON_SIZE_MAPPING: Record<number, { scale: IconScale; weight: IconWeight }> = {
   24: { scale: 16, weight: 'bold' },
   32: { scale: 20, weight: 'regular' },
-  48: { scale: 28, weight: 'regular' },
+  48: { scale: 22, weight: 'regular' },
+  64: { scale: 36, weight: 'regular' },
   72: { scale: 40, weight: 'regular' },
   88: { scale: 48, weight: 'regular' },
   124: { scale: 64, weight: 'light' },
@@ -53,7 +48,7 @@ const STYLE = {
 
 const DEFAULTS = {
   PRESENCE: PresenceType.Default,
-  SIZE: SIZES[24],
+  SIZE: 24,
   COLOR: AVATAR_COLORS.default,
   TYPE: TYPES.person,
   HIDE_DEFAULT_TOOLTIP: false,

--- a/src/components/Avatar/Avatar.constants.ts
+++ b/src/components/Avatar/Avatar.constants.ts
@@ -22,7 +22,7 @@ const AVATAR_PRESENCE_ICON_SIZE_MAPPING: Record<number, IconScale> = {
 const AVATAR_ICON_SIZE_MAPPING: Record<number, { scale: IconScale; weight: IconWeight }> = {
   24: { scale: 16, weight: 'bold' },
   32: { scale: 20, weight: 'regular' },
-  48: { scale: 22, weight: 'regular' },
+  48: { scale: 28, weight: 'regular' },
   64: { scale: 36, weight: 'regular' },
   72: { scale: 40, weight: 'regular' },
   88: { scale: 48, weight: 'regular' },

--- a/src/components/Avatar/Avatar.stories.args.tsx
+++ b/src/components/Avatar/Avatar.stories.args.tsx
@@ -1,0 +1,156 @@
+import { TEAM_COLORS } from '../ThemeProvider/ThemeProvider.constants';
+import { DEFAULTS, SIZES, TYPES } from './Avatar.constants';
+import { PresenceType } from './Avatar.types';
+
+export default {
+  className: {
+    defaultValue: undefined,
+    description:
+      'If present, the class name will be added to the underlying component. Used to override styles by consumers.',
+    control: { type: 'text' },
+    table: {
+      type: {
+        summary: 'string',
+      },
+      defaultValue: {
+        summary: undefined,
+      },
+    },
+  },
+  size: {
+    defaultValue: DEFAULTS.SIZE,
+    description: 'Size represents the size of the avatar.',
+    options: SIZES,
+    control: { type: 'select' },
+    table: {
+      type: {
+        summary: 'number',
+      },
+      defaultValue: {
+        summary: DEFAULTS.SIZE,
+      },
+    },
+  },
+  presence: {
+    defaultValue: DEFAULTS.PRESENCE,
+    description: 'Determines the current state of the user. (User is in meeting, presenting etc).',
+    options: [...Object.values(PresenceType)],
+    control: { type: 'select' },
+    table: {
+      type: {
+        summary: 'string',
+      },
+      defaultValue: {
+        summary: DEFAULTS.PRESENCE,
+      },
+    },
+  },
+  src: {
+    defaultValue: undefined,
+    description: 'URL with profile image for the avatar.',
+    control: { type: 'text' },
+    table: {
+      type: {
+        summary: 'string',
+      },
+      defaultValue: {
+        summary: undefined,
+      },
+    },
+  },
+  initials: {
+    defaultValue: undefined,
+    description: 'Initials to display inside the avatar.',
+    control: { type: 'text' },
+    table: {
+      type: {
+        summary: 'string',
+      },
+      defaultValue: {
+        summary: undefined,
+      },
+    },
+  },
+  title: {
+    defaultValue: undefined,
+    description:
+      'Name of person/space. The component will extract initials from this value and display accordingly',
+    control: { type: 'text', required: true },
+    table: {
+      type: {
+        summary: 'string',
+      },
+      defaultValue: {
+        summary: undefined,
+      },
+    },
+  },
+  color: {
+    defaultValue: DEFAULTS.COLOR,
+    description:
+      'In case `src` is not provided, we can provide a color for the avatar using this property.',
+    options: [...Object.values(TEAM_COLORS)],
+    control: { type: 'select' },
+    table: {
+      type: {
+        summary: 'string',
+      },
+      defaultValue: {
+        summary: DEFAULTS.COLOR,
+      },
+    },
+  },
+  icon: {
+    defaultValue: undefined,
+    description: 'Name of the icon to be displayed inside the Avatar. Must be a valid icon name.',
+    control: { type: 'text' },
+    table: {
+      type: {
+        summary: 'string',
+      },
+      defaultValue: {
+        summary: undefined,
+      },
+    },
+  },
+  type: {
+    defaultValue: DEFAULTS.TYPE,
+    description: 'Determines whether the avatar is for a person or a space.',
+    options: [...Object.values(TYPES)],
+    control: { type: 'select' },
+    table: {
+      type: {
+        summary: 'string',
+      },
+      defaultValue: {
+        summary: DEFAULTS.TYPE,
+      },
+    },
+  },
+  isTyping: {
+    defaultValue: false,
+    description: 'Determines whether the user is typing.',
+    control: { type: 'boolean' },
+    table: {
+      type: {
+        summary: 'boolean',
+      },
+      defaultValue: {
+        summary: false,
+      },
+    },
+  },
+  failureBadge: {
+    defaultValue: false,
+    description: 'Determines if there is an error in the Avatar component.',
+    control: { type: 'boolean' },
+    table: {
+      type: {
+        summary: 'boolean',
+      },
+      defaultValue: {
+        summary: false,
+      },
+    },
+  },
+};

--- a/src/components/Avatar/Avatar.stories.tsx
+++ b/src/components/Avatar/Avatar.stories.tsx
@@ -15,7 +15,7 @@ import {
 import Documentation from './Avatar.documentation.mdx';
 import argTypes from './Avatar.stories.args';
 import { PresenceType } from './Avatar.types';
-import { AVATAR_COLORS, DEFAULTS, SIZES, TYPES } from './Avatar.constants';
+import { AVATAR_COLORS, SIZES } from './Avatar.constants';
 
 const DocsPage: FC = () => (
   <>

--- a/src/components/Avatar/Avatar.stories.tsx
+++ b/src/components/Avatar/Avatar.stories.tsx
@@ -13,6 +13,7 @@ import {
 } from '@storybook/addon-docs';
 
 import Documentation from './Avatar.documentation.mdx';
+import argTypes from './Avatar.stories.args';
 import { PresenceType } from './Avatar.types';
 import { AVATAR_COLORS, DEFAULTS, SIZES, TYPES } from './Avatar.constants';
 
@@ -34,159 +35,6 @@ export default {
     expanded: true,
     docs: {
       page: DocsPage,
-    },
-  },
-  argTypes: {
-    className: {
-      defaultValue: undefined,
-      description:
-        'If present, the class name will be added to the underlying component. Used to override styles by consumers.',
-      control: { type: 'text' },
-      table: {
-        type: {
-          summary: 'string',
-        },
-        defaultValue: {
-          summary: undefined,
-        },
-      },
-    },
-    size: {
-      defaultValue: DEFAULTS.SIZE,
-      description: 'Size represents the size of te avatar.',
-      options: [undefined, ...Object.values(SIZES)],
-      control: { type: 'select' },
-      table: {
-        type: {
-          summary: 'number',
-        },
-        defaultValue: {
-          summary: DEFAULTS.SIZE,
-        },
-      },
-    },
-    presence: {
-      defaultValue: DEFAULTS.PRESENCE,
-      description:
-        'Determines the current state of the user. (User is in meeting, presenting etc).',
-      options: [undefined, ...Object.values(PresenceType)],
-      control: { type: 'select' },
-      table: {
-        type: {
-          summary: 'string',
-        },
-        defaultValue: {
-          summary: DEFAULTS.PRESENCE,
-        },
-      },
-    },
-    src: {
-      defaultValue: undefined,
-      description: 'URL with profile image for the avatar.',
-      control: { type: 'text' },
-      table: {
-        type: {
-          summary: 'string',
-        },
-        defaultValue: {
-          summary: undefined,
-        },
-      },
-    },
-    initials: {
-      defaultValue: undefined,
-      description: 'Initials to display inside the avatar.',
-      control: { type: 'text' },
-      table: {
-        type: {
-          summary: 'string',
-        },
-        defaultValue: {
-          summary: undefined,
-        },
-      },
-    },
-    title: {
-      defaultValue: undefined,
-      description:
-        'Name of person/space. The component will extract initials from this value and display accordingly',
-      control: { type: 'text', required: true },
-      table: {
-        type: {
-          summary: 'string',
-        },
-        defaultValue: {
-          summary: undefined,
-        },
-      },
-    },
-    color: {
-      defaultValue: DEFAULTS.COLOR,
-      description:
-        'In case `src` is not provided, we can provide a color for the avatar using this property.',
-      options: [undefined, ...Object.values(AVATAR_COLORS)],
-      control: { type: 'select' },
-      table: {
-        type: {
-          summary: 'string',
-        },
-        defaultValue: {
-          summary: DEFAULTS.COLOR,
-        },
-      },
-    },
-    icon: {
-      defaultValue: undefined,
-      description: 'Name of the icon to be displayed inside the Avatar. Must be a valid icon name.',
-      control: { type: 'text' },
-      table: {
-        type: {
-          summary: 'string',
-        },
-        defaultValue: {
-          summary: undefined,
-        },
-      },
-    },
-    type: {
-      defaultValue: DEFAULTS.TYPE,
-      description: 'Determines whether the avatar is for a person or a space.',
-      options: [undefined, ...Object.values(TYPES)],
-      control: { type: 'select' },
-      table: {
-        type: {
-          summary: 'string',
-        },
-        defaultValue: {
-          summary: DEFAULTS.TYPE,
-        },
-      },
-    },
-    isTyping: {
-      defaultValue: false,
-      description: 'Determines whether the user is typing.',
-      control: { type: 'boolean' },
-      table: {
-        type: {
-          summary: 'boolean',
-        },
-        defaultValue: {
-          summary: false,
-        },
-      },
-    },
-    failureBadge: {
-      defaultValue: false,
-      description: 'Determines if there is an error in the Avatar component.',
-      control: { type: 'boolean' },
-      table: {
-        type: {
-          summary: 'boolean',
-        },
-        defaultValue: {
-          summary: false,
-        },
-      },
     },
   },
 };
@@ -219,12 +67,17 @@ const MultiTemplate: Story<AvatarProps> = (args: AvatarProps, { parameters }) =>
 
 const Example = Template.bind({});
 
+Example.argTypes = { ...argTypes };
+
 Example.args = {
   src: 'https://images.unsplash.com/photo-1583195764036-6dc248ac07d9?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=2855&q=80',
   initials: 'AS',
 };
 
 const PresenceTypes = MultiTemplate.bind({});
+
+PresenceTypes.argTypes = { ...argTypes };
+delete PresenceTypes.argTypes.presence;
 
 PresenceTypes.args = {
   initials: 'AS',
@@ -241,6 +94,9 @@ PresenceTypes.parameters = {
 };
 
 const Sizes = MultiTemplate.bind({});
+
+Sizes.argTypes = { ...argTypes };
+delete Sizes.argTypes.size;
 
 Sizes.args = {
   initials: 'A',
@@ -260,6 +116,8 @@ Sizes.parameters = {
 
 const Icons = MultiTemplate.bind({});
 
+Icons.argTypes = { ...argTypes };
+
 Icons.args = {
   initials: 'A',
 };
@@ -277,6 +135,9 @@ Icons.parameters = {
 };
 
 const Color = MultiTemplate.bind({});
+
+Color.argTypes = { ...argTypes };
+delete Color.argTypes.color;
 
 Color.args = {
   initials: 'A',
@@ -298,6 +159,10 @@ const Common = MultiTemplate.bind({});
 
 const cartesian = <T extends (string | number)[][]>(...arr: T) =>
   arr.reduce((a, b) => a.flatMap((c) => b.map((d) => [...c, d])), [[]]);
+
+Common.argTypes = { ...argTypes };
+delete Common.argTypes.size;
+delete Common.argTypes.presence;
 
 Common.args = {
   initials: 'B',

--- a/src/components/Avatar/Avatar.style.scss
+++ b/src/components/Avatar/Avatar.style.scss
@@ -101,8 +101,8 @@
     }
 
     .md-avatar-presence-icon-wrapper {
-      width: 0.75rem;
-      height: 0.75rem;
+      width: 1rem;
+      height: 1rem;
     }
 
     width: 1.5rem;
@@ -135,6 +135,20 @@
 
     width: 3rem;
     height: 3rem;
+  }
+
+  &[data-size='64'] {
+    span {
+      font-size: 1.625rem;
+    }
+
+    .md-avatar-presence-icon-wrapper {
+      width: 1.375rem;
+      height: 1.375rem;
+    }
+
+    width: 4rem;
+    height: 4rem;
   }
 
   &[data-size='72'] {

--- a/src/components/Avatar/Avatar.style.scss
+++ b/src/components/Avatar/Avatar.style.scss
@@ -9,6 +9,10 @@
   justify-content: center;
   bottom: -0.2rem;
   right: -0.2rem;
+
+  &[data-shape='false'] {
+    border-radius: 25%;
+  }
 }
 
 .md-avatar-wrapper {

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -60,7 +60,7 @@ const Avatar: React.FC<Props> = (props: Props) => {
   const renderPresence = (presenceType: PresenceType) => {
     let presenceIcon: string;
     let presenceColor: string;
-    let wrapperIsCircle = true;
+    let isCircularWrapper = true;
 
     //TODO: temporary fix until design gives proper design spec for failure badge
     if (failureBadge) {
@@ -78,17 +78,17 @@ const Avatar: React.FC<Props> = (props: Props) => {
         case PresenceType.Meet:
           presenceIcon = 'camera-presence';
           presenceColor = 'var(--avatar-presence-icon-meeting)';
-          wrapperIsCircle = false;
+          isCircularWrapper = false;
           break;
         case PresenceType.Schedule:
           presenceIcon = 'meetings-presence';
           presenceColor = 'var(--avatar-presence-icon-schedule)';
-          wrapperIsCircle = false;
+          isCircularWrapper = false;
           break;
         case PresenceType.Call:
           presenceIcon = 'handset';
           presenceColor = 'var(--avatar-presence-icon-call)';
-          wrapperIsCircle = false;
+          isCircularWrapper = false;
           break;
         case PresenceType.DND:
           presenceIcon = 'dnd-presence';
@@ -97,7 +97,7 @@ const Avatar: React.FC<Props> = (props: Props) => {
         case PresenceType.Presenting:
           presenceIcon = 'share-screen';
           presenceColor = 'var(--avatar-presence-icon-presenting)';
-          wrapperIsCircle = false;
+          isCircularWrapper = false;
           break;
         case PresenceType.QuietHours:
           presenceIcon = 'quiet-hours-presence';
@@ -118,17 +118,17 @@ const Avatar: React.FC<Props> = (props: Props) => {
         case PresenceType.OnMobile:
           presenceIcon = 'phone';
           presenceColor = 'var(--avatar-presence-icon-on-mobile)';
-          wrapperIsCircle = false;
+          isCircularWrapper = false;
           break;
         case PresenceType.OnDevice:
           presenceIcon = 'generic-device-video';
           presenceColor = 'var(--avatar-presence-icon-on-device)';
-          wrapperIsCircle = false;
+          isCircularWrapper = false;
           break;
         case PresenceType.OnHold:
           presenceIcon = 'pause';
           presenceColor = 'var(--avatar-presence-icon-on-hold)';
-          wrapperIsCircle = false;
+          isCircularWrapper = false;
           break;
         default:
           break;
@@ -136,7 +136,7 @@ const Avatar: React.FC<Props> = (props: Props) => {
     }
 
     return (
-      <div className={STYLE.presenceIconWrapper} data-shape={wrapperIsCircle}>
+      <div className={STYLE.presenceIconWrapper} data-shape={isCircularWrapper}>
         <Icon
           name={presenceIcon}
           weight={presenceIcon === 'busy-presence' ? 'bold' : 'filled'}

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -60,6 +60,7 @@ const Avatar: React.FC<Props> = (props: Props) => {
   const renderPresence = (presenceType: PresenceType) => {
     let presenceIcon: string;
     let presenceColor: string;
+    let wrapperIsCircle = true;
 
     //TODO: temporary fix until design gives proper design spec for failure badge
     if (failureBadge) {
@@ -77,14 +78,17 @@ const Avatar: React.FC<Props> = (props: Props) => {
         case PresenceType.Meet:
           presenceIcon = 'camera-presence';
           presenceColor = 'var(--avatar-presence-icon-meeting)';
+          wrapperIsCircle = false;
           break;
         case PresenceType.Schedule:
           presenceIcon = 'meetings-presence';
           presenceColor = 'var(--avatar-presence-icon-schedule)';
+          wrapperIsCircle = false;
           break;
         case PresenceType.Call:
           presenceIcon = 'handset';
           presenceColor = 'var(--avatar-presence-icon-call)';
+          wrapperIsCircle = false;
           break;
         case PresenceType.DND:
           presenceIcon = 'dnd-presence';
@@ -93,6 +97,7 @@ const Avatar: React.FC<Props> = (props: Props) => {
         case PresenceType.Presenting:
           presenceIcon = 'share-screen';
           presenceColor = 'var(--avatar-presence-icon-presenting)';
+          wrapperIsCircle = false;
           break;
         case PresenceType.QuietHours:
           presenceIcon = 'quiet-hours-presence';
@@ -113,14 +118,17 @@ const Avatar: React.FC<Props> = (props: Props) => {
         case PresenceType.OnMobile:
           presenceIcon = 'phone';
           presenceColor = 'var(--avatar-presence-icon-on-mobile)';
+          wrapperIsCircle = false;
           break;
         case PresenceType.OnDevice:
           presenceIcon = 'generic-device-video';
           presenceColor = 'var(--avatar-presence-icon-on-device)';
+          wrapperIsCircle = false;
           break;
         case PresenceType.OnHold:
           presenceIcon = 'pause';
           presenceColor = 'var(--avatar-presence-icon-on-hold)';
+          wrapperIsCircle = false;
           break;
         default:
           break;
@@ -128,7 +136,7 @@ const Avatar: React.FC<Props> = (props: Props) => {
     }
 
     return (
-      <div className={STYLE.presenceIconWrapper}>
+      <div className={STYLE.presenceIconWrapper} data-shape={wrapperIsCircle}>
         <Icon
           name={presenceIcon}
           weight={presenceIcon === 'busy-presence' ? 'bold' : 'filled'}

--- a/src/components/Avatar/Avatar.types.ts
+++ b/src/components/Avatar/Avatar.types.ts
@@ -1,5 +1,6 @@
 import { TeamColor } from '../ThemeProvider/ThemeProvider.types';
 import { AriaButtonProps } from '@react-types/button';
+import { SIZES } from './Avatar.constants';
 
 export enum PresenceType {
   Default = 'default',
@@ -20,7 +21,7 @@ export enum PresenceType {
   OnHold = 'onHold',
 }
 
-export type AvatarSize = 24 | 32 | 48 | 72 | 88 | 124;
+export type AvatarSize = typeof SIZES[number];
 export type AvatarColor = TeamColor | 'yellow';
 
 export interface Props extends Omit<AriaButtonProps, 'type'> {

--- a/src/components/Avatar/Avatar.unit.test.tsx
+++ b/src/components/Avatar/Avatar.unit.test.tsx
@@ -130,7 +130,7 @@ describe('Avatar', () => {
     it('should pass the size prop', () => {
       expect.assertions(1);
 
-      const size = SIZES[48] as AvatarSize;
+      const size = SIZES[2] as AvatarSize;
 
       const element = mount(<Avatar initials="CW" size={size} />)
         .find(`div.${STYLE.wrapper}`)

--- a/src/components/Avatar/Avatar.unit.test.tsx.snap
+++ b/src/components/Avatar/Avatar.unit.test.tsx.snap
@@ -33,11 +33,12 @@ exports[`Avatar snapshot should match snapshot with failureBadge 1`] = `
     </span>
     <div
       className="md-avatar-presence-icon-wrapper"
+      data-shape={true}
     >
       <Icon
         fillColor="var(--avatar-presence-icon-dnd)"
         name="warning"
-        scale={8}
+        scale={14}
         strokeColor="none"
         weight="filled"
       >
@@ -47,7 +48,7 @@ exports[`Avatar snapshot should match snapshot with failureBadge 1`] = `
           <svg
             className=""
             data-autoscale={false}
-            data-scale={8}
+            data-scale={14}
             data-test="warning"
             height="100%"
             style={
@@ -267,11 +268,12 @@ exports[`Avatar snapshot should match snapshot with presence 1`] = `
       </span>
       <div
         className="md-avatar-presence-icon-wrapper"
+        data-shape={true}
       >
         <Icon
           fillColor="var(--avatar-presence-icon-active)"
           name="unread"
-          scale={8}
+          scale={14}
           strokeColor="none"
           weight="filled"
         >
@@ -281,7 +283,7 @@ exports[`Avatar snapshot should match snapshot with presence 1`] = `
             <svg
               className=""
               data-autoscale={false}
-              data-scale={8}
+              data-scale={14}
               data-test="unread"
               height="100%"
               style={
@@ -314,11 +316,12 @@ exports[`Avatar snapshot should match snapshot with presence 1`] = `
       </span>
       <div
         className="md-avatar-presence-icon-wrapper"
+        data-shape={false}
       >
         <Icon
           fillColor="var(--avatar-presence-icon-meeting)"
           name="camera-presence"
-          scale={8}
+          scale={14}
           strokeColor="none"
           weight="filled"
         >
@@ -328,7 +331,7 @@ exports[`Avatar snapshot should match snapshot with presence 1`] = `
             <svg
               className=""
               data-autoscale={false}
-              data-scale={8}
+              data-scale={14}
               data-test="camera-presence"
               height="100%"
               style={
@@ -361,11 +364,12 @@ exports[`Avatar snapshot should match snapshot with presence 1`] = `
       </span>
       <div
         className="md-avatar-presence-icon-wrapper"
+        data-shape={false}
       >
         <Icon
           fillColor="var(--avatar-presence-icon-schedule)"
           name="meetings-presence"
-          scale={8}
+          scale={14}
           strokeColor="none"
           weight="filled"
         >
@@ -375,7 +379,7 @@ exports[`Avatar snapshot should match snapshot with presence 1`] = `
             <svg
               className=""
               data-autoscale={false}
-              data-scale={8}
+              data-scale={14}
               data-test="meetings-presence"
               height="100%"
               style={
@@ -408,11 +412,12 @@ exports[`Avatar snapshot should match snapshot with presence 1`] = `
       </span>
       <div
         className="md-avatar-presence-icon-wrapper"
+        data-shape={false}
       >
         <Icon
           fillColor="var(--avatar-presence-icon-call)"
           name="handset"
-          scale={8}
+          scale={14}
           strokeColor="none"
           weight="filled"
         >
@@ -422,7 +427,7 @@ exports[`Avatar snapshot should match snapshot with presence 1`] = `
             <svg
               className=""
               data-autoscale={false}
-              data-scale={8}
+              data-scale={14}
               data-test="handset"
               height="100%"
               style={
@@ -455,11 +460,12 @@ exports[`Avatar snapshot should match snapshot with presence 1`] = `
       </span>
       <div
         className="md-avatar-presence-icon-wrapper"
+        data-shape={true}
       >
         <Icon
           fillColor="var(--avatar-presence-icon-dnd)"
           name="dnd-presence"
-          scale={8}
+          scale={14}
           strokeColor="none"
           weight="filled"
         >
@@ -469,7 +475,7 @@ exports[`Avatar snapshot should match snapshot with presence 1`] = `
             <svg
               className=""
               data-autoscale={false}
-              data-scale={8}
+              data-scale={14}
               data-test="dnd-presence"
               height="100%"
               style={
@@ -502,11 +508,12 @@ exports[`Avatar snapshot should match snapshot with presence 1`] = `
       </span>
       <div
         className="md-avatar-presence-icon-wrapper"
+        data-shape={false}
       >
         <Icon
           fillColor="var(--avatar-presence-icon-presenting)"
           name="share-screen"
-          scale={8}
+          scale={14}
           strokeColor="none"
           weight="filled"
         >
@@ -516,7 +523,7 @@ exports[`Avatar snapshot should match snapshot with presence 1`] = `
             <svg
               className=""
               data-autoscale={false}
-              data-scale={8}
+              data-scale={14}
               data-test="share-screen"
               height="100%"
               style={
@@ -549,11 +556,12 @@ exports[`Avatar snapshot should match snapshot with presence 1`] = `
       </span>
       <div
         className="md-avatar-presence-icon-wrapper"
+        data-shape={true}
       >
         <Icon
           fillColor="var(--avatar-presence-icon-quiet-hours)"
           name="quiet-hours-presence"
-          scale={8}
+          scale={14}
           strokeColor="none"
           weight="filled"
         >
@@ -563,7 +571,7 @@ exports[`Avatar snapshot should match snapshot with presence 1`] = `
             <svg
               className=""
               data-autoscale={false}
-              data-scale={8}
+              data-scale={14}
               data-test="quiet-hours-presence"
               height="100%"
               style={
@@ -596,11 +604,12 @@ exports[`Avatar snapshot should match snapshot with presence 1`] = `
       </span>
       <div
         className="md-avatar-presence-icon-wrapper"
+        data-shape={true}
       >
         <Icon
           fillColor="var(--avatar-presence-icon-away)"
           name="recents-presence"
-          scale={8}
+          scale={14}
           strokeColor="none"
           weight="filled"
         >
@@ -610,7 +619,7 @@ exports[`Avatar snapshot should match snapshot with presence 1`] = `
             <svg
               className=""
               data-autoscale={false}
-              data-scale={8}
+              data-scale={14}
               data-test="recents-presence"
               height="100%"
               style={
@@ -643,11 +652,12 @@ exports[`Avatar snapshot should match snapshot with presence 1`] = `
       </span>
       <div
         className="md-avatar-presence-icon-wrapper"
+        data-shape={true}
       >
         <Icon
           fillColor="var(--avatar-presence-icon-ooo)"
           name="pto-presence"
-          scale={8}
+          scale={14}
           strokeColor="none"
           weight="filled"
         >
@@ -657,7 +667,7 @@ exports[`Avatar snapshot should match snapshot with presence 1`] = `
             <svg
               className=""
               data-autoscale={false}
-              data-scale={8}
+              data-scale={14}
               data-test="pto-presence"
               height="100%"
               style={
@@ -690,11 +700,12 @@ exports[`Avatar snapshot should match snapshot with presence 1`] = `
       </span>
       <div
         className="md-avatar-presence-icon-wrapper"
+        data-shape={true}
       >
         <Icon
           fillColor="var(--avatar-presence-icon-busy)"
           name="busy-presence"
-          scale={8}
+          scale={14}
           strokeColor="none"
           weight="bold"
         >
@@ -704,7 +715,7 @@ exports[`Avatar snapshot should match snapshot with presence 1`] = `
             <svg
               className=""
               data-autoscale={false}
-              data-scale={8}
+              data-scale={14}
               data-test="busy-presence"
               height="100%"
               style={
@@ -737,11 +748,12 @@ exports[`Avatar snapshot should match snapshot with presence 1`] = `
       </span>
       <div
         className="md-avatar-presence-icon-wrapper"
+        data-shape={false}
       >
         <Icon
           fillColor="var(--avatar-presence-icon-on-mobile)"
           name="phone"
-          scale={8}
+          scale={14}
           strokeColor="none"
           weight="filled"
         >
@@ -751,7 +763,7 @@ exports[`Avatar snapshot should match snapshot with presence 1`] = `
             <svg
               className=""
               data-autoscale={false}
-              data-scale={8}
+              data-scale={14}
               data-test="phone"
               height="100%"
               style={
@@ -784,11 +796,12 @@ exports[`Avatar snapshot should match snapshot with presence 1`] = `
       </span>
       <div
         className="md-avatar-presence-icon-wrapper"
+        data-shape={false}
       >
         <Icon
           fillColor="var(--avatar-presence-icon-on-device)"
           name="generic-device-video"
-          scale={8}
+          scale={14}
           strokeColor="none"
           weight="filled"
         >
@@ -798,7 +811,7 @@ exports[`Avatar snapshot should match snapshot with presence 1`] = `
             <svg
               className=""
               data-autoscale={false}
-              data-scale={8}
+              data-scale={14}
               data-test="generic-device-video"
               height="100%"
               style={
@@ -831,11 +844,12 @@ exports[`Avatar snapshot should match snapshot with presence 1`] = `
       </span>
       <div
         className="md-avatar-presence-icon-wrapper"
+        data-shape={false}
       >
         <Icon
           fillColor="var(--avatar-presence-icon-on-hold)"
           name="pause"
-          scale={8}
+          scale={14}
           strokeColor="none"
           weight="filled"
         >
@@ -845,7 +859,7 @@ exports[`Avatar snapshot should match snapshot with presence 1`] = `
             <svg
               className=""
               data-autoscale={false}
-              data-scale={8}
+              data-scale={14}
               data-test="pause"
               height="100%"
               style={

--- a/src/components/AvatarMeetingsListItem/AvatarMeetingsListItem.unit.test.tsx.snap
+++ b/src/components/AvatarMeetingsListItem/AvatarMeetingsListItem.unit.test.tsx.snap
@@ -172,11 +172,12 @@ exports[`<AvatarMeetingsListItem /> snapshot should match snapshot with avatarPr
                   </span>
                   <div
                     className="md-avatar-presence-icon-wrapper"
+                    data-shape={true}
                   >
                     <Icon
                       fillColor="var(--avatar-presence-icon-active)"
                       name="unread"
-                      scale={12}
+                      scale={14}
                       strokeColor="none"
                       weight="filled"
                     >
@@ -186,7 +187,7 @@ exports[`<AvatarMeetingsListItem /> snapshot should match snapshot with avatarPr
                         <svg
                           className=""
                           data-autoscale={false}
-                          data-scale={12}
+                          data-scale={14}
                           data-test="unread"
                           height="100%"
                           style={


### PR DESCRIPTION
# Description

This PR aligns the avatar component more with what appears on the Figma:

- Add avatar size 64
- Change shape of presence icon wrapper depending on presence used
- Moved story argTypes to a separate file
- Removed unnecessary args from each story in storybook

# Links

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-367923

https://www.figma.com/file/vdL18BATeJAIq2JvGAjRPD/Components---Web?node-id=41210%3A65884

Before: 
<img width="335" alt="Screenshot 2022-09-26 at 14 07 15" src="https://user-images.githubusercontent.com/86778628/192284460-fe35f22b-462b-43c3-95d1-efddaad6dac5.png">
<img width="768" alt="Screenshot 2022-09-26 at 14 06 34" src="https://user-images.githubusercontent.com/86778628/192284471-c21d772c-1102-4380-afaa-4e13e9f60802.png">

After: 
<img width="498" alt="Screenshot 2022-09-26 at 14 03 14" src="https://user-images.githubusercontent.com/86778628/192284491-046a6952-56df-4208-88fb-c67a2693b0d7.png">
<img width="791" alt="Screenshot 2022-09-26 at 14 06 20" src="https://user-images.githubusercontent.com/86778628/192284500-abe8c4f2-24c3-4df5-a685-8d145ae92053.png">

