### PR TITLE
feat(select-arrow-fix): fix direction of arrow

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -25,7 +25,7 @@ function Select<T extends object>(props: Props<T>, ref: RefObject<HTMLDivElement
     placeholder,
     direction = DEFAULTS.DIRECTION,
     title,
-    showBorder = DEFAULTS.SHOULD_SHOW_BORDER
+    showBorder = DEFAULTS.SHOULD_SHOW_BORDER,
   } = props;
   const state = useSelectState(props);
 
@@ -52,13 +52,7 @@ function Select<T extends object>(props: Props<T>, ref: RefObject<HTMLDivElement
     overlayRef
   );
 
-  const getArrowIcon = (isOpen: boolean) => {
-    if (direction === 'bottom') {
-      return isOpen ? 'arrow-up' : 'arrow-down';
-    } else {
-      return isOpen ? 'arrow-down' : 'arrow-up';
-    }
-  };
+  const getArrowIcon = (isOpen: boolean) => (isOpen ? 'arrow-up' : 'arrow-down');
 
   // used to calculate position of top direction dropdown
   useEffect(() => {

--- a/src/components/Select/Select.unit.test.tsx.snap
+++ b/src/components/Select/Select.unit.test.tsx.snap
@@ -2201,7 +2201,7 @@ exports[`Select snapshot should match snapshot with direction 1`] = `
                   class=""
                   data-autoscale="false"
                   data-scale="16"
-                  data-test="arrow-up"
+                  data-test="arrow-down"
                   fill="currentColor"
                   height="100%"
                   viewBox="0, 0, 32, 32"
@@ -2302,7 +2302,7 @@ exports[`Select snapshot should match snapshot with direction 1`] = `
             className="md-select-icon-wrapper"
           >
             <Icon
-              name="arrow-up"
+              name="arrow-down"
               scale={16}
               weight="bold"
             >
@@ -2313,7 +2313,7 @@ exports[`Select snapshot should match snapshot with direction 1`] = `
                   className=""
                   data-autoscale={false}
                   data-scale={16}
-                  data-test="arrow-up"
+                  data-test="arrow-down"
                   fill="currentColor"
                   height="100%"
                   style={Object {}}


### PR DESCRIPTION
# Description

When a Select opens upwards (direct = up), the arrow shouldn't swap position. 

Universally, arrow-down means the Select is closed and arrow-up means the Select is open. Disregards the direction of the dropdown. 
Check Gmail for example:

Close dropdown = arrow down
![image](https://github.com/momentum-design/momentum-react-v2/assets/56999622/ac579712-9220-4cd1-969f-9259327e96d0)

Open dropdown = arrow up
![image](https://github.com/momentum-design/momentum-react-v2/assets/56999622/27d473f1-c174-483d-92bb-4d6b451c81f0)

