### PR TITLE
fix/AlertBanner/change grow from 100% to auto to respect margin

### DIFF
--- a/src/components/AlertBanner/AlertBanner.style.scss
+++ b/src/components/AlertBanner/AlertBanner.style.scss
@@ -133,7 +133,7 @@
   }
 
   &[data-grow='true'] {
-    width: 100%;
+    width: auto;
   }
 
   &[data-pill='true'] {


### PR DESCRIPTION
# IMPORTANT

**Currently, this project is closed to any external contributions. Any pull request made against this project from external sources will likely be closed. If you would like to make changes to this project, please fork this project.**

# Guide

**This "Help" section can be deleted before submitting this pull request.**

*Update the name of this pull request to reflect the following shape:*

```
{type}/{scope?}/{message}
```

* **type** - A [conventional commit type](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional#type-enum) **REQUIRED**
* **scope** - The kabab-case scope of the changes in this request
* **message** - A short, kebab-case statement describing the changes **REQUIRED**

*Provide a general summary of the scope of the changes in this pull request.*

* [Readme](https://github.com/momentum-design/momentum-react-v2/blob/master/README.md)
* [Getting Started Guide](https://github.com/momentum-design/momentum-react-v2/blob/master/GETTING_STARTED.md)
* [Contributing Guide](https://github.com/momentum-design/momentum-react-v2/blob/master/CONTRIBUTING.md)

# Description
change "grow" AlertBanners from `width: 100%` to `width: auto`. note how in the screenshots, the AlertBanner does not clip out of it's parent container
see https://stackoverflow.com/a/22666723/18094213 for description of issue

# Links
before: 
<img width="1566" alt="image" src="https://github.com/momentum-design/momentum-react-v2/assets/11569788/c7db92b4-1d9d-4e3d-ac4a-90838473d726">

after:
<img width="1563" alt="image" src="https://github.com/momentum-design/momentum-react-v2/assets/11569788/019f4fd3-8253-4e23-802d-3db2ddf10d31">

