### PR TITLE
feat(listitem): navigation with child elements

### DIFF
--- a/src/components/List/List.unit.test.tsx
+++ b/src/components/List/List.unit.test.tsx
@@ -240,7 +240,7 @@ describe('<List />', () => {
     });
 
     it('should handle focus on tabbable elements in the list row', async () => {
-      expect.assertions(11);
+      expect.assertions(10);
       const user = userEvent.setup();
 
       const { getAllByRole } = render(
@@ -267,40 +267,36 @@ describe('<List />', () => {
 
       expect(listItems[0]).toHaveFocus();
 
-      await user.tab();
+      await user.keyboard('{ArrowRight}');
       expect(inputs[0]).toHaveFocus();
 
-      await user.tab();
+      await user.keyboard('{ArrowRight}');
       expect(buttons[0]).toHaveFocus();
 
       await user.tab();
       expect(document.body).toHaveFocus();
 
       await user.tab({ shift: true });
-      expect(buttons[0]).toHaveFocus();
+      expect(listItems[0]).toHaveFocus();
 
-      await user.tab({ shift: true });
+      await user.keyboard('{ArrowRight}');
 
       expect(inputs[0]).toHaveFocus();
 
       await user.keyboard('{ArrowDown}');
       expect(listItems[1]).toHaveFocus();
 
-      await user.tab();
+      await user.keyboard('{ArrowRight}');
 
       expect(inputs[1]).toHaveFocus();
 
-      await user.tab();
+      await user.keyboard('{ArrowRight}');
 
       expect(buttons[1]).toHaveFocus();
 
-      await user.tab({ shift: true });
+      await user.keyboard('{ArrowLeft}');
 
       expect(inputs[1]).toHaveFocus();
-
-      await user.tab({ shift: true });
-
-      expect(listItems[1]).toHaveFocus();
     });
 
     it('should handle menu in the list item', async () => {
@@ -326,7 +322,7 @@ describe('<List />', () => {
 
       expect(listItems[0]).toHaveFocus();
 
-      await user.tab();
+      await user.keyboard('{ArrowRight}');
       await user.keyboard('{Enter}');
 
       const firstMenuItem = (await findAllByText('menu item 1'))[0].closest('li');
@@ -365,7 +361,7 @@ describe('<List />', () => {
 
       expect(listItems[0]).toHaveFocus();
 
-      await user.tab();
+      await user.keyboard('{ArrowRight}');
       expect(buttons[0]).toHaveFocus();
 
       const updatedButton = await findAllByText('muted');

--- a/src/components/ListItemBase/ListItemBase.constants.ts
+++ b/src/components/ListItemBase/ListItemBase.constants.ts
@@ -27,4 +27,14 @@ const STYLE = {
   contextMenuWrapper: `${CLASS_PREFIX}-context-menu-wrapper`,
 };
 
-export { DEFAULTS, STYLE, SIZES, SHAPES };
+const KEYS = {
+  TAB_KEY: 'Tab',
+  ENTER_KEY: 'Enter',
+  SPACE_KEY: ' ',
+  LEFT_KEY: 'ArrowLeft',
+  UP_KEY: 'ArrowUp',
+  RIGHT_KEY: 'ArrowRight',
+  DOWN_KEY: 'ArrowDown',
+};
+
+export { DEFAULTS, KEYS, STYLE, SIZES, SHAPES };

--- a/src/components/ListItemBase/ListItemBase.tsx
+++ b/src/components/ListItemBase/ListItemBase.tsx
@@ -21,7 +21,11 @@ import { useOverlay } from '@react-aria/overlays';
 import { useListContext } from '../List/List.utils';
 import ButtonSimple from '../ButtonSimple';
 import Text from '../Text';
-import { getKeyboardFocusableElements, useDidUpdateEffect } from './ListItemBase.utils';
+import {
+  getKeyboardFocusableElements,
+  handleLeftRightArrowNavigation,
+  useDidUpdateEffect,
+} from './ListItemBase.utils';
 import { useMutationObservable } from '../../hooks/useMutationObservable';
 
 //TODO: Implement multi-line
@@ -97,48 +101,12 @@ const ListItemBase = (props: Props, providedRef: RefObject<HTMLLIElement>) => {
         pressProps.onKeyDown(event);
       }
 
-      const { target, key } = event;
-      if (key === KEYS.RIGHT_KEY) {
-        // right keycode
-        let newTarget;
+      if (event.key === KEYS.RIGHT_KEY || event.key === KEYS.LEFT_KEY) {
         if (!navigableChildren.current) {
           navigableChildren.current = getKeyboardFocusableElements(ref.current, false);
         }
         if (navigableChildren.current.length > 0) {
-          const index = navigableChildren.current.indexOf(target);
-          if (index > -1) {
-            if (index + 1 < navigableChildren.current.length) {
-              newTarget = navigableChildren.current[index + 1];
-            } else {
-              newTarget = navigableChildren.current[0];
-            }
-          } else {
-            newTarget = navigableChildren.current[0];
-          }
-          event.preventDefault();
-          event.stopPropagation();
-          newTarget.focus();
-        }
-      } else if (key === KEYS.LEFT_KEY) {
-        // left keycode
-        let newTarget;
-        if (!navigableChildren.current) {
-          navigableChildren.current = getKeyboardFocusableElements(ref.current, false);
-        }
-        if (navigableChildren.current.length > 0) {
-          const index = navigableChildren.current.indexOf(target);
-          if (index > -1) {
-            if (index > 0) {
-              newTarget = navigableChildren.current[index - 1];
-            } else {
-              newTarget = navigableChildren.current[navigableChildren.current.length - 1];
-            }
-          } else {
-            newTarget = navigableChildren.current[navigableChildren.current.length - 1];
-          }
-          event.preventDefault();
-          event.stopPropagation();
-          newTarget.focus();
+          handleLeftRightArrowNavigation(event, navigableChildren.current);
         }
       }
     },

--- a/src/components/ListItemBase/ListItemBase.unit.test.tsx
+++ b/src/components/ListItemBase/ListItemBase.unit.test.tsx
@@ -1,8 +1,13 @@
+import ListItemBaseSection from '../ListItemBaseSection';
+import ButtonPill from '../ButtonPill';
 import ListItemBase from '.';
 import { mount } from 'enzyme';
 import React from 'react';
+import '@testing-library/jest-dom';
 import { STYLE } from './ListItemBase.constants';
 import * as ListContext from '../List/List.utils';
+import userEvent from '@testing-library/user-event';
+import { render } from '@testing-library/react';
 
 describe('ListItemBase', () => {
   let container;
@@ -253,6 +258,55 @@ describe('ListItemBase', () => {
       });
 
       expect(mockCallback).toBeCalledTimes(1);
+    });
+  });
+
+  describe('keydown', () => {
+    const renderWithButtons = () => {
+      container = render(
+        <ListItemBase data-testid="list-item-1" itemIndex={0}>
+          <ListItemBaseSection position="end">
+            <ButtonPill data-testid="first-button-1" color="join" size={24}>
+              Join
+            </ButtonPill>
+          </ListItemBaseSection>
+          <ListItemBaseSection position="end">
+            <ButtonPill data-testid="second-button-1" color="join" size={24}>
+              Join
+            </ButtonPill>
+          </ListItemBaseSection>
+        </ListItemBase>
+      );
+    };
+
+    it('should handle right arrow key', async () => {
+      const user = userEvent.setup();
+      renderWithButtons();
+
+      const { getByTestId } = container;
+      await user.tab();
+      await user.keyboard('{ArrowRight}');
+      expect(getByTestId('first-button-1')).toHaveFocus();
+      await user.keyboard('{ArrowRight}');
+      expect(getByTestId('second-button-1')).toHaveFocus();
+      // loop back
+      await user.keyboard('{ArrowRight}');
+      expect(getByTestId('first-button-1')).toHaveFocus();
+    });
+
+    it('should handle left arrow key', async () => {
+      const user = userEvent.setup();
+      renderWithButtons();
+
+      const { getByTestId } = container;
+      await user.tab();
+      await user.keyboard('{ArrowLeft}');
+      expect(getByTestId('second-button-1')).toHaveFocus();
+      await user.keyboard('{ArrowLeft}');
+      expect(getByTestId('first-button-1')).toHaveFocus();
+      // loop back
+      await user.keyboard('{ArrowLeft}');
+      expect(getByTestId('second-button-1')).toHaveFocus();
     });
   });
 });

--- a/src/components/ListItemBase/ListItemBase.utils.test.tsx
+++ b/src/components/ListItemBase/ListItemBase.utils.test.tsx
@@ -1,5 +1,9 @@
 import { renderHook } from '@testing-library/react-hooks';
-import { getKeyboardFocusableElements, useDidUpdateEffect } from './ListItemBase.utils';
+import {
+  getKeyboardFocusableElements,
+  handleLeftRightArrowNavigation,
+  useDidUpdateEffect,
+} from './ListItemBase.utils';
 
 describe('getKeyboardFocusableElements', () => {
   const createRootNodeRef = (content = '') => {
@@ -72,5 +76,97 @@ describe('useDidUpdateEffect', () => {
     expect(effect).not.toBeCalled();
     rerender({ effect, input: ['two'] });
     expect(effect).toBeCalled();
+  });
+});
+
+describe('handleLeftRightArrowNavigation', () => {
+  const preventDefaultSpy = jest.fn();
+  const stopPropagationSpy = jest.fn();
+  const generateEvent = (key: string, target: Record<string, unknown>) => {
+    return {
+      key: key,
+      target: target,
+      preventDefault: preventDefaultSpy,
+      stopPropagation: stopPropagationSpy,
+    };
+  };
+  const checkFocus = (focusSpy: jest.Mock<any, any>) => {
+    expect(preventDefaultSpy).toBeCalledTimes(1);
+    expect(stopPropagationSpy).toBeCalledTimes(1);
+    expect(focusSpy).toBeCalledTimes(1);
+    jest.clearAllMocks();
+  };
+  it('handles right arrow navigation in a list of elements', () => {
+    const focusSpies = new Array(3).fill(jest.fn());
+    const navigableElements = [
+      {
+        focus: focusSpies[0],
+      },
+      {
+        focus: focusSpies[1],
+      },
+      {
+        focus: focusSpies[2],
+      },
+    ];
+
+    handleLeftRightArrowNavigation(
+      generateEvent('ArrowRight', null) as unknown as KeyboardEvent,
+      navigableElements as unknown as Element[]
+    );
+    checkFocus(focusSpies[0]);
+    handleLeftRightArrowNavigation(
+      generateEvent('ArrowRight', navigableElements[0]) as unknown as KeyboardEvent,
+      navigableElements as unknown as Element[]
+    );
+    checkFocus(focusSpies[1]);
+    handleLeftRightArrowNavigation(
+      generateEvent('ArrowRight', navigableElements[1]) as unknown as KeyboardEvent,
+      navigableElements as unknown as Element[]
+    );
+    checkFocus(focusSpies[2]);
+    // loop back
+    handleLeftRightArrowNavigation(
+      generateEvent('ArrowRight', navigableElements[2]) as unknown as KeyboardEvent,
+      navigableElements as unknown as Element[]
+    );
+    checkFocus(focusSpies[0]);
+  });
+
+  it('handles left arrow navigation in a list of elements', () => {
+    const focusSpies = new Array(3).fill(jest.fn());
+    const navigableElements = [
+      {
+        focus: focusSpies[0],
+      },
+      {
+        focus: focusSpies[1],
+      },
+      {
+        focus: focusSpies[2],
+      },
+    ];
+
+    handleLeftRightArrowNavigation(
+      generateEvent('ArrowLeft', null) as unknown as KeyboardEvent,
+      navigableElements as unknown as Element[]
+    );
+    checkFocus(focusSpies[2]);
+    handleLeftRightArrowNavigation(
+      generateEvent('ArrowLeft', navigableElements[0]) as unknown as KeyboardEvent,
+      navigableElements as unknown as Element[]
+    );
+    checkFocus(focusSpies[1]);
+    handleLeftRightArrowNavigation(
+      generateEvent('ArrowLeft', navigableElements[1]) as unknown as KeyboardEvent,
+      navigableElements as unknown as Element[]
+    );
+    checkFocus(focusSpies[0]);
+    // loop back
+    handleLeftRightArrowNavigation(
+      generateEvent('ArrowLeft', navigableElements[2]) as unknown as KeyboardEvent,
+      navigableElements as unknown as Element[]
+    );
+    checkFocus(focusSpies[2]);
   });
 });

--- a/src/components/ListItemBase/ListItemBase.utils.test.tsx
+++ b/src/components/ListItemBase/ListItemBase.utils.test.tsx
@@ -12,7 +12,7 @@ describe('getKeyboardFocusableElements', () => {
     expect(getKeyboardFocusableElements(createRootNodeRef())).toEqual([]);
   });
 
-  it('should return with focusable tags', () => {
+  it('should return with focusable tags for only elements which can be focused with tab', () => {
     const ids = getKeyboardFocusableElements(
       createRootNodeRef(`
       <a id='1'/>
@@ -24,10 +24,31 @@ describe('getKeyboardFocusableElements', () => {
       <details id='7'></details>
       <div tabindex='0' id='8'>
       <div tabindex='-1' id='9'>
+      <div id='10'></div>
     `)
     ).map((n) => n.id);
 
     expect(ids).toEqual(['2', '3', '4', '5', '6', '7', '8']);
+  });
+
+  it('should return with focusable tags for any elements which can be focused', () => {
+    const ids = getKeyboardFocusableElements(
+      createRootNodeRef(`
+      <a id='1'/>
+      <a href="#" id='2'/>
+      <button id='3'/>
+      <input id='4'/>
+      <textarea id='5'></textarea>
+      <select id='6'></select>
+      <details id='7'></details>
+      <div tabindex='0' id='8'>
+      <div tabindex='-1' id='9'>
+      <div id='10'></div>
+    `),
+      false
+    ).map((n) => n.id);
+
+    expect(ids).toEqual(['2', '3', '4', '5', '6', '7', '8', '9']);
   });
   it('should return filter out disabled and aria hidden nodes', () => {
     const ids = getKeyboardFocusableElements(

--- a/src/components/ListItemBase/ListItemBase.utils.tsx
+++ b/src/components/ListItemBase/ListItemBase.utils.tsx
@@ -1,7 +1,8 @@
 import { DependencyList, EffectCallback, useEffect, useRef } from 'react';
+import { KEYS } from './ListItemBase.constants';
 
 /**
- * Same as useEffect but ignores first render.
+ * Returns all focusable child elements as an Element Array
  * @param root - root node to search in
  * @param tabOnly - whether only tabbable children should be returned or all
  * children that can be focused. Element with 0 tabindex can be tabbed to,
@@ -33,4 +34,47 @@ export const useDidUpdateEffect = (fn: EffectCallback, inputs: DependencyList): 
     }
     didMountRef.current = true;
   }, inputs);
+};
+
+/**
+ * Handles left and right arrow key navigation for the given Element Array
+ * @param event - keyboard trigger event
+ * @param navigableElements - Element Array to navigate through
+ */
+export const handleLeftRightArrowNavigation = (
+  event: KeyboardEvent,
+  navigableElements: Element[]
+): void => {
+  const { key, target } = event;
+  if (key === KEYS.RIGHT_KEY) {
+    let newTarget;
+    const index = navigableElements.indexOf(target as Element);
+    if (index > -1) {
+      if (index + 1 < navigableElements.length) {
+        newTarget = navigableElements[index + 1];
+      } else {
+        newTarget = navigableElements[0];
+      }
+    } else {
+      newTarget = navigableElements[0];
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    newTarget.focus();
+  } else if (key === KEYS.LEFT_KEY) {
+    let newTarget;
+    const index = navigableElements.indexOf(target as Element);
+    if (index > -1) {
+      if (index > 0) {
+        newTarget = navigableElements[index - 1];
+      } else {
+        newTarget = navigableElements[navigableElements.length - 1];
+      }
+    } else {
+      newTarget = navigableElements[navigableElements.length - 1];
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    newTarget.focus();
+  }
 };

--- a/src/components/ListItemBase/ListItemBase.utils.tsx
+++ b/src/components/ListItemBase/ListItemBase.utils.tsx
@@ -1,8 +1,19 @@
 import { DependencyList, EffectCallback, useEffect, useRef } from 'react';
 
-export function getKeyboardFocusableElements<T extends HTMLElement>(root: T): Element[] {
-  const focusableNodes =
-    'a[href], button, input, textarea, select, details,[tabindex]:not([tabindex="-1"])';
+/**
+ * Same as useEffect but ignores first render.
+ * @param root - root node to search in
+ * @param tabOnly - whether only tabbable children should be returned or all
+ * children that can be focused. Element with 0 tabindex can be tabbed to,
+ * while elements with any tabindex value can be manually focused
+ */
+export function getKeyboardFocusableElements<T extends HTMLElement>(
+  root: T,
+  tabOnly = true
+): Element[] {
+  const focusableNodes = 'a[href], button, input, textarea, select, details,'.concat(
+    tabOnly ? '[tabindex]:not([tabindex="-1"]' : '[tabindex]:not([tabindex=""]'
+  );
 
   return Array.from(root.querySelectorAll(focusableNodes)).filter(
     (el) => !el.hasAttribute('disabled') && el.getAttribute('aria-hidden') !== 'true'


### PR DESCRIPTION
# Description
Change keyboard navigation of ListItems with interactive children to use left/right arrow keys. Since there's no guidelines on interactive elements within interactive list items (discouraged actually) other similar structures have been used for reference, such as Grid.

As per new accessibility requirements, if a list item has interactive children then pressing left/right arrow keys should be how they are navigated, instead of the current behavior which utilizes tab. Up/down arrow keys will still navigate from one list item to other, including when pressed on a child element within a list item. Pressing tab/shift+tab on a list item will move the focus out to the list item, further tab/shift+tab on a list item will move focus out of the list, and when navigating back to the list then the last active list item will receive focus.

I made tabindex of all navigable child elements "-1" so they can receive focus via element.focus() but tab key will never focus on them. An issue with react-aria meant that pressing tab on a child element with "-1" tabindex moved the focus to nearest "0" tabindex element, which was always the parent list item. For this reason, the tabindex of a list item is only changed to "0" when exiting the list either by pressing tab, shift+tab, or enter (e.g. opening a space). Any other navigation action that keeps the focus within the list context changes a "0" tabindex to "-1" on the list item. These include pressing arrow keys on a list item with "0" tabindex to move to a different list item or within the same list item.

# Links
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-398376
https://www.w3.org/WAI/ARIA/apg/patterns/listbox/
https://www.w3.org/WAI/ARIA/apg/example-index/grid/LayoutGrids.html
*Links to relevent resources.*

[ListItem Navigation.webm](https://user-images.githubusercontent.com/50709949/216297373-b36de624-bc24-4424-898c-b8a118e1c00c.webm)
