### PR TITLE
feat(shallow-disabled-button-circle): implement shallow disabled state

### DIFF
--- a/src/components/ButtonCircle/ButtonCircle.constants.ts
+++ b/src/components/ButtonCircle/ButtonCircle.constants.ts
@@ -5,6 +5,7 @@ const CLASS_PREFIX = 'md-button-circle';
 const DEFAULTS = {
   COLOR: 'primary',
   DISABLED: false,
+  SHALLOW_DISABLED: false,
   GHOST: false,
   OUTLINE: false,
   SIZE: 40,

--- a/src/components/ButtonCircle/ButtonCircle.stories.args.ts
+++ b/src/components/ButtonCircle/ButtonCircle.stories.args.ts
@@ -49,6 +49,20 @@ const buttonCircleArgTypes = {
       },
     },
   },
+  shallowDisabled: {
+    description:
+      'Whether to render the COMPONENT looking as if disabled, but allowing onPress actions to still be passed.',
+    options: [true, false],
+    control: { type: 'boolean' },
+    table: {
+      type: {
+        summary: 'boolean',
+      },
+      defaultValue: {
+        summary: CONSTANTS.DEFAULTS.SHALLOW_DISABLED,
+      },
+    },
+  },
   ghost: {
     description:
       'Whether this component is a ghost. This overrides the `color` and `outline` props.',

--- a/src/components/ButtonCircle/ButtonCircle.style.scss
+++ b/src/components/ButtonCircle/ButtonCircle.style.scss
@@ -130,6 +130,7 @@
       }
     }
 
+    &[data-shallow-disabled='true'],
     &[data-disabled='true'],
     &.disable {
       background-color: var(--mds-color-theme-button-secondary-normal);
@@ -172,6 +173,7 @@
       color: var(--mds-color-theme-text-primary-normal);
     }
 
+    &[data-shallow-disabled='true'],
     &[data-disabled='true'],
     &.disable {
       background-color: var(--mds-color-theme-button-inverted-normal);
@@ -212,6 +214,7 @@
       color: var(--mds-color-theme-text-primary-normal);
     }
 
+    &[data-shallow-disabled='true'],
     &[data-disabled='true'],
     &.disable {
       background-color: var(--mds-color-theme-button-secondary-normal);
@@ -249,6 +252,7 @@
     }
   }
 
+  &[data-shallow-disabled='true'],
   &[data-disabled='true'],
   &.disable {
     background-color: var(--mds-color-theme-button-primary-disabled);

--- a/src/components/ButtonCircle/ButtonCircle.tsx
+++ b/src/components/ButtonCircle/ButtonCircle.tsx
@@ -7,8 +7,18 @@ import { Props } from './ButtonCircle.types';
 import './ButtonCircle.style.scss';
 
 const ButtonCircle = forwardRef((props: Props, providedRef: RefObject<HTMLButtonElement>) => {
-  const { children, className, color, disabled, ghost, outline, solid, size, ...otherProps } =
-    props;
+  const {
+    children,
+    className,
+    color,
+    disabled,
+    shallowDisabled,
+    ghost,
+    outline,
+    solid,
+    size,
+    ...otherProps
+  } = props;
 
   const multipleChildren = Children.count(children) > 1;
 
@@ -23,6 +33,7 @@ const ButtonCircle = forwardRef((props: Props, providedRef: RefObject<HTMLButton
       data-size={size || DEFAULTS.SIZE}
       data-solid={solid || DEFAULTS.SOLID}
       data-disabled={disabled || DEFAULTS.DISABLED}
+      data-shallow-disabled={shallowDisabled || DEFAULTS.SHALLOW_DISABLED}
       isDisabled={disabled}
       {...otherProps}
     >

--- a/src/components/ButtonCircle/ButtonCircle.types.ts
+++ b/src/components/ButtonCircle/ButtonCircle.types.ts
@@ -18,6 +18,11 @@ export interface Props extends ButtonSimpleProps {
   disabled?: boolean;
 
   /**
+   * Whether or not this ButtonCircle should look disabled, but allowing actions like onPress to be passed.
+   */
+  shallowDisabled?: boolean;
+
+  /**
    * Whether or not this ButtonCircle is ghosted.
    */
   ghost?: boolean;

--- a/src/components/ButtonCircle/ButtonCircle.unit.test.tsx
+++ b/src/components/ButtonCircle/ButtonCircle.unit.test.tsx
@@ -90,6 +90,16 @@ describe('<ButtonCircle />', () => {
       expect(container).toMatchSnapshot();
     });
 
+    it('should match snapshot when shallow disabled', () => {
+      expect.assertions(1);
+
+      const shallowDisabled = !DEFAULTS.SHALLOW_DISABLED;
+
+      const container = mount(<ButtonCircle shallowDisabled={shallowDisabled}>X</ButtonCircle>);
+
+      expect(container).toMatchSnapshot();
+    });
+
     it('should match snapshot when a ghost', () => {
       expect.assertions(1);
 
@@ -207,6 +217,18 @@ describe('<ButtonCircle />', () => {
       expect(element.getAttribute('data-disabled')).toBe(`${disabled}`);
     });
 
+    it('should pass sallow disabled prop', () => {
+      expect.assertions(1);
+
+      const shallowDisabled = !DEFAULTS.DISABLED;
+
+      const element = mount(<ButtonCircle shallowDisabled={shallowDisabled} />)
+        .find(ButtonCircle)
+        .getDOMNode();
+
+      expect(element.getAttribute('data-shallow-disabled')).toBe(`${shallowDisabled}`);
+    });
+
     it('should pass ghost prop', () => {
       expect.assertions(1);
 
@@ -295,6 +317,28 @@ describe('<ButtonCircle />', () => {
       const mockCallback = jest.fn();
 
       const component = mount(<ButtonCircle onPress={mockCallback} />).find(ButtonCircle);
+
+      component.props().onPress({
+        type: 'press',
+        pointerType: 'mouse',
+        altKey: false,
+        shiftKey: false,
+        ctrlKey: false,
+        metaKey: false,
+        target: component.getDOMNode(),
+      });
+
+      expect(mockCallback).toBeCalledTimes(1);
+    });
+
+    it('should handle mouse press events if shallow disabled', () => {
+      expect.assertions(1);
+
+      const mockCallback = jest.fn();
+
+      const component = mount(<ButtonCircle shallowDisabled onPress={mockCallback} />).find(
+        ButtonCircle
+      );
 
       component.props().onPress({
         type: 'press',

--- a/src/components/ButtonCircle/ButtonCircle.unit.test.tsx.snap
+++ b/src/components/ButtonCircle/ButtonCircle.unit.test.tsx.snap
@@ -9,6 +9,7 @@ exports[`<ButtonCircle /> snapshot should match snapshot 1`] = `
     data-ghost={false}
     data-multiple-children={false}
     data-outline={false}
+    data-shallow-disabled={false}
     data-size={40}
     data-solid={false}
   >
@@ -24,6 +25,7 @@ exports[`<ButtonCircle /> snapshot should match snapshot 1`] = `
           data-ghost={false}
           data-multiple-children={false}
           data-outline={false}
+          data-shallow-disabled={false}
           data-size={40}
           data-solid={false}
           onBlur={[Function]}
@@ -59,6 +61,7 @@ exports[`<ButtonCircle /> snapshot should match snapshot when a ghost 1`] = `
     data-ghost={true}
     data-multiple-children={false}
     data-outline={false}
+    data-shallow-disabled={false}
     data-size={40}
     data-solid={false}
   >
@@ -74,6 +77,7 @@ exports[`<ButtonCircle /> snapshot should match snapshot when a ghost 1`] = `
           data-ghost={true}
           data-multiple-children={false}
           data-outline={false}
+          data-shallow-disabled={false}
           data-size={40}
           data-solid={false}
           onBlur={[Function]}
@@ -114,6 +118,7 @@ exports[`<ButtonCircle /> snapshot should match snapshot when a ghost and disabl
     data-ghost={true}
     data-multiple-children={false}
     data-outline={false}
+    data-shallow-disabled={false}
     data-size={40}
     data-solid={false}
     isDisabled={true}
@@ -133,6 +138,7 @@ exports[`<ButtonCircle /> snapshot should match snapshot when a ghost and disabl
           data-ghost={true}
           data-multiple-children={false}
           data-outline={false}
+          data-shallow-disabled={false}
           data-size={40}
           data-solid={false}
           disabled={true}
@@ -173,6 +179,7 @@ exports[`<ButtonCircle /> snapshot should match snapshot when color is outlined 
     data-ghost={false}
     data-multiple-children={false}
     data-outline={true}
+    data-shallow-disabled={false}
     data-size={40}
     data-solid={false}
   >
@@ -188,6 +195,7 @@ exports[`<ButtonCircle /> snapshot should match snapshot when color is outlined 
           data-ghost={false}
           data-multiple-children={false}
           data-outline={true}
+          data-shallow-disabled={false}
           data-size={40}
           data-solid={false}
           onBlur={[Function]}
@@ -228,6 +236,7 @@ exports[`<ButtonCircle /> snapshot should match snapshot when color is outlined 
     data-ghost={false}
     data-multiple-children={false}
     data-outline={true}
+    data-shallow-disabled={false}
     data-size={40}
     data-solid={true}
   >
@@ -243,6 +252,7 @@ exports[`<ButtonCircle /> snapshot should match snapshot when color is outlined 
           data-ghost={false}
           data-multiple-children={false}
           data-outline={true}
+          data-shallow-disabled={false}
           data-size={40}
           data-solid={true}
           onBlur={[Function]}
@@ -278,6 +288,7 @@ exports[`<ButtonCircle /> snapshot should match snapshot when disabled 1`] = `
     data-ghost={false}
     data-multiple-children={false}
     data-outline={false}
+    data-shallow-disabled={false}
     data-size={40}
     data-solid={false}
     isDisabled={true}
@@ -297,9 +308,66 @@ exports[`<ButtonCircle /> snapshot should match snapshot when disabled 1`] = `
           data-ghost={false}
           data-multiple-children={false}
           data-outline={false}
+          data-shallow-disabled={false}
           data-size={40}
           data-solid={false}
           disabled={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onDragStart={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchCancel={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          type="button"
+        >
+          <span>
+            X
+          </span>
+        </button>
+      </FocusRing>
+    </FocusRing>
+  </ButtonSimple>
+</ButtonCircle>
+`;
+
+exports[`<ButtonCircle /> snapshot should match snapshot when shallow disabled 1`] = `
+<ButtonCircle
+  shallowDisabled={true}
+>
+  <ButtonSimple
+    className="md-button-circle-wrapper"
+    data-color="primary"
+    data-disabled={false}
+    data-ghost={false}
+    data-multiple-children={false}
+    data-outline={false}
+    data-shallow-disabled={true}
+    data-size={40}
+    data-solid={false}
+  >
+    <FocusRing>
+      <FocusRing
+        focusClass="md-focus-ring-wrapper children"
+        focusRingClass="md-focus-ring-wrapper children"
+      >
+        <button
+          className="md-button-circle-wrapper md-button-simple-wrapper"
+          data-color="primary"
+          data-disabled={false}
+          data-ghost={false}
+          data-multiple-children={false}
+          data-outline={false}
+          data-shallow-disabled={true}
+          data-size={40}
+          data-solid={false}
           onBlur={[Function]}
           onClick={[Function]}
           onDragStart={[Function]}
@@ -337,6 +405,7 @@ exports[`<ButtonCircle /> snapshot should match snapshot with className 1`] = `
     data-ghost={false}
     data-multiple-children={false}
     data-outline={false}
+    data-shallow-disabled={false}
     data-size={40}
     data-solid={false}
   >
@@ -352,6 +421,7 @@ exports[`<ButtonCircle /> snapshot should match snapshot with className 1`] = `
           data-ghost={false}
           data-multiple-children={false}
           data-outline={false}
+          data-shallow-disabled={false}
           data-size={40}
           data-solid={false}
           onBlur={[Function]}
@@ -387,6 +457,7 @@ exports[`<ButtonCircle /> snapshot should match snapshot with color 1`] = `
     data-ghost={false}
     data-multiple-children={false}
     data-outline={false}
+    data-shallow-disabled={false}
     data-size={40}
     data-solid={false}
   >
@@ -402,6 +473,7 @@ exports[`<ButtonCircle /> snapshot should match snapshot with color 1`] = `
           data-ghost={false}
           data-multiple-children={false}
           data-outline={false}
+          data-shallow-disabled={false}
           data-size={40}
           data-solid={false}
           onBlur={[Function]}
@@ -441,6 +513,7 @@ exports[`<ButtonCircle /> snapshot should match snapshot with id 1`] = `
     data-ghost={false}
     data-multiple-children={false}
     data-outline={false}
+    data-shallow-disabled={false}
     data-size={40}
     data-solid={false}
     id="example-id"
@@ -457,6 +530,7 @@ exports[`<ButtonCircle /> snapshot should match snapshot with id 1`] = `
           data-ghost={false}
           data-multiple-children={false}
           data-outline={false}
+          data-shallow-disabled={false}
           data-size={40}
           data-solid={false}
           id="example-id"
@@ -491,6 +565,7 @@ exports[`<ButtonCircle /> snapshot should match snapshot with multiple children 
     data-ghost={false}
     data-multiple-children={true}
     data-outline={false}
+    data-shallow-disabled={false}
     data-size={40}
     data-solid={false}
   >
@@ -506,6 +581,7 @@ exports[`<ButtonCircle /> snapshot should match snapshot with multiple children 
           data-ghost={false}
           data-multiple-children={true}
           data-outline={false}
+          data-shallow-disabled={false}
           data-size={40}
           data-solid={false}
           onBlur={[Function]}
@@ -548,6 +624,7 @@ exports[`<ButtonCircle /> snapshot should match snapshot with size 1`] = `
     data-ghost={false}
     data-multiple-children={false}
     data-outline={false}
+    data-shallow-disabled={false}
     data-size={64}
     data-solid={false}
   >
@@ -563,6 +640,7 @@ exports[`<ButtonCircle /> snapshot should match snapshot with size 1`] = `
           data-ghost={false}
           data-multiple-children={false}
           data-outline={false}
+          data-shallow-disabled={false}
           data-size={64}
           data-solid={false}
           onBlur={[Function]}
@@ -606,6 +684,7 @@ exports[`<ButtonCircle /> snapshot should match snapshot with style 1`] = `
     data-ghost={false}
     data-multiple-children={false}
     data-outline={false}
+    data-shallow-disabled={false}
     data-size={40}
     data-solid={false}
     style={
@@ -626,6 +705,7 @@ exports[`<ButtonCircle /> snapshot should match snapshot with style 1`] = `
           data-ghost={false}
           data-multiple-children={false}
           data-outline={false}
+          data-shallow-disabled={false}
           data-size={40}
           data-solid={false}
           onBlur={[Function]}
@@ -666,6 +746,7 @@ exports[`<ButtonCircle /> snapshot should match snapshot with title 1`] = `
     data-ghost={false}
     data-multiple-children={false}
     data-outline={false}
+    data-shallow-disabled={false}
     data-size={40}
     data-solid={false}
     title="Example Text"
@@ -682,6 +763,7 @@ exports[`<ButtonCircle /> snapshot should match snapshot with title 1`] = `
           data-ghost={false}
           data-multiple-children={false}
           data-outline={false}
+          data-shallow-disabled={false}
           data-size={40}
           data-solid={false}
           onBlur={[Function]}


### PR DESCRIPTION
# Description
Just as we did for ButtonPill, Im implementing shallow disabled for button circle so that onPress events can be passed or it can be placed as trigger of a popover even when disabled.
