### PR TITLE
fix: handle dynamic changes in the list base item subtree

### DIFF
--- a/src/components/ListItemBase/ListItemBase.tsx
+++ b/src/components/ListItemBase/ListItemBase.tsx
@@ -1,4 +1,12 @@
-import React, { RefObject, forwardRef, ReactNode, useRef, useEffect, useState } from 'react';
+import React, {
+  RefObject,
+  forwardRef,
+  ReactNode,
+  useRef,
+  useEffect,
+  useState,
+  useCallback,
+} from 'react';
 import classnames from 'classnames';
 
 import './ListItemBase.style.scss';
@@ -14,6 +22,7 @@ import { useListContext } from '../List/List.utils';
 import ButtonSimple from '../ButtonSimple';
 import Text from '../Text';
 import { getKeyboardFocusableElements } from './ListItemBase.utils';
+import { useMutationObservable } from '../../hooks/useMutationObservable';
 
 //TODO: Implement multi-line
 const ListItemBase = (props: Props, providedRef: RefObject<HTMLLIElement>) => {
@@ -106,25 +115,23 @@ const ListItemBase = (props: Props, providedRef: RefObject<HTMLLIElement>) => {
     }
   }, [isPressed]);
 
+  const updateTabIndexes = useCallback(() => {
+    getKeyboardFocusableElements(ref.current)
+      .filter((el) => el.closest(`.${STYLE.wrapper}`) === ref.current)
+      .forEach((el) => el.setAttribute('tabindex', focus ? '0' : '-2'));
+  }, [ref, focus]);
+
   useEffect(() => {
     if (listContext?.currentFocus === undefined) {
       return;
     }
-
-    const focusableElements = getKeyboardFocusableElements(ref);
-
     if (focus) {
       ref.current.focus();
-
-      focusableElements.forEach((element) => {
-        element.setAttribute('tabindex', '0');
-      });
-    } else {
-      focusableElements.forEach((element) => {
-        element.setAttribute('tabindex', '-2');
-      });
     }
+    updateTabIndexes();
   }, [listContext?.currentFocus]);
+
+  useMutationObservable(ref.current, updateTabIndexes);
 
   /**
    * Context menu

--- a/src/components/ListItemBase/ListItemBase.utils.test.tsx
+++ b/src/components/ListItemBase/ListItemBase.utils.test.tsx
@@ -4,7 +4,7 @@ describe('getKeyboardFocusableElements', () => {
   const createRootNodeRef = (content = '') => {
     const root = document.createElement('div');
     root.innerHTML = content;
-    return { current: root };
+    return root;
   };
 
   it('should return with empty array when no child of the root node', () => {

--- a/src/components/ListItemBase/ListItemBase.utils.tsx
+++ b/src/components/ListItemBase/ListItemBase.utils.tsx
@@ -1,10 +1,8 @@
-import { RefObject } from 'react';
-
-export function getKeyboardFocusableElements<T extends HTMLElement>(root: RefObject<T>): Element[] {
+export function getKeyboardFocusableElements<T extends HTMLElement>(root: T): Element[] {
   const focusableNodes =
     'a[href], button, input, textarea, select, details,[tabindex]:not([tabindex="-1"])';
 
-  return Array.from(root.current.querySelectorAll(focusableNodes)).filter(
+  return Array.from(root.querySelectorAll(focusableNodes)).filter(
     (el) => !el.hasAttribute('disabled') && el.getAttribute('aria-hidden') !== 'true'
   );
 }

--- a/src/hooks/useMutationObservable.test.tsx
+++ b/src/hooks/useMutationObservable.test.tsx
@@ -1,0 +1,63 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { act, render } from '@testing-library/react';
+import { useMutationObservable } from './useMutationObservable';
+
+describe('useMutationObservable', () => {
+  const setup = (callback: () => void, config?: Parameters<typeof useMutationObservable>[2]) => {
+    let timer;
+    const DynamicComponent = () => {
+      const [counter, setCounter] = useState(0);
+      // Update component 3 times
+      useEffect(() => {
+        timer = setInterval(
+          () =>
+            act(() => {
+              setCounter((n) => {
+                if (n === 1) clearInterval(timer);
+                return n + 1;
+              });
+            }),
+          100
+        );
+      }, []);
+
+      return <button name={counter.toString()}>{counter}</button>;
+    };
+
+    const Wrapper = () => {
+      const ref = useRef();
+      useMutationObservable(ref.current, callback, config);
+      return (
+        <div ref={ref}>
+          <DynamicComponent />
+        </div>
+      );
+    };
+
+    return Wrapper;
+  };
+
+  beforeAll(() => {
+    jest.clearAllTimers();
+    jest.useFakeTimers('modern');
+  });
+
+  it('should call the callback after DOM change', async function () {
+    expect.assertions(1);
+    const callback = jest.fn();
+    const Wrapper = setup(callback, {
+      subtree: true,
+      attributes: true,
+      childList: true,
+    });
+
+    const { findAllByText } = render(<Wrapper />);
+
+    await findAllByText('2');
+
+    expect(callback.mock.calls).toEqual([
+      [[expect.any(MutationRecord)], expect.any(MutationObserver)],
+      [[expect.any(MutationRecord)], expect.any(MutationObserver)],
+    ]);
+  });
+});

--- a/src/hooks/useMutationObservable.ts
+++ b/src/hooks/useMutationObservable.ts
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react';
+
+const DEFAULT_OPTIONS = {
+  attributes: false,
+  childList: true,
+  subtree: true,
+};
+
+/**
+ * This custom hooks abstracts the usage of the Mutation Observer with React components.
+ * Watch for changes being made to the DOM tree and trigger a custom callback.
+ *
+ * Note: with debounce the intermediate MutationRecords will be lost
+ *
+ * @param targetEl Observed DOM element
+ * @param callback Mutation callback
+ * @param config Mutation Observer config and other config
+ *
+ * @link https://blog.logrocket.com/guide-to-custom-react-hooks-with-mutationobserver/
+ */
+export const useMutationObservable = (
+  targetEl: Node,
+  callback: MutationCallback,
+  config: MutationObserverInit = DEFAULT_OPTIONS
+) => {
+  const [observer, setObserver] = useState<MutationObserver>(null);
+
+  useEffect(() => {
+    setObserver(() => new MutationObserver(callback));
+  }, [callback, config]);
+
+  useEffect(() => {
+    observer?.observe(targetEl, config);
+    return () => {
+      observer?.disconnect();
+    };
+  }, [observer, targetEl, config]);
+};

--- a/src/hooks/useMutationObservable.ts
+++ b/src/hooks/useMutationObservable.ts
@@ -22,7 +22,7 @@ export const useMutationObservable = (
   targetEl: Node,
   callback: MutationCallback,
   config: MutationObserverInit = DEFAULT_OPTIONS
-) => {
+): void => {
   const [observer, setObserver] = useState<MutationObserver>(null);
 
   useEffect(() => {


### PR DESCRIPTION
Use MutationObserver to detect when any focusable item changed in list item subtree. It is necessary to set the tabindex to -1 of all focusable elements which are in non-selected row.

issue: https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-376372