### PR TITLE
fix(buttongroup): added role prop for accessibility

### DIFF
--- a/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.tsx
@@ -6,7 +6,7 @@ import { Props } from './ButtonGroup.types';
 import './ButtonGroup.style.scss';
 
 const ButtonGroup: FC<Props> = (props: Props) => {
-  const { children, className, id, round, spaced, compressed, style } = props;
+  const { children, className, id, round, spaced, compressed, style, role } = props;
 
   return (
     <div
@@ -16,6 +16,7 @@ const ButtonGroup: FC<Props> = (props: Props) => {
       data-compressed={compressed || DEFAULTS.COMPRESSED}
       id={id}
       style={style}
+      role={role}
     >
       {children}
     </div>

--- a/src/components/ButtonGroup/ButtonGroup.types.ts
+++ b/src/components/ButtonGroup/ButtonGroup.types.ts
@@ -40,4 +40,9 @@ export interface Props {
    * Custom style for overriding this component's CSS.
    */
   style?: CSSProperties;
+
+  /**
+   * Role for adding accessibility
+   */
+  role?: string;
 }

--- a/src/components/ButtonGroup/ButtonGroup.unit.test.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.unit.test.tsx
@@ -73,6 +73,16 @@ describe('<ButtonPill />', () => {
 
       expect(container).toMatchSnapshot();
     });
+
+    it('should match snapshot with role', () => {
+      expect.assertions(1);
+
+      const role = 'tablist';
+
+      container = mount(<ButtonGroup role={role}>{childrenTemplate}</ButtonGroup>);
+
+      expect(container).toMatchSnapshot();
+    });
   });
 
   describe('attributes', () => {
@@ -145,6 +155,18 @@ describe('<ButtonPill />', () => {
         .getDOMNode();
 
       expect(element.getAttribute('data-round')).toBe(`${round}`);
+    });
+
+    it('should pass role prop', () => {
+      expect.assertions(1);
+
+      const role = 'tablist';
+
+      const element = mount(<ButtonGroup role={role}>{childrenTemplate}</ButtonGroup>)
+        .find(ButtonGroup)
+        .getDOMNode();
+
+      expect(element.getAttribute('role')).toBe(role);
     });
   });
 });

--- a/src/components/ButtonGroup/ButtonGroup.unit.test.tsx.snap
+++ b/src/components/ButtonGroup/ButtonGroup.unit.test.tsx.snap
@@ -324,6 +324,121 @@ exports[`<ButtonPill /> snapshot should match snapshot with id 1`] = `
 </ButtonCircle>
 `;
 
+exports[`<ButtonPill /> snapshot should match snapshot with role 1`] = `
+<ButtonGroup
+  role="tablist"
+>
+  <div
+    className="md-button-group-wrapper"
+    data-compressed={false}
+    data-round={false}
+    data-spaced={false}
+    role="tablist"
+  >
+    <ButtonPill
+      key="0"
+    >
+      <ButtonSimple
+        className="md-button-pill-wrapper"
+        data-color="primary"
+        data-disabled={false}
+        data-ghost={false}
+        data-grown={false}
+        data-outline={false}
+        data-size={40}
+        data-solid={false}
+      >
+        <FocusRing>
+          <FocusRing
+            focusClass="md-focus-ring-wrapper children"
+            focusRingClass="md-focus-ring-wrapper children"
+          >
+            <button
+              className="md-button-pill-wrapper md-button-simple-wrapper"
+              data-color="primary"
+              data-disabled={false}
+              data-ghost={false}
+              data-grown={false}
+              data-outline={false}
+              data-size={40}
+              data-solid={false}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onDragStart={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+              onTouchCancel={[Function]}
+              onTouchEnd={[Function]}
+              onTouchMove={[Function]}
+              onTouchStart={[Function]}
+              type="button"
+            >
+              <span>
+                Example A
+              </span>
+            </button>
+          </FocusRing>
+        </FocusRing>
+      </ButtonSimple>
+    </ButtonPill>
+    <ButtonCircle
+      key="1"
+    >
+      <ButtonSimple
+        className="md-button-circle-wrapper"
+        data-color="primary"
+        data-disabled={false}
+        data-ghost={false}
+        data-multiple-children={false}
+        data-outline={false}
+        data-size={40}
+      >
+        <FocusRing>
+          <FocusRing
+            focusClass="md-focus-ring-wrapper children"
+            focusRingClass="md-focus-ring-wrapper children"
+          >
+            <button
+              className="md-button-circle-wrapper md-button-simple-wrapper"
+              data-color="primary"
+              data-disabled={false}
+              data-ghost={false}
+              data-multiple-children={false}
+              data-outline={false}
+              data-size={40}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onDragStart={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+              onTouchCancel={[Function]}
+              onTouchEnd={[Function]}
+              onTouchMove={[Function]}
+              onTouchStart={[Function]}
+              type="button"
+            >
+              <span>
+                A
+              </span>
+            </button>
+          </FocusRing>
+        </FocusRing>
+      </ButtonSimple>
+    </ButtonCircle>
+  </div>
+</ButtonGroup>
+`;
+
 exports[`<ButtonPill /> snapshot should match snapshot with round 1`] = `
 <ButtonGroup
   round={true}

--- a/src/components/ButtonSimple/ButtonSimple.tsx
+++ b/src/components/ButtonSimple/ButtonSimple.tsx
@@ -15,7 +15,7 @@ import './ButtonSimple.style.scss';
  */
 
 const ButtonSimple = forwardRef((props: Props, providedRef: RefObject<HTMLButtonElement>) => {
-  const { children, className, isDisabled, id, style, title, useNativeKeyDown } = props;
+  const { children, className, isDisabled, id, style, title, useNativeKeyDown, role } = props;
   const internalRef = useRef();
   const ref = providedRef || internalRef;
 
@@ -34,6 +34,7 @@ const ButtonSimple = forwardRef((props: Props, providedRef: RefObject<HTMLButton
         {...hoverProps}
         // override of onKeyDown to ensure the standard html button behavior (on enter => onClick) happens
         onKeyDown={useNativeKeyDown ? props.onKeyDown : buttonProps.onKeyDown}
+        role={role}
       >
         {typeof children === 'string' ? <span>{children}</span> : children}
       </button>

--- a/src/components/ButtonSimple/ButtonSimple.types.ts
+++ b/src/components/ButtonSimple/ButtonSimple.types.ts
@@ -34,4 +34,9 @@ export interface Props extends AriaButtonProps, HoverProps {
    * This is necessary since `react-aria` supress that behaviour by design.
    */
   useNativeKeyDown?: boolean;
+
+  /**
+   * Role for adding accessibility
+   */
+  role?: string;
 }

--- a/src/components/ButtonSimple/ButtonSimple.unit.test.tsx
+++ b/src/components/ButtonSimple/ButtonSimple.unit.test.tsx
@@ -63,6 +63,16 @@ describe('<ButtonSimple />', () => {
 
       expect(container).toMatchSnapshot();
     });
+
+    it('should match snapshot with role', () => {
+      expect.assertions(1);
+
+      const role = 'tab';
+
+      const container = mount(<ButtonSimple role={role} />);
+
+      expect(container).toMatchSnapshot();
+    });
   });
 
   describe('attributes', () => {
@@ -113,6 +123,18 @@ describe('<ButtonSimple />', () => {
         .getDOMNode();
 
       expect(element.getAttribute('title')).toBe(title);
+    });
+
+    it('should have the role when provided', () => {
+      expect.assertions(1);
+
+      const role = 'tab';
+
+      const element = mount(<ButtonSimple role={role} />)
+        .find(ButtonSimple)
+        .getDOMNode();
+
+      expect(element.getAttribute('role')).toBe(role);
     });
   });
 

--- a/src/components/ButtonSimple/ButtonSimple.unit.test.tsx.snap
+++ b/src/components/ButtonSimple/ButtonSimple.unit.test.tsx.snap
@@ -129,6 +129,39 @@ exports[`<ButtonSimple /> snapshot should match snapshot with id 1`] = `
 </ButtonSimple>
 `;
 
+exports[`<ButtonSimple /> snapshot should match snapshot with role 1`] = `
+<ButtonSimple
+  role="tab"
+>
+  <FocusRing>
+    <FocusRing
+      focusClass="md-focus-ring-wrapper children"
+      focusRingClass="md-focus-ring-wrapper children"
+    >
+      <button
+        className="md-button-simple-wrapper"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onDragStart={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        onTouchCancel={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
+        role="tab"
+        type="button"
+      />
+    </FocusRing>
+  </FocusRing>
+</ButtonSimple>
+`;
+
 exports[`<ButtonSimple /> snapshot should match snapshot with style 1`] = `
 <ButtonSimple
   style={


### PR DESCRIPTION
# Description


PR to add role prop for ButtonGroup and ButtonSimple components for accessibility fixes related to [Jira](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-367395). 
Right now the tablist and tab roles are not getting reflected due to which screen readers cannot correctly work on the Space List Header buttons (All, Direct and Spaces).