### PR TITLE
Activity-item-fix-2: fix right margin and icon chip background color

### DIFF
--- a/css/momentum-ui.css
+++ b/css/momentum-ui.css
@@ -21317,7 +21317,7 @@ button.md-close {
       align-items: center;
       flex-flow: row nowrap;
       width: 40%;
-      margin-right: 3px; }
+      margin-right: 12px; }
 
 .md-content-file {
   display: flex;

--- a/scss/components/content-item/content-item.scss
+++ b/scss/components/content-item/content-item.scss
@@ -200,7 +200,7 @@
       bottom: 0px;
       width: 204px;
       height: 56px;
-      background-color: var(--mds-color-theme-background-solid-quaternary-normal);;
+      background-color: var(--mds-color-theme-common-overlay-primary-normal);;
       border-radius: 0 0 4px 4px;
       visibility: hidden;
     }

--- a/scss/components/content-item/content-item.scss
+++ b/scss/components/content-item/content-item.scss
@@ -115,7 +115,7 @@
       bottom: 56px;
       width: 100%;
       height: 56px;
-      background-color: var(--mds-color-theme-background-solid-quaternary-normal);
+      background-color: var(--mds-color-theme-common-overlay-primary-normal);
       border-radius: 0 0 4px 4px;
       visibility: hidden;
       align-self: flex-end;
@@ -187,7 +187,7 @@
       bottom: 56px;
       width: 204px;
       height: 56px;
-      background-color: var(--mds-color-theme-background-solid-quaternary-normal);
+      background-color: var(--mds-color-theme-common-overlay-primary-normal);
       border-radius: 0 0 4px 4px;
       visibility: hidden;
       align-self: flex-end;


### PR DESCRIPTION
Before
<img width="455" alt="image" src="https://github.com/momentum-design/momentum-react-v2/assets/56999622/78d66ad9-76b1-4c8d-82fb-362ecedbfc97">

<img width="233" alt="image" src="https://github.com/momentum-design/momentum-react-v2/assets/56999622/b6a69f7e-d8fb-46ef-ad45-40e08fe99caa">

After
<img width="231" alt="image" src="https://github.com/momentum-design/momentum-react-v2/assets/56999622/5e1f5632-73e9-4011-a618-92c7f3766fa7">

<img width="432" alt="image" src="https://github.com/momentum-design/momentum-react-v2/assets/56999622/8366e0a5-9165-4595-9fff-2d95b7d23c12">
