### PR TITLE
refactor(overlay-alert): default overlay color

### DIFF
--- a/src/components/OverlayAlert/OverlayAlert.constants.ts
+++ b/src/components/OverlayAlert/OverlayAlert.constants.ts
@@ -1,4 +1,10 @@
+import { OVERLAY_CONSTANTS } from '../Overlay';
+
 const CLASS_PREFIX = 'md-overlay-alert';
+
+const DEFAULTS = {
+  OVERLAY_COLOR: OVERLAY_CONSTANTS.COLORS.SECONDARY,
+};
 
 const STYLE = {
   details: `${CLASS_PREFIX}-details`,
@@ -6,4 +12,4 @@ const STYLE = {
   wrapper: `${CLASS_PREFIX}-wrapper`,
 };
 
-export { CLASS_PREFIX, STYLE };
+export { CLASS_PREFIX, DEFAULTS, STYLE };

--- a/src/components/OverlayAlert/OverlayAlert.stories.args.ts
+++ b/src/components/OverlayAlert/OverlayAlert.stories.args.ts
@@ -3,6 +3,7 @@ import { overlayArgTypes } from '../Overlay/Overlay.stories.args';
 
 import { MODAL_CONTAINER_CONSTANTS } from '../ModalContainer';
 import { OVERLAY_CONSTANTS } from '../Overlay';
+import { OVERLAY_ALERT_CONSTANTS } from '.';
 
 const overlayAlertArgTypes = {
   actions: {
@@ -78,7 +79,7 @@ const overlayAlertArgTypes = {
         summary: 'ReactNode',
       },
       defaultValue: {
-        summary: OVERLAY_CONSTANTS.DEFAULTS.COLOR,
+        summary: OVERLAY_ALERT_CONSTANTS.DEFAULTS.OVERLAY_COLOR,
       },
     },
   },

--- a/src/components/OverlayAlert/OverlayAlert.tsx
+++ b/src/components/OverlayAlert/OverlayAlert.tsx
@@ -5,7 +5,7 @@ import ModalContainer from '../ModalContainer';
 import Overlay from '../Overlay';
 import Text from '../Text';
 
-import { STYLE } from './OverlayAlert.constants';
+import { DEFAULTS, STYLE } from './OverlayAlert.constants';
 import { Props } from './OverlayAlert.types';
 import './OverlayAlert.style.scss';
 
@@ -22,7 +22,7 @@ const OverlayAlert: FC<Props> = (props: Props) => {
     controls,
     details,
     modalColor,
-    overlayColor,
+    overlayColor = DEFAULTS.OVERLAY_COLOR,
     title,
     ...other
   } = props;

--- a/src/components/OverlayAlert/OverlayAlert.unit.test.tsx
+++ b/src/components/OverlayAlert/OverlayAlert.unit.test.tsx
@@ -179,10 +179,20 @@ describe('<OverlayAlert />', () => {
       expect(element.getAttribute('style')).toBe(styleString);
     });
 
+    it('should provided the local <Overlay /> with the "secondary" color by default', () => {
+      expect.assertions(1);
+
+      const overlayColor = OVERLAY_ALERT_CONSTANTS.DEFAULTS.OVERLAY_COLOR;
+
+      const element = mount(<OverlayAlert />).find(Overlay);
+
+      expect(element.props().color).toBe(overlayColor);
+    });
+
     it('should provide the local <Overlay /> with its respective color', () => {
       expect.assertions(1);
 
-      const overlayColor = Object.values(OVERLAY_CONSTANTS.COLORS).pop();
+      const overlayColor = Object.values(OVERLAY_CONSTANTS.COLORS).shift();
 
       const element = mount(<OverlayAlert overlayColor={overlayColor} />).find(Overlay);
 

--- a/src/components/OverlayAlert/OverlayAlert.unit.test.tsx.snap
+++ b/src/components/OverlayAlert/OverlayAlert.unit.test.tsx.snap
@@ -4,10 +4,11 @@ exports[`<OverlayAlert /> snapshot should match snapshot 1`] = `
 <OverlayAlert>
   <Overlay
     className="md-overlay-alert-wrapper"
+    color="secondary"
   >
     <div
       className="md-overlay-alert-wrapper md-overlay-wrapper"
-      data-color="primary"
+      data-color="secondary"
       data-fullscreen={false}
     >
       <ModalContainer>
@@ -43,10 +44,11 @@ exports[`<OverlayAlert /> snapshot should match snapshot with actions 1`] = `
 >
   <Overlay
     className="md-overlay-alert-wrapper"
+    color="secondary"
   >
     <div
       className="md-overlay-alert-wrapper md-overlay-wrapper"
-      data-color="primary"
+      data-color="secondary"
       data-fullscreen={false}
     >
       <ModalContainer>
@@ -130,10 +132,11 @@ exports[`<OverlayAlert /> snapshot should match snapshot with className 1`] = `
 >
   <Overlay
     className="example-class md-overlay-alert-wrapper"
+    color="secondary"
   >
     <div
       className="example-class md-overlay-alert-wrapper md-overlay-wrapper"
-      data-color="primary"
+      data-color="secondary"
       data-fullscreen={false}
     >
       <ModalContainer>
@@ -169,10 +172,11 @@ exports[`<OverlayAlert /> snapshot should match snapshot with controls 1`] = `
 >
   <Overlay
     className="md-overlay-alert-wrapper"
+    color="secondary"
   >
     <div
       className="md-overlay-alert-wrapper md-overlay-wrapper"
-      data-color="primary"
+      data-color="secondary"
       data-fullscreen={false}
     >
       <ModalContainer>
@@ -244,10 +248,11 @@ exports[`<OverlayAlert /> snapshot should match snapshot with details 1`] = `
 >
   <Overlay
     className="md-overlay-alert-wrapper"
+    color="secondary"
   >
     <div
       className="md-overlay-alert-wrapper md-overlay-wrapper"
-      data-color="primary"
+      data-color="secondary"
       data-fullscreen={false}
     >
       <ModalContainer>
@@ -291,10 +296,11 @@ exports[`<OverlayAlert /> snapshot should match snapshot with details and childr
 >
   <Overlay
     className="md-overlay-alert-wrapper"
+    color="secondary"
   >
     <div
       className="md-overlay-alert-wrapper md-overlay-wrapper"
-      data-color="primary"
+      data-color="secondary"
       data-fullscreen={false}
     >
       <ModalContainer>
@@ -328,11 +334,12 @@ exports[`<OverlayAlert /> snapshot should match snapshot with id 1`] = `
 >
   <Overlay
     className="md-overlay-alert-wrapper"
+    color="secondary"
     id="example-id"
   >
     <div
       className="md-overlay-alert-wrapper md-overlay-wrapper"
-      data-color="primary"
+      data-color="secondary"
       data-fullscreen={false}
       id="example-id"
     >
@@ -380,10 +387,11 @@ exports[`<OverlayAlert /> snapshot should match snapshot with multiple actions 1
 >
   <Overlay
     className="md-overlay-alert-wrapper"
+    color="secondary"
   >
     <div
       className="md-overlay-alert-wrapper md-overlay-wrapper"
-      data-color="primary"
+      data-color="secondary"
       data-fullscreen={false}
     >
       <ModalContainer>
@@ -593,10 +601,11 @@ exports[`<OverlayAlert /> snapshot should match snapshot with multiple controls 
 >
   <Overlay
     className="md-overlay-alert-wrapper"
+    color="secondary"
   >
     <div
       className="md-overlay-alert-wrapper md-overlay-wrapper"
-      data-color="primary"
+      data-color="secondary"
       data-fullscreen={false}
     >
       <ModalContainer>
@@ -757,6 +766,7 @@ exports[`<OverlayAlert /> snapshot should match snapshot with style 1`] = `
 >
   <Overlay
     className="md-overlay-alert-wrapper"
+    color="secondary"
     style={
       Object {
         "color": "pink",
@@ -765,7 +775,7 @@ exports[`<OverlayAlert /> snapshot should match snapshot with style 1`] = `
   >
     <div
       className="md-overlay-alert-wrapper md-overlay-wrapper"
-      data-color="primary"
+      data-color="secondary"
       data-fullscreen={false}
       style={
         Object {
@@ -802,10 +812,11 @@ exports[`<OverlayAlert /> snapshot should match snapshot with title 1`] = `
 >
   <Overlay
     className="md-overlay-alert-wrapper"
+    color="secondary"
   >
     <div
       className="md-overlay-alert-wrapper md-overlay-wrapper"
-      data-color="primary"
+      data-color="secondary"
       data-fullscreen={false}
     >
       <ModalContainer>


### PR DESCRIPTION
# Description

The scope of the changes in this pull request is to update `<OverlayAlert />` to have a default `<Overlay />` color of `secondary` for the more common use case within consuming applications with this component.