### PR TITLE
Fix/overlay alert/support no title

### DIFF
--- a/src/components/ModalContainer/index.ts
+++ b/src/components/ModalContainer/index.ts
@@ -1,9 +1,11 @@
 import { default as ModalContainer } from './ModalContainer';
 import * as CONSTANTS from './ModalContainer.constants';
-import type { Props } from './ModalContainer.types';
 
 export { CONSTANTS as MODAL_CONTAINER_CONSTANTS };
 
-export type ModalContainerProps = Props;
+export type {
+  Props as ModalContainerProps,
+  Color as ModalContainerColor,
+} from './ModalContainer.types';
 
 export default ModalContainer;

--- a/src/components/Overlay/index.ts
+++ b/src/components/Overlay/index.ts
@@ -1,9 +1,8 @@
 import { default as Overlay } from './Overlay';
 import * as CONSTANTS from './Overlay.constants';
-import { Props } from './Overlay.types';
 
 export { CONSTANTS as OVERLAY_CONSTANTS };
 
-export type OverlayProps = Props;
+export type { Props as OverlayProps, Color as OverlayColor } from './Overlay.types';
 
 export default Overlay;

--- a/src/components/OverlayAlert/OverlayAlert.stories.args.ts
+++ b/src/components/OverlayAlert/OverlayAlert.stories.args.ts
@@ -1,6 +1,9 @@
 import { commonStyles, extendArgTypes } from '../../storybook/helper.stories.argtypes';
 import { overlayArgTypes } from '../Overlay/Overlay.stories.args';
 
+import { MODAL_CONTAINER_CONSTANTS } from '../ModalContainer';
+import { OVERLAY_CONSTANTS } from '../Overlay';
+
 const overlayAlertArgTypes = {
   actions: {
     description:
@@ -53,6 +56,32 @@ const overlayAlertArgTypes = {
       },
     },
   },
+  modalColor: {
+    description: 'Provides the color for the modal container of this element.',
+    control: { type: 'select' },
+    options: [undefined, ...Object.values(MODAL_CONTAINER_CONSTANTS.COLORS)],
+    table: {
+      type: {
+        summary: 'ReactNode',
+      },
+      defaultValue: {
+        summary: MODAL_CONTAINER_CONSTANTS.DEFAULTS.COLOR,
+      },
+    },
+  },
+  overlayColor: {
+    description: 'Provides the color for the overlay of this element.',
+    control: { type: 'select' },
+    options: [undefined, ...Object.values(OVERLAY_CONSTANTS.COLORS)],
+    table: {
+      type: {
+        summary: 'ReactNode',
+      },
+      defaultValue: {
+        summary: OVERLAY_CONSTANTS.DEFAULTS.COLOR,
+      },
+    },
+  },
   title: {
     description: 'Provides the title within this component as a `string`.',
     control: { type: 'text' },
@@ -71,6 +100,6 @@ export { overlayAlertArgTypes };
 
 export default {
   ...commonStyles,
-  ...extendArgTypes('Overlay', overlayArgTypes),
+  ...extendArgTypes('Overlay', overlayArgTypes, ['color']),
   ...overlayAlertArgTypes,
 };

--- a/src/components/OverlayAlert/OverlayAlert.style.scss
+++ b/src/components/OverlayAlert/OverlayAlert.style.scss
@@ -4,7 +4,7 @@
     min-width: 20rem;
 
     > :first-child {
-      align-items: center;
+      align-items: flex-end;
       display: flex;
       justify-content: space-between;
       width: 100%;

--- a/src/components/OverlayAlert/OverlayAlert.tsx
+++ b/src/components/OverlayAlert/OverlayAlert.tsx
@@ -15,17 +15,29 @@ import './OverlayAlert.style.scss';
  * @beta
  */
 const OverlayAlert: FC<Props> = (props: Props) => {
-  const { actions, children, className, controls, details, title, ...other } = props;
+  const {
+    actions,
+    children,
+    className,
+    controls,
+    details,
+    modalColor,
+    overlayColor,
+    title,
+    ...other
+  } = props;
 
   return (
-    <Overlay className={classnames(className, STYLE.wrapper)} {...other}>
-      <ModalContainer>
+    <Overlay className={classnames(className, STYLE.wrapper)} color={overlayColor} {...other}>
+      <ModalContainer color={modalColor}>
         <div>
-          {!!title && (
-            <Text className={classnames(STYLE.title)} type="header-primary">
-              {title}
-            </Text>
-          )}
+          <div className={classnames(STYLE.title)}>
+            {!!title && (
+              <Text className={classnames(STYLE.title)} type="header-primary">
+                {title}
+              </Text>
+            )}
+          </div>
           <div>{controls}</div>
         </div>
         <div>

--- a/src/components/OverlayAlert/OverlayAlert.types.ts
+++ b/src/components/OverlayAlert/OverlayAlert.types.ts
@@ -1,9 +1,10 @@
-import { CSSProperties, ReactElement, ReactNode } from 'react';
+import type { CSSProperties, ReactElement, ReactNode } from 'react';
 
-import { ButtonControlProps } from '../ButtonControl';
-import { ButtonSimpleProps } from '../ButtonSimple';
-import { ButtonGroupProps } from '../ButtonGroup';
-import { OverlayProps } from '../Overlay';
+import type { ButtonControlProps } from '../ButtonControl';
+import type { ButtonSimpleProps } from '../ButtonSimple';
+import type { ButtonGroupProps } from '../ButtonGroup';
+import type { OverlayProps, OverlayColor } from '../Overlay';
+import type { ModalContainerColor } from '../ModalContainer';
 
 export type SupportedActions = ButtonSimpleProps | ButtonGroupProps;
 export type SupportedControls = ButtonControlProps;
@@ -38,6 +39,16 @@ export interface Props extends OverlayProps {
    * Custom id for overriding this component's CSS.
    */
   id?: string;
+
+  /**
+   * Color of the nested modal within this component.
+   */
+  modalColor?: ModalContainerColor;
+
+  /**
+   * Color of the overlay of this component.
+   */
+  overlayColor?: OverlayColor;
 
   /**
    * Custom style for overriding this component's CSS.

--- a/src/components/OverlayAlert/OverlayAlert.unit.test.tsx
+++ b/src/components/OverlayAlert/OverlayAlert.unit.test.tsx
@@ -3,6 +3,8 @@ import { mount } from 'enzyme';
 
 import ButtonControl from '../ButtonControl';
 import ButtonPill from '../ButtonPill';
+import ModalContainer, { MODAL_CONTAINER_CONSTANTS } from '../ModalContainer';
+import Overlay, { OVERLAY_CONSTANTS } from '../Overlay';
 
 import OverlayAlert, { OVERLAY_ALERT_CONSTANTS as CONSTANTS, OVERLAY_ALERT_CONSTANTS } from './';
 
@@ -177,6 +179,26 @@ describe('<OverlayAlert />', () => {
       expect(element.getAttribute('style')).toBe(styleString);
     });
 
+    it('should provide the local <Overlay /> with its respective color', () => {
+      expect.assertions(1);
+
+      const overlayColor = Object.values(OVERLAY_CONSTANTS.COLORS).pop();
+
+      const element = mount(<OverlayAlert overlayColor={overlayColor} />).find(Overlay);
+
+      expect(element.props().color).toBe(overlayColor);
+    });
+
+    it('should provide the local <ModalContainer /> with its respective color', () => {
+      expect.assertions(1);
+
+      const modalColor = Object.values(MODAL_CONTAINER_CONSTANTS.COLORS).pop();
+
+      const element = mount(<OverlayAlert modalColor={modalColor} />).find(ModalContainer);
+
+      expect(element.props().color).toBe(modalColor);
+    });
+
     it('should have provided actions when actions is provided', () => {
       expect.assertions(1);
 
@@ -228,7 +250,19 @@ describe('<OverlayAlert />', () => {
         .getDOMNode()
         .getElementsByClassName(OVERLAY_ALERT_CONSTANTS.STYLE.title)[0];
 
-      expect(target.innerHTML).toBe(title);
+      expect(target.innerHTML.includes(title)).toBe(true);
+    });
+
+    it('should still render a empty div with the appropriate class when no title is provided', () => {
+      expect.assertions(1);
+
+      const component = mount(<OverlayAlert />).find(OverlayAlert);
+
+      const target = component
+        .getDOMNode()
+        .getElementsByClassName(OVERLAY_ALERT_CONSTANTS.STYLE.title)[0];
+
+      expect(target.classList.contains(OVERLAY_ALERT_CONSTANTS.STYLE.title)).toBe(true);
     });
 
     it('should have provided children when details and children are provided', () => {

--- a/src/components/OverlayAlert/OverlayAlert.unit.test.tsx.snap
+++ b/src/components/OverlayAlert/OverlayAlert.unit.test.tsx.snap
@@ -19,6 +19,9 @@ exports[`<OverlayAlert /> snapshot should match snapshot 1`] = `
           data-round={0}
         >
           <div>
+            <div
+              className="md-overlay-alert-title"
+            />
             <div />
           </div>
           <div />
@@ -55,6 +58,9 @@ exports[`<OverlayAlert /> snapshot should match snapshot with actions 1`] = `
           data-round={0}
         >
           <div>
+            <div
+              className="md-overlay-alert-title"
+            />
             <div />
           </div>
           <div />
@@ -137,6 +143,9 @@ exports[`<OverlayAlert /> snapshot should match snapshot with className 1`] = `
           data-round={0}
         >
           <div>
+            <div
+              className="md-overlay-alert-title"
+            />
             <div />
           </div>
           <div />
@@ -173,6 +182,9 @@ exports[`<OverlayAlert /> snapshot should match snapshot with controls 1`] = `
           data-round={0}
         >
           <div>
+            <div
+              className="md-overlay-alert-title"
+            />
             <div>
               <ButtonControl
                 control="close"
@@ -245,6 +257,9 @@ exports[`<OverlayAlert /> snapshot should match snapshot with details 1`] = `
           data-round={0}
         >
           <div>
+            <div
+              className="md-overlay-alert-title"
+            />
             <div />
           </div>
           <div>
@@ -289,6 +304,9 @@ exports[`<OverlayAlert /> snapshot should match snapshot with details and childr
           data-round={0}
         >
           <div>
+            <div
+              className="md-overlay-alert-title"
+            />
             <div />
           </div>
           <div>
@@ -325,6 +343,9 @@ exports[`<OverlayAlert /> snapshot should match snapshot with id 1`] = `
           data-round={0}
         >
           <div>
+            <div
+              className="md-overlay-alert-title"
+            />
             <div />
           </div>
           <div />
@@ -372,6 +393,9 @@ exports[`<OverlayAlert /> snapshot should match snapshot with multiple actions 1
           data-round={0}
         >
           <div>
+            <div
+              className="md-overlay-alert-title"
+            />
             <div />
           </div>
           <div />
@@ -576,6 +600,9 @@ exports[`<OverlayAlert /> snapshot should match snapshot with multiple controls 
           data-round={0}
         >
           <div>
+            <div
+              className="md-overlay-alert-title"
+            />
             <div>
               <ButtonControl
                 control="close"
@@ -747,6 +774,9 @@ exports[`<OverlayAlert /> snapshot should match snapshot with style 1`] = `
           data-round={0}
         >
           <div>
+            <div
+              className="md-overlay-alert-title"
+            />
             <div />
           </div>
           <div />
@@ -779,17 +809,21 @@ exports[`<OverlayAlert /> snapshot should match snapshot with title 1`] = `
           data-round={0}
         >
           <div>
-            <Text
+            <div
               className="md-overlay-alert-title"
-              type="header-primary"
             >
-              <h3
-                className="md-text-wrapper md-overlay-alert-title"
-                data-type="header-primary"
+              <Text
+                className="md-overlay-alert-title"
+                type="header-primary"
               >
-                example-title
-              </h3>
-            </Text>
+                <h3
+                  className="md-text-wrapper md-overlay-alert-title"
+                  data-type="header-primary"
+                >
+                  example-title
+                </h3>
+              </Text>
+            </div>
             <div />
           </div>
           <div />

--- a/src/components/ThemeProvider/ThemeProvider.style.scss
+++ b/src/components/ThemeProvider/ThemeProvider.style.scss
@@ -133,7 +133,8 @@
   // Firefox fix for scrollbar
   // On macOS, you need to set the General > Show scroll bars
   // setting in System Preferences to "Always" for this property to have any effect.
-  scrollbar-color: var(--mds-color-theme-scrollbar-background-secondary-normal) var(--mds-color-theme-scrollbar-button-normal);
+  scrollbar-color: var(--mds-color-theme-scrollbar-background-secondary-normal)
+    var(--mds-color-theme-scrollbar-button-normal);
 }
 
 /* Global variables not available as tokens. */
@@ -143,7 +144,8 @@
     0 0 0 0.125rem var(--mds-color-theme-outline-theme-normal);
   --md-globals-focus-ring-box-shadow-accent: 0 0 0 0.0625rem
       var(--mds-color-theme-background-solid-primary-normal),
-    0 0 0 0.3125rem rgba(100, 180, 250, 0.3), 0 0 0 0.1875rem var(--mds-color-theme-outline-theme-normal);
+    0 0 0 0.3125rem rgba(100, 180, 250, 0.3),
+    0 0 0 0.1875rem var(--mds-color-theme-outline-theme-normal);
   --md-globals-focus-ring-box-shadow-inset: var(--md-globals-focus-ring-box-shadow) inset;
   --md-globals-elevation-0: 0 0 0 rgba(0, 0, 0, 0.2), 0 0 0.0625rem rgba(0, 0, 0, 0.11);
   --md-globals-elevation-1: 0 0.25rem 0.5rem rgba(0, 0, 0, 0.2), 0 0 0.0625rem rgba(0, 0, 0, 0.11);
@@ -156,6 +158,8 @@
   --md-globals-elevation-8: 0 2rem 4rem rgba(0, 0, 0, 0.2), 0 0 0.0625rem rgba(0, 0, 0, 0.11);
   --md-globals-focus-ring-outline: none;
   --md-globals-font-default: 'CiscoSansTT';
+  --md-globals-border-style-none: none;
+  --md-globals-border-style-solid: solid;
 
   // Gradient backgrounds
   --md-globals-gradient-primary: var(--mds-color-theme-background-gradient-primary);


### PR DESCRIPTION
# Description

The scope of the changes in this pull request are to add support for the lack of a `title` prop to `<OverlayAlert />` and to add color props to the existing `<OverlayAlert />` component that bubble into `<ModalContainer />` and `<Overlay />` respectively. This also is inclusive of a small fix around border style globals and exports of additional types.