### PR TITLE
fix(popover): arrowId memoryleak

### DIFF
--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -64,7 +64,8 @@ const Popover: FC<Props> = (props: Props) => {
 
   const tippyRef = React.useRef(null);
 
-  const arrowId = `${ARROW_ID}${uuidV4()}`;
+  // memoize arrow id to avoid memory leak (arrow will be different, but JS still tries to find old ones):
+  const arrowId = React.useMemo(() => `${ARROW_ID}${uuidV4()}`, []);
 
   const handleOnCloseButtonClick = useCallback(() => {
     tippyRef?.current?._tippy?.hide();


### PR DESCRIPTION
# Description

- The arrowId is constantly updated on every update, but should persist between updates - otherwise Tippy's JS code can not find the old elements references anymore between component updates, which leads to function locks. There is a infinite loop trying to find a element, which doesn't exist in Tippy's source code (Popper source code to be precise).
Fixing it by using `useMemo` to keep arrowId between updates.