### PR TITLE
fix(hideborder): ability to hide border for select

### DIFF
--- a/src/components/Select/Select.constants.ts
+++ b/src/components/Select/Select.constants.ts
@@ -10,6 +10,7 @@ const DIRECTIONS: Record<string, SelectDirection> = {
 const DEFAULTS = {
   DIRECTION: DIRECTIONS.bottom,
   SHOULD_AUTOFOCUS: true,
+  SHOULD_SHOW_BORDER: true,
 };
 
 const STYLE = {
@@ -21,6 +22,7 @@ const STYLE = {
   selectedItemWrapper: `${CLASS_PREFIX}-selected-item-wrapper`,
   overlay: `${CLASS_PREFIX}-overlay`,
   menuListBox: `${CLASS_PREFIX}-menu-listbox`,
+  borderLess: 'borderLess',
 };
 
 const SELECT_HEIGHT_ADJUST_BORDER = 2; // 2px extra because of the border(top, down);

--- a/src/components/Select/Select.stories.args.ts
+++ b/src/components/Select/Select.stories.args.ts
@@ -46,6 +46,20 @@ export default {
       },
     },
   },
+  showBorder: {
+    defaultValue: CONSTANTS.DEFAULTS.SHOULD_SHOW_BORDER,
+    description: 'If this component should have border around it.',
+    control: { type: 'boolean' },
+    options: [true, false],
+    table: {
+      type: {
+        summary: 'boolean',
+      },
+      defaultValue: {
+        summary: CONSTANTS.DEFAULTS.SHOULD_SHOW_BORDER,
+      },
+    },
+  },
   items: {
     defaultValue: [],
     description:

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -311,6 +311,7 @@ Common.parameters = {
       label: 'Direction Top',
       items: singleItems,
       direction: 'top',
+      showBorder: true,
       children: (item) => <Item key={item.id}>{item.value}</Item>,
     },
   ],

--- a/src/components/Select/Select.style.scss
+++ b/src/components/Select/Select.style.scss
@@ -30,6 +30,7 @@
   outline: none !important;
   cursor: pointer;
 
+
   > span:first-of-type {
     display: block;
     text-overflow: ellipsis;
@@ -99,4 +100,8 @@
   &[data-direction='bottom'] {
     margin-top: 0.25rem;
   }
+}
+
+.borderLess {
+  border: none;
 }

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -25,6 +25,7 @@ function Select<T extends object>(props: Props<T>, ref: RefObject<HTMLDivElement
     placeholder,
     direction = DEFAULTS.DIRECTION,
     title,
+    showBorder = DEFAULTS.SHOULD_SHOW_BORDER
   } = props;
   const state = useSelectState(props);
 
@@ -117,7 +118,8 @@ function Select<T extends object>(props: Props<T>, ref: RefObject<HTMLDivElement
           className={classnames(
             STYLE.dropdownInput,
             { [STYLE.selected]: state.selectedItem },
-            { [STYLE.open]: state.isOpen }
+            { [STYLE.open]: state.isOpen },
+            { [STYLE.borderLess]: !showBorder }
           )}
           ref={selectRef}
           title={title}

--- a/src/components/Select/Select.types.ts
+++ b/src/components/Select/Select.types.ts
@@ -34,4 +34,8 @@ export interface Props<T> extends AriaSelectProps<T> {
    * title to use for this component.
    */
   title?: string;
+  /**
+   * showBorder for the component
+   */
+  showBorder?: boolean;
 }

--- a/src/components/Select/Select.unit.test.tsx
+++ b/src/components/Select/Select.unit.test.tsx
@@ -99,6 +99,21 @@ describe('Select', () => {
       expect(container).toMatchSnapshot();
     });
 
+    it('should match snapshot with border', async () => {
+      expect.assertions(1);
+
+      const showBorder = false;
+
+      container = await mountAndWait(
+        <Select id="test-id" showBorder={showBorder} label="test">
+          <Item>Item 1</Item>
+          <Item>Item 2</Item>
+        </Select>
+      );
+
+      expect(container).toMatchSnapshot();
+    });
+
     it('should match snapshot with listbox opened', async () => {
       expect.assertions(1);
 

--- a/src/components/Select/Select.unit.test.tsx.snap
+++ b/src/components/Select/Select.unit.test.tsx.snap
@@ -1403,6 +1403,315 @@ exports[`Select snapshot should match snapshot before and after opening select d
 </Select>
 `;
 
+exports[`Select snapshot should match snapshot with border 1`] = `
+<Select
+  id="test-id"
+  label="test"
+  showBorder={false}
+>
+  <div
+    className="md-select-wrapper"
+    id="test-id"
+  >
+    <label
+      id="test-ID"
+      onClick={[Function]}
+    >
+      test
+    </label>
+    <HiddenSelect
+      label="test"
+      state={
+        Object {
+          "close": [Function],
+          "collection": ListCollection {
+            "firstKey": "$.0",
+            "iterable": Object {
+              Symbol(Symbol.iterator): [Function],
+            },
+            "keyMap": Map {
+              "$.0" => Object {
+                "aria-label": undefined,
+                "childNodes": Object {
+                  Symbol(Symbol.iterator): [Function],
+                },
+                "hasChildNodes": false,
+                "index": 0,
+                "key": "$.0",
+                "level": 0,
+                "nextKey": "$.1",
+                "parentKey": null,
+                "prevKey": undefined,
+                "props": Object {
+                  "children": "Item 1",
+                },
+                "rendered": "Item 1",
+                "shouldInvalidate": undefined,
+                "textValue": "Item 1",
+                "type": "item",
+                "value": undefined,
+                "wrapper": undefined,
+              },
+              "$.1" => Object {
+                "aria-label": undefined,
+                "childNodes": Object {
+                  Symbol(Symbol.iterator): [Function],
+                },
+                "hasChildNodes": false,
+                "index": 1,
+                "key": "$.1",
+                "level": 0,
+                "nextKey": undefined,
+                "parentKey": null,
+                "prevKey": "$.0",
+                "props": Object {
+                  "children": "Item 2",
+                },
+                "rendered": "Item 2",
+                "shouldInvalidate": undefined,
+                "textValue": "Item 2",
+                "type": "item",
+                "value": undefined,
+                "wrapper": undefined,
+              },
+            },
+            "lastKey": "$.1",
+          },
+          "disabledKeys": Set {},
+          "focusStrategy": null,
+          "isFocused": false,
+          "isOpen": false,
+          "open": [Function],
+          "selectedItem": null,
+          "selectedKey": null,
+          "selectionManager": SelectionManager {
+            "_isSelectAll": null,
+            "allowsCellSelection": false,
+            "collection": ListCollection {
+              "firstKey": "$.0",
+              "iterable": Object {
+                Symbol(Symbol.iterator): [Function],
+              },
+              "keyMap": Map {
+                "$.0" => Object {
+                  "aria-label": undefined,
+                  "childNodes": Object {
+                    Symbol(Symbol.iterator): [Function],
+                  },
+                  "hasChildNodes": false,
+                  "index": 0,
+                  "key": "$.0",
+                  "level": 0,
+                  "nextKey": "$.1",
+                  "parentKey": null,
+                  "prevKey": undefined,
+                  "props": Object {
+                    "children": "Item 1",
+                  },
+                  "rendered": "Item 1",
+                  "shouldInvalidate": undefined,
+                  "textValue": "Item 1",
+                  "type": "item",
+                  "value": undefined,
+                  "wrapper": undefined,
+                },
+                "$.1" => Object {
+                  "aria-label": undefined,
+                  "childNodes": Object {
+                    Symbol(Symbol.iterator): [Function],
+                  },
+                  "hasChildNodes": false,
+                  "index": 1,
+                  "key": "$.1",
+                  "level": 0,
+                  "nextKey": undefined,
+                  "parentKey": null,
+                  "prevKey": "$.0",
+                  "props": Object {
+                    "children": "Item 2",
+                  },
+                  "rendered": "Item 2",
+                  "shouldInvalidate": undefined,
+                  "textValue": "Item 2",
+                  "type": "item",
+                  "value": undefined,
+                  "wrapper": undefined,
+                },
+              },
+              "lastKey": "$.1",
+            },
+            "state": Object {
+              "childFocusStrategy": null,
+              "disabledKeys": Set {},
+              "disallowEmptySelection": true,
+              "focusedKey": null,
+              "isFocused": false,
+              "selectedKeys": Set {},
+              "selectionMode": "single",
+              "setFocused": [Function],
+              "setFocusedKey": [Function],
+              "setSelectedKeys": [Function],
+            },
+          },
+          "setFocused": [Function],
+          "setSelectedKey": [Function],
+          "toggle": [Function],
+        }
+      }
+      triggerRef={
+        Object {
+          "current": <button
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            aria-labelledby="test-ID test-ID"
+            class="md-select-dropdown-input borderLess"
+            id="test-ID"
+            type="button"
+          >
+            <span
+              class="md-select-selected-item-wrapper"
+              id="test-ID"
+            />
+            <span
+              aria-hidden="true"
+              class="md-select-icon-wrapper"
+            >
+              <div
+                class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+              >
+                <svg
+                  class=""
+                  data-autoscale="false"
+                  data-scale="16"
+                  data-test="arrow-down"
+                  fill="currentColor"
+                  height="100%"
+                  viewBox="0, 0, 32, 32"
+                  width="100%"
+                />
+              </div>
+            </span>
+          </button>,
+        }
+      }
+    >
+      <div
+        aria-hidden={true}
+        style={
+          Object {
+            "border": 0,
+            "clip": "rect(0 0 0 0)",
+            "clipPath": "inset(50%)",
+            "height": 1,
+            "margin": "0 -1px -1px 0",
+            "overflow": "hidden",
+            "padding": 0,
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": 1,
+          }
+        }
+      >
+        <input
+          onFocus={[Function]}
+          style={
+            Object {
+              "fontSize": 16,
+            }
+          }
+          tabIndex={-1}
+          type="text"
+        />
+        <label>
+          test
+          <select
+            onChange={[Function]}
+            size={2}
+            tabIndex={-1}
+            value=""
+          >
+            <option />
+            <option
+              key="$.0"
+              value="$.0"
+            >
+              Item 1
+            </option>
+            <option
+              key="$.1"
+              value="$.1"
+            >
+              Item 2
+            </option>
+          </select>
+        </label>
+      </div>
+    </HiddenSelect>
+    <FocusRing>
+      <FocusRing
+        focusClass="md-focus-ring-wrapper children"
+        focusRingClass="md-focus-ring-wrapper children"
+      >
+        <button
+          aria-controls={null}
+          aria-expanded={false}
+          aria-haspopup="listbox"
+          aria-labelledby="test-ID test-ID"
+          className="md-select-dropdown-input borderLess"
+          id="test-ID"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onDragStart={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchCancel={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          type="button"
+        >
+          <span
+            className="md-select-selected-item-wrapper"
+            id="test-ID"
+          />
+          <span
+            aria-hidden="true"
+            className="md-select-icon-wrapper"
+          >
+            <Icon
+              name="arrow-down"
+              scale={16}
+              weight="bold"
+            >
+              <div
+                className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+              >
+                <svg
+                  className=""
+                  data-autoscale={false}
+                  data-scale={16}
+                  data-test="arrow-down"
+                  fill="currentColor"
+                  height="100%"
+                  style={Object {}}
+                  viewBox="0, 0, 32, 32"
+                  width="100%"
+                />
+              </div>
+            </Icon>
+          </span>
+        </button>
+      </FocusRing>
+    </FocusRing>
+  </div>
+</Select>
+`;
+
 exports[`Select snapshot should match snapshot with className 1`] = `
 <Select
   className="example-class"


### PR DESCRIPTION
# IMPORTANT

**Currently, this project is closed to any external contributions. Any pull request made against this project from external sources will likely be closed. If you would like to make changes to this project, please fork this project.**

# Guide

**This "Help" section can be deleted before submitting this pull request.**

*Update the name of this pull request to reflect the following shape:*

```
{type}/{scope?}/{message}
```

* **type** - A [conventional commit type](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional#type-enum) **REQUIRED**
* **scope** - The kabab-case scope of the changes in this request
* **message** - A short, kebab-case statement describing the changes **REQUIRED**

*Provide a general summary of the scope of the changes in this pull request.*

* [Readme](https://github.com/momentum-design/momentum-react-v2/blob/master/README.md)
* [Getting Started Guide](https://github.com/momentum-design/momentum-react-v2/blob/master/GETTING_STARTED.md)
* [Contributing Guide](https://github.com/momentum-design/momentum-react-v2/blob/master/CONTRIBUTING.md)

# Description

Add a property to Select so that border can be hidden, by default it is on

# Links

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-408602
