### PR TITLE
SPARK-399325: add separator line in button group

### DIFF
--- a/src/components/Banner/Banner.unit.test.tsx.snap
+++ b/src/components/Banner/Banner.unit.test.tsx.snap
@@ -105,6 +105,7 @@ exports[`<Banner /> snapshot should match a complex snapshot 1`] = `
           className="md-button-group-wrapper"
           data-compressed={false}
           data-round={false}
+          data-separator={false}
           data-spaced={true}
         >
           <ButtonCircle
@@ -361,6 +362,7 @@ exports[`<Banner /> snapshot should match snapshot with actions 1`] = `
           className="md-button-group-wrapper"
           data-compressed={false}
           data-round={false}
+          data-separator={false}
           data-spaced={true}
         >
           <ButtonCircle

--- a/src/components/ButtonGroup/ButtonGroup.constants.ts
+++ b/src/components/ButtonGroup/ButtonGroup.constants.ts
@@ -4,6 +4,7 @@ const DEFAULTS = {
   ROUND: false,
   SPACED: false,
   COMPRESSED: false,
+  SEPARATOR: false,
 };
 
 const STYLE = {

--- a/src/components/ButtonGroup/ButtonGroup.stories.args.ts
+++ b/src/components/ButtonGroup/ButtonGroup.stories.args.ts
@@ -61,4 +61,19 @@ export default {
       },
     },
   },
+  separator: {
+    defaultValue: CONSTANTS.DEFAULTS.SEPARATOR,
+    description:
+      'Whether to to add a separator line between ChildNodes. Recommended to be used with ghost buttons',
+    options: [true, false],
+    control: { type: 'boolean' },
+    table: {
+      type: {
+        summary: 'boolean',
+      },
+      defaultValue: {
+        summary: CONSTANTS.DEFAULTS.SEPARATOR,
+      },
+    },
+  },
 };

--- a/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -28,11 +28,13 @@ export default {
 };
 
 const commonChildren = [
-  <ButtonPill key="0">Example</ButtonPill>,
-  <ButtonCircle key="1">
+  <ButtonPill ghost key="0">
+    Example
+  </ButtonPill>,
+  <ButtonCircle ghost key="1">
     <Icon name="redo" autoScale={150} />
   </ButtonCircle>,
-  <ButtonCircle key="2">
+  <ButtonCircle ghost key="2">
     <Icon name="cancel" autoScale={150} />
   </ButtonCircle>,
 ];
@@ -70,6 +72,19 @@ Spacing.parameters = {
 
 Spacing.argTypes = { ...argTypes };
 delete Spacing.argTypes.spaced;
+
+const Separator = MultiTemplate<ButtonGroupProps>(ButtonGroup).bind({});
+
+Separator.args = {
+  children: [...commonChildren],
+};
+
+Separator.parameters = {
+  variants: [{}, { separator: true }],
+};
+
+Separator.argTypes = { ...argTypes };
+delete Separator.argTypes.separator;
 
 const AudioVideoControls = MultiTemplate<ButtonGroupProps>(ButtonGroup).bind({});
 AudioVideoControls.argTypes = { ...argTypes };
@@ -281,4 +296,4 @@ Common.parameters = {
   ],
 };
 
-export { Example, Spacing, AudioVideoControls, Common };
+export { Example, Rounding, Spacing, Separator, AudioVideoControls, Common };

--- a/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -28,13 +28,11 @@ export default {
 };
 
 const commonChildren = [
-  <ButtonPill ghost key="0">
-    Example
-  </ButtonPill>,
-  <ButtonCircle ghost key="1">
+  <ButtonPill key="0">Example</ButtonPill>,
+  <ButtonCircle key="1">
     <Icon name="redo" autoScale={150} />
   </ButtonCircle>,
-  <ButtonCircle ghost key="2">
+  <ButtonCircle key="2">
     <Icon name="cancel" autoScale={150} />
   </ButtonCircle>,
 ];
@@ -75,16 +73,59 @@ delete Spacing.argTypes.spaced;
 
 const Separator = MultiTemplate<ButtonGroupProps>(ButtonGroup).bind({});
 
-Separator.args = {
-  children: [...commonChildren],
-};
+const separatorCommonChildren = [
+  <ButtonPill ghost key="0">
+    Example
+  </ButtonPill>,
+  <ButtonCircle ghost key="1">
+    <Icon name="redo" autoScale={150} />
+  </ButtonCircle>,
+  <ButtonCircle ghost key="2">
+    <Icon name="cancel" autoScale={150} />
+  </ButtonCircle>,
+];
+
+const callControlsCommonChildren = [
+  <ButtonCircle ghost key="0" size={40}>
+    <Icon key="0" name="raise-hand" autoScale={125} />
+  </ButtonCircle>,
+  <MenuTrigger
+    key="2"
+    placement="top-end"
+    triggerComponent={
+      <ButtonCircle ghost key="1" size={40}>
+        <Icon name="reactions" autoScale={125} />
+      </ButtonCircle>
+    }
+    children={[
+      <Menu key="0" selectionMode="single">
+        <Item>Item 1</Item>
+        <Item>Item 2</Item>
+      </Menu>,
+    ]}
+  />,
+];
 
 Separator.parameters = {
-  variants: [{}, { separator: true }],
+  variants: [
+    { children: separatorCommonChildren },
+    { children: separatorCommonChildren, separator: true },
+    { children: separatorCommonChildren, round: true },
+    { children: separatorCommonChildren, round: true, separator: true },
+    {
+      style: { marginTop: '1rem' },
+      children: callControlsCommonChildren,
+      round: true,
+      separator: true,
+    },
+  ],
 };
 
 Separator.argTypes = { ...argTypes };
 delete Separator.argTypes.separator;
+delete Separator.argTypes.round;
+delete Separator.argTypes.compressed;
+delete Separator.argTypes.spaced;
 
 const AudioVideoControls = MultiTemplate<ButtonGroupProps>(ButtonGroup).bind({});
 AudioVideoControls.argTypes = { ...argTypes };

--- a/src/components/ButtonGroup/ButtonGroup.style.scss
+++ b/src/components/ButtonGroup/ButtonGroup.style.scss
@@ -3,7 +3,10 @@
   display: flex;
   height: fit-content;
   width: fit-content;
-  border: 1px solid var(--mds-color-theme-outline-button-normal);
+
+  &[data-separator='true'] {
+    border: 1px solid var(--mds-color-theme-outline-button-normal);
+  }
 
   &[data-spaced='true'] {
     > * {

--- a/src/components/ButtonGroup/ButtonGroup.style.scss
+++ b/src/components/ButtonGroup/ButtonGroup.style.scss
@@ -27,6 +27,24 @@
       margin: 0;
       border-radius: 0;
     }
+
+    &[data-compressed='false'] {
+      &[data-separator='true'] {
+        > button {
+          &:not(:first-of-type) {
+            border-image: -webkit-linear-gradient(
+                top,
+                rgba(1, 1, 1, 0) 25%,
+                var(--mds-color-theme-outline-button-normal) 25%,
+                var(--mds-color-theme-outline-button-normal) 75%,
+                rgba(1, 1, 1, 0) 75%
+              )
+              1;
+            border-image-width: 0px 0px 0px 1px;
+          }
+        }
+      }
+    }
   }
 
   &[data-round='true'] {
@@ -42,22 +60,6 @@
         &:last-of-type {
           border-top-right-radius: 100vh;
           border-bottom-right-radius: 100vh;
-        }
-      }
-
-      &[data-separator='true'] {
-        > button {
-          &:not(:first-of-type) {
-            border-image: -webkit-linear-gradient(
-                top,
-                rgba(1, 1, 1, 0) 25%,
-                var(--mds-color-theme-outline-button-normal) 25%,
-                var(--mds-color-theme-outline-button-normal) 75%,
-                rgba(1, 1, 1, 0) 75%
-              )
-              1;
-            border-image-width: 0px 0px 0px 1px;
-          }
         }
       }
 
@@ -78,24 +80,6 @@
   }
 
   &[data-round='false'] {
-    &[data-compressed='false'] {
-      &[data-separator='true'] {
-        > button {
-          &:not(:first-of-type) {
-            border-image: -webkit-linear-gradient(
-                top,
-                rgba(1, 1, 1, 0) 25%,
-                var(--mds-color-theme-outline-button-normal) 25%,
-                var(--mds-color-theme-outline-button-normal) 75%,
-                rgba(1, 1, 1, 0) 75%
-              )
-              1;
-            border-image-width: 0px 0px 0px 1px;
-          }
-        }
-      }
-    }
-
     &[data-compressed='true'] {
       > button {
         &:not(:first-of-type) {

--- a/src/components/ButtonGroup/ButtonGroup.style.scss
+++ b/src/components/ButtonGroup/ButtonGroup.style.scss
@@ -3,6 +3,7 @@
   display: flex;
   height: fit-content;
   width: fit-content;
+  border: 1px solid var(--mds-color-theme-outline-button-normal);
 
   &[data-spaced='true'] {
     > * {
@@ -41,6 +42,22 @@
         }
       }
 
+      &[data-separator='true'] {
+        > button {
+          &:not(:first-of-type) {
+            border-image: -webkit-linear-gradient(
+                top,
+                rgba(1, 1, 1, 0) 25%,
+                var(--mds-color-theme-outline-button-normal) 25%,
+                var(--mds-color-theme-outline-button-normal) 75%,
+                rgba(1, 1, 1, 0) 75%
+              )
+              1;
+            border-image-width: 0px 0px 0px 1px;
+          }
+        }
+      }
+
       &[data-compressed='true'] {
         > button {
           &:not(:first-of-type) {
@@ -58,6 +75,24 @@
   }
 
   &[data-round='false'] {
+    &[data-compressed='false'] {
+      &[data-separator='true'] {
+        > button {
+          &:not(:first-of-type) {
+            border-image: -webkit-linear-gradient(
+                top,
+                rgba(1, 1, 1, 0) 25%,
+                var(--mds-color-theme-outline-button-normal) 25%,
+                var(--mds-color-theme-outline-button-normal) 75%,
+                rgba(1, 1, 1, 0) 75%
+              )
+              1;
+            border-image-width: 0px 0px 0px 1px;
+          }
+        }
+      }
+    }
+
     &[data-compressed='true'] {
       > button {
         &:not(:first-of-type) {

--- a/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.tsx
@@ -6,7 +6,7 @@ import { Props } from './ButtonGroup.types';
 import './ButtonGroup.style.scss';
 
 const ButtonGroup: FC<Props> = (props: Props) => {
-  const { children, className, id, round, spaced, compressed, style, role } = props;
+  const { children, className, id, round, spaced, compressed, separator, style, role } = props;
 
   return (
     <div
@@ -14,6 +14,7 @@ const ButtonGroup: FC<Props> = (props: Props) => {
       data-round={round || DEFAULTS.ROUND}
       data-spaced={spaced || DEFAULTS.SPACED}
       data-compressed={compressed || DEFAULTS.COMPRESSED}
+      data-separator={separator || DEFAULTS.SEPARATOR}
       id={id}
       style={style}
       role={role}

--- a/src/components/ButtonGroup/ButtonGroup.types.ts
+++ b/src/components/ButtonGroup/ButtonGroup.types.ts
@@ -37,6 +37,11 @@ export interface Props {
   compressed?: boolean;
 
   /**
+   * Whether to to add a separator line between <SupportedComponents />.
+   */
+  separator?: boolean;
+
+  /**
    * Custom style for overriding this component's CSS.
    */
   style?: CSSProperties;

--- a/src/components/ButtonGroup/ButtonGroup.unit.test.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.unit.test.tsx
@@ -8,7 +8,7 @@ import {
 
 import { DEFAULTS, STYLE } from './ButtonGroup.constants';
 
-describe('<ButtonPill />', () => {
+describe('<ButtonGroup />', () => {
   const childrenTemplate = [
     <ButtonPill key="0">Example A</ButtonPill>,
     <ButtonCircle key="1">A</ButtonCircle>,
@@ -40,6 +40,16 @@ describe('<ButtonPill />', () => {
       const spaced = !DEFAULTS.SPACED;
 
       container = mount(<ButtonGroup spaced={spaced}>{childrenTemplate}</ButtonGroup>);
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match snapshot with separator', () => {
+      expect.assertions(1);
+
+      const separator = !DEFAULTS.SEPARATOR;
+
+      container = mount(<ButtonGroup separator={separator}>{childrenTemplate}</ButtonGroup>);
 
       expect(container).toMatchSnapshot();
     });
@@ -155,6 +165,18 @@ describe('<ButtonPill />', () => {
         .getDOMNode();
 
       expect(element.getAttribute('data-round')).toBe(`${round}`);
+    });
+
+    it('should pass separator prop', () => {
+      expect.assertions(1);
+
+      const separator = !DEFAULTS.SEPARATOR;
+
+      const element = mount(<ButtonGroup separator={separator}>{childrenTemplate}</ButtonGroup>)
+        .find(ButtonGroup)
+        .getDOMNode();
+
+      expect(element.getAttribute('data-separator')).toBe(`${separator}`);
     });
 
     it('should pass role prop', () => {

--- a/src/components/ButtonGroup/ButtonGroup.unit.test.tsx.snap
+++ b/src/components/ButtonGroup/ButtonGroup.unit.test.tsx.snap
@@ -1,11 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<ButtonPill /> snapshot should match snapshot 1`] = `
+exports[`<ButtonGroup /> snapshot should match snapshot 1`] = `
 <ButtonGroup>
   <div
     className="md-button-group-wrapper"
     data-compressed={false}
     data-round={false}
+    data-separator={false}
     data-spaced={false}
   >
     <ButtonPill
@@ -112,7 +113,7 @@ exports[`<ButtonPill /> snapshot should match snapshot 1`] = `
 </ButtonGroup>
 `;
 
-exports[`<ButtonPill /> snapshot should match snapshot when spaced 1`] = `
+exports[`<ButtonGroup /> snapshot should match snapshot when spaced 1`] = `
 <ButtonGroup
   spaced={true}
 >
@@ -120,6 +121,7 @@ exports[`<ButtonPill /> snapshot should match snapshot when spaced 1`] = `
     className="md-button-group-wrapper"
     data-compressed={false}
     data-round={false}
+    data-separator={false}
     data-spaced={true}
   >
     <ButtonPill
@@ -226,7 +228,7 @@ exports[`<ButtonPill /> snapshot should match snapshot when spaced 1`] = `
 </ButtonGroup>
 `;
 
-exports[`<ButtonPill /> snapshot should match snapshot with className 1`] = `
+exports[`<ButtonGroup /> snapshot should match snapshot with className 1`] = `
 <ButtonCircle
   className="example-class"
 >
@@ -274,7 +276,7 @@ exports[`<ButtonPill /> snapshot should match snapshot with className 1`] = `
 </ButtonCircle>
 `;
 
-exports[`<ButtonPill /> snapshot should match snapshot with id 1`] = `
+exports[`<ButtonGroup /> snapshot should match snapshot with id 1`] = `
 <ButtonCircle
   id="example-id"
 >
@@ -324,7 +326,7 @@ exports[`<ButtonPill /> snapshot should match snapshot with id 1`] = `
 </ButtonCircle>
 `;
 
-exports[`<ButtonPill /> snapshot should match snapshot with role 1`] = `
+exports[`<ButtonGroup /> snapshot should match snapshot with role 1`] = `
 <ButtonGroup
   role="tablist"
 >
@@ -332,6 +334,7 @@ exports[`<ButtonPill /> snapshot should match snapshot with role 1`] = `
     className="md-button-group-wrapper"
     data-compressed={false}
     data-round={false}
+    data-separator={false}
     data-spaced={false}
     role="tablist"
   >
@@ -439,7 +442,7 @@ exports[`<ButtonPill /> snapshot should match snapshot with role 1`] = `
 </ButtonGroup>
 `;
 
-exports[`<ButtonPill /> snapshot should match snapshot with round 1`] = `
+exports[`<ButtonGroup /> snapshot should match snapshot with round 1`] = `
 <ButtonGroup
   round={true}
 >
@@ -447,6 +450,7 @@ exports[`<ButtonPill /> snapshot should match snapshot with round 1`] = `
     className="md-button-group-wrapper"
     data-compressed={false}
     data-round={true}
+    data-separator={false}
     data-spaced={false}
   >
     <ButtonPill
@@ -553,7 +557,122 @@ exports[`<ButtonPill /> snapshot should match snapshot with round 1`] = `
 </ButtonGroup>
 `;
 
-exports[`<ButtonPill /> snapshot should match snapshot with style 1`] = `
+exports[`<ButtonGroup /> snapshot should match snapshot with separator 1`] = `
+<ButtonGroup
+  separator={true}
+>
+  <div
+    className="md-button-group-wrapper"
+    data-compressed={false}
+    data-round={false}
+    data-separator={true}
+    data-spaced={false}
+  >
+    <ButtonPill
+      key="0"
+    >
+      <ButtonSimple
+        className="md-button-pill-wrapper"
+        data-color="primary"
+        data-disabled={false}
+        data-ghost={false}
+        data-grown={false}
+        data-outline={false}
+        data-size={40}
+        data-solid={false}
+      >
+        <FocusRing>
+          <FocusRing
+            focusClass="md-focus-ring-wrapper children"
+            focusRingClass="md-focus-ring-wrapper children"
+          >
+            <button
+              className="md-button-pill-wrapper md-button-simple-wrapper"
+              data-color="primary"
+              data-disabled={false}
+              data-ghost={false}
+              data-grown={false}
+              data-outline={false}
+              data-size={40}
+              data-solid={false}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onDragStart={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+              onTouchCancel={[Function]}
+              onTouchEnd={[Function]}
+              onTouchMove={[Function]}
+              onTouchStart={[Function]}
+              type="button"
+            >
+              <span>
+                Example A
+              </span>
+            </button>
+          </FocusRing>
+        </FocusRing>
+      </ButtonSimple>
+    </ButtonPill>
+    <ButtonCircle
+      key="1"
+    >
+      <ButtonSimple
+        className="md-button-circle-wrapper"
+        data-color="primary"
+        data-disabled={false}
+        data-ghost={false}
+        data-multiple-children={false}
+        data-outline={false}
+        data-size={40}
+      >
+        <FocusRing>
+          <FocusRing
+            focusClass="md-focus-ring-wrapper children"
+            focusRingClass="md-focus-ring-wrapper children"
+          >
+            <button
+              className="md-button-circle-wrapper md-button-simple-wrapper"
+              data-color="primary"
+              data-disabled={false}
+              data-ghost={false}
+              data-multiple-children={false}
+              data-outline={false}
+              data-size={40}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onDragStart={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+              onTouchCancel={[Function]}
+              onTouchEnd={[Function]}
+              onTouchMove={[Function]}
+              onTouchStart={[Function]}
+              type="button"
+            >
+              <span>
+                A
+              </span>
+            </button>
+          </FocusRing>
+        </FocusRing>
+      </ButtonSimple>
+    </ButtonCircle>
+  </div>
+</ButtonGroup>
+`;
+
+exports[`<ButtonGroup /> snapshot should match snapshot with style 1`] = `
 <ButtonCircle
   style={
     Object {

--- a/src/components/Coachmark/Coachmark.unit.test.tsx.snap
+++ b/src/components/Coachmark/Coachmark.unit.test.tsx.snap
@@ -51,6 +51,7 @@ exports[`<Coachmark /> snapshot should match snapshot with header 1`] = `
             class="md-button-group-wrapper"
             data-compressed="false"
             data-round="true"
+            data-separator="false"
             data-spaced="false"
           >
             <button
@@ -92,6 +93,7 @@ exports[`<Coachmark /> snapshot should match snapshot with header 1`] = `
           class="md-button-group-wrapper"
           data-compressed="false"
           data-round="true"
+          data-separator="false"
           data-spaced="true"
         >
           <button
@@ -198,6 +200,7 @@ exports[`<Coachmark /> snapshot should match snapshot without header 1`] = `
             class="md-button-group-wrapper"
             data-compressed="false"
             data-round="true"
+            data-separator="false"
             data-spaced="true"
           >
             <button
@@ -236,6 +239,7 @@ exports[`<Coachmark /> snapshot should match snapshot without header 1`] = `
           class="md-button-group-wrapper md-coachmark-controls"
           data-compressed="false"
           data-round="true"
+          data-separator="false"
           data-spaced="false"
         >
           <button

--- a/src/components/MeetingContainer/MeetingContainer.unit.test.tsx.snap
+++ b/src/components/MeetingContainer/MeetingContainer.unit.test.tsx.snap
@@ -92,6 +92,7 @@ exports[`<MeetingContainer /> snapshot should match snapshot 1`] = `
                     className="md-button-group-wrapper"
                     data-compressed={false}
                     data-round={false}
+                    data-separator={false}
                     data-spaced={true}
                   />
                 </ButtonGroup>
@@ -218,6 +219,7 @@ exports[`<MeetingContainer /> snapshot should match snapshot with avatar supplie
                     className="md-button-group-wrapper"
                     data-compressed={false}
                     data-round={false}
+                    data-separator={false}
                     data-spaced={true}
                   />
                 </ButtonGroup>
@@ -325,6 +327,7 @@ exports[`<MeetingContainer /> snapshot should match snapshot with children suppl
                     className="md-button-group-wrapper"
                     data-compressed={false}
                     data-round={false}
+                    data-separator={false}
                     data-spaced={true}
                   />
                 </ButtonGroup>
@@ -473,6 +476,7 @@ exports[`<MeetingContainer /> snapshot should match snapshot with circle action 
                     className="md-button-group-wrapper"
                     data-compressed={false}
                     data-round={false}
+                    data-separator={false}
                     data-spaced={true}
                   >
                     <ButtonCircle
@@ -740,6 +744,7 @@ exports[`<MeetingContainer /> snapshot should match snapshot with className 1`] 
                     className="md-button-group-wrapper"
                     data-compressed={false}
                     data-round={false}
+                    data-separator={false}
                     data-spaced={true}
                   />
                 </ButtonGroup>
@@ -1038,6 +1043,7 @@ exports[`<MeetingContainer /> snapshot should match snapshot with disable suppli
                     className="md-button-group-wrapper"
                     data-compressed={false}
                     data-round={false}
+                    data-separator={false}
                     data-spaced={true}
                   >
                     <ButtonPill
@@ -1267,6 +1273,7 @@ exports[`<MeetingContainer /> snapshot should match snapshot with id 1`] = `
                     className="md-button-group-wrapper"
                     data-compressed={false}
                     data-round={false}
+                    data-separator={false}
                     data-spaced={true}
                   />
                 </ButtonGroup>
@@ -1409,6 +1416,7 @@ exports[`<MeetingContainer /> snapshot should match snapshot with pill action bu
                     className="md-button-group-wrapper"
                     data-compressed={false}
                     data-round={false}
+                    data-separator={false}
                     data-spaced={true}
                   >
                     <ButtonPill
@@ -1637,6 +1645,7 @@ exports[`<MeetingContainer /> snapshot should match snapshot with scheduleInfoFi
                     className="md-button-group-wrapper"
                     data-compressed={false}
                     data-round={false}
+                    data-separator={false}
                     data-spaced={true}
                   />
                 </ButtonGroup>
@@ -1747,6 +1756,7 @@ exports[`<MeetingContainer /> snapshot should match snapshot with scheduleInfoFi
                     className="md-button-group-wrapper"
                     data-compressed={false}
                     data-round={false}
+                    data-separator={false}
                     data-spaced={true}
                   />
                 </ButtonGroup>
@@ -1861,6 +1871,7 @@ exports[`<MeetingContainer /> snapshot should match snapshot with scheduleInfoSe
                     className="md-button-group-wrapper"
                     data-compressed={false}
                     data-round={false}
+                    data-separator={false}
                     data-spaced={true}
                   />
                 </ButtonGroup>
@@ -1976,6 +1987,7 @@ exports[`<MeetingContainer /> snapshot should match snapshot with scheduleInfoSe
                     className="md-button-group-wrapper"
                     data-compressed={false}
                     data-round={false}
+                    data-separator={false}
                     data-spaced={true}
                   />
                 </ButtonGroup>
@@ -2139,6 +2151,7 @@ exports[`<MeetingContainer /> snapshot should match snapshot with spacelink supp
                     className="md-button-group-wrapper"
                     data-compressed={false}
                     data-round={false}
+                    data-separator={false}
                     data-spaced={true}
                   />
                 </ButtonGroup>
@@ -2265,6 +2278,7 @@ exports[`<MeetingContainer /> snapshot should match snapshot with style 1`] = `
                     className="md-button-group-wrapper"
                     data-compressed={false}
                     data-round={false}
+                    data-separator={false}
                     data-spaced={true}
                   />
                 </ButtonGroup>
@@ -2492,6 +2506,7 @@ exports[`<MeetingContainer /> snapshot should match snapshot with tags supplied 
                     className="md-button-group-wrapper"
                     data-compressed={false}
                     data-round={false}
+                    data-separator={false}
                     data-spaced={true}
                   />
                 </ButtonGroup>

--- a/src/components/MeetingListItem/MeetingListItem.unit.test.tsx.snap
+++ b/src/components/MeetingListItem/MeetingListItem.unit.test.tsx.snap
@@ -150,6 +150,7 @@ exports[`<MeetingListItem /> snapshot should match snapshot with buttonGroup 1`]
                   className="md-button-group-wrapper"
                   data-compressed={false}
                   data-round={false}
+                  data-separator={false}
                   data-spaced={false}
                 />
               </ButtonGroup>

--- a/src/components/ReactionPicker/ReactionPicker.unit.test.tsx.snap
+++ b/src/components/ReactionPicker/ReactionPicker.unit.test.tsx.snap
@@ -10,6 +10,7 @@ exports[`<ReactionPicker /> snapshot should match snapshot 1`] = `
       className="md-button-group-wrapper md-reaction-picker-wrapper"
       data-compressed={false}
       data-round={true}
+      data-separator={false}
       data-spaced={false}
     />
   </ButtonGroup>
@@ -26,6 +27,7 @@ exports[`<ReactionPicker /> snapshot should match snapshot with children 1`] = `
       className="md-button-group-wrapper md-reaction-picker-wrapper"
       data-compressed={false}
       data-round={true}
+      data-separator={false}
       data-spaced={false}
     >
       <ReactionButton>
@@ -96,6 +98,7 @@ exports[`<ReactionPicker /> snapshot should match snapshot with className 1`] = 
       className="md-button-group-wrapper example-class md-reaction-picker-wrapper"
       data-compressed={false}
       data-round={true}
+      data-separator={false}
       data-spaced={false}
     />
   </ButtonGroup>
@@ -115,6 +118,7 @@ exports[`<ReactionPicker /> snapshot should match snapshot with id 1`] = `
       className="md-button-group-wrapper md-reaction-picker-wrapper"
       data-compressed={false}
       data-round={true}
+      data-separator={false}
       data-spaced={false}
       id="example-id"
     />
@@ -143,6 +147,7 @@ exports[`<ReactionPicker /> snapshot should match snapshot with style 1`] = `
       className="md-button-group-wrapper md-reaction-picker-wrapper"
       data-compressed={false}
       data-round={true}
+      data-separator={false}
       data-spaced={false}
       style={
         Object {

--- a/src/components/Toast/Toast.unit.test.tsx.snap
+++ b/src/components/Toast/Toast.unit.test.tsx.snap
@@ -392,6 +392,7 @@ exports[`<Toast /> snapshot should match snapshot 1`] = `
             className="md-button-group-wrapper md-toast-content-actions"
             data-compressed={false}
             data-round={false}
+            data-separator={false}
             data-spaced={true}
           >
             <ButtonCircle
@@ -1019,6 +1020,7 @@ exports[`<Toast /> snapshot should match snapshot with className 1`] = `
             className="md-button-group-wrapper md-toast-content-actions"
             data-compressed={false}
             data-round={false}
+            data-separator={false}
             data-spaced={true}
           >
             <ButtonCircle
@@ -1603,6 +1605,7 @@ exports[`<Toast /> snapshot should match snapshot with content children and deta
             className="md-button-group-wrapper md-toast-content-actions"
             data-compressed={false}
             data-round={false}
+            data-separator={false}
             data-spaced={true}
           >
             <ButtonCircle
@@ -2174,6 +2177,7 @@ exports[`<Toast /> snapshot should match snapshot with details and content child
             className="md-button-group-wrapper md-toast-content-actions"
             data-compressed={false}
             data-round={false}
+            data-separator={false}
             data-spaced={true}
           >
             <ButtonCircle
@@ -2787,6 +2791,7 @@ exports[`<Toast /> snapshot should match snapshot with details children and cont
             className="md-button-group-wrapper md-toast-content-actions"
             data-compressed={false}
             data-round={false}
+            data-separator={false}
             data-spaced={true}
           >
             <ButtonCircle
@@ -3415,6 +3420,7 @@ exports[`<Toast /> snapshot should match snapshot with id 1`] = `
             className="md-button-group-wrapper md-toast-content-actions"
             data-compressed={false}
             data-round={false}
+            data-separator={false}
             data-spaced={true}
           >
             <ButtonCircle
@@ -4051,6 +4057,7 @@ exports[`<Toast /> snapshot should match snapshot with style 1`] = `
             className="md-button-group-wrapper md-toast-content-actions"
             data-compressed={false}
             data-round={false}
+            data-separator={false}
             data-spaced={true}
           >
             <ButtonCircle
@@ -4665,6 +4672,7 @@ exports[`<Toast /> snapshot should match snapshot with title 1`] = `
             className="md-button-group-wrapper md-toast-content-actions"
             data-compressed={false}
             data-round={false}
+            data-separator={false}
             data-spaced={true}
           >
             <ButtonCircle

--- a/src/components/ToastContent/ToastContent.unit.test.tsx.snap
+++ b/src/components/ToastContent/ToastContent.unit.test.tsx.snap
@@ -161,6 +161,7 @@ exports[`<ToastContent /> snapshot should match snapshot with complex props 1`] 
         className="md-button-group-wrapper md-toast-content-actions"
         data-compressed={false}
         data-round={false}
+        data-separator={false}
         data-spaced={true}
       >
         <ButtonPill>


### PR DESCRIPTION
# Description

For in-meeting reactions, we need a button group that has a small separator in the middle. I added a separator property to our Button Group to enable/disable this ui element in the component. 

Spec
<img width="154" alt="image" src="https://user-images.githubusercontent.com/56999622/215106758-03717fed-5552-4098-88d4-bdd2aba53059.png">

Storybook
<img width="563" alt="image" src="https://user-images.githubusercontent.com/56999622/215107243-7a5c27a5-1cc2-4ae1-a80e-77aa92fba342.png">


# Links
[SPARK-399325](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-399325)

