### PR TITLE
Popover first focus

### DIFF
--- a/src/components/AriaToolbar/AriaToolbar.tsx
+++ b/src/components/AriaToolbar/AriaToolbar.tsx
@@ -1,9 +1,10 @@
-import React, { FC, ReactNode, useRef, useState, useEffect } from 'react';
+import React, { FC, useRef, useState, useEffect } from 'react';
 import classnames from 'classnames';
 
 import { DEFAULTS, STYLE } from './AriaToolbar.constants';
 import { Props } from './AriaToolbar.types';
 import { useKeyboard } from '@react-aria/interactions';
+import { map } from 'lodash';
 
 /**
  * The AriaToolbar component. A style-less component implementing the Aria Toolbar pattern
@@ -23,7 +24,8 @@ const AriaToolbar: FC<Props> = (props: Props) => {
 
   const [currentFocus, setCurrentFocus] = useState(undefined);
 
-  const numChildren = React.Children.count(children);
+  const validChildren = React.Children.toArray(children);
+  const numChildren = validChildren.length;
 
   const buttonRefs = useRef({});
 
@@ -66,7 +68,7 @@ const AriaToolbar: FC<Props> = (props: Props) => {
       id={id}
       style={style}
     >
-      {React.Children.map<ReactNode, ReactNode>(children, (child, index) => {
+      {map(validChildren, (child, index) => {
         return React.cloneElement(child as React.ReactElement<any>, {
           tabIndex: index === (currentFocus || 0) ? 0 : -1,
           ref: (e) => {
@@ -74,10 +76,8 @@ const AriaToolbar: FC<Props> = (props: Props) => {
           },
           onPress: () => {
             setCurrentFocus(index);
-            if (React.isValidElement(child)) {
-              if (child.props.onPress) {
-                child.props.onPress();
-              }
+            if (child.props.onPress) {
+              child.props.onPress();
             }
           },
           ...keyboardProps,

--- a/src/components/AriaToolbar/AriaToolbar.tsx
+++ b/src/components/AriaToolbar/AriaToolbar.tsx
@@ -56,7 +56,9 @@ const AriaToolbar: FC<Props> = (props: Props) => {
   });
 
   useEffect(() => {
-    buttonRefs.current[currentFocus]?.focus();
+    setTimeout(() => {
+      buttonRefs.current[currentFocus]?.focus();
+    });
   }, [currentFocus]);
 
   return (
@@ -69,10 +71,19 @@ const AriaToolbar: FC<Props> = (props: Props) => {
       style={style}
     >
       {map(validChildren, (child, index) => {
-        return React.cloneElement(child as React.ReactElement<any>, {
+        return React.cloneElement(child, {
           tabIndex: index === (currentFocus || 0) ? 0 : -1,
           ref: (e) => {
             buttonRefs.current[index] = e;
+            if (child.ref) {
+              child.ref(e);
+            }
+          },
+          onFocus: (e) => {
+            setCurrentFocus(index);
+            if (child.props.onFocus) {
+              child.props.onFocus(e);
+            }
           },
           onPress: () => {
             setCurrentFocus(index);

--- a/src/components/AriaToolbar/AriaToolbar.tsx
+++ b/src/components/AriaToolbar/AriaToolbar.tsx
@@ -56,9 +56,7 @@ const AriaToolbar: FC<Props> = (props: Props) => {
   });
 
   useEffect(() => {
-    setTimeout(() => {
-      buttonRefs.current[currentFocus]?.focus();
-    });
+    buttonRefs.current[currentFocus]?.focus();
   }, [currentFocus]);
 
   return (

--- a/src/components/AriaToolbar/AriaToolbar.unit.test.tsx
+++ b/src/components/AriaToolbar/AriaToolbar.unit.test.tsx
@@ -71,6 +71,19 @@ describe('<AriaToolbar />', () => {
       expect(container).toMatchSnapshot();
     });
 
+    it('should not render invalid elements', () => {
+      expect.assertions(1);
+
+      const container = mount(
+        <AriaToolbar orientation="vertical" ariaLabel="test">
+          <ButtonSimple />
+          {null}
+        </AriaToolbar>
+      );
+
+      expect(container).toMatchSnapshot();
+    });
+
     it('should set tab index appropriately - vertical orientation', () => {
       expect.assertions(4);
 

--- a/src/components/AriaToolbar/AriaToolbar.unit.test.tsx
+++ b/src/components/AriaToolbar/AriaToolbar.unit.test.tsx
@@ -109,6 +109,32 @@ describe('<AriaToolbar />', () => {
 
       expect(container).toMatchSnapshot();
     });
+
+    it('should update order if triggered externally', () => {
+      expect.assertions(4);
+
+      const container = mount(
+        <AriaToolbar orientation="vertical" ariaLabel="test">
+          <ButtonSimple />
+          <ButtonSimple />
+          <ButtonSimple />
+        </AriaToolbar>
+      );
+
+      expect(container).toMatchSnapshot();
+
+      container.find(ButtonSimple).at(2).simulate('focus');
+
+      expect(container).toMatchSnapshot();
+
+      container.find(ButtonSimple).at(2).simulate('keyDown', { key: 'ArrowUp' });
+
+      expect(container).toMatchSnapshot();
+
+      container.find(ButtonSimple).at(1).simulate('keyDown', { key: 'ArrowDown' });
+
+      expect(container).toMatchSnapshot();
+    });
   });
 
   describe('attributes', () => {

--- a/src/components/AriaToolbar/AriaToolbar.unit.test.tsx
+++ b/src/components/AriaToolbar/AriaToolbar.unit.test.tsx
@@ -4,6 +4,9 @@ import { mount } from 'enzyme';
 import AriaToolbar, { ARIA_TOOLBAR_CONSTANTS as CONSTANTS } from './';
 import ButtonSimple from '../ButtonSimple';
 import { triggerPress } from '../../../test/utils';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
 
 describe('<AriaToolbar />', () => {
   describe('snapshot', () => {
@@ -110,10 +113,10 @@ describe('<AriaToolbar />', () => {
       expect(container).toMatchSnapshot();
     });
 
-    it('should update order if triggered externally', () => {
-      expect.assertions(4);
-
-      const container = mount(
+    it('should update order if triggered externally', async () => {
+      expect.assertions(7);
+      const user = userEvent.setup();
+      const { getAllByRole, container } = render(
         <AriaToolbar orientation="vertical" ariaLabel="test">
           <ButtonSimple />
           <ButtonSimple />
@@ -123,16 +126,21 @@ describe('<AriaToolbar />', () => {
 
       expect(container).toMatchSnapshot();
 
-      container.find(ButtonSimple).at(2).simulate('focus');
+      const buttons = getAllByRole('button');
 
+      buttons[2].focus();
+
+      expect(buttons[2]).toHaveFocus();
       expect(container).toMatchSnapshot();
 
-      container.find(ButtonSimple).at(2).simulate('keyDown', { key: 'ArrowUp' });
+      await user.keyboard('{ArrowUp}');
 
+      expect(buttons[1]).toHaveFocus();
       expect(container).toMatchSnapshot();
 
-      container.find(ButtonSimple).at(1).simulate('keyDown', { key: 'ArrowDown' });
+      await user.keyboard('{ArrowDown}');
 
+      expect(buttons[2]).toHaveFocus();
       expect(container).toMatchSnapshot();
     });
   });

--- a/src/components/AriaToolbar/AriaToolbar.unit.test.tsx.snap
+++ b/src/components/AriaToolbar/AriaToolbar.unit.test.tsx.snap
@@ -61,6 +61,52 @@ exports[`<AriaToolbar /> snapshot should match snapshot with style 1`] = `
 </AriaToolbar>
 `;
 
+exports[`<AriaToolbar /> snapshot should not render invalid elements 1`] = `
+<AriaToolbar
+  ariaLabel="test"
+  orientation="vertical"
+>
+  <div
+    aria-label="test"
+    className="md-aria-toolbar-wrapper"
+    role="toolbar"
+  >
+    <ButtonSimple
+      key=".0"
+      onKeyDown={[Function]}
+      onPress={[Function]}
+      tabIndex={0}
+    >
+      <FocusRing>
+        <FocusRing
+          focusClass="md-focus-ring-wrapper children"
+          focusRingClass="md-focus-ring-wrapper children"
+        >
+          <button
+            className="md-button-simple-wrapper"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onDragStart={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchCancel={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            type="button"
+          />
+        </FocusRing>
+      </FocusRing>
+    </ButtonSimple>
+  </div>
+</AriaToolbar>
+`;
+
 exports[`<AriaToolbar /> snapshot should set tab index appropriately - horizontal orientation 1`] = `
 <AriaToolbar
   ariaLabel="test"

--- a/src/components/AriaToolbar/AriaToolbar.unit.test.tsx.snap
+++ b/src/components/AriaToolbar/AriaToolbar.unit.test.tsx.snap
@@ -1025,461 +1025,101 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - vertical 
 `;
 
 exports[`<AriaToolbar /> snapshot should update order if triggered externally 1`] = `
-<AriaToolbar
-  ariaLabel="test"
-  orientation="vertical"
->
+<div>
   <div
     aria-label="test"
-    className="md-aria-toolbar-wrapper"
+    class="md-aria-toolbar-wrapper"
     role="toolbar"
   >
-    <ButtonSimple
-      key=".0"
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onPress={[Function]}
-      tabIndex={0}
-    >
-      <FocusRing>
-        <FocusRing
-          focusClass="md-focus-ring-wrapper children"
-          focusRingClass="md-focus-ring-wrapper children"
-        >
-          <button
-            className="md-button-simple-wrapper"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onDragStart={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchCancel={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            type="button"
-          />
-        </FocusRing>
-      </FocusRing>
-    </ButtonSimple>
-    <ButtonSimple
-      key=".1"
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onPress={[Function]}
-      tabIndex={-1}
-    >
-      <FocusRing>
-        <FocusRing
-          focusClass="md-focus-ring-wrapper children"
-          focusRingClass="md-focus-ring-wrapper children"
-        >
-          <button
-            className="md-button-simple-wrapper"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onDragStart={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchCancel={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            tabIndex={-1}
-            type="button"
-          />
-        </FocusRing>
-      </FocusRing>
-    </ButtonSimple>
-    <ButtonSimple
-      key=".2"
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onPress={[Function]}
-      tabIndex={-1}
-    >
-      <FocusRing>
-        <FocusRing
-          focusClass="md-focus-ring-wrapper children"
-          focusRingClass="md-focus-ring-wrapper children"
-        >
-          <button
-            className="md-button-simple-wrapper"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onDragStart={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchCancel={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            tabIndex={-1}
-            type="button"
-          />
-        </FocusRing>
-      </FocusRing>
-    </ButtonSimple>
+    <button
+      class="md-button-simple-wrapper"
+      type="button"
+    />
+    <button
+      class="md-button-simple-wrapper"
+      tabindex="-1"
+      type="button"
+    />
+    <button
+      class="md-button-simple-wrapper"
+      tabindex="-1"
+      type="button"
+    />
   </div>
-</AriaToolbar>
+</div>
 `;
 
 exports[`<AriaToolbar /> snapshot should update order if triggered externally 2`] = `
-<AriaToolbar
-  ariaLabel="test"
-  orientation="vertical"
->
+<div>
   <div
     aria-label="test"
-    className="md-aria-toolbar-wrapper"
+    class="md-aria-toolbar-wrapper"
     role="toolbar"
   >
-    <ButtonSimple
-      key=".0"
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onPress={[Function]}
-      tabIndex={-1}
-    >
-      <FocusRing>
-        <FocusRing
-          focusClass="md-focus-ring-wrapper children"
-          focusRingClass="md-focus-ring-wrapper children"
-        >
-          <button
-            className="md-button-simple-wrapper"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onDragStart={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchCancel={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            tabIndex={-1}
-            type="button"
-          />
-        </FocusRing>
-      </FocusRing>
-    </ButtonSimple>
-    <ButtonSimple
-      key=".1"
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onPress={[Function]}
-      tabIndex={-1}
-    >
-      <FocusRing>
-        <FocusRing
-          focusClass="md-focus-ring-wrapper children"
-          focusRingClass="md-focus-ring-wrapper children"
-        >
-          <button
-            className="md-button-simple-wrapper"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onDragStart={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchCancel={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            tabIndex={-1}
-            type="button"
-          />
-        </FocusRing>
-      </FocusRing>
-    </ButtonSimple>
-    <ButtonSimple
-      key=".2"
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onPress={[Function]}
-      tabIndex={0}
-    >
-      <FocusRing>
-        <FocusRing
-          focusClass="md-focus-ring-wrapper children"
-          focusRingClass="md-focus-ring-wrapper children"
-        >
-          <button
-            className="md-button-simple-wrapper md-focus-ring-wrapper children"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onDragStart={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchCancel={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            type="button"
-          />
-        </FocusRing>
-      </FocusRing>
-    </ButtonSimple>
+    <button
+      class="md-button-simple-wrapper"
+      tabindex="-1"
+      type="button"
+    />
+    <button
+      class="md-button-simple-wrapper"
+      tabindex="-1"
+      type="button"
+    />
+    <button
+      class="md-button-simple-wrapper md-focus-ring-wrapper children"
+      type="button"
+    />
   </div>
-</AriaToolbar>
+</div>
 `;
 
 exports[`<AriaToolbar /> snapshot should update order if triggered externally 3`] = `
-<AriaToolbar
-  ariaLabel="test"
-  orientation="vertical"
->
+<div>
   <div
     aria-label="test"
-    className="md-aria-toolbar-wrapper"
+    class="md-aria-toolbar-wrapper"
     role="toolbar"
   >
-    <ButtonSimple
-      key=".0"
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onPress={[Function]}
-      tabIndex={-1}
-    >
-      <FocusRing>
-        <FocusRing
-          focusClass="md-focus-ring-wrapper children"
-          focusRingClass="md-focus-ring-wrapper children"
-        >
-          <button
-            className="md-button-simple-wrapper"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onDragStart={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchCancel={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            tabIndex={-1}
-            type="button"
-          />
-        </FocusRing>
-      </FocusRing>
-    </ButtonSimple>
-    <ButtonSimple
-      key=".1"
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onPress={[Function]}
-      tabIndex={0}
-    >
-      <FocusRing>
-        <FocusRing
-          focusClass="md-focus-ring-wrapper children"
-          focusRingClass="md-focus-ring-wrapper children"
-        >
-          <button
-            className="md-button-simple-wrapper"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onDragStart={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchCancel={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            type="button"
-          />
-        </FocusRing>
-      </FocusRing>
-    </ButtonSimple>
-    <ButtonSimple
-      key=".2"
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onPress={[Function]}
-      tabIndex={-1}
-    >
-      <FocusRing>
-        <FocusRing
-          focusClass="md-focus-ring-wrapper children"
-          focusRingClass="md-focus-ring-wrapper children"
-        >
-          <button
-            className="md-button-simple-wrapper md-focus-ring-wrapper children"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onDragStart={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchCancel={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            tabIndex={-1}
-            type="button"
-          />
-        </FocusRing>
-      </FocusRing>
-    </ButtonSimple>
+    <button
+      class="md-button-simple-wrapper"
+      tabindex="-1"
+      type="button"
+    />
+    <button
+      class="md-button-simple-wrapper md-focus-ring-wrapper children"
+      type="button"
+    />
+    <button
+      class="md-button-simple-wrapper"
+      tabindex="-1"
+      type="button"
+    />
   </div>
-</AriaToolbar>
+</div>
 `;
 
 exports[`<AriaToolbar /> snapshot should update order if triggered externally 4`] = `
-<AriaToolbar
-  ariaLabel="test"
-  orientation="vertical"
->
+<div>
   <div
     aria-label="test"
-    className="md-aria-toolbar-wrapper"
+    class="md-aria-toolbar-wrapper"
     role="toolbar"
   >
-    <ButtonSimple
-      key=".0"
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onPress={[Function]}
-      tabIndex={-1}
-    >
-      <FocusRing>
-        <FocusRing
-          focusClass="md-focus-ring-wrapper children"
-          focusRingClass="md-focus-ring-wrapper children"
-        >
-          <button
-            className="md-button-simple-wrapper"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onDragStart={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchCancel={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            tabIndex={-1}
-            type="button"
-          />
-        </FocusRing>
-      </FocusRing>
-    </ButtonSimple>
-    <ButtonSimple
-      key=".1"
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onPress={[Function]}
-      tabIndex={-1}
-    >
-      <FocusRing>
-        <FocusRing
-          focusClass="md-focus-ring-wrapper children"
-          focusRingClass="md-focus-ring-wrapper children"
-        >
-          <button
-            className="md-button-simple-wrapper"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onDragStart={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchCancel={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            tabIndex={-1}
-            type="button"
-          />
-        </FocusRing>
-      </FocusRing>
-    </ButtonSimple>
-    <ButtonSimple
-      key=".2"
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onPress={[Function]}
-      tabIndex={0}
-    >
-      <FocusRing>
-        <FocusRing
-          focusClass="md-focus-ring-wrapper children"
-          focusRingClass="md-focus-ring-wrapper children"
-        >
-          <button
-            className="md-button-simple-wrapper md-focus-ring-wrapper children"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onDragStart={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchCancel={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            type="button"
-          />
-        </FocusRing>
-      </FocusRing>
-    </ButtonSimple>
+    <button
+      class="md-button-simple-wrapper"
+      tabindex="-1"
+      type="button"
+    />
+    <button
+      class="md-button-simple-wrapper"
+      tabindex="-1"
+      type="button"
+    />
+    <button
+      class="md-button-simple-wrapper md-focus-ring-wrapper children"
+      type="button"
+    />
   </div>
-</AriaToolbar>
+</div>
 `;

--- a/src/components/AriaToolbar/AriaToolbar.unit.test.tsx.snap
+++ b/src/components/AriaToolbar/AriaToolbar.unit.test.tsx.snap
@@ -73,6 +73,7 @@ exports[`<AriaToolbar /> snapshot should not render invalid elements 1`] = `
   >
     <ButtonSimple
       key=".0"
+      onFocus={[Function]}
       onKeyDown={[Function]}
       onPress={[Function]}
       tabIndex={0}
@@ -118,6 +119,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - horizonta
   >
     <ButtonSimple
       key=".0"
+      onFocus={[Function]}
       onKeyDown={[Function]}
       onPress={[Function]}
       tabIndex={0}
@@ -150,6 +152,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - horizonta
     </ButtonSimple>
     <ButtonSimple
       key=".1"
+      onFocus={[Function]}
       onKeyDown={[Function]}
       onPress={[Function]}
       tabIndex={-1}
@@ -183,6 +186,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - horizonta
     </ButtonSimple>
     <ButtonSimple
       key=".2"
+      onFocus={[Function]}
       onKeyDown={[Function]}
       onPress={[Function]}
       tabIndex={-1}
@@ -229,6 +233,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - horizonta
   >
     <ButtonSimple
       key=".0"
+      onFocus={[Function]}
       onKeyDown={[Function]}
       onPress={[Function]}
       tabIndex={-1}
@@ -262,6 +267,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - horizonta
     </ButtonSimple>
     <ButtonSimple
       key=".1"
+      onFocus={[Function]}
       onKeyDown={[Function]}
       onPress={[Function]}
       tabIndex={-1}
@@ -295,6 +301,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - horizonta
     </ButtonSimple>
     <ButtonSimple
       key=".2"
+      onFocus={[Function]}
       onKeyDown={[Function]}
       onPress={[Function]}
       tabIndex={0}
@@ -340,6 +347,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - horizonta
   >
     <ButtonSimple
       key=".0"
+      onFocus={[Function]}
       onKeyDown={[Function]}
       onPress={[Function]}
       tabIndex={-1}
@@ -373,6 +381,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - horizonta
     </ButtonSimple>
     <ButtonSimple
       key=".1"
+      onFocus={[Function]}
       onKeyDown={[Function]}
       onPress={[Function]}
       tabIndex={0}
@@ -405,6 +414,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - horizonta
     </ButtonSimple>
     <ButtonSimple
       key=".2"
+      onFocus={[Function]}
       onKeyDown={[Function]}
       onPress={[Function]}
       tabIndex={-1}
@@ -451,6 +461,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - horizonta
   >
     <ButtonSimple
       key=".0"
+      onFocus={[Function]}
       onKeyDown={[Function]}
       onPress={[Function]}
       tabIndex={-1}
@@ -484,6 +495,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - horizonta
     </ButtonSimple>
     <ButtonSimple
       key=".1"
+      onFocus={[Function]}
       onKeyDown={[Function]}
       onPress={[Function]}
       tabIndex={-1}
@@ -517,6 +529,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - horizonta
     </ButtonSimple>
     <ButtonSimple
       key=".2"
+      onFocus={[Function]}
       onKeyDown={[Function]}
       onPress={[Function]}
       tabIndex={0}
@@ -563,6 +576,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - vertical 
   >
     <ButtonSimple
       key=".0"
+      onFocus={[Function]}
       onKeyDown={[Function]}
       onPress={[Function]}
       tabIndex={0}
@@ -595,6 +609,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - vertical 
     </ButtonSimple>
     <ButtonSimple
       key=".1"
+      onFocus={[Function]}
       onKeyDown={[Function]}
       onPress={[Function]}
       tabIndex={-1}
@@ -628,6 +643,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - vertical 
     </ButtonSimple>
     <ButtonSimple
       key=".2"
+      onFocus={[Function]}
       onKeyDown={[Function]}
       onPress={[Function]}
       tabIndex={-1}
@@ -675,6 +691,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - vertical 
   >
     <ButtonSimple
       key=".0"
+      onFocus={[Function]}
       onKeyDown={[Function]}
       onPress={[Function]}
       tabIndex={-1}
@@ -708,6 +725,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - vertical 
     </ButtonSimple>
     <ButtonSimple
       key=".1"
+      onFocus={[Function]}
       onKeyDown={[Function]}
       onPress={[Function]}
       tabIndex={-1}
@@ -741,6 +759,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - vertical 
     </ButtonSimple>
     <ButtonSimple
       key=".2"
+      onFocus={[Function]}
       onKeyDown={[Function]}
       onPress={[Function]}
       tabIndex={0}
@@ -787,6 +806,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - vertical 
   >
     <ButtonSimple
       key=".0"
+      onFocus={[Function]}
       onKeyDown={[Function]}
       onPress={[Function]}
       tabIndex={-1}
@@ -820,6 +840,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - vertical 
     </ButtonSimple>
     <ButtonSimple
       key=".1"
+      onFocus={[Function]}
       onKeyDown={[Function]}
       onPress={[Function]}
       tabIndex={0}
@@ -852,6 +873,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - vertical 
     </ButtonSimple>
     <ButtonSimple
       key=".2"
+      onFocus={[Function]}
       onKeyDown={[Function]}
       onPress={[Function]}
       tabIndex={-1}
@@ -899,6 +921,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - vertical 
   >
     <ButtonSimple
       key=".0"
+      onFocus={[Function]}
       onKeyDown={[Function]}
       onPress={[Function]}
       tabIndex={-1}
@@ -932,6 +955,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - vertical 
     </ButtonSimple>
     <ButtonSimple
       key=".1"
+      onFocus={[Function]}
       onKeyDown={[Function]}
       onPress={[Function]}
       tabIndex={-1}
@@ -965,6 +989,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - vertical 
     </ButtonSimple>
     <ButtonSimple
       key=".2"
+      onFocus={[Function]}
       onKeyDown={[Function]}
       onPress={[Function]}
       tabIndex={0}
@@ -976,6 +1001,466 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - vertical 
         >
           <button
             className="md-button-simple-wrapper"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onDragStart={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchCancel={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            type="button"
+          />
+        </FocusRing>
+      </FocusRing>
+    </ButtonSimple>
+  </div>
+</AriaToolbar>
+`;
+
+exports[`<AriaToolbar /> snapshot should update order if triggered externally 1`] = `
+<AriaToolbar
+  ariaLabel="test"
+  orientation="vertical"
+>
+  <div
+    aria-label="test"
+    className="md-aria-toolbar-wrapper"
+    role="toolbar"
+  >
+    <ButtonSimple
+      key=".0"
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onPress={[Function]}
+      tabIndex={0}
+    >
+      <FocusRing>
+        <FocusRing
+          focusClass="md-focus-ring-wrapper children"
+          focusRingClass="md-focus-ring-wrapper children"
+        >
+          <button
+            className="md-button-simple-wrapper"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onDragStart={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchCancel={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            type="button"
+          />
+        </FocusRing>
+      </FocusRing>
+    </ButtonSimple>
+    <ButtonSimple
+      key=".1"
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onPress={[Function]}
+      tabIndex={-1}
+    >
+      <FocusRing>
+        <FocusRing
+          focusClass="md-focus-ring-wrapper children"
+          focusRingClass="md-focus-ring-wrapper children"
+        >
+          <button
+            className="md-button-simple-wrapper"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onDragStart={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchCancel={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex={-1}
+            type="button"
+          />
+        </FocusRing>
+      </FocusRing>
+    </ButtonSimple>
+    <ButtonSimple
+      key=".2"
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onPress={[Function]}
+      tabIndex={-1}
+    >
+      <FocusRing>
+        <FocusRing
+          focusClass="md-focus-ring-wrapper children"
+          focusRingClass="md-focus-ring-wrapper children"
+        >
+          <button
+            className="md-button-simple-wrapper"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onDragStart={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchCancel={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex={-1}
+            type="button"
+          />
+        </FocusRing>
+      </FocusRing>
+    </ButtonSimple>
+  </div>
+</AriaToolbar>
+`;
+
+exports[`<AriaToolbar /> snapshot should update order if triggered externally 2`] = `
+<AriaToolbar
+  ariaLabel="test"
+  orientation="vertical"
+>
+  <div
+    aria-label="test"
+    className="md-aria-toolbar-wrapper"
+    role="toolbar"
+  >
+    <ButtonSimple
+      key=".0"
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onPress={[Function]}
+      tabIndex={-1}
+    >
+      <FocusRing>
+        <FocusRing
+          focusClass="md-focus-ring-wrapper children"
+          focusRingClass="md-focus-ring-wrapper children"
+        >
+          <button
+            className="md-button-simple-wrapper"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onDragStart={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchCancel={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex={-1}
+            type="button"
+          />
+        </FocusRing>
+      </FocusRing>
+    </ButtonSimple>
+    <ButtonSimple
+      key=".1"
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onPress={[Function]}
+      tabIndex={-1}
+    >
+      <FocusRing>
+        <FocusRing
+          focusClass="md-focus-ring-wrapper children"
+          focusRingClass="md-focus-ring-wrapper children"
+        >
+          <button
+            className="md-button-simple-wrapper"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onDragStart={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchCancel={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex={-1}
+            type="button"
+          />
+        </FocusRing>
+      </FocusRing>
+    </ButtonSimple>
+    <ButtonSimple
+      key=".2"
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onPress={[Function]}
+      tabIndex={0}
+    >
+      <FocusRing>
+        <FocusRing
+          focusClass="md-focus-ring-wrapper children"
+          focusRingClass="md-focus-ring-wrapper children"
+        >
+          <button
+            className="md-button-simple-wrapper md-focus-ring-wrapper children"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onDragStart={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchCancel={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            type="button"
+          />
+        </FocusRing>
+      </FocusRing>
+    </ButtonSimple>
+  </div>
+</AriaToolbar>
+`;
+
+exports[`<AriaToolbar /> snapshot should update order if triggered externally 3`] = `
+<AriaToolbar
+  ariaLabel="test"
+  orientation="vertical"
+>
+  <div
+    aria-label="test"
+    className="md-aria-toolbar-wrapper"
+    role="toolbar"
+  >
+    <ButtonSimple
+      key=".0"
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onPress={[Function]}
+      tabIndex={-1}
+    >
+      <FocusRing>
+        <FocusRing
+          focusClass="md-focus-ring-wrapper children"
+          focusRingClass="md-focus-ring-wrapper children"
+        >
+          <button
+            className="md-button-simple-wrapper"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onDragStart={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchCancel={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex={-1}
+            type="button"
+          />
+        </FocusRing>
+      </FocusRing>
+    </ButtonSimple>
+    <ButtonSimple
+      key=".1"
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onPress={[Function]}
+      tabIndex={0}
+    >
+      <FocusRing>
+        <FocusRing
+          focusClass="md-focus-ring-wrapper children"
+          focusRingClass="md-focus-ring-wrapper children"
+        >
+          <button
+            className="md-button-simple-wrapper"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onDragStart={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchCancel={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            type="button"
+          />
+        </FocusRing>
+      </FocusRing>
+    </ButtonSimple>
+    <ButtonSimple
+      key=".2"
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onPress={[Function]}
+      tabIndex={-1}
+    >
+      <FocusRing>
+        <FocusRing
+          focusClass="md-focus-ring-wrapper children"
+          focusRingClass="md-focus-ring-wrapper children"
+        >
+          <button
+            className="md-button-simple-wrapper md-focus-ring-wrapper children"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onDragStart={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchCancel={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex={-1}
+            type="button"
+          />
+        </FocusRing>
+      </FocusRing>
+    </ButtonSimple>
+  </div>
+</AriaToolbar>
+`;
+
+exports[`<AriaToolbar /> snapshot should update order if triggered externally 4`] = `
+<AriaToolbar
+  ariaLabel="test"
+  orientation="vertical"
+>
+  <div
+    aria-label="test"
+    className="md-aria-toolbar-wrapper"
+    role="toolbar"
+  >
+    <ButtonSimple
+      key=".0"
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onPress={[Function]}
+      tabIndex={-1}
+    >
+      <FocusRing>
+        <FocusRing
+          focusClass="md-focus-ring-wrapper children"
+          focusRingClass="md-focus-ring-wrapper children"
+        >
+          <button
+            className="md-button-simple-wrapper"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onDragStart={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchCancel={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex={-1}
+            type="button"
+          />
+        </FocusRing>
+      </FocusRing>
+    </ButtonSimple>
+    <ButtonSimple
+      key=".1"
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onPress={[Function]}
+      tabIndex={-1}
+    >
+      <FocusRing>
+        <FocusRing
+          focusClass="md-focus-ring-wrapper children"
+          focusRingClass="md-focus-ring-wrapper children"
+        >
+          <button
+            className="md-button-simple-wrapper"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onDragStart={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchCancel={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex={-1}
+            type="button"
+          />
+        </FocusRing>
+      </FocusRing>
+    </ButtonSimple>
+    <ButtonSimple
+      key=".2"
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onPress={[Function]}
+      tabIndex={0}
+    >
+      <FocusRing>
+        <FocusRing
+          focusClass="md-focus-ring-wrapper children"
+          focusRingClass="md-focus-ring-wrapper children"
+        >
+          <button
+            className="md-button-simple-wrapper md-focus-ring-wrapper children"
             onBlur={[Function]}
             onClick={[Function]}
             onDragStart={[Function]}

--- a/src/components/Popover/Popover.stories.tsx
+++ b/src/components/Popover/Popover.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { MultiTemplate, Template } from '../../storybook/helper.stories.templates';
 import { DocumentationPage } from '../../storybook/helper.stories.docs';
 import StyleDocs from '../../storybook/docs.stories.style.mdx';
@@ -13,6 +13,7 @@ import { COLORS } from '../ModalContainer/ModalContainer.constants';
 import argTypes from './Popover.stories.args';
 import { PLACEMENTS } from '../ModalArrow/ModalArrow.constants';
 import Flex from '../Flex';
+import AriaToolbar from '../AriaToolbar';
 
 export default {
   title: 'Momentum UI/Popover',
@@ -67,6 +68,40 @@ InteractiveContent.args = {
       <Item key="five">Five</Item>
       <Item key="six">Six</Item>
     </Menu>
+  ),
+};
+
+const PopoverWithFirstFocus = (props) => {
+  const [ref, setRef] = useState<HTMLButtonElement>();
+
+  return (
+    <Popover firstFocusElement={ref} {...props}>
+      <AriaToolbar ariaLabel="toolbar">
+        <ButtonPill key={1}>1</ButtonPill>
+        <ButtonPill key={2} ref={setRef}>
+          2
+        </ButtonPill>
+        <ButtonPill key={3}>3</ButtonPill>
+        <ButtonPill key={4}>4</ButtonPill>
+      </AriaToolbar>
+    </Popover>
+  );
+};
+
+const InteractiveFocus = Template<PopoverProps>(PopoverWithFirstFocus).bind({});
+
+InteractiveFocus.argTypes = { ...argTypes };
+
+InteractiveFocus.args = {
+  trigger: 'click',
+  placement: PLACEMENTS.BOTTOM,
+  showArrow: true,
+  interactive: true,
+  variant: 'small',
+  color: COLORS.TERTIARY,
+  delay: [0, 0],
+  triggerComponent: (
+    <ButtonPill style={{ margin: '10rem auto', display: 'flex' }}>Click me!</ButtonPill>
   ),
 };
 
@@ -173,4 +208,4 @@ Common.parameters = {
   ],
 };
 
-export { Example, InteractiveContent, WithCloseButton, Offset, Common };
+export { Example, InteractiveContent, InteractiveFocus, WithCloseButton, Offset, Common };

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback } from 'react';
+import React, { FC, useCallback, useEffect } from 'react';
 import './Popover.style.scss';
 import ModalContainer from '../ModalContainer';
 import ButtonCircle from '../ButtonCircle';
@@ -59,6 +59,7 @@ const Popover: FC<Props> = (props: Props) => {
     onTrigger,
     onUntrigger,
     onClickOutside,
+    firstFocusElement,
     ...rest
   } = props;
 
@@ -83,6 +84,10 @@ const Popover: FC<Props> = (props: Props) => {
       setInstance?.(tippyRef.current._tippy);
     }
   }, [tippyRef, setInstance]);
+
+  useEffect(() => {
+    firstFocusElement?.focus();
+  }, [firstFocusElement]);
 
   return (
     <LazyTippy

--- a/src/components/Popover/Popover.types.ts
+++ b/src/components/Popover/Popover.types.ts
@@ -170,4 +170,11 @@ export interface Props extends PopoverCommonStyleProps, Partial<LifecycleHooks> 
    * @default 'undefined'
    */
   offsetSkidding?: number;
+
+  /**
+   * The element used to focus on when the popover opens
+   * See PopoverWithFirstFocus in storybook for example usage
+   * @default 'undefined'
+   */
+  firstFocusElement?: HTMLElement;
 }

--- a/src/components/Popover/Popover.unit.test.tsx
+++ b/src/components/Popover/Popover.unit.test.tsx
@@ -794,6 +794,46 @@ describe('<Popover />', () => {
       expect(document.activeElement).toEqual(triggerComponent);
     });
 
+    it('it should focus on the firstFocusElement', async () => {
+      expect.assertions(3);
+      const user = userEvent.setup();
+
+      const FirstFocusComponent = () => {
+        const [ref, setRef] = useState<HTMLButtonElement>();
+
+        return (
+          <Popover
+            closeButtonProps={{ 'aria-label': 'Close' }}
+            triggerComponent={<button>Click Me!</button>}
+            interactive
+            closeButtonPlacement="top-right"
+            trigger="click"
+            hideOnEsc={false}
+            firstFocusElement={ref}
+          >
+            <ButtonSimple role="group" ref={setRef}>
+              FirstFocusButton
+            </ButtonSimple>
+            <p>Content</p>
+          </Popover>
+        );
+      };
+
+      render(<FirstFocusComponent />);
+
+      // assert no popover on screen
+      const contentBeforeClick = screen.queryByText('Content');
+      expect(contentBeforeClick).not.toBeInTheDocument();
+
+      // after click, popover should be shown
+      await openPopoverByClickingOnTriggerAndCheckContent(user);
+
+      // focus should now be on the first focus el
+      const button = screen.getByRole('group');
+
+      expect(document.activeElement).toEqual(button);
+    });
+
     it('should hide Popover after clicking on the backdrop', async () => {
       expect.assertions(3);
       const user = userEvent.setup();


### PR DESCRIPTION
# Description

This allows specifying the element that a popover should focus on render using a function ref. See storybook for how this works.

Also in this PR are modifications to the AriaToolbar to
1) not render elements like null
2) handle being focused from outside
