### PR TITLE
feat(inverted-hyperlink): add inverted prop to hyperlink

### DIFF
--- a/src/components/ButtonHyperlink/ButtonHyperlink.constants.ts
+++ b/src/components/ButtonHyperlink/ButtonHyperlink.constants.ts
@@ -2,6 +2,7 @@ const CLASS_PREFIX = 'md-button-hyperlink';
 
 const DEFAULTS = {
   DISABLED: false,
+  INVERTED: false,
 };
 
 const STYLE = {

--- a/src/components/ButtonHyperlink/ButtonHyperlink.stories.args.ts
+++ b/src/components/ButtonHyperlink/ButtonHyperlink.stories.args.ts
@@ -35,4 +35,17 @@ export default {
       },
     },
   },
+  inverted: {
+    description: 'Whether to render the `<ButtonHyperlink />` with inverted theme colors',
+    options: [true, false],
+    control: { type: 'boolean' },
+    table: {
+      type: {
+        summary: 'boolean',
+      },
+      defaultValue: {
+        summary: CONSTANTS.DEFAULTS.INVERTED,
+      },
+    },
+  },
 };

--- a/src/components/ButtonHyperlink/ButtonHyperlink.stories.tsx
+++ b/src/components/ButtonHyperlink/ButtonHyperlink.stories.tsx
@@ -1,4 +1,4 @@
-import { MultiTemplate, Template } from '../../storybook/helper.stories.templates';
+import { MultiTemplateWithPseudoStates, Template } from '../../storybook/helper.stories.templates';
 import { DocumentationPage } from '../../storybook/helper.stories.docs';
 import StyleDocs from '../../storybook/docs.stories.style.mdx';
 import AriaButtonDocs from '../../storybook/docs.stories.aria-button.mdx';
@@ -26,13 +26,14 @@ const Example = Template<ButtonHyperlinkProps>(ButtonHyperlink).bind({});
 
 Example.argTypes = { ...argTypes };
 
-const States = MultiTemplate<ButtonHyperlinkProps>(ButtonHyperlink).bind({});
+const States = MultiTemplateWithPseudoStates<ButtonHyperlinkProps>(ButtonHyperlink).bind({});
 
 States.parameters = {
-  variants: [{}, { disabled: true }],
+  variants: [{ label: 'Default hyperlink' }, { inverted: true }],
 };
 
 States.argTypes = { ...argTypes };
 delete States.argTypes.disabled;
+delete States.argTypes.inverted;
 
 export { Example, States };

--- a/src/components/ButtonHyperlink/ButtonHyperlink.style.scss
+++ b/src/components/ButtonHyperlink/ButtonHyperlink.style.scss
@@ -9,19 +9,48 @@
   text-decoration: underline;
   transition: background-color 0.2s, color 0.2s, border-color 0.2s;
 
-  &:focus {
+  &:focus,
+  &.focus {
     color: var(--mds-color-theme-text-accent-normal);
   }
 
-  &:hover {
+  &:hover,
+  &.hover {
     color: var(--mds-color-theme-text-accent-hover);
   }
 
-  &:active {
+  &:active,
+  &.active {
     color: var(--mds-color-theme-text-accent-active);
   }
 
-  &[data-disabled='true'] {
+  &[data-inverted='true'] {
+    color: var(--mds-color-theme-teaching-text-accent-normal);
+
+    &:focus,
+    &.focus {
+      color: var(--mds-color-theme-teaching-text-accent-normal);
+    }
+
+    &:hover,
+    &.hover {
+      color: var(--mds-color-theme-teaching-text-accent-hover);
+    }
+
+    &:active,
+    &.active {
+      color: var(--mds-color-theme-teaching-text-accent-hover);
+    }
+
+    &[data-disabled='true'],
+    &.disable {
+      color: var(--mds-color-theme-teaching-text-accent-disabled);
+      cursor: auto;
+    }
+  }
+
+  &[data-disabled='true'],
+  &.disable {
     color: var(--mds-color-theme-text-primary-disabled);
     cursor: auto;
   }

--- a/src/components/ButtonHyperlink/ButtonHyperlink.tsx
+++ b/src/components/ButtonHyperlink/ButtonHyperlink.tsx
@@ -15,6 +15,7 @@ const ButtonHyperlink = forwardRef((props: Props, providedRef: RefObject<HTMLAnc
   const mutatedProps = {
     ...props,
     isDisabled: props.disabled,
+    isInverted: props.inverted,
   };
 
   delete mutatedProps.disabled;
@@ -29,6 +30,7 @@ const ButtonHyperlink = forwardRef((props: Props, providedRef: RefObject<HTMLAnc
         {...buttonProps}
         ref={ref}
         data-disabled={props.disabled || DEFAULTS.DISABLED}
+        data-inverted={props.inverted || DEFAULTS.INVERTED}
         title={title}
       >
         {props.children}

--- a/src/components/ButtonHyperlink/ButtonHyperlink.types.ts
+++ b/src/components/ButtonHyperlink/ButtonHyperlink.types.ts
@@ -17,6 +17,11 @@ export interface Props extends AriaButtonProps<'a'> {
   disabled?: boolean;
 
   /**
+   * Whether or not this ButtonDialpad has inverted theme colors.
+   */
+  inverted?: boolean;
+
+  /**
    * title to use for this component.
    */
   title?: string;

--- a/src/components/ButtonHyperlink/ButtonHyperlink.unit.test.tsx
+++ b/src/components/ButtonHyperlink/ButtonHyperlink.unit.test.tsx
@@ -26,6 +26,16 @@ describe('ButtonHyperlink', () => {
       expect(container).toMatchSnapshot();
     });
 
+    it('should match snapshot when inverted', () => {
+      expect.assertions(1);
+
+      const inverted = !DEFAULTS.INVERTED;
+
+      container = mount(<ButtonHyperlink inverted={inverted}>Hyperlink</ButtonHyperlink>);
+
+      expect(container).toMatchSnapshot();
+    });
+
     it('should match snapshot with title', () => {
       expect.assertions(1);
 
@@ -67,6 +77,18 @@ describe('ButtonHyperlink', () => {
         .getDOMNode();
 
       expect(element.getAttribute('data-disabled')).toBe(`${disabled}`);
+    });
+
+    it('should pass inverted prop', () => {
+      expect.assertions(1);
+
+      const inverted = !DEFAULTS.INVERTED;
+
+      const element = mount(<ButtonHyperlink inverted={inverted} />)
+        .find(ButtonHyperlink)
+        .getDOMNode();
+
+      expect(element.getAttribute('data-inverted')).toBe(`${inverted}`);
     });
 
     it('should pass child prop', () => {

--- a/src/components/ButtonHyperlink/ButtonHyperlink.unit.test.tsx.snap
+++ b/src/components/ButtonHyperlink/ButtonHyperlink.unit.test.tsx.snap
@@ -10,6 +10,7 @@ exports[`ButtonHyperlink snapshot should match snapshot 1`] = `
       <a
         className="md-button-hyperlink-wrapper"
         data-disabled={false}
+        data-inverted={false}
         onBlur={[Function]}
         onClick={[Function]}
         onDragStart={[Function]}
@@ -50,6 +51,7 @@ exports[`ButtonHyperlink snapshot should match snapshot when disabled 1`] = `
         aria-disabled={true}
         className="md-button-hyperlink-wrapper"
         data-disabled={true}
+        data-inverted={false}
         onBlur={[Function]}
         onClick={[Function]}
         onDragStart={[Function]}
@@ -73,6 +75,43 @@ exports[`ButtonHyperlink snapshot should match snapshot when disabled 1`] = `
 </ButtonHyperlink>
 `;
 
+exports[`ButtonHyperlink snapshot should match snapshot when inverted 1`] = `
+<ButtonHyperlink
+  inverted={true}
+>
+  <FocusRing>
+    <FocusRing
+      focusClass="md-focus-ring-wrapper children"
+      focusRingClass="md-focus-ring-wrapper children"
+    >
+      <a
+        className="md-button-hyperlink-wrapper"
+        data-disabled={false}
+        data-inverted={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onDragStart={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        onTouchCancel={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
+        role="button"
+        tabIndex={0}
+      >
+        Hyperlink
+      </a>
+    </FocusRing>
+  </FocusRing>
+</ButtonHyperlink>
+`;
+
 exports[`ButtonHyperlink snapshot should match snapshot with title 1`] = `
 <ButtonHyperlink
   title="Example Text"
@@ -85,6 +124,7 @@ exports[`ButtonHyperlink snapshot should match snapshot with title 1`] = `
       <a
         className="md-button-hyperlink-wrapper"
         data-disabled={false}
+        data-inverted={false}
         onBlur={[Function]}
         onClick={[Function]}
         onDragStart={[Function]}

--- a/src/components/MeetingContainer/MeetingContainer.unit.test.tsx.snap
+++ b/src/components/MeetingContainer/MeetingContainer.unit.test.tsx.snap
@@ -876,6 +876,7 @@ exports[`<MeetingContainer /> snapshot should match snapshot with disable suppli
                         <a
                           className="md-button-hyperlink-wrapper md-meeting-container-space-link"
                           data-disabled={false}
+                          data-inverted={false}
                           onBlur={[Function]}
                           onClick={[Function]}
                           onDragStart={[Function]}
@@ -2086,6 +2087,7 @@ exports[`<MeetingContainer /> snapshot should match snapshot with spacelink supp
                         <a
                           className="md-button-hyperlink-wrapper md-meeting-container-space-link"
                           data-disabled={false}
+                          data-inverted={false}
                           onBlur={[Function]}
                           onClick={[Function]}
                           onDragStart={[Function]}


### PR DESCRIPTION
# Description

Adding inverted property to hyperlink to be able to get a hyperlink that works with an opposite-theme background, as added to the [Component Figma Library](https://www.figma.com/file/vdL18BATeJAIq2JvGAjRPD/Components---Web-Application?node-id=4649%3A91&t=hecg0EMC6gzAraod-1). 

<img width="258" alt="image" src="https://user-images.githubusercontent.com/56999622/216574561-de62cab0-3357-4992-882c-f85f7b9a0b16.png">

That is to achieve inverted elements like in this spec:
<img width="597" alt="image" src="https://user-images.githubusercontent.com/56999622/216574764-69b04842-ecf9-4b97-b05a-749417313a49.png">

