### PR TITLE
feat(menu-trigger-fix): fix double click bug on menuTrigger component

### DIFF
--- a/src/components/MenuTrigger/MenuTrigger.tsx
+++ b/src/components/MenuTrigger/MenuTrigger.tsx
@@ -50,22 +50,21 @@ const MenuTrigger: FC<Props> = (props: Props) => {
     buttonRef.current?.focus();
   }, []);
 
-  const menuContext = {
-    ...menuProps,
-    onClose: state.close,
-    closeOnSelect,
-    ref: menuRef,
-  };
-
   /**
    * Handle closeOnSelect from @react-aria manually
    */
-  useEffect(() => {
-    if (!state.isOpen && popoverInstance?.state.isVisible) {
-      popoverInstance.hide();
-      handleFocusBackOnTrigger();
-    }
-  }, [state.isOpen, popoverInstance]);
+  const closeMenuTrigger = () => {
+    state.close();
+    popoverInstance.hide();
+    handleFocusBackOnTrigger();
+  };
+
+  const menuContext = {
+    ...menuProps,
+    onClose: closeMenuTrigger,
+    closeOnSelect,
+    ref: menuRef,
+  };
 
   /**
    * Handle isOpen from @react-aria manually

--- a/src/components/MenuTrigger/MenuTrigger.tsx
+++ b/src/components/MenuTrigger/MenuTrigger.tsx
@@ -86,12 +86,12 @@ const MenuTrigger: FC<Props> = (props: Props) => {
   const { keyboardProps } = useKeyboard({
     onKeyDown: (event) => {
       if (event.key === 'Escape') {
-        state.close();
+        closeMenuTrigger();
       }
       // When there are more than one menus inside the menu trigger, we should not close the overlay
       // according to W-ARIA
       if (state.isOpen && event.key === 'Tab' && menus.length === 1) {
-        state.close();
+        closeMenuTrigger();
       }
     },
   });
@@ -119,13 +119,13 @@ const MenuTrigger: FC<Props> = (props: Props) => {
       variant={variant as VariantType}
       delay={delay}
       color={color}
-      onClickOutside={state.close}
+      onClickOutside={closeMenuTrigger}
       setInstance={setPopoverInstance}
       hideOnEsc={false}
       {...(keyboardProps as Omit<React.HTMLAttributes<HTMLElement>, 'color'>)}
     >
       <FocusScope restoreFocus contain>
-        <DismissButton onDismiss={state.close} />
+        <DismissButton onDismiss={closeMenuTrigger} />
         {menus.map((menu: ReactElement, index) => {
           return (
             <MenuContext.Provider
@@ -142,7 +142,7 @@ const MenuTrigger: FC<Props> = (props: Props) => {
             </MenuContext.Provider>
           );
         })}
-        <DismissButton onDismiss={state.close} />
+        <DismissButton onDismiss={closeMenuTrigger} />
       </FocusScope>
     </Popover>
   );


### PR DESCRIPTION
# Description

[SPARK-383510](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-383510): MenuTrigger component opens again when double clicking for 1st time. 

Every time you open Menu Trigger for the first time, or after clicking away of it:
1 Click --> Opens menu (correct)
2 Click --> Opens menu again! (bug)
3 Click --> Closes menu  (correct)
4 Click --> Opens menu (correct)
5 Click --> Closes menu  (correct)
6 Click --> Opens menu (correct)
7 Click --> Closes menu  (correct)
8 Click --> Opens menu (correct)