### PR TITLE
feat(fix-button-pill-disabled): fix background and text color for but…

### DIFF
--- a/src/components/ButtonPill/ButtonPill.style.scss
+++ b/src/components/ButtonPill/ButtonPill.style.scss
@@ -62,6 +62,85 @@
     }
   }
 
+  &[data-shallow-disabled='true'],
+  &[data-disabled='true'],
+  &.disable {
+    background-color: var(--mds-color-theme-button-primary-disabled);
+    color: var(--mds-color-theme-text-primary-disabled);
+    cursor: auto;
+
+    &:hover,
+    &.hover {
+      background-color: var(--mds-color-theme-button-primary-disabled);
+      color: var(--mds-color-theme-text-primary-disabled);
+    }
+
+    &:active,
+    &.active {
+      background-color: var(--mds-color-theme-button-primary-disabled);
+      color: var(--mds-color-theme-text-primary-disabled);
+    }
+
+    &[data-ghost='true'] {
+      background-color: var(--mds-color-theme-button-secondary-normal);
+      color: var(--mds-color-theme-text-primary-disabled);
+      cursor: auto;
+
+      &:hover,
+      &.hover {
+        background-color: var(--mds-color-theme-button-secondary-normal);
+        color: var(--mds-color-theme-text-primary-disabled);
+      }
+
+      &:active,
+      &.active {
+        background-color: var(--mds-color-theme-button-secondary-normal);
+        color: var(--mds-color-theme-text-primary-disabled);
+      }
+    }
+
+    &[data-outline='true'] {
+      background-color: var(--mds-color-theme-button-secondary-normal);
+      border-color: var(--mds-color-theme-outline-disabled-normal);
+      color: var(--mds-color-theme-text-primary-disabled);
+      cursor: auto;
+
+      &:hover,
+      &.hover {
+        background-color: var(--mds-color-theme-button-secondary-normal);
+        border-color: var(--mds-color-theme-outline-disabled-normal);
+        color: var(--mds-color-theme-text-primary-disabled);
+      }
+
+      &:active,
+      &.active {
+        background-color: var(--mds-color-theme-button-secondary-normal);
+        border-color: var(--mds-color-theme-outline-disabled-normal);
+        color: var(--mds-color-theme-text-primary-disabled);
+      }
+
+      &[data-solid='true'] {
+        background-color: var(--mds-color-theme-button-inverted-normal);
+        border-color: var(--mds-color-theme-outline-disabled-normal);
+        color: var(--mds-color-theme-text-primary-disabled);
+
+        &:hover,
+        &.hover {
+          background-color: var(--mds-color-theme-button-inverted-normal);
+          border-color: var(--mds-color-theme-outline-disabled-normal);
+          color: var(--mds-color-theme-text-primary-disabled);
+        }
+
+        &:active,
+        &.active {
+          background-color: var(--mds-color-theme-button-inverted-normal);
+          border-color: var(--mds-color-theme-outline-disabled-normal);
+          color: var(--mds-color-theme-text-primary-disabled);
+        }
+      }
+    }
+  }
+
   &[data-color='join'] {
     background-color: var(--mds-color-theme-button-join-normal);
     color: var(--mds-color-theme-common-text-white);
@@ -234,67 +313,6 @@
       &.active {
         background-color: var(--mds-color-theme-button-secondary-pressed);
         color: var(--mds-color-theme-text-primary-normal);
-      }
-    }
-  }
-
-  &[data-shallow-disabled='true'],
-  &[data-disabled='true'],
-  &.disable {
-    background-color: var(--mds-color-theme-button-primary-disabled);
-    color: var(--mds-color-theme-text-primary-disabled);
-    cursor: auto;
-
-    &:hover,
-    &.hover {
-      background-color: var(--mds-color-theme-button-primary-disabled);
-      color: var(--mds-color-theme-text-primary-disabled);
-    }
-
-    &:active,
-    &.active {
-      background-color: var(--mds-color-theme-button-primary-disabled);
-      color: var(--mds-color-theme-text-primary-disabled);
-    }
-
-    &[data-outline='true'] {
-      background-color: var(--mds-color-theme-button-secondary-normal);
-      border-color: var(--mds-color-theme-outline-disabled-normal);
-      color: var(--mds-color-theme-text-primary-disabled);
-      cursor: auto;
-
-      &:hover,
-      &.hover {
-        background-color: var(--mds-color-theme-button-secondary-normal);
-        border-color: var(--mds-color-theme-outline-disabled-normal);
-        color: var(--mds-color-theme-text-primary-disabled);
-      }
-
-      &:active,
-      &.active {
-        background-color: var(--mds-color-theme-button-secondary-normal);
-        border-color: var(--mds-color-theme-outline-disabled-normal);
-        color: var(--mds-color-theme-text-primary-disabled);
-      }
-
-      &[data-solid='true'] {
-        background-color: var(--mds-color-theme-button-inverted-normal);
-        border-color: var(--mds-color-theme-outline-disabled-normal);
-        color: var(--mds-color-theme-text-primary-disabled);
-
-        &:hover,
-        &.hover {
-          background-color: var(--mds-color-theme-button-inverted-normal);
-          border-color: var(--mds-color-theme-outline-disabled-normal);
-          color: var(--mds-color-theme-text-primary-disabled);
-        }
-
-        &:active,
-        &.active {
-          background-color: var(--mds-color-theme-button-inverted-normal);
-          border-color: var(--mds-color-theme-outline-disabled-normal);
-          color: var(--mds-color-theme-text-primary-disabled);
-        }
       }
     }
   }


### PR DESCRIPTION
# Description

When button pill was ghost and disabled, user could get a background color on hover. Disabled ghost buttons should not get background color on hover.


Figma:
<img width="117" alt="image" src="https://github.com/momentum-design/momentum-react-v2/assets/56999622/d6a7e2d0-31fc-4b02-a6fa-29370a086ade">

Implementation before:
<img width="214" alt="image" src="https://github.com/momentum-design/momentum-react-v2/assets/56999622/e4a6d02f-4d55-4f48-bb86-1150458894f2">

Implementation with changes:
<img width="282" alt="image" src="https://github.com/momentum-design/momentum-react-v2/assets/56999622/bc958763-09f1-4bde-afe6-96a1ddc45ab9">


# Links

*Links to relevent resources.*
