### PR TITLE
fix(overlay-alert): extend overlay props

### DIFF
--- a/src/components/OverlayAlert/OverlayAlert.types.ts
+++ b/src/components/OverlayAlert/OverlayAlert.types.ts
@@ -3,11 +3,12 @@ import { CSSProperties, ReactElement, ReactNode } from 'react';
 import { ButtonControlProps } from '../ButtonControl';
 import { ButtonSimpleProps } from '../ButtonSimple';
 import { ButtonGroupProps } from '../ButtonGroup';
+import { OverlayProps } from '../Overlay';
 
 export type SupportedActions = ButtonSimpleProps | ButtonGroupProps;
 export type SupportedControls = ButtonControlProps;
 
-export interface Props {
+export interface Props extends OverlayProps {
   /**
    * Actions associated with this OverlayAlert.
    */


### PR DESCRIPTION
# Description

The scope of the changes in this pull request are to add the missing props extension to the types file within `<OverlayAlert />` so that it properly extends the props from `<Overlay />`.