### PR TITLE
feat(ghost-solid-button): add styling

### DIFF
--- a/src/components/ButtonCircle/ButtonCircle.style.scss
+++ b/src/components/ButtonCircle/ButtonCircle.style.scss
@@ -111,6 +111,35 @@
     }
   }
 
+  // PRIMARY SOLID GHOST
+  &[data-ghost='true'],
+  &[data-solid='true'] {
+    &[data-outline='false'] {
+      background-color: var(--mds-color-theme-button-inverted-normal);
+      color: var(--mds-color-theme-text-primary-normal);
+
+      &:hover,
+      &.hover {
+        background-color: var(--mds-color-theme-button-inverted-hover);
+        color: var(--mds-color-theme-text-primary-normal);
+      }
+
+      &:active,
+      &.active {
+        background-color: var(--mds-color-theme-button-inverted-pressed);
+        color: var(--mds-color-theme-text-primary-normal);
+      }
+
+      &[data-disabled='true'],
+      &.disable,
+      &[data-shallow-disabled='true'] {
+        background-color: var(--mds-color-theme-button-secondary-normal);
+        color: var(--mds-color-theme-text-primary-disabled);
+        cursor: auto;
+      }
+    }
+  }
+
   // JOIN
   &[data-color='join'] {
     background-color: var(--mds-color-theme-button-join-normal);

--- a/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -107,10 +107,10 @@ const callControlsCommonChildren = [
 ];
 
 const paginationCommonChildren = [
-  <ButtonCircle solid disabled key="0" size={28}>
+  <ButtonCircle solid ghost disabled key="0" size={28}>
     <Icon name="arrow-up" autoScale={150} />
   </ButtonCircle>,
-  <ButtonCircle solid key="1" size={28}>
+  <ButtonCircle solid ghost key="1" size={28}>
     <Icon name="arrow-down" autoScale={150} />
   </ButtonCircle>,
 ];

--- a/src/components/ButtonPill/ButtonPill.style.scss
+++ b/src/components/ButtonPill/ButtonPill.style.scss
@@ -113,6 +113,35 @@
     }
   }
 
+  // PRIMARY SOLID GHOST
+  &[data-ghost='true'],
+  &[data-solid='true'] {
+    &[data-outline='false'] {
+      background-color: var(--mds-color-theme-button-inverted-normal);
+      color: var(--mds-color-theme-text-primary-normal);
+
+      &:hover,
+      &.hover {
+        background-color: var(--mds-color-theme-button-inverted-hover);
+        color: var(--mds-color-theme-text-primary-normal);
+      }
+
+      &:active,
+      &.active {
+        background-color: var(--mds-color-theme-button-inverted-pressed);
+        color: var(--mds-color-theme-text-primary-normal);
+      }
+
+      &[data-disabled='true'],
+      &.disable,
+      &[data-shallow-disabled='true'] {
+        background-color: var(--mds-color-theme-button-secondary-normal);
+        color: var(--mds-color-theme-text-primary-disabled);
+        cursor: auto;
+      }
+    }
+  }
+
   // JOIN
   &[data-color='join'] {
     background-color: var(--mds-color-theme-button-join-normal);


### PR DESCRIPTION
# Description

Although not speficied in Momentum Figma Library, there are some cases in which we need a ghost button that has a solid color without an outline: that is, a background that looks same color as theme background black/white, but it is not transparent and has no outline.

Like this but without the border/outline:
<img width="791" alt="image" src="https://github.com/momentum-design/momentum-react-v2/assets/56999622/b267ab3f-7dbd-4f3d-8d12-03c04eeeaab6">

That is, a button with these properties:
- ghost = true and solid = true. If it would be ghost=false and solid=true, that should result in the primary button which has a solid color. If it would be ghost=true and solid=false, that would result in a button with a transparent background.
- outline = false

That makes this button, for example, work correctly because we need solid buttons with ghost backgrounds.
<img width="909" alt="image" src="https://github.com/momentum-design/momentum-react-v2/assets/56999622/41bb122d-1427-4f6f-bc1a-dd1782470481">


# Links

*Links to relevent resources.*
