### PR TITLE
fix: slider exports and value handling

### DIFF
--- a/src/components/Slider/Slider.hooks.ts
+++ b/src/components/Slider/Slider.hooks.ts
@@ -23,17 +23,17 @@ const useSliderSideEffects = ({
   const trackRef = React.useRef<HTMLDivElement>(null);
   const numberFormatter = useNumberFormatter();
 
-  const handleChange = (newValue: number) => {
-    onChange(newValue);
+  const handleChange = (newValues: Array<number>) => {
+    onChange(newValues[0]);
   };
 
-  const sliderProps: SliderStateOptions<number> = {
+  const sliderProps: SliderStateOptions<Array<number>> = {
     isDisabled,
     step,
     minValue,
     maxValue,
     numberFormatter,
-    value: clamp(value, minValue, maxValue),
+    value: [clamp(value, minValue, maxValue)],
     onChange: handleChange,
   };
 

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -65,4 +65,4 @@ export { default as Chip } from './Chip';
 export { default as RadioGroup } from './RadioGroup';
 export { default as NotificationSystem } from './NotificationSystem';
 export { default as AriaToolbar } from './AriaToolbar';
-export { default as SliderNext } from './Slider';
+export { default as Slider } from './Slider';

--- a/src/index.js
+++ b/src/index.js
@@ -178,4 +178,5 @@ export {
   Chip as ChipNext,
   NotificationSystem,
   AriaToolbar,
+  Slider as SliderNext,
 } from './components';


### PR DESCRIPTION
# Description

- Fixes the exports of Slider component
- Had to revert the value handling of the useSlider hook, since it didn't work in Cantina
