### PR TITLE
chore(component/NotificationSystem): adding limit to toast notifs

### DIFF
--- a/src/components/NotificationSystem/NotificationSystem.stories.tsx
+++ b/src/components/NotificationSystem/NotificationSystem.stories.tsx
@@ -36,7 +36,7 @@ const Example = Template<NotificationSystemProps>((args) => {
       >
         Trigger a new low attention notification
       </ButtonPill>
-      <NotificationSystem {...args} />
+      <NotificationSystem {...args} limit={3} />
     </>
   );
 }).bind({});

--- a/src/components/NotificationSystem/NotificationSystem.tsx
+++ b/src/components/NotificationSystem/NotificationSystem.tsx
@@ -21,7 +21,14 @@ const slideAndBlur = cssTransition({
  * are exposed on the component directly, like `NotificationSystem.notify` or `NotificationSystem.update`
  */
 const NotificationSystem: FC<Props> & CompoundProps = (props: Props) => {
-  const { position = DEFAULTS.POSITION, zIndex = DEFAULTS.Z_INDEX, className, id, style } = props;
+  const {
+    position = DEFAULTS.POSITION,
+    zIndex = DEFAULTS.Z_INDEX,
+    className,
+    id,
+    style,
+    limit,
+  } = props;
 
   const commonProps = {
     newestOnTop: true,
@@ -47,11 +54,13 @@ const NotificationSystem: FC<Props> & CompoundProps = (props: Props) => {
       <ToastContainer
         {...commonProps}
         position={position}
+        limit={limit}
         containerId={getContainerID(id, attentionOrder[0])}
       />
       <ToastContainer
         {...commonProps}
         position={position}
+        limit={limit}
         containerId={getContainerID(id, attentionOrder[1])}
       />
     </div>

--- a/src/components/NotificationSystem/NotificationSystem.types.ts
+++ b/src/components/NotificationSystem/NotificationSystem.types.ts
@@ -103,4 +103,9 @@ export interface Props {
    * Custom style for overriding this component's CSS.
    */
   style?: CSSProperties;
+
+  /**
+   * limit the number of notifications displayed.
+   */
+  limit?: number;
 }

--- a/src/components/NotificationSystem/NotificationSystem.unit.test.tsx.snap
+++ b/src/components/NotificationSystem/NotificationSystem.unit.test.tsx.snap
@@ -1,5 +1,114 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<NotificationSystem /> should match snapshot when limit is set to notifications 1`] = `
+<div>
+  <div
+    class="md-notification-system-wrapper"
+    data-position="top-right"
+    style="z-index: 10000;"
+  >
+    <div
+      class="Toastify"
+      id="medium_notification_container"
+    />
+    <div
+      class="Toastify"
+      id="low_notification_container"
+    >
+      <div
+        class="Toastify__toast-container Toastify__toast-container--top-right"
+      >
+        <div
+          class="Toastify__toast Toastify__toast-theme--light Toastify__toast--default slideInRight"
+          id="123456"
+          style="--nth: 1; --len: 1;"
+        >
+          <div
+            class="Toastify__toast-body"
+            role="alert"
+          >
+            <div>
+              <div
+                class="md-toast-notification-wrapper md-modal-container-wrapper"
+                data-color="primary"
+                data-elevation="0"
+                data-padded="true"
+                data-round="50"
+              >
+                <div
+                  class="md-toast-notification-body"
+                >
+                  <div
+                    class="md-toast-notification-leading-visual"
+                  >
+                    <div
+                      class="md-icon-wrapper icon md-icon-no-shrink"
+                    >
+                      <svg
+                        class=""
+                        data-autoscale="false"
+                        data-scale="24"
+                        data-test="info-circle"
+                        height="100%"
+                        style="fill: lightblue;"
+                        viewBox="0, 0, 32, 32"
+                        width="100%"
+                      />
+                    </div>
+                  </div>
+                  <p
+                    class="md-text-wrapper md-toast-notification-text"
+                    data-type="body-primary"
+                  >
+                    This is a test
+                  </p>
+                  <div
+                    class="md-toast-notification-close-button"
+                  >
+                    <button
+                      class="md-button-circle-wrapper md-button-simple-wrapper"
+                      data-color="primary"
+                      data-disabled="false"
+                      data-ghost="true"
+                      data-multiple-children="false"
+                      data-outline="false"
+                      data-size="20"
+                      type="button"
+                    >
+                      <div
+                        class="md-icon-wrapper md-icon-no-shrink"
+                      >
+                        <svg
+                          class=""
+                          data-autoscale="false"
+                          data-scale="16"
+                          data-test="cancel"
+                          fill="currentColor"
+                          height="100%"
+                          viewBox="0, 0, 32, 32"
+                          width="100%"
+                        />
+                      </div>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            aria-hidden="true"
+            aria-label="notification timer"
+            class="Toastify__progress-bar Toastify__progress-bar--animated Toastify__progress-bar-theme--light Toastify__progress-bar--default"
+            role="progressbar"
+            style="animation-duration: 3000ms; animation-play-state: paused; opacity: 0;"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`<NotificationSystem /> snapshot should match snapshot 1`] = `
 <div>
   <div


### PR DESCRIPTION
# IMPORTANT

**Currently, this project is closed to any external contributions. Any pull request made against this project from external sources will likely be closed. If you would like to make changes to this project, please fork this project.**

# Guide

**This "Help" section can be deleted before submitting this pull request.**

*Update the name of this pull request to reflect the following shape:*

```
{type}/{scope?}/{message}
```

* **type** - A [conventional commit type](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional#type-enum) **REQUIRED**
* **scope** - The kabab-case scope of the changes in this request
* **message** - A short, kebab-case statement describing the changes **REQUIRED**

*Provide a general summary of the scope of the changes in this pull request.*

* [Readme](https://github.com/momentum-design/momentum-react-v2/blob/master/README.md)
* [Getting Started Guide](https://github.com/momentum-design/momentum-react-v2/blob/master/GETTING_STARTED.md)
* [Contributing Guide](https://github.com/momentum-design/momentum-react-v2/blob/master/CONTRIBUTING.md)

# Description

Adding a 'limit' prop to toast notifications to control the number of toast notifications displayed on the screen. 

Ticket for this:
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-395994

# Links

*Links to relevent resources.*
