### PR TITLE
feat(activity-item-ui-fix): fix hover background color

### DIFF
--- a/scss/components/content-item/content-item.scss
+++ b/scss/components/content-item/content-item.scss
@@ -115,7 +115,7 @@
       bottom: 56px;
       width: 100%;
       height: 56px;
-      background-color: var(--mds-color-theme-background-solid-quaternary-normal);
+      background-color: var(--mds-color-theme-common-overlay-primary-normal);
       border-radius: 0 0 4px 4px;
       visibility: hidden;
       align-self: flex-end;
@@ -187,7 +187,7 @@
       bottom: 56px;
       width: 204px;
       height: 56px;
-      background-color: var(--mds-color-theme-background-solid-quaternary-normal);
+      background-color: var(--mds-color-theme-common-overlay-primary-normal);
       border-radius: 0 0 4px 4px;
       visibility: hidden;
       align-self: flex-end;


### PR DESCRIPTION
# Description
Fixing the color assigned to the background of the overlay that appears when hovering on a content item.

Figma spec:
<img width="447" alt="image" src="https://github.com/momentum-design/momentum-react-v2/assets/56999622/b99c538a-e917-48f3-b72d-f8c0aba9a90f">

Before
<img width="501" alt="image" src="https://github.com/momentum-design/momentum-react-v2/assets/56999622/062591c3-3ad8-48e7-9e44-cfcd4b94a582">

<img width="496" alt="image" src="https://github.com/momentum-design/momentum-react-v2/assets/56999622/2f25dece-1c5f-4a1a-8ab9-4430ee2d1ea7">

After
<img width="425" alt="image" src="https://github.com/momentum-design/momentum-react-v2/assets/56999622/a08b4992-7c75-4159-94f8-197ca8279d6c">

<img width="538" alt="image" src="https://github.com/momentum-design/momentum-react-v2/assets/56999622/f64dac7c-d1a8-4692-8979-26599cb5c3e5">

# Links

Figma spec: https://www.figma.com/file/vdL18BATeJAIq2JvGAjRPD/Components---Web-Application?type=design&node-id=42642%3A78965&mode=design&t=TlmejMyT3XzAa3O9-1
