### PR TITLE
feat(button-pill-size): update text color of 28px pill button

### DIFF
--- a/src/components/ButtonPill/ButtonPill.style.scss
+++ b/src/components/ButtonPill/ButtonPill.style.scss
@@ -404,7 +404,7 @@
   }
 
   &[data-size='28'] {
-    font-size: 0.75rem;
+    font-size: 0.875rem;
     height: 1.75rem;
     padding: 0 0.625rem;
     line-height: 1.75rem;


### PR DESCRIPTION
# Description

According to lates figma, the text size of a 28px button is 14px (https://www.figma.com/file/vdL18BATeJAIq2JvGAjRPD/Components---Web-Application?node-id=4445%3A3906&t=BXY8iy3MUECRJwI1-1). 14px = 0.875rem

# Links

*Links to relevent resources.*
