### PR TITLE
fix(overlay-alert): export tree

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -21,6 +21,7 @@ export { default as Tab } from './Tab';
 export { default as ModalArrow } from './ModalArrow';
 export { default as ModalContainer } from './ModalContainer';
 export { default as Overlay } from './Overlay';
+export { default as OverlayAlert } from './OverlayAlert';
 export { default as ThemeProvider } from './ThemeProvider';
 export { default as Toast } from './Toast';
 export { default as ToastContent } from './ToastContent';

--- a/src/index.js
+++ b/src/index.js
@@ -132,6 +132,7 @@ export {
   ModalArrow,
   ModalContainer,
   Overlay,
+  OverlayAlert,
   Toast,
   ToastDetails,
   ToastContent,


### PR DESCRIPTION
# Description

The scope of the changes in this pull request are to add the export tree for the `<OverlayAlert />` component.