### PR TITLE
List no loop

### DIFF
--- a/src/components/List/List.stories.args.ts
+++ b/src/components/List/List.stories.args.ts
@@ -26,8 +26,20 @@ export default {
       },
     },
   },
-  shouldFocusOnPres: {
+  shouldFocusOnPress: {
     description: 'Determines if the onPress handler should also focus the selected item',
+    control: { type: 'boolean' },
+    table: {
+      type: {
+        summary: 'boolean',
+      },
+      defaultValue: {
+        summary: 'false',
+      },
+    },
+  },
+  noLoop: {
+    description: 'Determines if the focus should loop if you get to the end of the list',
     control: { type: 'boolean' },
     table: {
       type: {

--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -4,7 +4,7 @@ import classnames from 'classnames';
 import { STYLE } from './List.constants';
 import { Props } from './List.types';
 import './List.style.scss';
-import { ListContext } from './List.utils';
+import { ListContext, setNextFocus } from './List.utils';
 import { useKeyboard } from '@react-aria/interactions';
 
 const List: FC<Props> = (props: Props) => {
@@ -17,6 +17,7 @@ const List: FC<Props> = (props: Props) => {
     listSize,
     role,
     shouldItemFocusBeInset,
+    noLoop,
   } = props;
 
   const [currentFocus, setCurrentFocus] = useState<number>(0);
@@ -39,13 +40,13 @@ const List: FC<Props> = (props: Props) => {
         case 'ArrowUp':
         case 'ArrowLeft':
           e.preventDefault();
-          setCurrentFocus((listSize + currentFocus - 1) % listSize);
+          setNextFocus(true, listSize, currentFocus, noLoop, setCurrentFocus);
           break;
 
         case 'ArrowDown':
         case 'ArrowRight':
           e.preventDefault();
-          setCurrentFocus((listSize + currentFocus + 1) % listSize);
+          setNextFocus(false, listSize, currentFocus, noLoop, setCurrentFocus);
           break;
 
         default:

--- a/src/components/List/List.types.ts
+++ b/src/components/List/List.types.ts
@@ -27,6 +27,11 @@ export interface Props {
   listSize: number;
 
   /**
+   * Whether the list should loop when you reach the top/bottom
+   */
+  noLoop?: boolean;
+
+  /**
    * Aria role
    */
   role?: string;

--- a/src/components/List/List.unit.test.tsx
+++ b/src/components/List/List.unit.test.tsx
@@ -207,6 +207,43 @@ describe('<List />', () => {
       expect(listItems[2]).toHaveFocus();
     });
 
+    it('should handle up/down arrow keys correctly - no loop', async () => {
+      expect.assertions(5);
+      const user = userEvent.setup();
+
+      const { getAllByRole } = render(
+        <List listSize={3} noLoop>
+          <ListItemBase key="0" itemIndex={0}>
+            ListItemBase 1
+          </ListItemBase>
+          <ListItemBase key="1" itemIndex={1}>
+            ListItemBase 2
+          </ListItemBase>
+          <ListItemBase key="2" itemIndex={2}>
+            ListItemBase 3
+          </ListItemBase>
+        </List>
+      );
+
+      const listItems = getAllByRole('listitem');
+
+      await user.tab();
+
+      expect(listItems[0]).toHaveFocus();
+
+      await user.keyboard('{ArrowUp}');
+      expect(listItems[0]).toHaveFocus();
+
+      await user.keyboard('{ArrowDown}');
+      expect(listItems[1]).toHaveFocus();
+
+      await user.keyboard('{ArrowDown}');
+      expect(listItems[2]).toHaveFocus();
+
+      await user.keyboard('{ArrowDown}');
+      expect(listItems[2]).toHaveFocus();
+    });
+
     it('should handle left/right arrow keys correctly', async () => {
       expect.assertions(8);
       const user = userEvent.setup();
@@ -249,6 +286,42 @@ describe('<List />', () => {
       expect(listItems[0]).toHaveFocus();
 
       await user.keyboard('{ArrowLeft}');
+      expect(listItems[2]).toHaveFocus();
+    });
+
+    it('should handle left/right arrow keys correctly - no loop', async () => {
+      expect.assertions(5);
+      const user = userEvent.setup();
+
+      const { getAllByRole } = render(
+        <List listSize={3} noLoop>
+          <ListItemBase key="0" itemIndex={0}>
+            ListItemBase 1
+          </ListItemBase>
+          <ListItemBase key="1" itemIndex={1}>
+            ListItemBase 2
+          </ListItemBase>
+          <ListItemBase key="2" itemIndex={2}>
+            ListItemBase 3
+          </ListItemBase>
+        </List>
+      );
+      const listItems = getAllByRole('listitem');
+
+      await user.tab();
+
+      expect(listItems[0]).toHaveFocus();
+
+      await user.keyboard('{ArrowLeft}');
+      expect(listItems[0]).toHaveFocus();
+
+      await user.keyboard('{ArrowRight}');
+      expect(listItems[1]).toHaveFocus();
+
+      await user.keyboard('{ArrowRight}');
+      expect(listItems[2]).toHaveFocus();
+
+      await user.keyboard('{ArrowRight}');
       expect(listItems[2]).toHaveFocus();
     });
 

--- a/src/components/List/List.utils.tsx
+++ b/src/components/List/List.utils.tsx
@@ -1,11 +1,17 @@
-import React, { useContext } from 'react';
+import React, { Dispatch, SetStateAction, useContext } from 'react';
 import { ListContextValue } from './List.types';
 
 export const ListContext = React.createContext<ListContextValue>(null);
 
 export const useListContext = (): ListContextValue => useContext(ListContext);
 
-export const setNextFocus = (isUp, listSize, currentFocus, noLoop, setFocus) => {
+export const setNextFocus = (
+  isUp: boolean,
+  listSize: number,
+  currentFocus: number,
+  noLoop: boolean,
+  setFocus: Dispatch<SetStateAction<number>>
+): void => {
   let nextIndex;
 
   if (isUp) {

--- a/src/components/List/List.utils.tsx
+++ b/src/components/List/List.utils.tsx
@@ -4,3 +4,23 @@ import { ListContextValue } from './List.types';
 export const ListContext = React.createContext<ListContextValue>(null);
 
 export const useListContext = (): ListContextValue => useContext(ListContext);
+
+export const setNextFocus = (isUp, listSize, currentFocus, noLoop, setFocus) => {
+  let nextIndex;
+
+  if (isUp) {
+    nextIndex = (listSize + currentFocus - 1) % listSize;
+
+    if (noLoop && nextIndex > currentFocus) {
+      return;
+    }
+  } else {
+    nextIndex = (listSize + currentFocus + 1) % listSize;
+
+    if (noLoop && nextIndex < currentFocus) {
+      return;
+    }
+  }
+
+  setFocus(nextIndex);
+};


### PR DESCRIPTION
# Description

Introduce a noLoop option for lists to opt out of the behavior of jumping to the other end of the list when you reach it by keyboard navigation. This will be used in lists where this is not going to work e.g. virtualized lists.