### PR TITLE
feat(ButtonCircle): add solid prop

### DIFF
--- a/src/components/AddReactionButton/AddReactionButton.unit.test.tsx.snap
+++ b/src/components/AddReactionButton/AddReactionButton.unit.test.tsx.snap
@@ -14,6 +14,7 @@ exports[`<AddReactionButton /> snapshot should match snapshot 1`] = `
       data-multiple-children={false}
       data-outline={false}
       data-size={20}
+      data-solid={false}
     >
       <FocusRing>
         <FocusRing
@@ -28,6 +29,7 @@ exports[`<AddReactionButton /> snapshot should match snapshot 1`] = `
             data-multiple-children={false}
             data-outline={false}
             data-size={20}
+            data-solid={false}
             onBlur={[Function]}
             onClick={[Function]}
             onDragStart={[Function]}
@@ -88,6 +90,7 @@ exports[`<AddReactionButton /> snapshot should match snapshot with className 1`]
       data-multiple-children={false}
       data-outline={false}
       data-size={20}
+      data-solid={false}
     >
       <FocusRing>
         <FocusRing
@@ -102,6 +105,7 @@ exports[`<AddReactionButton /> snapshot should match snapshot with className 1`]
             data-multiple-children={false}
             data-outline={false}
             data-size={20}
+            data-solid={false}
             onBlur={[Function]}
             onClick={[Function]}
             onDragStart={[Function]}
@@ -163,6 +167,7 @@ exports[`<AddReactionButton /> snapshot should match snapshot with id 1`] = `
       data-multiple-children={false}
       data-outline={false}
       data-size={20}
+      data-solid={false}
       id="example-id"
     >
       <FocusRing>
@@ -178,6 +183,7 @@ exports[`<AddReactionButton /> snapshot should match snapshot with id 1`] = `
             data-multiple-children={false}
             data-outline={false}
             data-size={20}
+            data-solid={false}
             id="example-id"
             onBlur={[Function]}
             onClick={[Function]}
@@ -248,6 +254,7 @@ exports[`<AddReactionButton /> snapshot should match snapshot with style 1`] = `
       data-multiple-children={false}
       data-outline={false}
       data-size={20}
+      data-solid={false}
       style={
         Object {
           "color": "pink",
@@ -267,6 +274,7 @@ exports[`<AddReactionButton /> snapshot should match snapshot with style 1`] = `
             data-multiple-children={false}
             data-outline={false}
             data-size={20}
+            data-solid={false}
             onBlur={[Function]}
             onClick={[Function]}
             onDragStart={[Function]}

--- a/src/components/AvatarMeetingsListItem/AvatarMeetingsListItem.unit.test.tsx.snap
+++ b/src/components/AvatarMeetingsListItem/AvatarMeetingsListItem.unit.test.tsx.snap
@@ -495,6 +495,7 @@ exports[`<AvatarMeetingsListItem /> snapshot should match snapshot with displayM
                   data-multiple-children={false}
                   data-outline={false}
                   data-size={28}
+                  data-solid={false}
                 >
                   <FocusRing>
                     <FocusRing
@@ -509,6 +510,7 @@ exports[`<AvatarMeetingsListItem /> snapshot should match snapshot with displayM
                         data-multiple-children={false}
                         data-outline={false}
                         data-size={28}
+                        data-solid={false}
                         onBlur={[Function]}
                         onClick={[Function]}
                         onDragStart={[Function]}
@@ -680,6 +682,7 @@ exports[`<AvatarMeetingsListItem /> snapshot should match snapshot with displayM
                   data-multiple-children={false}
                   data-outline={false}
                   data-size={28}
+                  data-solid={false}
                 >
                   <FocusRing>
                     <FocusRing
@@ -694,6 +697,7 @@ exports[`<AvatarMeetingsListItem /> snapshot should match snapshot with displayM
                         data-multiple-children={false}
                         data-outline={false}
                         data-size={28}
+                        data-solid={false}
                         onBlur={[Function]}
                         onClick={[Function]}
                         onDragStart={[Function]}
@@ -870,6 +874,7 @@ exports[`<AvatarMeetingsListItem /> snapshot should match snapshot with displayM
                   data-multiple-children={false}
                   data-outline={false}
                   data-size={28}
+                  data-solid={false}
                 >
                   <FocusRing>
                     <FocusRing
@@ -884,6 +889,7 @@ exports[`<AvatarMeetingsListItem /> snapshot should match snapshot with displayM
                         data-multiple-children={false}
                         data-outline={false}
                         data-size={28}
+                        data-solid={false}
                         onBlur={[Function]}
                         onClick={[Function]}
                         onDragStart={[Function]}

--- a/src/components/Banner/Banner.unit.test.tsx.snap
+++ b/src/components/Banner/Banner.unit.test.tsx.snap
@@ -128,6 +128,7 @@ exports[`<Banner /> snapshot should match a complex snapshot 1`] = `
               data-multiple-children={false}
               data-outline={false}
               data-size={40}
+              data-solid={false}
             >
               <FocusRing>
                 <FocusRing
@@ -142,6 +143,7 @@ exports[`<Banner /> snapshot should match a complex snapshot 1`] = `
                     data-multiple-children={false}
                     data-outline={false}
                     data-size={40}
+                    data-solid={false}
                     onBlur={[Function]}
                     onClick={[Function]}
                     onDragStart={[Function]}
@@ -194,6 +196,7 @@ exports[`<Banner /> snapshot should match a complex snapshot 1`] = `
               data-multiple-children={false}
               data-outline={false}
               data-size={40}
+              data-solid={false}
             >
               <FocusRing>
                 <FocusRing
@@ -208,6 +211,7 @@ exports[`<Banner /> snapshot should match a complex snapshot 1`] = `
                     data-multiple-children={false}
                     data-outline={false}
                     data-size={40}
+                    data-solid={false}
                     onBlur={[Function]}
                     onClick={[Function]}
                     onDragStart={[Function]}
@@ -386,6 +390,7 @@ exports[`<Banner /> snapshot should match snapshot with actions 1`] = `
               data-multiple-children={false}
               data-outline={false}
               data-size={40}
+              data-solid={false}
             >
               <FocusRing>
                 <FocusRing
@@ -400,6 +405,7 @@ exports[`<Banner /> snapshot should match snapshot with actions 1`] = `
                     data-multiple-children={false}
                     data-outline={false}
                     data-size={40}
+                    data-solid={false}
                     onBlur={[Function]}
                     onClick={[Function]}
                     onDragStart={[Function]}
@@ -452,6 +458,7 @@ exports[`<Banner /> snapshot should match snapshot with actions 1`] = `
               data-multiple-children={false}
               data-outline={false}
               data-size={40}
+              data-solid={false}
             >
               <FocusRing>
                 <FocusRing
@@ -466,6 +473,7 @@ exports[`<Banner /> snapshot should match snapshot with actions 1`] = `
                     data-multiple-children={false}
                     data-outline={false}
                     data-size={40}
+                    data-solid={false}
                     onBlur={[Function]}
                     onClick={[Function]}
                     onDragStart={[Function]}

--- a/src/components/ButtonCircle/ButtonCircle.constants.ts
+++ b/src/components/ButtonCircle/ButtonCircle.constants.ts
@@ -8,6 +8,7 @@ const DEFAULTS = {
   GHOST: false,
   OUTLINE: false,
   SIZE: 40,
+  SOLID: false,
 };
 
 const COLORS = {

--- a/src/components/ButtonCircle/ButtonCircle.stories.args.ts
+++ b/src/components/ButtonCircle/ButtonCircle.stories.args.ts
@@ -76,6 +76,20 @@ const buttonCircleArgTypes = {
       },
     },
   },
+  solid: {
+    description:
+      'Whether to use the solid background variant of this `<ButtonCircle />`. Does not support `color` or `ghost`',
+    options: [true, false],
+    control: { type: 'boolean' },
+    table: {
+      type: {
+        summary: 'boolean',
+      },
+      defaultValue: {
+        summary: CONSTANTS.DEFAULTS.SOLID,
+      },
+    },
+  },
   size: {
     description: 'Modifies the size of this component.',
     options: [undefined, ...Object.values(CONSTANTS.SIZES)],

--- a/src/components/ButtonCircle/ButtonCircle.stories.tsx
+++ b/src/components/ButtonCircle/ButtonCircle.stories.tsx
@@ -56,16 +56,31 @@ Outline.args = {
 
 Outline.parameters = {
   variants: [
-    { outline: true },
-    { color: 'join', outline: true },
-    { color: 'cancel', outline: true },
-    { color: 'message', outline: true },
+    { outline: true, ghost: true },
+    { outline: true, ghost: false },
+    { color: 'join', outline: true, ghost: true },
+    { color: 'cancel', outline: true, ghost: true },
   ],
 };
 
 Outline.argTypes = { ...argTypes };
 delete Outline.argTypes.color;
 delete Outline.argTypes.outline;
+
+const Solid = MultiTemplate<ButtonCircleProps>(ButtonCircle).bind({});
+
+Solid.args = {
+  children: <Icon name="favorite" weight="filled" autoScale={150} />,
+};
+
+Solid.parameters = {
+  variants: [{ solid: true }],
+};
+
+Solid.argTypes = { ...argTypes };
+delete Solid.argTypes.solid;
+delete Solid.argTypes.color;
+delete Solid.argTypes.ghost;
 
 const States = MultiTemplate<ButtonCircleProps>(ButtonCircle).bind({});
 
@@ -139,6 +154,7 @@ delete Common.argTypes.color;
 delete Common.argTypes.disabled;
 delete Common.argTypes.ghost;
 delete Common.argTypes.outline;
+delete Common.argTypes.solid;
 
 Common.parameters = {
   variants: [
@@ -190,4 +206,4 @@ Common.parameters = {
   ],
 };
 
-export { Example, Colors, Outline, States, Sizes, Common };
+export { Example, Colors, Outline, Solid, States, Sizes, Common };

--- a/src/components/ButtonCircle/ButtonCircle.style.scss
+++ b/src/components/ButtonCircle/ButtonCircle.style.scss
@@ -71,25 +71,6 @@
     }
   }
 
-  &[data-disabled='true'],
-  &.disable {
-    background-color: var(--mds-color-theme-button-primary-disabled);
-    color: var(--mds-color-theme-text-primary-disabled);
-    cursor: auto;
-
-    &:hover,
-    &.hover {
-      background-color: var(--mds-color-theme-button-primary-disabled);
-      color: var(--mds-color-theme-text-primary-disabled);
-    }
-
-    &:active,
-    &.active {
-      background-color: var(--mds-color-theme-button-primary-disabled);
-      color: var(--mds-color-theme-text-primary-disabled);
-    }
-  }
-
   &[data-outline='true'][data-ghost='true'] {
     background-color: var(--mds-color-theme-button-secondary-normal);
     border-color: var(--mds-color-theme-outline-button-normal);
@@ -246,6 +227,59 @@
       &:active,
       &.active {
         background-color: var(--mds-color-theme-button-primary-disabled);
+        color: var(--mds-color-theme-text-primary-disabled);
+      }
+    }
+  }
+
+  &[data-solid='true'] {
+    background-color: var(--mds-color-theme-button-inverted-normal);
+    color: var(--mds-color-theme-text-primary-normal);
+
+    &:hover,
+    &.hover {
+      background-color: var(--mds-color-theme-button-inverted-hover);
+      color: var(--mds-color-theme-text-primary-normal);
+    }
+
+    &:active,
+    &.active {
+      background-color: var(--mds-color-theme-button-inverted-pressed);
+      color: var(--mds-color-theme-text-primary-normal);
+    }
+  }
+
+  &[data-disabled='true'],
+  &.disable {
+    background-color: var(--mds-color-theme-button-primary-disabled);
+    color: var(--mds-color-theme-text-primary-disabled);
+    cursor: auto;
+
+    &:hover,
+    &.hover {
+      background-color: var(--mds-color-theme-button-primary-disabled);
+      color: var(--mds-color-theme-text-primary-disabled);
+    }
+
+    &:active,
+    &.active {
+      background-color: var(--mds-color-theme-button-primary-disabled);
+      color: var(--mds-color-theme-text-primary-disabled);
+    }
+
+    &[data-solid='true'] {
+      background-color: var(--mds-color-theme-button-inverted-normal);
+      color: var(--mds-color-theme-text-primary-disabled);
+
+      &:hover,
+      &.hover {
+        background-color: var(--mds-color-theme-button-inverted-normal);
+        color: var(--mds-color-theme-text-primary-disabled);
+      }
+
+      &:active,
+      &.active {
+        background-color: var(--mds-color-theme-button-inverted-normal);
         color: var(--mds-color-theme-text-primary-disabled);
       }
     }

--- a/src/components/ButtonCircle/ButtonCircle.tsx
+++ b/src/components/ButtonCircle/ButtonCircle.tsx
@@ -7,7 +7,8 @@ import { Props } from './ButtonCircle.types';
 import './ButtonCircle.style.scss';
 
 const ButtonCircle = forwardRef((props: Props, providedRef: RefObject<HTMLButtonElement>) => {
-  const { children, className, color, disabled, ghost, outline, size, ...otherProps } = props;
+  const { children, className, color, disabled, ghost, outline, solid, size, ...otherProps } =
+    props;
 
   const multipleChildren = Children.count(children) > 1;
 
@@ -20,6 +21,7 @@ const ButtonCircle = forwardRef((props: Props, providedRef: RefObject<HTMLButton
       data-multiple-children={multipleChildren}
       data-outline={outline || DEFAULTS.OUTLINE}
       data-size={size || DEFAULTS.SIZE}
+      data-solid={solid || DEFAULTS.SOLID}
       data-disabled={disabled || DEFAULTS.DISABLED}
       isDisabled={disabled}
       {...otherProps}

--- a/src/components/ButtonCircle/ButtonCircle.types.ts
+++ b/src/components/ButtonCircle/ButtonCircle.types.ts
@@ -28,6 +28,11 @@ export interface Props extends ButtonSimpleProps {
   outline?: boolean;
 
   /**
+   * Whether to use the solid background variant of this ButtonCircle.
+   */
+  solid?: boolean;
+
+  /**
    * Size index of this ButtonCircle.
    */
   size?: Size;

--- a/src/components/ButtonCircle/ButtonCircle.unit.test.tsx
+++ b/src/components/ButtonCircle/ButtonCircle.unit.test.tsx
@@ -134,6 +134,17 @@ describe('<ButtonCircle />', () => {
 
       expect(container).toMatchSnapshot();
     });
+
+    it('should match snapshot when color is outlined and solid is set', () => {
+      expect.assertions(1);
+
+      const outline = !DEFAULTS.OUTLINE;
+      const solid = !DEFAULTS.SOLID;
+
+      const container = mount(<ButtonCircle outline={outline} solid={solid} />);
+
+      expect(container).toMatchSnapshot();
+    });
   });
 
   describe('attributes', () => {
@@ -254,6 +265,18 @@ describe('<ButtonCircle />', () => {
         .getDOMNode();
 
       expect(element.getAttribute('title')).toBe(title);
+    });
+
+    it('should pass solid prop', () => {
+      expect.assertions(1);
+
+      const solid = !DEFAULTS.SOLID;
+
+      const element = mount(<ButtonCircle solid={solid} />)
+        .find(ButtonCircle)
+        .getDOMNode();
+
+      expect(element.getAttribute('data-solid')).toBe(`${solid}`);
     });
 
     it('should render ButtonSimple', () => {

--- a/src/components/ButtonCircle/ButtonCircle.unit.test.tsx.snap
+++ b/src/components/ButtonCircle/ButtonCircle.unit.test.tsx.snap
@@ -10,6 +10,7 @@ exports[`<ButtonCircle /> snapshot should match snapshot 1`] = `
     data-multiple-children={false}
     data-outline={false}
     data-size={40}
+    data-solid={false}
   >
     <FocusRing>
       <FocusRing
@@ -24,6 +25,7 @@ exports[`<ButtonCircle /> snapshot should match snapshot 1`] = `
           data-multiple-children={false}
           data-outline={false}
           data-size={40}
+          data-solid={false}
           onBlur={[Function]}
           onClick={[Function]}
           onDragStart={[Function]}
@@ -58,6 +60,7 @@ exports[`<ButtonCircle /> snapshot should match snapshot when a ghost 1`] = `
     data-multiple-children={false}
     data-outline={false}
     data-size={40}
+    data-solid={false}
   >
     <FocusRing>
       <FocusRing
@@ -72,6 +75,7 @@ exports[`<ButtonCircle /> snapshot should match snapshot when a ghost 1`] = `
           data-multiple-children={false}
           data-outline={false}
           data-size={40}
+          data-solid={false}
           onBlur={[Function]}
           onClick={[Function]}
           onDragStart={[Function]}
@@ -111,6 +115,7 @@ exports[`<ButtonCircle /> snapshot should match snapshot when a ghost and disabl
     data-multiple-children={false}
     data-outline={false}
     data-size={40}
+    data-solid={false}
     isDisabled={true}
   >
     <FocusRing
@@ -129,6 +134,7 @@ exports[`<ButtonCircle /> snapshot should match snapshot when a ghost and disabl
           data-multiple-children={false}
           data-outline={false}
           data-size={40}
+          data-solid={false}
           disabled={true}
           onBlur={[Function]}
           onClick={[Function]}
@@ -168,6 +174,7 @@ exports[`<ButtonCircle /> snapshot should match snapshot when color is outlined 
     data-multiple-children={false}
     data-outline={true}
     data-size={40}
+    data-solid={false}
   >
     <FocusRing>
       <FocusRing
@@ -182,6 +189,7 @@ exports[`<ButtonCircle /> snapshot should match snapshot when color is outlined 
           data-multiple-children={false}
           data-outline={true}
           data-size={40}
+          data-solid={false}
           onBlur={[Function]}
           onClick={[Function]}
           onDragStart={[Function]}
@@ -208,6 +216,57 @@ exports[`<ButtonCircle /> snapshot should match snapshot when color is outlined 
 </ButtonCircle>
 `;
 
+exports[`<ButtonCircle /> snapshot should match snapshot when color is outlined and solid is set 1`] = `
+<ButtonCircle
+  outline={true}
+  solid={true}
+>
+  <ButtonSimple
+    className="md-button-circle-wrapper"
+    data-color="primary"
+    data-disabled={false}
+    data-ghost={false}
+    data-multiple-children={false}
+    data-outline={true}
+    data-size={40}
+    data-solid={true}
+  >
+    <FocusRing>
+      <FocusRing
+        focusClass="md-focus-ring-wrapper children"
+        focusRingClass="md-focus-ring-wrapper children"
+      >
+        <button
+          className="md-button-circle-wrapper md-button-simple-wrapper"
+          data-color="primary"
+          data-disabled={false}
+          data-ghost={false}
+          data-multiple-children={false}
+          data-outline={true}
+          data-size={40}
+          data-solid={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onDragStart={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchCancel={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          type="button"
+        />
+      </FocusRing>
+    </FocusRing>
+  </ButtonSimple>
+</ButtonCircle>
+`;
+
 exports[`<ButtonCircle /> snapshot should match snapshot when disabled 1`] = `
 <ButtonCircle
   disabled={true}
@@ -220,6 +279,7 @@ exports[`<ButtonCircle /> snapshot should match snapshot when disabled 1`] = `
     data-multiple-children={false}
     data-outline={false}
     data-size={40}
+    data-solid={false}
     isDisabled={true}
   >
     <FocusRing
@@ -238,6 +298,7 @@ exports[`<ButtonCircle /> snapshot should match snapshot when disabled 1`] = `
           data-multiple-children={false}
           data-outline={false}
           data-size={40}
+          data-solid={false}
           disabled={true}
           onBlur={[Function]}
           onClick={[Function]}
@@ -277,6 +338,7 @@ exports[`<ButtonCircle /> snapshot should match snapshot with className 1`] = `
     data-multiple-children={false}
     data-outline={false}
     data-size={40}
+    data-solid={false}
   >
     <FocusRing>
       <FocusRing
@@ -291,6 +353,7 @@ exports[`<ButtonCircle /> snapshot should match snapshot with className 1`] = `
           data-multiple-children={false}
           data-outline={false}
           data-size={40}
+          data-solid={false}
           onBlur={[Function]}
           onClick={[Function]}
           onDragStart={[Function]}
@@ -325,6 +388,7 @@ exports[`<ButtonCircle /> snapshot should match snapshot with color 1`] = `
     data-multiple-children={false}
     data-outline={false}
     data-size={40}
+    data-solid={false}
   >
     <FocusRing>
       <FocusRing
@@ -339,6 +403,7 @@ exports[`<ButtonCircle /> snapshot should match snapshot with color 1`] = `
           data-multiple-children={false}
           data-outline={false}
           data-size={40}
+          data-solid={false}
           onBlur={[Function]}
           onClick={[Function]}
           onDragStart={[Function]}
@@ -377,6 +442,7 @@ exports[`<ButtonCircle /> snapshot should match snapshot with id 1`] = `
     data-multiple-children={false}
     data-outline={false}
     data-size={40}
+    data-solid={false}
     id="example-id"
   >
     <FocusRing>
@@ -392,6 +458,7 @@ exports[`<ButtonCircle /> snapshot should match snapshot with id 1`] = `
           data-multiple-children={false}
           data-outline={false}
           data-size={40}
+          data-solid={false}
           id="example-id"
           onBlur={[Function]}
           onClick={[Function]}
@@ -425,6 +492,7 @@ exports[`<ButtonCircle /> snapshot should match snapshot with multiple children 
     data-multiple-children={true}
     data-outline={false}
     data-size={40}
+    data-solid={false}
   >
     <FocusRing>
       <FocusRing
@@ -439,6 +507,7 @@ exports[`<ButtonCircle /> snapshot should match snapshot with multiple children 
           data-multiple-children={true}
           data-outline={false}
           data-size={40}
+          data-solid={false}
           onBlur={[Function]}
           onClick={[Function]}
           onDragStart={[Function]}
@@ -480,6 +549,7 @@ exports[`<ButtonCircle /> snapshot should match snapshot with size 1`] = `
     data-multiple-children={false}
     data-outline={false}
     data-size={64}
+    data-solid={false}
   >
     <FocusRing>
       <FocusRing
@@ -494,6 +564,7 @@ exports[`<ButtonCircle /> snapshot should match snapshot with size 1`] = `
           data-multiple-children={false}
           data-outline={false}
           data-size={64}
+          data-solid={false}
           onBlur={[Function]}
           onClick={[Function]}
           onDragStart={[Function]}
@@ -536,6 +607,7 @@ exports[`<ButtonCircle /> snapshot should match snapshot with style 1`] = `
     data-multiple-children={false}
     data-outline={false}
     data-size={40}
+    data-solid={false}
     style={
       Object {
         "color": "pink",
@@ -555,6 +627,7 @@ exports[`<ButtonCircle /> snapshot should match snapshot with style 1`] = `
           data-multiple-children={false}
           data-outline={false}
           data-size={40}
+          data-solid={false}
           onBlur={[Function]}
           onClick={[Function]}
           onDragStart={[Function]}
@@ -594,6 +667,7 @@ exports[`<ButtonCircle /> snapshot should match snapshot with title 1`] = `
     data-multiple-children={false}
     data-outline={false}
     data-size={40}
+    data-solid={false}
     title="Example Text"
   >
     <FocusRing>
@@ -609,6 +683,7 @@ exports[`<ButtonCircle /> snapshot should match snapshot with title 1`] = `
           data-multiple-children={false}
           data-outline={false}
           data-size={40}
+          data-solid={false}
           onBlur={[Function]}
           onClick={[Function]}
           onDragStart={[Function]}

--- a/src/components/ButtonCircleToggle/ButtonCircleToggle.unit.test.tsx.snap
+++ b/src/components/ButtonCircleToggle/ButtonCircleToggle.unit.test.tsx.snap
@@ -21,6 +21,7 @@ exports[`<ButtonCircleToggle /> snapshot should match snapshot 1`] = `
       data-outline={false}
       data-selected={false}
       data-size={40}
+      data-solid={false}
       isDisabled={false}
       onPress={[Function]}
     >
@@ -42,6 +43,7 @@ exports[`<ButtonCircleToggle /> snapshot should match snapshot 1`] = `
             data-outline={false}
             data-selected={false}
             data-size={40}
+            data-solid={false}
             disabled={false}
             onBlur={[Function]}
             onClick={[Function]}
@@ -89,6 +91,7 @@ exports[`<ButtonCircleToggle /> snapshot should match snapshot with ghost being 
       data-outline={false}
       data-selected={false}
       data-size={40}
+      data-solid={false}
       isDisabled={false}
       onPress={[Function]}
     >
@@ -110,6 +113,7 @@ exports[`<ButtonCircleToggle /> snapshot should match snapshot with ghost being 
             data-outline={false}
             data-selected={false}
             data-size={40}
+            data-solid={false}
             disabled={false}
             onBlur={[Function]}
             onClick={[Function]}
@@ -157,6 +161,7 @@ exports[`<ButtonCircleToggle /> snapshot should match snapshot with ghost being 
       data-outline={false}
       data-selected={false}
       data-size={40}
+      data-solid={false}
       isDisabled={false}
       onPress={[Function]}
     >
@@ -178,6 +183,7 @@ exports[`<ButtonCircleToggle /> snapshot should match snapshot with ghost being 
             data-outline={false}
             data-selected={false}
             data-size={40}
+            data-solid={false}
             disabled={false}
             onBlur={[Function]}
             onClick={[Function]}
@@ -226,6 +232,7 @@ exports[`<ButtonCircleToggle /> snapshot should match snapshot with isSelected b
       data-outline={false}
       data-selected={false}
       data-size={40}
+      data-solid={false}
       isDisabled={false}
       isSelected={false}
       onPress={[Function]}
@@ -248,6 +255,7 @@ exports[`<ButtonCircleToggle /> snapshot should match snapshot with isSelected b
             data-outline={false}
             data-selected={false}
             data-size={40}
+            data-solid={false}
             disabled={false}
             onBlur={[Function]}
             onClick={[Function]}
@@ -296,6 +304,7 @@ exports[`<ButtonCircleToggle /> snapshot should match snapshot with isSelected b
       data-outline={false}
       data-selected={true}
       data-size={40}
+      data-solid={false}
       isDisabled={false}
       isSelected={true}
       onPress={[Function]}
@@ -318,6 +327,7 @@ exports[`<ButtonCircleToggle /> snapshot should match snapshot with isSelected b
             data-outline={false}
             data-selected={true}
             data-size={40}
+            data-solid={false}
             disabled={false}
             onBlur={[Function]}
             onClick={[Function]}
@@ -366,6 +376,7 @@ exports[`<ButtonCircleToggle /> snapshot should match snapshot with outline bein
       data-outline={false}
       data-selected={false}
       data-size={40}
+      data-solid={false}
       isDisabled={false}
       onPress={[Function]}
     >
@@ -387,6 +398,7 @@ exports[`<ButtonCircleToggle /> snapshot should match snapshot with outline bein
             data-outline={false}
             data-selected={false}
             data-size={40}
+            data-solid={false}
             disabled={false}
             onBlur={[Function]}
             onClick={[Function]}
@@ -435,6 +447,7 @@ exports[`<ButtonCircleToggle /> snapshot should match snapshot with outline bein
       data-outline={true}
       data-selected={false}
       data-size={40}
+      data-solid={false}
       isDisabled={false}
       onPress={[Function]}
     >
@@ -456,6 +469,7 @@ exports[`<ButtonCircleToggle /> snapshot should match snapshot with outline bein
             data-outline={true}
             data-selected={false}
             data-size={40}
+            data-solid={false}
             disabled={false}
             onBlur={[Function]}
             onClick={[Function]}

--- a/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -107,10 +107,10 @@ const callControlsCommonChildren = [
 ];
 
 const paginationCommonChildren = [
-  <ButtonCircle ghost key="0" size={28}>
+  <ButtonCircle solid disabled key="0" size={28}>
     <Icon name="arrow-up" autoScale={150} />
   </ButtonCircle>,
-  <ButtonCircle ghost key="1" size={28}>
+  <ButtonCircle solid key="1" size={28}>
     <Icon name="arrow-down" autoScale={150} />
   </ButtonCircle>,
 ];

--- a/src/components/ButtonGroup/ButtonGroup.unit.test.tsx.snap
+++ b/src/components/ButtonGroup/ButtonGroup.unit.test.tsx.snap
@@ -74,6 +74,7 @@ exports[`<ButtonGroup /> snapshot should match snapshot 1`] = `
         data-multiple-children={false}
         data-outline={false}
         data-size={40}
+        data-solid={false}
       >
         <FocusRing>
           <FocusRing
@@ -88,6 +89,7 @@ exports[`<ButtonGroup /> snapshot should match snapshot 1`] = `
               data-multiple-children={false}
               data-outline={false}
               data-size={40}
+              data-solid={false}
               onBlur={[Function]}
               onClick={[Function]}
               onDragStart={[Function]}
@@ -192,6 +194,7 @@ exports[`<ButtonGroup /> snapshot should match snapshot when spaced 1`] = `
         data-multiple-children={false}
         data-outline={false}
         data-size={40}
+        data-solid={false}
       >
         <FocusRing>
           <FocusRing
@@ -206,6 +209,7 @@ exports[`<ButtonGroup /> snapshot should match snapshot when spaced 1`] = `
               data-multiple-children={false}
               data-outline={false}
               data-size={40}
+              data-solid={false}
               onBlur={[Function]}
               onClick={[Function]}
               onDragStart={[Function]}
@@ -246,6 +250,7 @@ exports[`<ButtonGroup /> snapshot should match snapshot with className 1`] = `
     data-multiple-children={false}
     data-outline={false}
     data-size={40}
+    data-solid={false}
   >
     <FocusRing>
       <FocusRing
@@ -260,6 +265,7 @@ exports[`<ButtonGroup /> snapshot should match snapshot with className 1`] = `
           data-multiple-children={false}
           data-outline={false}
           data-size={40}
+          data-solid={false}
           onBlur={[Function]}
           onClick={[Function]}
           onDragStart={[Function]}
@@ -294,6 +300,7 @@ exports[`<ButtonGroup /> snapshot should match snapshot with id 1`] = `
     data-multiple-children={false}
     data-outline={false}
     data-size={40}
+    data-solid={false}
     id="example-id"
   >
     <FocusRing>
@@ -309,6 +316,7 @@ exports[`<ButtonGroup /> snapshot should match snapshot with id 1`] = `
           data-multiple-children={false}
           data-outline={false}
           data-size={40}
+          data-solid={false}
           id="example-id"
           onBlur={[Function]}
           onClick={[Function]}
@@ -408,6 +416,7 @@ exports[`<ButtonGroup /> snapshot should match snapshot with orientation = verti
         data-multiple-children={false}
         data-outline={false}
         data-size={40}
+        data-solid={false}
       >
         <FocusRing>
           <FocusRing
@@ -422,6 +431,7 @@ exports[`<ButtonGroup /> snapshot should match snapshot with orientation = verti
               data-multiple-children={false}
               data-outline={false}
               data-size={40}
+              data-solid={false}
               onBlur={[Function]}
               onClick={[Function]}
               onDragStart={[Function]}
@@ -527,6 +537,7 @@ exports[`<ButtonGroup /> snapshot should match snapshot with role 1`] = `
         data-multiple-children={false}
         data-outline={false}
         data-size={40}
+        data-solid={false}
       >
         <FocusRing>
           <FocusRing
@@ -541,6 +552,7 @@ exports[`<ButtonGroup /> snapshot should match snapshot with role 1`] = `
               data-multiple-children={false}
               data-outline={false}
               data-size={40}
+              data-solid={false}
               onBlur={[Function]}
               onClick={[Function]}
               onDragStart={[Function]}
@@ -645,6 +657,7 @@ exports[`<ButtonGroup /> snapshot should match snapshot with round 1`] = `
         data-multiple-children={false}
         data-outline={false}
         data-size={40}
+        data-solid={false}
       >
         <FocusRing>
           <FocusRing
@@ -659,6 +672,7 @@ exports[`<ButtonGroup /> snapshot should match snapshot with round 1`] = `
               data-multiple-children={false}
               data-outline={false}
               data-size={40}
+              data-solid={false}
               onBlur={[Function]}
               onClick={[Function]}
               onDragStart={[Function]}
@@ -763,6 +777,7 @@ exports[`<ButtonGroup /> snapshot should match snapshot with separator 1`] = `
         data-multiple-children={false}
         data-outline={false}
         data-size={40}
+        data-solid={false}
       >
         <FocusRing>
           <FocusRing
@@ -777,6 +792,7 @@ exports[`<ButtonGroup /> snapshot should match snapshot with separator 1`] = `
               data-multiple-children={false}
               data-outline={false}
               data-size={40}
+              data-solid={false}
               onBlur={[Function]}
               onClick={[Function]}
               onDragStart={[Function]}
@@ -821,6 +837,7 @@ exports[`<ButtonGroup /> snapshot should match snapshot with style 1`] = `
     data-multiple-children={false}
     data-outline={false}
     data-size={40}
+    data-solid={false}
     style={
       Object {
         "color": "pink",
@@ -840,6 +857,7 @@ exports[`<ButtonGroup /> snapshot should match snapshot with style 1`] = `
           data-multiple-children={false}
           data-outline={false}
           data-size={40}
+          data-solid={false}
           onBlur={[Function]}
           onClick={[Function]}
           onDragStart={[Function]}

--- a/src/components/MeetingContainer/MeetingContainer.unit.test.tsx.snap
+++ b/src/components/MeetingContainer/MeetingContainer.unit.test.tsx.snap
@@ -496,6 +496,7 @@ exports[`<MeetingContainer /> snapshot should match snapshot with circle action 
                         data-multiple-children={false}
                         data-outline={true}
                         data-size={28}
+                        data-solid={false}
                       >
                         <FocusRing>
                           <FocusRing
@@ -510,6 +511,7 @@ exports[`<MeetingContainer /> snapshot should match snapshot with circle action 
                               data-multiple-children={false}
                               data-outline={true}
                               data-size={28}
+                              data-solid={false}
                               onBlur={[Function]}
                               onClick={[Function]}
                               onDragStart={[Function]}
@@ -549,6 +551,7 @@ exports[`<MeetingContainer /> snapshot should match snapshot with circle action 
                         data-multiple-children={false}
                         data-outline={true}
                         data-size={28}
+                        data-solid={false}
                       >
                         <FocusRing>
                           <FocusRing
@@ -563,6 +566,7 @@ exports[`<MeetingContainer /> snapshot should match snapshot with circle action 
                               data-multiple-children={false}
                               data-outline={true}
                               data-size={28}
+                              data-solid={false}
                               onBlur={[Function]}
                               onClick={[Function]}
                               onDragStart={[Function]}
@@ -602,6 +606,7 @@ exports[`<MeetingContainer /> snapshot should match snapshot with circle action 
                         data-multiple-children={false}
                         data-outline={true}
                         data-size={28}
+                        data-solid={false}
                       >
                         <FocusRing>
                           <FocusRing
@@ -616,6 +621,7 @@ exports[`<MeetingContainer /> snapshot should match snapshot with circle action 
                               data-multiple-children={false}
                               data-outline={true}
                               data-size={28}
+                              data-solid={false}
                               onBlur={[Function]}
                               onClick={[Function]}
                               onDragStart={[Function]}

--- a/src/components/NotificationSystem/NotificationSystem.unit.test.tsx.snap
+++ b/src/components/NotificationSystem/NotificationSystem.unit.test.tsx.snap
@@ -74,6 +74,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot 1`] = `
                       data-multiple-children="false"
                       data-outline="false"
                       data-size="20"
+                      data-solid="false"
                       type="button"
                     >
                       <div
@@ -183,6 +184,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot if notification c
                       data-multiple-children="false"
                       data-outline="false"
                       data-size="20"
+                      data-solid="false"
                       type="button"
                     >
                       <div
@@ -293,6 +295,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot if notification c
                       data-multiple-children="false"
                       data-outline="false"
                       data-size="20"
+                      data-solid="false"
                       type="button"
                     >
                       <div
@@ -403,6 +406,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot when limit is set
                       data-multiple-children="false"
                       data-outline="false"
                       data-size="20"
+                      data-solid="false"
                       type="button"
                     >
                       <div
@@ -513,6 +517,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with body class n
                       data-multiple-children="false"
                       data-outline="false"
                       data-size="20"
+                      data-solid="false"
                       type="button"
                     >
                       <div
@@ -623,6 +628,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with className 1`
                       data-multiple-children="false"
                       data-outline="false"
                       data-size="20"
+                      data-solid="false"
                       type="button"
                     >
                       <div
@@ -733,6 +739,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with container cl
                       data-multiple-children="false"
                       data-outline="false"
                       data-size="20"
+                      data-solid="false"
                       type="button"
                     >
                       <div
@@ -839,6 +846,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with different at
                       data-multiple-children="false"
                       data-outline="false"
                       data-size="20"
+                      data-solid="false"
                       type="button"
                     >
                       <div
@@ -942,6 +950,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with different po
                       data-multiple-children="false"
                       data-outline="false"
                       data-size="20"
+                      data-solid="false"
                       type="button"
                     >
                       <div
@@ -1056,6 +1065,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with different zI
                       data-multiple-children="false"
                       data-outline="false"
                       data-size="20"
+                      data-solid="false"
                       type="button"
                     >
                       <div
@@ -1166,6 +1176,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with enter animat
                       data-multiple-children="false"
                       data-outline="false"
                       data-size="20"
+                      data-solid="false"
                       type="button"
                     >
                       <div
@@ -1276,6 +1287,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with id 1`] = `
                       data-multiple-children="false"
                       data-outline="false"
                       data-size="20"
+                      data-solid="false"
                       type="button"
                     >
                       <div
@@ -1386,6 +1398,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with newest on to
                       data-multiple-children="false"
                       data-outline="false"
                       data-size="20"
+                      data-solid="false"
                       type="button"
                     >
                       <div
@@ -1496,6 +1509,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with style 1`] = 
                       data-multiple-children="false"
                       data-outline="false"
                       data-size="20"
+                      data-solid="false"
                       type="button"
                     >
                       <div
@@ -1606,6 +1620,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with toast class 
                       data-multiple-children="false"
                       data-outline="false"
                       data-size="20"
+                      data-solid="false"
                       type="button"
                     >
                       <div

--- a/src/components/Popover/Popover.unit.test.tsx.snap
+++ b/src/components/Popover/Popover.unit.test.tsx.snap
@@ -628,6 +628,7 @@ exports[`<Popover /> snapshot should match snapshot with closeButtonPlacement 2`
         data-outline="false"
         data-placement="top-right"
         data-size="20"
+        data-solid="false"
         type="button"
       >
         <div

--- a/src/components/ReactionButton/ReactionButton.unit.test.tsx.snap
+++ b/src/components/ReactionButton/ReactionButton.unit.test.tsx.snap
@@ -16,6 +16,7 @@ exports[`<ReactionButton /> snapshot should match snapshot 1`] = `
       data-outline={false}
       data-reacted={false}
       data-size={32}
+      data-solid={false}
     >
       <FocusRing>
         <FocusRing
@@ -31,6 +32,7 @@ exports[`<ReactionButton /> snapshot should match snapshot 1`] = `
             data-outline={false}
             data-reacted={false}
             data-size={32}
+            data-solid={false}
             onBlur={[Function]}
             onClick={[Function]}
             onDragStart={[Function]}
@@ -82,6 +84,7 @@ exports[`<ReactionButton /> snapshot should match snapshot with className 1`] = 
       data-outline={false}
       data-reacted={false}
       data-size={32}
+      data-solid={false}
     >
       <FocusRing>
         <FocusRing
@@ -97,6 +100,7 @@ exports[`<ReactionButton /> snapshot should match snapshot with className 1`] = 
             data-outline={false}
             data-reacted={false}
             data-size={32}
+            data-solid={false}
             onBlur={[Function]}
             onClick={[Function]}
             onDragStart={[Function]}
@@ -149,6 +153,7 @@ exports[`<ReactionButton /> snapshot should match snapshot with id 1`] = `
       data-outline={false}
       data-reacted={false}
       data-size={32}
+      data-solid={false}
       id="example-id"
     >
       <FocusRing>
@@ -165,6 +170,7 @@ exports[`<ReactionButton /> snapshot should match snapshot with id 1`] = `
             data-outline={false}
             data-reacted={false}
             data-size={32}
+            data-solid={false}
             id="example-id"
             onBlur={[Function]}
             onClick={[Function]}
@@ -217,6 +223,7 @@ exports[`<ReactionButton /> snapshot should match snapshot with reacted 1`] = `
       data-outline={false}
       data-reacted={true}
       data-size={32}
+      data-solid={false}
     >
       <FocusRing>
         <FocusRing
@@ -232,6 +239,7 @@ exports[`<ReactionButton /> snapshot should match snapshot with reacted 1`] = `
             data-outline={false}
             data-reacted={true}
             data-size={32}
+            data-solid={false}
             onBlur={[Function]}
             onClick={[Function]}
             onDragStart={[Function]}
@@ -292,6 +300,7 @@ exports[`<ReactionButton /> snapshot should match snapshot with style 1`] = `
       data-outline={false}
       data-reacted={false}
       data-size={32}
+      data-solid={false}
       style={
         Object {
           "color": "pink",
@@ -312,6 +321,7 @@ exports[`<ReactionButton /> snapshot should match snapshot with style 1`] = `
             data-outline={false}
             data-reacted={false}
             data-size={32}
+            data-solid={false}
             onBlur={[Function]}
             onClick={[Function]}
             onDragStart={[Function]}

--- a/src/components/ReactionPicker/ReactionPicker.unit.test.tsx.snap
+++ b/src/components/ReactionPicker/ReactionPicker.unit.test.tsx.snap
@@ -47,6 +47,7 @@ exports[`<ReactionPicker /> snapshot should match snapshot with children 1`] = `
             data-outline={false}
             data-reacted={false}
             data-size={32}
+            data-solid={false}
           >
             <FocusRing>
               <FocusRing
@@ -62,6 +63,7 @@ exports[`<ReactionPicker /> snapshot should match snapshot with children 1`] = `
                   data-outline={false}
                   data-reacted={false}
                   data-size={32}
+                  data-solid={false}
                   onBlur={[Function]}
                   onClick={[Function]}
                   onDragStart={[Function]}

--- a/src/components/Toast/Toast.unit.test.tsx.snap
+++ b/src/components/Toast/Toast.unit.test.tsx.snap
@@ -416,6 +416,7 @@ exports[`<Toast /> snapshot should match snapshot 1`] = `
                 data-multiple-children={false}
                 data-outline={true}
                 data-size={28}
+                data-solid={false}
               >
                 <FocusRing>
                   <FocusRing
@@ -430,6 +431,7 @@ exports[`<Toast /> snapshot should match snapshot 1`] = `
                       data-multiple-children={false}
                       data-outline={true}
                       data-size={28}
+                      data-solid={false}
                       onBlur={[Function]}
                       onClick={[Function]}
                       onDragStart={[Function]}
@@ -1059,6 +1061,7 @@ exports[`<Toast /> snapshot should match snapshot with className 1`] = `
                 data-multiple-children={false}
                 data-outline={true}
                 data-size={28}
+                data-solid={false}
               >
                 <FocusRing>
                   <FocusRing
@@ -1073,6 +1076,7 @@ exports[`<Toast /> snapshot should match snapshot with className 1`] = `
                       data-multiple-children={false}
                       data-outline={true}
                       data-size={28}
+                      data-solid={false}
                       onBlur={[Function]}
                       onClick={[Function]}
                       onDragStart={[Function]}
@@ -1659,6 +1663,7 @@ exports[`<Toast /> snapshot should match snapshot with content children and deta
                 data-multiple-children={false}
                 data-outline={true}
                 data-size={28}
+                data-solid={false}
               >
                 <FocusRing>
                   <FocusRing
@@ -1673,6 +1678,7 @@ exports[`<Toast /> snapshot should match snapshot with content children and deta
                       data-multiple-children={false}
                       data-outline={true}
                       data-size={28}
+                      data-solid={false}
                       onBlur={[Function]}
                       onClick={[Function]}
                       onDragStart={[Function]}
@@ -2246,6 +2252,7 @@ exports[`<Toast /> snapshot should match snapshot with details and content child
                 data-multiple-children={false}
                 data-outline={true}
                 data-size={28}
+                data-solid={false}
               >
                 <FocusRing>
                   <FocusRing
@@ -2260,6 +2267,7 @@ exports[`<Toast /> snapshot should match snapshot with details and content child
                       data-multiple-children={false}
                       data-outline={true}
                       data-size={28}
+                      data-solid={false}
                       onBlur={[Function]}
                       onClick={[Function]}
                       onDragStart={[Function]}
@@ -2875,6 +2883,7 @@ exports[`<Toast /> snapshot should match snapshot with details children and cont
                 data-multiple-children={false}
                 data-outline={true}
                 data-size={28}
+                data-solid={false}
               >
                 <FocusRing>
                   <FocusRing
@@ -2889,6 +2898,7 @@ exports[`<Toast /> snapshot should match snapshot with details children and cont
                       data-multiple-children={false}
                       data-outline={true}
                       data-size={28}
+                      data-solid={false}
                       onBlur={[Function]}
                       onClick={[Function]}
                       onDragStart={[Function]}
@@ -3519,6 +3529,7 @@ exports[`<Toast /> snapshot should match snapshot with id 1`] = `
                 data-multiple-children={false}
                 data-outline={true}
                 data-size={28}
+                data-solid={false}
               >
                 <FocusRing>
                   <FocusRing
@@ -3533,6 +3544,7 @@ exports[`<Toast /> snapshot should match snapshot with id 1`] = `
                       data-multiple-children={false}
                       data-outline={true}
                       data-size={28}
+                      data-solid={false}
                       onBlur={[Function]}
                       onClick={[Function]}
                       onDragStart={[Function]}
@@ -4171,6 +4183,7 @@ exports[`<Toast /> snapshot should match snapshot with style 1`] = `
                 data-multiple-children={false}
                 data-outline={true}
                 data-size={28}
+                data-solid={false}
               >
                 <FocusRing>
                   <FocusRing
@@ -4185,6 +4198,7 @@ exports[`<Toast /> snapshot should match snapshot with style 1`] = `
                       data-multiple-children={false}
                       data-outline={true}
                       data-size={28}
+                      data-solid={false}
                       onBlur={[Function]}
                       onClick={[Function]}
                       onDragStart={[Function]}
@@ -4801,6 +4815,7 @@ exports[`<Toast /> snapshot should match snapshot with title 1`] = `
                 data-multiple-children={false}
                 data-outline={true}
                 data-size={28}
+                data-solid={false}
               >
                 <FocusRing>
                   <FocusRing
@@ -4815,6 +4830,7 @@ exports[`<Toast /> snapshot should match snapshot with title 1`] = `
                       data-multiple-children={false}
                       data-outline={true}
                       data-size={28}
+                      data-solid={false}
                       onBlur={[Function]}
                       onClick={[Function]}
                       onDragStart={[Function]}


### PR DESCRIPTION
# Description

This PR adds the ```solid``` prop to ButtonCircle for use in pagination buttons. The ```solid``` prop cannot be used along with the ```color``` or ```ghost``` prop.

# Examples

|ButtonCircle|ButtonGroup|
|---|---|
|![Screenshot 2023-05-25 at 21 22 57](https://github.com/momentum-design/momentum-react-v2/assets/86778628/027c8f98-3111-4d9f-b3fc-dfe9662cefb9)|![Screenshot 2023-05-25 at 21 22 47](https://github.com/momentum-design/momentum-react-v2/assets/86778628/66a9f823-5444-4180-9f3e-1255cd43b5ff)|


