### PR TITLE
fix(space-list-item): cover null case for second-line

### DIFF
--- a/src/components/SpaceListItem/SpaceListItem.constants.ts
+++ b/src/components/SpaceListItem/SpaceListItem.constants.ts
@@ -4,7 +4,6 @@ const CLASS_PREFIX = 'md-space-list-item';
 
 const DEFAULTS = {
   TEAM_COLOR: TEAM_COLORS.default,
-  SECOND_LINE: [],
 };
 
 const STYLE = {

--- a/src/components/SpaceListItem/SpaceListItem.tsx
+++ b/src/components/SpaceListItem/SpaceListItem.tsx
@@ -25,7 +25,7 @@ const SpaceListItem: FC<Props> = forwardRef(
       style,
       avatar,
       firstLine,
-      secondLine = DEFAULTS.SECOND_LINE,
+      secondLine,
       isNewActivity,
       isUnread,
       teamColor = DEFAULTS.TEAM_COLOR,

--- a/src/components/SpaceListItem/SpaceListItem.tsx
+++ b/src/components/SpaceListItem/SpaceListItem.tsx
@@ -10,6 +10,7 @@ import Text from '../Text';
 import Icon from '../Icon';
 import DividerDot from '../DividerDot';
 import SecondLineElement from './SecondLineElement';
+import { cleanSecondLine } from './SpaceListItem.utils';
 
 //TODO: support 2-line labels for right/position-end section.
 /**
@@ -42,15 +43,7 @@ const SpaceListItem: FC<Props> = forwardRef(
     } = props;
 
     const renderText = () => {
-      const secondLineArray: string[] = typeof secondLine === 'string' ? [secondLine] : secondLine;
-
-      const secondLineArrayClean = secondLineArray.reduce((filteredArray, nextElement) => {
-        const nextElementClean = nextElement.trim();
-        if (nextElementClean) {
-          filteredArray.push(nextElementClean);
-        }
-        return filteredArray;
-      }, []);
+      const secondLineArrayClean = cleanSecondLine(secondLine);
 
       if (secondLineArrayClean.length) {
         return (

--- a/src/components/SpaceListItem/SpaceListItem.unit.test.tsx
+++ b/src/components/SpaceListItem/SpaceListItem.unit.test.tsx
@@ -306,6 +306,30 @@ describe('<SpaceListItem />', () => {
       expect(element.getAttribute('aria-label')).toBe(ariaLabel);
     });
 
+    it('should not have secondLine when secondLine is null', async () => {
+      expect.assertions(1);
+
+      const secondLine = null;
+
+      const container = await mountAndWait(
+        <SpaceListItem firstLine="firstLine" secondLine={secondLine} />
+      );
+
+      expect(container.find(DividerDot).filter(`[data-type="body-secondary"]`).length).toEqual(0);
+    });
+
+    it('should not have secondLine when secondLine is undefined', async () => {
+      expect.assertions(1);
+
+      const secondLine = undefined;
+
+      const container = await mountAndWait(
+        <SpaceListItem firstLine="firstLine" secondLine={secondLine} />
+      );
+
+      expect(container.find(DividerDot).filter(`[data-type="body-secondary"]`).length).toEqual(0);
+    });
+
     it('should have provided dot in compact mode', async () => {
       expect.assertions(1);
 

--- a/src/components/SpaceListItem/SpaceListItem.utils.test.tsx
+++ b/src/components/SpaceListItem/SpaceListItem.utils.test.tsx
@@ -1,0 +1,22 @@
+import { cleanSecondLine } from './SpaceListItem.utils';
+
+describe('cleanSecondLine', () => {
+  it.each([
+    { secondLine: '', expected: [] },
+    { secondLine: null, expected: [] },
+    { secondLine: undefined, expected: [] },
+    { secondLine: 'one', expected: ['one'] },
+    { secondLine: '   one', expected: ['one'] },
+    { secondLine: '   one   ', expected: ['one'] },
+    { secondLine: ['one'], expected: ['one'] },
+    { secondLine: ['one', 'two'], expected: ['one', 'two'] },
+    { secondLine: ['one', '   two'], expected: ['one', 'two'] },
+    { secondLine: ['one', '   two'], expected: ['one', 'two'] },
+    { secondLine: ['one', 'two', 'three'], expected: ['one', 'two', 'three'] },
+    { secondLine: ['   ', 'two', '  ', 'four', 'five    '], expected: ['two', 'four', 'five'] },
+    { secondLine: [null, 'two', '  ', 'four', 'five    '], expected: ['two', 'four', 'five'] },
+    { secondLine: [null, 'two', '', 'four', undefined], expected: ['two', 'four'] },
+  ])('cleanSecondLine($i)', ({ secondLine, expected }) => {
+    expect(cleanSecondLine(secondLine)).toStrictEqual(expected);
+  });
+});

--- a/src/components/SpaceListItem/SpaceListItem.utils.ts
+++ b/src/components/SpaceListItem/SpaceListItem.utils.ts
@@ -1,0 +1,24 @@
+/**
+ * Cleans the param of any leading or trailing spaces and non-string values
+ * @param secondLine
+ * @returns an array containing all trimmed, non-empty strings in secondLine
+ */
+export const cleanSecondLine = (secondLine: string | string[] | null): Array<string> => {
+  if (secondLine === null || secondLine === undefined) {
+    return [];
+  }
+
+  const secondLineArray: string[] = typeof secondLine === 'string' ? [secondLine] : secondLine;
+
+  const secondLineArrayClean = secondLineArray.reduce((filteredArray, nextElement) => {
+    if (typeof nextElement === 'string') {
+      const nextElementClean = nextElement.trim();
+      if (nextElementClean) {
+        filteredArray.push(nextElementClean);
+      }
+    }
+    return filteredArray;
+  }, []);
+
+  return secondLineArrayClean;
+};


### PR DESCRIPTION
# Description

This PR covers the case where secondLine can be passed as null as a prop. I separated out some of the logic to a utils file and wrote a test to cover edge cases.
