### PR TITLE
SPARK-382369: only set flex-shrink:0 on Icon if scale property is passed

### DIFF
--- a/src/components/AddReactionButton/AddReactionButton.unit.test.tsx.snap
+++ b/src/components/AddReactionButton/AddReactionButton.unit.test.tsx.snap
@@ -49,7 +49,7 @@ exports[`<AddReactionButton /> snapshot should match snapshot 1`] = `
               scale={12}
             >
               <div
-                className="md-icon-wrapper"
+                className="md-icon-wrapper md-icon-no-shrink"
               >
                 <svg
                   className=""
@@ -123,7 +123,7 @@ exports[`<AddReactionButton /> snapshot should match snapshot with className 1`]
               scale={12}
             >
               <div
-                className="md-icon-wrapper"
+                className="md-icon-wrapper md-icon-no-shrink"
               >
                 <svg
                   className=""
@@ -200,7 +200,7 @@ exports[`<AddReactionButton /> snapshot should match snapshot with id 1`] = `
               scale={12}
             >
               <div
-                className="md-icon-wrapper"
+                className="md-icon-wrapper md-icon-no-shrink"
               >
                 <svg
                   className=""
@@ -293,7 +293,7 @@ exports[`<AddReactionButton /> snapshot should match snapshot with style 1`] = `
               scale={12}
             >
               <div
-                className="md-icon-wrapper"
+                className="md-icon-wrapper md-icon-no-shrink"
               >
                 <svg
                   className=""

--- a/src/components/Avatar/Avatar.unit.test.tsx.snap
+++ b/src/components/Avatar/Avatar.unit.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`Avatar snapshot should match snapshot with failureBadge 1`] = `
         weight="filled"
       >
         <div
-          className="md-icon-wrapper"
+          className="md-icon-wrapper md-icon-no-shrink"
         >
           <svg
             className=""
@@ -101,7 +101,7 @@ exports[`Avatar snapshot should match snapshot with icon 1`] = `
       weight="bold"
     >
       <div
-        className="md-icon-wrapper md-avatar-icon-wrapper"
+        className="md-icon-wrapper md-avatar-icon-wrapper md-icon-no-shrink"
       >
         <svg
           className=""
@@ -278,7 +278,7 @@ exports[`Avatar snapshot should match snapshot with presence 1`] = `
           weight="filled"
         >
           <div
-            className="md-icon-wrapper"
+            className="md-icon-wrapper md-icon-no-shrink"
           >
             <svg
               className=""
@@ -326,7 +326,7 @@ exports[`Avatar snapshot should match snapshot with presence 1`] = `
           weight="filled"
         >
           <div
-            className="md-icon-wrapper"
+            className="md-icon-wrapper md-icon-no-shrink"
           >
             <svg
               className=""
@@ -374,7 +374,7 @@ exports[`Avatar snapshot should match snapshot with presence 1`] = `
           weight="filled"
         >
           <div
-            className="md-icon-wrapper"
+            className="md-icon-wrapper md-icon-no-shrink"
           >
             <svg
               className=""
@@ -422,7 +422,7 @@ exports[`Avatar snapshot should match snapshot with presence 1`] = `
           weight="filled"
         >
           <div
-            className="md-icon-wrapper"
+            className="md-icon-wrapper md-icon-no-shrink"
           >
             <svg
               className=""
@@ -470,7 +470,7 @@ exports[`Avatar snapshot should match snapshot with presence 1`] = `
           weight="filled"
         >
           <div
-            className="md-icon-wrapper"
+            className="md-icon-wrapper md-icon-no-shrink"
           >
             <svg
               className=""
@@ -518,7 +518,7 @@ exports[`Avatar snapshot should match snapshot with presence 1`] = `
           weight="filled"
         >
           <div
-            className="md-icon-wrapper"
+            className="md-icon-wrapper md-icon-no-shrink"
           >
             <svg
               className=""
@@ -566,7 +566,7 @@ exports[`Avatar snapshot should match snapshot with presence 1`] = `
           weight="filled"
         >
           <div
-            className="md-icon-wrapper"
+            className="md-icon-wrapper md-icon-no-shrink"
           >
             <svg
               className=""
@@ -614,7 +614,7 @@ exports[`Avatar snapshot should match snapshot with presence 1`] = `
           weight="filled"
         >
           <div
-            className="md-icon-wrapper"
+            className="md-icon-wrapper md-icon-no-shrink"
           >
             <svg
               className=""
@@ -662,7 +662,7 @@ exports[`Avatar snapshot should match snapshot with presence 1`] = `
           weight="filled"
         >
           <div
-            className="md-icon-wrapper"
+            className="md-icon-wrapper md-icon-no-shrink"
           >
             <svg
               className=""
@@ -710,7 +710,7 @@ exports[`Avatar snapshot should match snapshot with presence 1`] = `
           weight="bold"
         >
           <div
-            className="md-icon-wrapper"
+            className="md-icon-wrapper md-icon-no-shrink"
           >
             <svg
               className=""
@@ -758,7 +758,7 @@ exports[`Avatar snapshot should match snapshot with presence 1`] = `
           weight="filled"
         >
           <div
-            className="md-icon-wrapper"
+            className="md-icon-wrapper md-icon-no-shrink"
           >
             <svg
               className=""
@@ -806,7 +806,7 @@ exports[`Avatar snapshot should match snapshot with presence 1`] = `
           weight="filled"
         >
           <div
-            className="md-icon-wrapper"
+            className="md-icon-wrapper md-icon-no-shrink"
           >
             <svg
               className=""
@@ -854,7 +854,7 @@ exports[`Avatar snapshot should match snapshot with presence 1`] = `
           weight="filled"
         >
           <div
-            className="md-icon-wrapper"
+            className="md-icon-wrapper md-icon-no-shrink"
           >
             <svg
               className=""

--- a/src/components/AvatarMeetingsListItem/AvatarMeetingsListItem.unit.test.tsx.snap
+++ b/src/components/AvatarMeetingsListItem/AvatarMeetingsListItem.unit.test.tsx.snap
@@ -182,7 +182,7 @@ exports[`<AvatarMeetingsListItem /> snapshot should match snapshot with avatarPr
                       weight="filled"
                     >
                       <div
-                        className="md-icon-wrapper"
+                        className="md-icon-wrapper md-icon-no-shrink"
                       >
                         <svg
                           className=""
@@ -492,7 +492,7 @@ exports[`<AvatarMeetingsListItem /> snapshot should match snapshot with displayM
                           weight="bold"
                         >
                           <div
-                            className="md-icon-wrapper"
+                            className="md-icon-wrapper md-icon-no-shrink"
                           >
                             <svg
                               className=""
@@ -671,7 +671,7 @@ exports[`<AvatarMeetingsListItem /> snapshot should match snapshot with displayM
                           weight="bold"
                         >
                           <div
-                            className="md-icon-wrapper"
+                            className="md-icon-wrapper md-icon-no-shrink"
                           >
                             <svg
                               className=""
@@ -853,7 +853,7 @@ exports[`<AvatarMeetingsListItem /> snapshot should match snapshot with displayM
                           weight="bold"
                         >
                           <div
-                            className="md-icon-wrapper"
+                            className="md-icon-wrapper md-icon-no-shrink"
                           >
                             <svg
                               className=""
@@ -1179,7 +1179,7 @@ exports[`<AvatarMeetingsListItem /> snapshot should match snapshot with schedule
                 weight="bold"
               >
                 <div
-                  className="md-icon-wrapper"
+                  className="md-icon-wrapper md-icon-no-shrink"
                 >
                   <svg
                     className=""
@@ -1309,7 +1309,7 @@ exports[`<AvatarMeetingsListItem /> snapshot should match snapshot with schedule
                 weight="bold"
               >
                 <div
-                  className="md-icon-wrapper"
+                  className="md-icon-wrapper md-icon-no-shrink"
                 >
                   <svg
                     className=""
@@ -1439,7 +1439,7 @@ exports[`<AvatarMeetingsListItem /> snapshot should match snapshot with schedule
                 weight="bold"
               >
                 <div
-                  className="md-icon-wrapper"
+                  className="md-icon-wrapper md-icon-no-shrink"
                 >
                   <svg
                     className=""
@@ -1569,7 +1569,7 @@ exports[`<AvatarMeetingsListItem /> snapshot should match snapshot with schedule
                 weight="bold"
               >
                 <div
-                  className="md-icon-wrapper"
+                  className="md-icon-wrapper md-icon-no-shrink"
                 >
                   <svg
                     className=""

--- a/src/components/Checkbox/Checkbox.unit.test.tsx.snap
+++ b/src/components/Checkbox/Checkbox.unit.test.tsx.snap
@@ -278,7 +278,7 @@ exports[`<Checkbox /> snapshot should match snapshot with indeterminate checkbox
         weight="bold"
       >
         <div
-          className="md-icon-wrapper md-checkbox-icon"
+          className="md-icon-wrapper md-checkbox-icon md-icon-no-shrink"
         >
           <svg
             className=""
@@ -468,7 +468,7 @@ exports[`<Checkbox /> snapshot should match snapshot with selected checkbox 1`] 
         weight="bold"
       >
         <div
-          className="md-icon-wrapper md-checkbox-icon"
+          className="md-icon-wrapper md-checkbox-icon md-icon-no-shrink"
         >
           <svg
             className=""

--- a/src/components/GlobalSearchInput/GlobalSearchInput.unit.test.tsx.snap
+++ b/src/components/GlobalSearchInput/GlobalSearchInput.unit.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`<GlobalSearchInput /> snapshot should match snapshot 1`] = `
           weight="light"
         >
           <div
-            className="md-icon-wrapper md-global-search-input-search"
+            className="md-icon-wrapper md-global-search-input-search md-icon-no-shrink"
           >
             <svg
               className=""
@@ -114,7 +114,7 @@ exports[`<GlobalSearchInput /> snapshot should match snapshot when filters are s
           weight="light"
         >
           <div
-            className="md-icon-wrapper md-global-search-input-search"
+            className="md-icon-wrapper md-global-search-input-search md-icon-no-shrink"
           >
             <svg
               className=""
@@ -203,7 +203,7 @@ exports[`<GlobalSearchInput /> snapshot should match snapshot when filters are s
                 scale={18}
               >
                 <div
-                  className="md-icon-wrapper"
+                  className="md-icon-wrapper md-icon-no-shrink"
                 >
                   <svg
                     className=""
@@ -250,7 +250,7 @@ exports[`<GlobalSearchInput /> snapshot should match snapshot when searching 1`]
           weight="light"
         >
           <div
-            className="md-icon-wrapper md-global-search-input-search"
+            className="md-icon-wrapper md-global-search-input-search md-icon-no-shrink"
           >
             <svg
               className=""
@@ -314,7 +314,7 @@ exports[`<GlobalSearchInput /> snapshot should match snapshot with className 1`]
           weight="light"
         >
           <div
-            className="md-icon-wrapper md-global-search-input-search"
+            className="md-icon-wrapper md-global-search-input-search md-icon-no-shrink"
           >
             <svg
               className=""
@@ -379,7 +379,7 @@ exports[`<GlobalSearchInput /> snapshot should match snapshot with id 1`] = `
           weight="light"
         >
           <div
-            className="md-icon-wrapper md-global-search-input-search"
+            className="md-icon-wrapper md-global-search-input-search md-icon-no-shrink"
           >
             <svg
               className=""
@@ -452,7 +452,7 @@ exports[`<GlobalSearchInput /> snapshot should match snapshot with style 1`] = `
           weight="light"
         >
           <div
-            className="md-icon-wrapper md-global-search-input-search"
+            className="md-icon-wrapper md-global-search-input-search md-icon-no-shrink"
           >
             <svg
               className=""

--- a/src/components/Icon/Icon.constants.ts
+++ b/src/components/Icon/Icon.constants.ts
@@ -70,6 +70,7 @@ const STYLE = {
   wrapper: `${CLASS_PREFIX}-wrapper`,
   notFound: `${CLASS_PREFIX}-not-found`,
   coloured: `${CLASS_PREFIX}-coloured`,
+  noShrink: `${CLASS_PREFIX}-no-shrink`,
 };
 
 export {

--- a/src/components/Icon/Icon.style.scss
+++ b/src/components/Icon/Icon.style.scss
@@ -7,13 +7,16 @@ svg.md-icon-coloured {
   }
 }
 
+.md-icon-no-shrink {
+  flex-shrink: 0;
+}
+
 .md-icon-wrapper {
   align-items: center;
   display: flex;
   height: fit-content;
   justify-content: center;
   width: fit-content;
-  flex-shrink: 0;
 
   > *[data-autoscale='true'] {
     width: 1em;

--- a/src/components/Icon/Icon.style.scss
+++ b/src/components/Icon/Icon.style.scss
@@ -13,138 +13,139 @@ svg.md-icon-coloured {
   height: fit-content;
   justify-content: center;
   width: fit-content;
+  flex-shrink: 0;
 
-  > *[data-autoscale=true] {
+  > *[data-autoscale='true'] {
     width: 1em;
     height: 1em;
   }
 
-  > *[data-autoscale="25"] {
+  > *[data-autoscale='25'] {
     width: 0.25em;
     height: 0.25em;
   }
 
-  > *[data-autoscale="50"] {
-    width: 0.50em;
-    height: 0.50em;
+  > *[data-autoscale='50'] {
+    width: 0.5em;
+    height: 0.5em;
   }
 
-  > *[data-autoscale="75"] {
+  > *[data-autoscale='75'] {
     width: 0.75em;
     height: 0.75em;
   }
 
-  > *[data-autoscale="100"] {
+  > *[data-autoscale='100'] {
     width: 1em;
     height: 1em;
   }
 
-  > *[data-autoscale="125"] {
+  > *[data-autoscale='125'] {
     width: 1.25em;
     height: 1.25em;
   }
 
-  > *[data-autoscale="150"] {
+  > *[data-autoscale='150'] {
     width: 1.5em;
     height: 1.5em;
   }
 
-  > *[data-autoscale="175"] {
+  > *[data-autoscale='175'] {
     width: 1.75em;
     height: 1.75em;
   }
 
-  > *[data-autoscale="200"] {
+  > *[data-autoscale='200'] {
     width: 2em;
     height: 2em;
   }
 
-  > *[data-scale="8"] {
+  > *[data-scale='8'] {
     width: 0.5rem;
     height: 0.5rem;
   }
 
-  > *[data-scale="10"] {
+  > *[data-scale='10'] {
     width: 0.625rem;
     height: 0.625rem;
   }
 
-  > *[data-scale="12"] {
+  > *[data-scale='12'] {
     width: 0.75rem;
     height: 0.75rem;
   }
 
-  > *[data-scale="14"] {
+  > *[data-scale='14'] {
     width: 0.875rem;
     height: 0.875rem;
   }
 
-  > *[data-scale="16"] {
+  > *[data-scale='16'] {
     width: 1rem;
     height: 1rem;
   }
 
-  > *[data-scale="18"] {
+  > *[data-scale='18'] {
     width: 1.125rem;
     height: 1.125rem;
   }
 
-  > *[data-scale="20"] {
+  > *[data-scale='20'] {
     width: 1.25rem;
     height: 1.25rem;
   }
 
-  > *[data-scale="22"] {
+  > *[data-scale='22'] {
     width: 1.375rem;
     height: 1.375rem;
   }
 
-  > *[data-scale="24"] {
+  > *[data-scale='24'] {
     width: 1.5rem;
     height: 1.5rem;
   }
 
-  > *[data-scale="28"] {
+  > *[data-scale='28'] {
     width: 1.75rem;
     height: 1.75rem;
   }
 
-  > *[data-scale="32"] {
+  > *[data-scale='32'] {
     width: 2rem;
     height: 2rem;
   }
 
-  > *[data-scale="36"] {
+  > *[data-scale='36'] {
     width: 2.25rem;
     height: 2.25rem;
   }
 
-  > *[data-scale="40"] {
+  > *[data-scale='40'] {
     width: 2.5rem;
     height: 2.5rem;
   }
 
-  > *[data-scale="48"] {
+  > *[data-scale='48'] {
     width: 3rem;
     height: 3rem;
   }
 
-  > *[data-scale="56"] {
+  > *[data-scale='56'] {
     width: 3.5rem;
     height: 3.5rem;
   }
 
-  > *[data-scale="64"] {
+  > *[data-scale='64'] {
     width: 4rem;
     height: 4rem;
   }
 
-  > *[data-scale="120"] {
+  > *[data-scale='120'] {
     width: 7.5rem;
     height: 7.5rem;
   }
 
-  > *[data-scale="124"] {
+  > *[data-scale='124'] {
     width: 7.75rem;
     height: 7.75rem;
   }

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -82,7 +82,12 @@ const Icon: React.FC<Props> = (props: Props) => {
 
   if (SvgIcon) {
     return (
-      <div className={classnames(STYLE.wrapper, className)} id={id} style={style} title={title}>
+      <div
+        className={classnames(STYLE.wrapper, className, { [STYLE.noShrink]: scale })}
+        id={id}
+        style={style}
+        title={title}
+      >
         <SvgIcon
           // coloured class is added to avoid theming the fixed colours inside coloured icons
           data-test={name}

--- a/src/components/Icon/Icon.unit.test.tsx
+++ b/src/components/Icon/Icon.unit.test.tsx
@@ -193,20 +193,28 @@ describe('<Icon />', () => {
     it('should pass scale prop', async () => {
       const scale = 16;
 
-      const wrapper = await mountAndWait(<Icon name={'accessibility'} scale={scale} />);
+      const wrapper = await mountAndWait(
+        <Icon name={'accessibility'} id={'fake-id'} scale={scale} />
+      );
       const icon = wrapper.find('svg').getDOMNode();
+      const div = wrapper.find('div').filter({ id: 'fake-id' });
 
       expect(icon.getAttribute('data-scale')).toBe(`${scale}`);
+      expect(div.props().className).toBe('md-icon-wrapper md-icon-no-shrink');
     });
 
     it('should pass autoScale prop and disable scale prop', async () => {
       const autoScale = true;
 
-      const wrapper = await mountAndWait(<Icon name={'accessibility'} autoScale={autoScale} />);
+      const wrapper = await mountAndWait(
+        <Icon name={'accessibility'} autoScale={autoScale} id={'fake-id'} />
+      );
       const icon = wrapper.find('svg').getDOMNode();
+      const div = wrapper.find('div').filter({ id: 'fake-id' });
 
       expect(icon.getAttribute('data-autoscale')).toBe(`${autoScale}`);
       expect(icon.getAttribute('data-scale')).toBe('false');
+      expect(div.props().className).toBe('md-icon-wrapper');
     });
 
     it('should pass autoScale prop as numeric value when set appropriately', async () => {

--- a/src/components/Icon/Icon.unit.test.tsx.snap
+++ b/src/components/Icon/Icon.unit.test.tsx.snap
@@ -192,7 +192,7 @@ exports[`<Icon /> snapshot should match snapshot with scale 1`] = `
   scale={16}
 >
   <div
-    className="md-icon-wrapper"
+    className="md-icon-wrapper md-icon-no-shrink"
   >
     <svg
       className=""
@@ -215,7 +215,7 @@ exports[`<Icon /> snapshot should match snapshot with small icons 1`] = `
   scale={14}
 >
   <div
-    className="md-icon-wrapper"
+    className="md-icon-wrapper md-icon-no-shrink"
   >
     <svg
       className=""

--- a/src/components/InputMessage/InputMessage.unit.test.tsx.snap
+++ b/src/components/InputMessage/InputMessage.unit.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`InputMessage snapshot should match snapshot 1`] = `
           weight="bold"
         >
           <div
-            className="md-icon-wrapper"
+            className="md-icon-wrapper md-icon-no-shrink"
           >
             <svg
               className=""

--- a/src/components/LoadingSpinner/LoadingSpinner.unit.test.tsx.snap
+++ b/src/components/LoadingSpinner/LoadingSpinner.unit.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`<LoadingSpinner /> snapshot should match snapshot 1`] = `
       weight="regular"
     >
       <div
-        className="md-icon-wrapper"
+        className="md-icon-wrapper md-icon-no-shrink"
       >
         <svg
           className=""
@@ -33,7 +33,7 @@ exports[`<LoadingSpinner /> snapshot should match snapshot 1`] = `
       weight="regular"
     >
       <div
-        className="md-icon-wrapper md-loading-spinner-arch"
+        className="md-icon-wrapper md-loading-spinner-arch md-icon-no-shrink"
       >
         <svg
           className=""
@@ -65,7 +65,7 @@ exports[`<LoadingSpinner /> snapshot should match snapshot with className 1`] = 
       weight="regular"
     >
       <div
-        className="md-icon-wrapper"
+        className="md-icon-wrapper md-icon-no-shrink"
       >
         <svg
           className=""
@@ -87,7 +87,7 @@ exports[`<LoadingSpinner /> snapshot should match snapshot with className 1`] = 
       weight="regular"
     >
       <div
-        className="md-icon-wrapper md-loading-spinner-arch"
+        className="md-icon-wrapper md-loading-spinner-arch md-icon-no-shrink"
       >
         <svg
           className=""
@@ -120,7 +120,7 @@ exports[`<LoadingSpinner /> snapshot should match snapshot with id 1`] = `
       weight="regular"
     >
       <div
-        className="md-icon-wrapper"
+        className="md-icon-wrapper md-icon-no-shrink"
       >
         <svg
           className=""
@@ -142,7 +142,7 @@ exports[`<LoadingSpinner /> snapshot should match snapshot with id 1`] = `
       weight="regular"
     >
       <div
-        className="md-icon-wrapper md-loading-spinner-arch"
+        className="md-icon-wrapper md-loading-spinner-arch md-icon-no-shrink"
       >
         <svg
           className=""
@@ -174,7 +174,7 @@ exports[`<LoadingSpinner /> snapshot should match snapshot with scale 1`] = `
       weight="regular"
     >
       <div
-        className="md-icon-wrapper"
+        className="md-icon-wrapper md-icon-no-shrink"
       >
         <svg
           className=""
@@ -196,7 +196,7 @@ exports[`<LoadingSpinner /> snapshot should match snapshot with scale 1`] = `
       weight="regular"
     >
       <div
-        className="md-icon-wrapper md-loading-spinner-arch"
+        className="md-icon-wrapper md-loading-spinner-arch md-icon-no-shrink"
       >
         <svg
           className=""
@@ -237,7 +237,7 @@ exports[`<LoadingSpinner /> snapshot should match snapshot with style 1`] = `
       weight="regular"
     >
       <div
-        className="md-icon-wrapper"
+        className="md-icon-wrapper md-icon-no-shrink"
       >
         <svg
           className=""
@@ -259,7 +259,7 @@ exports[`<LoadingSpinner /> snapshot should match snapshot with style 1`] = `
       weight="regular"
     >
       <div
-        className="md-icon-wrapper md-loading-spinner-arch"
+        className="md-icon-wrapper md-loading-spinner-arch md-icon-no-shrink"
       >
         <svg
           className=""

--- a/src/components/MeetingListItem/MeetingListItem.unit.test.tsx.snap
+++ b/src/components/MeetingListItem/MeetingListItem.unit.test.tsx.snap
@@ -449,7 +449,7 @@ exports[`<MeetingListItem /> snapshot should match snapshot with image 1`] = `
                 weight="bold"
               >
                 <div
-                  className="md-icon-wrapper"
+                  className="md-icon-wrapper md-icon-no-shrink"
                 >
                   <svg
                     className=""

--- a/src/components/NavigationTab/NavigationTab.unit.test.tsx.snap
+++ b/src/components/NavigationTab/NavigationTab.unit.test.tsx.snap
@@ -255,7 +255,7 @@ exports[`<NavigationTab /> snapshot should match snapshot with icon 1`] = `
                 weight="filled"
               >
                 <div
-                  className="md-icon-wrapper md-navigation-tab-icon"
+                  className="md-icon-wrapper md-navigation-tab-icon md-icon-no-shrink"
                 >
                   <svg
                     className=""
@@ -533,7 +533,7 @@ exports[`<NavigationTab /> snapshot should match snapshot with size, label, icon
                 weight="filled"
               >
                 <div
-                  className="md-icon-wrapper md-navigation-tab-icon"
+                  className="md-icon-wrapper md-navigation-tab-icon md-icon-no-shrink"
                 >
                   <svg
                     className=""
@@ -614,7 +614,7 @@ exports[`<NavigationTab /> snapshot should match snapshot with size, label, icon
                 weight="filled"
               >
                 <div
-                  className="md-icon-wrapper md-navigation-tab-icon"
+                  className="md-icon-wrapper md-navigation-tab-icon md-icon-no-shrink"
                 >
                   <svg
                     className=""

--- a/src/components/NotificationSystem/NotificationSystem.unit.test.tsx.snap
+++ b/src/components/NotificationSystem/NotificationSystem.unit.test.tsx.snap
@@ -42,7 +42,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot 1`] = `
                     class="md-toast-notification-leading-visual"
                   >
                     <div
-                      class="md-icon-wrapper icon"
+                      class="md-icon-wrapper icon md-icon-no-shrink"
                     >
                       <svg
                         class=""
@@ -76,7 +76,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot 1`] = `
                       type="button"
                     >
                       <div
-                        class="md-icon-wrapper"
+                        class="md-icon-wrapper md-icon-no-shrink"
                       >
                         <svg
                           class=""
@@ -151,7 +151,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with className 1`
                     class="md-toast-notification-leading-visual"
                   >
                     <div
-                      class="md-icon-wrapper icon"
+                      class="md-icon-wrapper icon md-icon-no-shrink"
                     >
                       <svg
                         class=""
@@ -185,7 +185,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with className 1`
                       type="button"
                     >
                       <div
-                        class="md-icon-wrapper"
+                        class="md-icon-wrapper md-icon-no-shrink"
                       >
                         <svg
                           class=""
@@ -256,7 +256,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with different at
                     class="md-toast-notification-leading-visual"
                   >
                     <div
-                      class="md-icon-wrapper icon"
+                      class="md-icon-wrapper icon md-icon-no-shrink"
                     >
                       <svg
                         class=""
@@ -290,7 +290,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with different at
                       type="button"
                     >
                       <div
-                        class="md-icon-wrapper"
+                        class="md-icon-wrapper md-icon-no-shrink"
                       >
                         <svg
                           class=""
@@ -358,7 +358,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with different po
                     class="md-toast-notification-leading-visual"
                   >
                     <div
-                      class="md-icon-wrapper icon"
+                      class="md-icon-wrapper icon md-icon-no-shrink"
                     >
                       <svg
                         class=""
@@ -392,7 +392,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with different po
                       type="button"
                     >
                       <div
-                        class="md-icon-wrapper"
+                        class="md-icon-wrapper md-icon-no-shrink"
                       >
                         <svg
                           class=""
@@ -471,7 +471,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with different zI
                     class="md-toast-notification-leading-visual"
                   >
                     <div
-                      class="md-icon-wrapper icon"
+                      class="md-icon-wrapper icon md-icon-no-shrink"
                     >
                       <svg
                         class=""
@@ -505,7 +505,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with different zI
                       type="button"
                     >
                       <div
-                        class="md-icon-wrapper"
+                        class="md-icon-wrapper md-icon-no-shrink"
                       >
                         <svg
                           class=""
@@ -580,7 +580,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with id 1`] = `
                     class="md-toast-notification-leading-visual"
                   >
                     <div
-                      class="md-icon-wrapper icon"
+                      class="md-icon-wrapper icon md-icon-no-shrink"
                     >
                       <svg
                         class=""
@@ -614,7 +614,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with id 1`] = `
                       type="button"
                     >
                       <div
-                        class="md-icon-wrapper"
+                        class="md-icon-wrapper md-icon-no-shrink"
                       >
                         <svg
                           class=""
@@ -689,7 +689,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with style 1`] = 
                     class="md-toast-notification-leading-visual"
                   >
                     <div
-                      class="md-icon-wrapper icon"
+                      class="md-icon-wrapper icon md-icon-no-shrink"
                     >
                       <svg
                         class=""
@@ -723,7 +723,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with style 1`] = 
                       type="button"
                     >
                       <div
-                        class="md-icon-wrapper"
+                        class="md-icon-wrapper md-icon-no-shrink"
                       >
                         <svg
                           class=""

--- a/src/components/Popover/Popover.unit.test.tsx.snap
+++ b/src/components/Popover/Popover.unit.test.tsx.snap
@@ -173,22 +173,7 @@ exports[`<Popover /> snapshot should match snapshot with closeButtonPlacement 2`
         data-placement="top-right"
         data-size="20"
         type="button"
-      >
-        <div
-          class="md-icon-wrapper"
-        >
-          <svg
-            class=""
-            data-autoscale="false"
-            data-scale="16"
-            data-test="cancel"
-            fill="currentColor"
-            height="100%"
-            viewBox="0, 0, 32, 32"
-            width="100%"
-          />
-        </div>
-      </button>
+      />
       <p>
         Content
       </p>

--- a/src/components/SearchInput/SearchInput.unit.test.tsx.snap
+++ b/src/components/SearchInput/SearchInput.unit.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`<SearchInput /> snapshot should match snapshot 1`] = `
           weight="bold"
         >
           <div
-            className="md-icon-wrapper md-search-input-search"
+            className="md-icon-wrapper md-search-input-search md-icon-no-shrink"
           >
             <svg
               className=""
@@ -123,7 +123,7 @@ exports[`<SearchInput /> snapshot should match snapshot when filters are set 1`]
           weight="bold"
         >
           <div
-            className="md-icon-wrapper md-search-input-search"
+            className="md-icon-wrapper md-search-input-search md-icon-no-shrink"
           >
             <svg
               className=""
@@ -192,7 +192,7 @@ exports[`<SearchInput /> snapshot should match snapshot when filters are set 1`]
                 weight="bold"
               >
                 <div
-                  className="md-icon-wrapper"
+                  className="md-icon-wrapper md-icon-no-shrink"
                 >
                   <svg
                     className=""
@@ -263,7 +263,7 @@ exports[`<SearchInput /> snapshot should match snapshot when searching 1`] = `
               weight="regular"
             >
               <div
-                className="md-icon-wrapper"
+                className="md-icon-wrapper md-icon-no-shrink"
               >
                 <svg
                   className=""
@@ -285,7 +285,7 @@ exports[`<SearchInput /> snapshot should match snapshot when searching 1`] = `
               weight="regular"
             >
               <div
-                className="md-icon-wrapper md-loading-spinner-arch"
+                className="md-icon-wrapper md-loading-spinner-arch md-icon-no-shrink"
               >
                 <svg
                   className=""
@@ -371,7 +371,7 @@ exports[`<SearchInput /> snapshot should match snapshot with a label 1`] = `
           weight="bold"
         >
           <div
-            className="md-icon-wrapper md-search-input-search"
+            className="md-icon-wrapper md-search-input-search md-icon-no-shrink"
           >
             <svg
               className=""
@@ -450,7 +450,7 @@ exports[`<SearchInput /> snapshot should match snapshot with className 1`] = `
           weight="bold"
         >
           <div
-            className="md-icon-wrapper md-search-input-search"
+            className="md-icon-wrapper md-search-input-search md-icon-no-shrink"
           >
             <svg
               className=""
@@ -528,7 +528,7 @@ exports[`<SearchInput /> snapshot should match snapshot with height 1`] = `
           weight="bold"
         >
           <div
-            className="md-icon-wrapper md-search-input-search"
+            className="md-icon-wrapper md-search-input-search md-icon-no-shrink"
           >
             <svg
               className=""
@@ -607,7 +607,7 @@ exports[`<SearchInput /> snapshot should match snapshot with id 1`] = `
           weight="bold"
         >
           <div
-            className="md-icon-wrapper md-search-input-search"
+            className="md-icon-wrapper md-search-input-search md-icon-no-shrink"
           >
             <svg
               className=""
@@ -694,7 +694,7 @@ exports[`<SearchInput /> snapshot should match snapshot with style 1`] = `
           weight="bold"
         >
           <div
-            className="md-icon-wrapper md-search-input-search"
+            className="md-icon-wrapper md-search-input-search md-icon-no-shrink"
           >
             <svg
               className=""

--- a/src/components/Select/Select.unit.test.tsx.snap
+++ b/src/components/Select/Select.unit.test.tsx.snap
@@ -173,7 +173,7 @@ exports[`Select snapshot should match snapshot 1`] = `
               class="md-select-icon-wrapper"
             >
               <div
-                class="md-icon-wrapper"
+                class="md-icon-wrapper md-icon-no-shrink"
               >
                 <svg
                   class=""
@@ -285,7 +285,7 @@ exports[`Select snapshot should match snapshot 1`] = `
               weight="bold"
             >
               <div
-                className="md-icon-wrapper"
+                className="md-icon-wrapper md-icon-no-shrink"
               >
                 <svg
                   className=""
@@ -481,7 +481,7 @@ exports[`Select snapshot should match snapshot before and after opening select d
               class="md-select-icon-wrapper"
             >
               <div
-                class="md-icon-wrapper"
+                class="md-icon-wrapper md-icon-no-shrink"
               >
                 <svg
                   class=""
@@ -593,7 +593,7 @@ exports[`Select snapshot should match snapshot before and after opening select d
               weight="bold"
             >
               <div
-                className="md-icon-wrapper"
+                className="md-icon-wrapper md-icon-no-shrink"
               >
                 <svg
                   className=""
@@ -790,7 +790,7 @@ exports[`Select snapshot should match snapshot before and after opening select d
               class="md-select-icon-wrapper"
             >
               <div
-                class="md-icon-wrapper"
+                class="md-icon-wrapper md-icon-no-shrink"
               >
                 <svg
                   class=""
@@ -902,7 +902,7 @@ exports[`Select snapshot should match snapshot before and after opening select d
               weight="bold"
             >
               <div
-                className="md-icon-wrapper"
+                className="md-icon-wrapper md-icon-no-shrink"
               >
                 <svg
                   className=""
@@ -1577,7 +1577,7 @@ exports[`Select snapshot should match snapshot with className 1`] = `
               class="md-select-icon-wrapper"
             >
               <div
-                class="md-icon-wrapper"
+                class="md-icon-wrapper md-icon-no-shrink"
               >
                 <svg
                   class=""
@@ -1689,7 +1689,7 @@ exports[`Select snapshot should match snapshot with className 1`] = `
               weight="bold"
             >
               <div
-                className="md-icon-wrapper"
+                className="md-icon-wrapper md-icon-no-shrink"
               >
                 <svg
                   className=""
@@ -1886,7 +1886,7 @@ exports[`Select snapshot should match snapshot with direction 1`] = `
               class="md-select-icon-wrapper"
             >
               <div
-                class="md-icon-wrapper"
+                class="md-icon-wrapper md-icon-no-shrink"
               >
                 <svg
                   class=""
@@ -1998,7 +1998,7 @@ exports[`Select snapshot should match snapshot with direction 1`] = `
               weight="bold"
             >
               <div
-                className="md-icon-wrapper"
+                className="md-icon-wrapper md-icon-no-shrink"
               >
                 <svg
                   className=""
@@ -2205,7 +2205,7 @@ exports[`Select snapshot should match snapshot with disabled option 1`] = `
               class="md-select-icon-wrapper"
             >
               <div
-                class="md-icon-wrapper"
+                class="md-icon-wrapper md-icon-no-shrink"
               >
                 <svg
                   class=""
@@ -2317,7 +2317,7 @@ exports[`Select snapshot should match snapshot with disabled option 1`] = `
               weight="bold"
             >
               <div
-                className="md-icon-wrapper"
+                className="md-icon-wrapper md-icon-no-shrink"
               >
                 <svg
                   className=""
@@ -2995,7 +2995,7 @@ exports[`Select snapshot should match snapshot with id 1`] = `
               class="md-select-icon-wrapper"
             >
               <div
-                class="md-icon-wrapper"
+                class="md-icon-wrapper md-icon-no-shrink"
               >
                 <svg
                   class=""
@@ -3107,7 +3107,7 @@ exports[`Select snapshot should match snapshot with id 1`] = `
               weight="bold"
             >
               <div
-                className="md-icon-wrapper"
+                className="md-icon-wrapper md-icon-no-shrink"
               >
                 <svg
                   className=""
@@ -3305,7 +3305,7 @@ exports[`Select snapshot should match snapshot with listbox opened 1`] = `
               class="md-select-icon-wrapper"
             >
               <div
-                class="md-icon-wrapper"
+                class="md-icon-wrapper md-icon-no-shrink"
               >
                 <svg
                   class=""
@@ -3417,7 +3417,7 @@ exports[`Select snapshot should match snapshot with listbox opened 1`] = `
               weight="bold"
             >
               <div
-                className="md-icon-wrapper"
+                className="md-icon-wrapper md-icon-no-shrink"
               >
                 <svg
                   className=""
@@ -4094,7 +4094,7 @@ exports[`Select snapshot should match snapshot with placeholder 1`] = `
               class="md-select-icon-wrapper"
             >
               <div
-                class="md-icon-wrapper"
+                class="md-icon-wrapper md-icon-no-shrink"
               >
                 <svg
                   class=""
@@ -4208,7 +4208,7 @@ exports[`Select snapshot should match snapshot with placeholder 1`] = `
               weight="bold"
             >
               <div
-                className="md-icon-wrapper"
+                className="md-icon-wrapper md-icon-no-shrink"
               >
                 <svg
                   className=""
@@ -4431,7 +4431,7 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
               class="md-select-icon-wrapper"
             >
               <div
-                class="md-icon-wrapper"
+                class="md-icon-wrapper md-icon-no-shrink"
               >
                 <svg
                   class=""
@@ -4546,7 +4546,7 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
               weight="bold"
             >
               <div
-                className="md-icon-wrapper"
+                className="md-icon-wrapper md-icon-no-shrink"
               >
                 <svg
                   className=""
@@ -4771,7 +4771,7 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
               class="md-select-icon-wrapper"
             >
               <div
-                class="md-icon-wrapper"
+                class="md-icon-wrapper md-icon-no-shrink"
               >
                 <svg
                   class=""
@@ -4886,7 +4886,7 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
               weight="bold"
             >
               <div
-                className="md-icon-wrapper"
+                className="md-icon-wrapper md-icon-no-shrink"
               >
                 <svg
                   className=""
@@ -5269,7 +5269,7 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
                                   weight="bold"
                                 >
                                   <div
-                                    className="md-icon-wrapper md-list-box-item-tick-icon"
+                                    className="md-icon-wrapper md-list-box-item-tick-icon md-icon-no-shrink"
                                   >
                                     <svg
                                       className=""
@@ -5628,7 +5628,7 @@ exports[`Select snapshot should match snapshot with style 1`] = `
               class="md-select-icon-wrapper"
             >
               <div
-                class="md-icon-wrapper"
+                class="md-icon-wrapper md-icon-no-shrink"
               >
                 <svg
                   class=""
@@ -5740,7 +5740,7 @@ exports[`Select snapshot should match snapshot with style 1`] = `
               weight="bold"
             >
               <div
-                className="md-icon-wrapper"
+                className="md-icon-wrapper md-icon-no-shrink"
               >
                 <svg
                   className=""
@@ -5936,7 +5936,7 @@ exports[`Select snapshot should match snapshot with title 1`] = `
               class="md-select-icon-wrapper"
             >
               <div
-                class="md-icon-wrapper"
+                class="md-icon-wrapper md-icon-no-shrink"
               >
                 <svg
                   class=""
@@ -6049,7 +6049,7 @@ exports[`Select snapshot should match snapshot with title 1`] = `
               weight="bold"
             >
               <div
-                className="md-icon-wrapper"
+                className="md-icon-wrapper md-icon-no-shrink"
               >
                 <svg
                   className=""

--- a/src/components/SpaceListItem/SpaceListItem.unit.test.tsx.snap
+++ b/src/components/SpaceListItem/SpaceListItem.unit.test.tsx.snap
@@ -624,7 +624,7 @@ exports[`<SpaceListItem /> snapshot should match snapshot with isAlert 1`] = `
                 weight="bold"
               >
                 <div
-                  className="md-icon-wrapper"
+                  className="md-icon-wrapper md-icon-no-shrink"
                 >
                   <svg
                     className=""
@@ -734,7 +734,7 @@ exports[`<SpaceListItem /> snapshot should match snapshot with isAlertMuted 1`] 
                 weight="bold"
               >
                 <div
-                  className="md-icon-wrapper"
+                  className="md-icon-wrapper md-icon-no-shrink"
                 >
                   <svg
                     className=""
@@ -844,7 +844,7 @@ exports[`<SpaceListItem /> snapshot should match snapshot with isEnterRoom 1`] =
                 weight="bold"
               >
                 <div
-                  className="md-icon-wrapper"
+                  className="md-icon-wrapper md-icon-no-shrink"
                 >
                   <svg
                     className=""
@@ -954,7 +954,7 @@ exports[`<SpaceListItem /> snapshot should match snapshot with isError 1`] = `
                 weight="filled"
               >
                 <div
-                  className="md-icon-wrapper"
+                  className="md-icon-wrapper md-icon-no-shrink"
                 >
                   <svg
                     className=""
@@ -1064,7 +1064,7 @@ exports[`<SpaceListItem /> snapshot should match snapshot with isMention 1`] = `
                 weight="bold"
               >
                 <div
-                  className="md-icon-wrapper"
+                  className="md-icon-wrapper md-icon-no-shrink"
                 >
                   <svg
                     className=""
@@ -1340,7 +1340,7 @@ exports[`<SpaceListItem /> snapshot should match snapshot with isSelected and dr
                 weight="bold"
               >
                 <div
-                  className="md-icon-wrapper"
+                  className="md-icon-wrapper md-icon-no-shrink"
                 >
                   <svg
                     className=""
@@ -1450,7 +1450,7 @@ exports[`<SpaceListItem /> snapshot should match snapshot with isUnread 1`] = `
                 weight="bold"
               >
                 <div
-                  className="md-icon-wrapper"
+                  className="md-icon-wrapper md-icon-no-shrink"
                 >
                   <svg
                     className=""

--- a/src/components/Tab/Tab.unit.test.tsx.snap
+++ b/src/components/Tab/Tab.unit.test.tsx.snap
@@ -365,7 +365,7 @@ exports[`<Tab /> snapshot Icon children should match snapshot 1`] = `
             weight="bold"
           >
             <div
-              className="md-icon-wrapper"
+              className="md-icon-wrapper md-icon-no-shrink"
             >
               <svg
                 className=""
@@ -428,7 +428,7 @@ exports[`<Tab /> snapshot Icon children should match snapshot with active 1`] = 
             weight="bold"
           >
             <div
-              className="md-icon-wrapper"
+              className="md-icon-wrapper md-icon-no-shrink"
             >
               <svg
                 className=""
@@ -491,7 +491,7 @@ exports[`<Tab /> snapshot Icon children should match snapshot with className 1`]
             weight="bold"
           >
             <div
-              className="md-icon-wrapper"
+              className="md-icon-wrapper md-icon-no-shrink"
             >
               <svg
                 className=""
@@ -554,7 +554,7 @@ exports[`<Tab /> snapshot Icon children should match snapshot with disabled 1`] 
             weight="bold"
           >
             <div
-              className="md-icon-wrapper"
+              className="md-icon-wrapper md-icon-no-shrink"
             >
               <svg
                 className=""
@@ -619,7 +619,7 @@ exports[`<Tab /> snapshot Icon children should match snapshot with id 1`] = `
             weight="bold"
           >
             <div
-              className="md-icon-wrapper"
+              className="md-icon-wrapper md-icon-no-shrink"
             >
               <svg
                 className=""
@@ -696,7 +696,7 @@ exports[`<Tab /> snapshot Icon children should match snapshot with style 1`] = `
             weight="bold"
           >
             <div
-              className="md-icon-wrapper"
+              className="md-icon-wrapper md-icon-no-shrink"
             >
               <svg
                 className=""

--- a/src/components/TextInput/TextInput.unit.test.tsx.snap
+++ b/src/components/TextInput/TextInput.unit.test.tsx.snap
@@ -181,7 +181,7 @@ exports[`<TextInput/> snapshot should match snapshot with error text 1`] = `
                   weight="bold"
                 >
                   <div
-                    className="md-icon-wrapper"
+                    className="md-icon-wrapper md-icon-no-shrink"
                   >
                     <svg
                       className=""

--- a/src/components/ToastNotification/ToastNotification.unit.test.tsx.snap
+++ b/src/components/ToastNotification/ToastNotification.unit.test.tsx.snap
@@ -305,7 +305,7 @@ exports[`<ToastNotification /> snapshot should match snapshot with leading visua
             weight="bold"
           >
             <div
-              className="md-icon-wrapper"
+              className="md-icon-wrapper md-icon-no-shrink"
             >
               <svg
                 className=""


### PR DESCRIPTION
# Description

Icons without a set scale/size should shrink and adopt to their parent component. To allow that, we should only apply flex-shrink to the icons that have a scale defined. 
