### PR TITLE
[Do-not-merge-yet] feat(consume-new-icons): consume new momentum-design icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0",
+    "@momentum-design/icons": "^0.0.2",
     "@momentum-ui/animations": "^1.4.0",
     "@momentum-ui/design-tokens": "^0.0.59",
     "@momentum-ui/icons": "8.28.4",

--- a/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -97,7 +97,7 @@ AudioVideoControls.parameters = {
           placement="top-end"
           triggerComponent={
             <ButtonCircle outline ghost key="1" size={40}>
-              <Icon name="arrow-down-optical" autoScale={100} />
+              <Icon name="arrow-down" autoScale={100} />
             </ButtonCircle>
           }
           children={[
@@ -126,7 +126,7 @@ AudioVideoControls.parameters = {
           </div>
         </ButtonPill>,
         <ButtonCircle outline ghost key="1" size={40}>
-          <Icon name="arrow-down-optical" autoScale={100} />
+          <Icon name="arrow-down" autoScale={100} />
         </ButtonCircle>,
       ],
       round: true,
@@ -135,13 +135,13 @@ AudioVideoControls.parameters = {
     {
       children: [
         <ButtonPill outline ghost key="0" size={40} style={{ minWidth: '8.3rem' }}>
-          <Icon key="0" name="camera-on-colored" autoScale={125} style={{ marginLeft: 'auto' }} />
+          <Icon key="0" name="camera-on" autoScale={125} style={{ marginLeft: 'auto' }} />
           <div key="1" style={{ marginRight: 'auto' }}>
             Stop Video
           </div>
         </ButtonPill>,
         <ButtonCircle outline ghost key="1" size={40}>
-          <Icon name="arrow-down-optical" autoScale={100} />
+          <Icon name="arrow-down" autoScale={100} />
         </ButtonCircle>,
       ],
       round: true,
@@ -154,7 +154,7 @@ AudioVideoControls.parameters = {
           <div key="1">Start Video</div>
         </ButtonPill>,
         <ButtonCircle outline ghost key="1" size={40}>
-          <Icon name="arrow-down-optical" autoScale={100} />
+          <Icon name="arrow-down" autoScale={100} />
         </ButtonCircle>,
       ],
       round: true,
@@ -167,7 +167,7 @@ AudioVideoControls.parameters = {
           <div key="1">Long Label Possibly German</div>
         </ButtonPill>,
         <ButtonCircle outline ghost key="1" size={40}>
-          <Icon name="arrow-down-optical" autoScale={100} />
+          <Icon name="arrow-down" autoScale={100} />
         </ButtonCircle>,
       ],
       round: true,

--- a/src/components/Icon/Icon.stories.docs.mdx
+++ b/src/components/Icon/Icon.stories.docs.mdx
@@ -30,8 +30,8 @@ The internal logic to find icons is as follows: `resolvedSVGName` = `name` + `we
 | `<Icon name="cancel" weight="regular"/>`                   | `cancel-regular.svg`                         |                                                                      | <Icon name="cancel" weight="regular"/>                   |
 | `<Icon name="cancel" weight="bold"/>`                      | `cancel-bold.svg`                            |                                                                      | <Icon name="cancel" weight="bold"/>                      |
 | `<Icon name="cancel" weight="filled"/>`                    | `cancel-filled.svg`                          | Weight `filled` for `cancel` icon doens't exist.                     | <Icon name="cancel" weight="filled"/>                    |
-| `<Icon name="webex-assistant-active-colored" weightless/>` | `webex-assistant-active-colored.svg`         |                                                                      | <Icon name="webex-assistant-active-colored" weightless/> |
-| `<Icon name="webex-assistant-active-colored"/>`            | `webex-assistant-active-colored-regular.svg` | ⚠️ This will break! Make sure you check if the icon supports weights. | <Icon name="webex-assistant-active-colored" />           |
+| `<Icon name="webex-assistant-active" weightless/>`         | `webex-assistant-active.svg`                 |                                                                      | <Icon name="webex-assistant-active" weightless/>         |
+| `<Icon name="webex-assistant-active"/>`                    | `webex-assistant-active-regular.svg`         | ⚠️ This will break! Make sure you check if the icon supports weights. | <Icon name="webex-assistant-active" />                   |
 
 # Figma Icons Library
 

--- a/src/components/LoadingSpinner/LoadingSpinner.constants.ts
+++ b/src/components/LoadingSpinner/LoadingSpinner.constants.ts
@@ -6,7 +6,7 @@ const DEFAULTS = {
 
 const STYLE = {
   wrapper: `${CLASS_PREFIX}-wrapper`,
-  arch: `${CLASS_PREFIX}-arch`,
+  icon: `${CLASS_PREFIX}-icon`,
 };
 
 export { CLASS_PREFIX, DEFAULTS, STYLE };

--- a/src/components/LoadingSpinner/LoadingSpinner.style.scss
+++ b/src/components/LoadingSpinner/LoadingSpinner.style.scss
@@ -1,10 +1,6 @@
 .md-loading-spinner-wrapper {
   position: relative;
 
-  svg {
-    fill: var(--spinner-loading-track);
-  }
-
   @keyframes spin-animation {
     from {
       transform: rotate(0deg);
@@ -15,15 +11,17 @@
     }
   }
 
-  .md-loading-spinner-arch {
-    position: absolute;
-    top: 0;
+  .md-loading-spinner-icon {
     animation-name: spin-animation;
     animation-duration: 0.75s;
     animation-iteration-count: infinite;
     animation-timing-function: linear;
 
-    svg {
+    svg > path:first-child {
+      fill: var(--spinner-loading-track);
+    }
+
+    svg > path:nth-child(2) {
       fill: var(--spinner-loading-cursor);
     }
   }

--- a/src/components/LoadingSpinner/LoadingSpinner.tsx
+++ b/src/components/LoadingSpinner/LoadingSpinner.tsx
@@ -11,8 +11,7 @@ const LoadingSpinner: FC<Props> = (props: Props) => {
 
   return (
     <div className={classnames(className, STYLE.wrapper)} id={id} style={style} {...rest}>
-      <Icon scale={scale} name="spinner" weight="regular" />
-      <Icon scale={scale} className={STYLE.arch} name="spinner-partial" weight="regular" />
+      <Icon className={STYLE.icon} scale={scale} name="spinner-filled" weight="regular" />
     </div>
   );
 };

--- a/src/hooks/useDynamicSVGImport.test.ts
+++ b/src/hooks/useDynamicSVGImport.test.ts
@@ -10,7 +10,7 @@ describe('Icon', () => {
     const onErrorMock = jest.fn();
     const mockSVG = 'SVG_CONTENT';
     jest.mock(
-      '@momentum-ui/icons-rebrand/svg/test_icon-regular.svg?svgr',
+      '@momentum-design/icons/dist/svg/test_icon-regular.svg?svgr',
       () => {
         return { ReactComponent: mockSVG };
       },
@@ -42,7 +42,7 @@ describe('Icon', () => {
     const expectedError = new Error('error');
 
     jest.mock(
-      '@momentum-ui/icons-rebrand/svg/bad_icon.svg?svgr',
+      '@momentum-design/icons/dist/svg/bad_icon.svg?svgr',
       () => {
         throw expectedError;
       },

--- a/src/hooks/useDynamicSVGImport.ts
+++ b/src/hooks/useDynamicSVGImport.ts
@@ -38,7 +38,7 @@ function useDynamicSVGImport(
       try {
         setError(undefined);
         ImportedIconRef.current = (
-          await import(`@momentum-ui/icons-rebrand/svg/${name}.svg?svgr`)
+          await import(`@momentum-design/icons/dist/svg/${name}.svg?svgr`)
         ).ReactComponent;
         if (isMounted()) {
           onCompleted?.(name, ImportedIconRef.current);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1822,6 +1822,11 @@
   resolved "https://registry.yarnpkg.com/@mdx-js/util/-/util-1.6.22.tgz#219dfd89ae5b97a8801f015323ffa4b62f45718b"
   integrity sha512-H1rQc1ZOHANWBvPcW+JpGwr+juXSxM8Q8YCkm3GhZd8REu1fHR3z99CErO1p9pkcfcxZnMdIZdIsXkOHY0NilA==
 
+"@momentum-design/icons@^0.0.2":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@momentum-design/icons/-/icons-0.0.2.tgz#e24ee0293bedf8a72df0629262ea1e5483dfef42"
+  integrity sha512-xMhFePSQd8rKfzfS7+gkbNUh2wWidbu+YNfT8uLV7MUvKmdqPTO2tF8QjQi5wFytA9WD9ULanbC4HeJ13notXA==
+
 "@momentum-ui/animations@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@momentum-ui/animations/-/animations-1.4.0.tgz#feafac71b564c3bc6433d3499ad5b9ea98196a39"


### PR DESCRIPTION
**Description of changes made (Required)**
Icons will be now published and automatically updated from Figma by the Design team on the [new icons repository](https://github.com/momentum-design/momentum-design/tree/main/packages/%40momentum-design/icons) consumable by [this npm package](https://www.npmjs.com/package/@momentum-design/icons).

The main difference between the new and old icons repo is that the new one mirrors exactly what is in [Figma icons library](https://www.figma.com/file/SXK8Gb5tMlN9xiG2cC4OBu/Assets---Icon-Library?node-id=0%3A1&t=SnCjaTtL5I27wDVc-1), given they are constantly in synch thanks to the new Figma plugin that Momentum Engineering has built for this. 

In this PR, some naming of icons have been changed in order for them to match exactly the name in the Figma icon library mentioned above. This prepares MRV2 to well-receive the migration to the new icons repo without any break. 

DO NOT MERGE THIS PR YET because the [new icon repo](https://github.com/momentum-design/momentum-design/tree/main/packages/%40momentum-design/icons) is not 100% in sync with Figma just yet. It will be soon.

_You must get at least 1 approved review from someone on the web-client team before you can push to our Jenkins pipeline_

