### PR TITLE
feat(overlay-alert): focus lock

### DIFF
--- a/src/components/Overlay/Overlay.stories.tsx
+++ b/src/components/Overlay/Overlay.stories.tsx
@@ -33,7 +33,8 @@ const Example: Story<OverlayProps> = (args: OverlayProps) => {
       style={{
         alignItems: 'center',
         backgroundColor: 'var(--mds-color-theme-background-solid-primary-normal)',
-        border: '1px var(--md-globals-border-style-solid) var(--mds-color-theme-outline-secondary-normal)',
+        border:
+          '1px var(--md-globals-border-style-solid) var(--mds-color-theme-outline-secondary-normal)',
         display: 'flex',
         padding: '4rem',
         position: 'relative',
@@ -58,4 +59,43 @@ const Example: Story<OverlayProps> = (args: OverlayProps) => {
 
 Example.argTypes = { ...argTypes };
 
-export { Example };
+const WithFocusLock: Story<OverlayProps> = (args: OverlayProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const toggleOpen = () => {
+    setIsOpen(!isOpen);
+  };
+
+  return (
+    <div
+      style={{
+        alignItems: 'center',
+        backgroundColor: 'var(--mds-color-theme-background-solid-primary-normal)',
+        border:
+          '1px var(--md-globals-border-style-solid) var(--mds-color-theme-outline-secondary-normal)',
+        display: 'flex',
+        padding: '4rem',
+        position: 'relative',
+        width: '80%',
+      }}
+    >
+      {isOpen && (
+        <Overlay focusLockProps={{ returnFocus: true }} {...args}>
+          <ModalContainer color="tertiary" elevation={2} round={50} isPadded>
+            <div style={{ marginRight: '1rem' }}>Foreground Container</div>
+            <button>A Button</button>
+            <button onClick={toggleOpen}>Close Overlay</button>
+          </ModalContainer>
+        </Overlay>
+      )}
+      <ModalContainer color="tertiary" elevation={2} round={50} isPadded>
+        <div style={{ marginRight: '1rem' }}>Background Container</div>
+        <button onClick={toggleOpen}>Open Overlay</button>
+      </ModalContainer>
+    </div>
+  );
+};
+
+WithFocusLock.argTypes = { ...argTypes };
+
+export { Example, WithFocusLock };

--- a/src/components/Overlay/Overlay.tsx
+++ b/src/components/Overlay/Overlay.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react';
 import classnames from 'classnames';
+import FocusLock from 'react-focus-lock';
 
 import { DEFAULTS, STYLE } from './Overlay.constants';
 import { Props } from './Overlay.types';
@@ -16,9 +17,10 @@ const Overlay: FC<Props> = (props: Props) => {
     fullscreen = DEFAULTS.FULLSCREEN,
     id,
     style,
+    focusLockProps,
   } = props;
 
-  return (
+  const content = (
     <div
       className={classnames(className, STYLE.wrapper)}
       data-color={color}
@@ -29,6 +31,12 @@ const Overlay: FC<Props> = (props: Props) => {
       {children}
     </div>
   );
+
+  if (!focusLockProps) {
+    return <>{content}</>;
+  }
+
+  return <FocusLock {...focusLockProps}>{content}</FocusLock>;
 };
 
 export default Overlay;

--- a/src/components/Overlay/Overlay.types.ts
+++ b/src/components/Overlay/Overlay.types.ts
@@ -1,4 +1,5 @@
-import { CSSProperties, ReactNode } from 'react';
+import { CSSProperties, ReactNode, ComponentProps } from 'react';
+import FocusLock from 'react-focus-lock';
 
 export type Color = 'primary' | 'secondary';
 
@@ -32,4 +33,9 @@ export interface Props {
    * Custom style for overriding this component's CSS.
    */
   style?: CSSProperties;
+
+  /**
+   * Props to be passed to FocusLock
+   */
+  focusLockProps?: Omit<ComponentProps<typeof FocusLock>, 'children'>;
 }

--- a/src/components/Overlay/Overlay.unit.test.tsx
+++ b/src/components/Overlay/Overlay.unit.test.tsx
@@ -1,5 +1,8 @@
 import React from 'react';
 import { mount } from 'enzyme';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
 
 import Overlay, { OVERLAY_CONSTANTS as CONSTANTS } from './';
 
@@ -140,6 +143,80 @@ describe('<Overlay />', () => {
         .getDOMNode();
 
       expect(element.getAttribute('data-fullscreen')).toBe(`${fullscreen}`);
+    });
+  });
+
+  describe('actions', () => {
+    it('should not lock focus if no focusLockProps are supplied', async () => {
+      expect.assertions(5);
+
+      const Component = () => {
+        return (
+          <>
+            <button>button</button>
+            <Overlay>
+              <button>button</button>
+              <button>button</button>
+            </Overlay>
+          </>
+        );
+      };
+
+      const user = userEvent.setup();
+
+      render(<Component />);
+
+      const buttons = await screen.findAllByText('button');
+
+      expect(document.body).toHaveFocus();
+
+      await user.tab();
+
+      expect(buttons[0]).toHaveFocus();
+
+      await user.tab();
+
+      expect(buttons[1]).toHaveFocus();
+
+      await user.tab();
+
+      expect(buttons[2]).toHaveFocus();
+
+      await user.tab();
+
+      expect(document.body).toHaveFocus();
+    });
+
+    it('should lock focus around the children', async () => {
+      expect.assertions(3);
+
+      const Component = () => {
+        return (
+          <>
+            <button>button</button>
+            <Overlay focusLockProps={{}}>
+              <button>button</button>
+              <button>button</button>
+            </Overlay>
+          </>
+        );
+      };
+
+      const user = userEvent.setup();
+
+      render(<Component />);
+
+      const buttons = await screen.findAllByText('button');
+
+      expect(buttons[1]).toHaveFocus();
+
+      await user.tab();
+
+      expect(buttons[2]).toHaveFocus();
+
+      await user.tab();
+
+      expect(buttons[1]).toHaveFocus();
     });
   });
 });

--- a/src/components/Overlay/Overlay.unit.test.tsx
+++ b/src/components/Overlay/Overlay.unit.test.tsx
@@ -60,6 +60,14 @@ describe('<Overlay />', () => {
 
       expect(container).toMatchSnapshot();
     });
+
+    it('should match snapshot with focusLockProps', () => {
+      expect.assertions(1);
+
+      const container = mount(<Overlay focusLockProps={{ returnFocus: true }} />);
+
+      expect(container).toMatchSnapshot();
+    });
   });
 
   describe('attributes', () => {

--- a/src/components/Overlay/Overlay.unit.test.tsx.snap
+++ b/src/components/Overlay/Overlay.unit.test.tsx.snap
@@ -34,6 +34,124 @@ exports[`<Overlay /> snapshot should match snapshot with color 1`] = `
 </Overlay>
 `;
 
+exports[`<Overlay /> snapshot should match snapshot with focusLockProps 1`] = `
+<Overlay
+  focusLockProps={
+    Object {
+      "returnFocus": true,
+    }
+  }
+>
+  <FocusLock
+    as="div"
+    autoFocus={true}
+    disabled={false}
+    lockProps={Object {}}
+    noFocusGuards={false}
+    persistentFocus={false}
+    returnFocus={true}
+  >
+    <div
+      data-focus-guard={true}
+      key="guard-first"
+      style={
+        Object {
+          "height": "0px",
+          "left": "1px",
+          "overflow": "hidden",
+          "padding": 0,
+          "position": "fixed",
+          "top": "1px",
+          "width": "1px",
+        }
+      }
+      tabIndex={0}
+    />
+    <div
+      data-focus-guard={true}
+      key="guard-nearest"
+      style={
+        Object {
+          "height": "0px",
+          "left": "1px",
+          "overflow": "hidden",
+          "padding": 0,
+          "position": "fixed",
+          "top": "1px",
+          "width": "1px",
+        }
+      }
+      tabIndex={1}
+    />
+    <div
+      data-focus-lock-disabled={false}
+      onBlur={[Function]}
+      onFocus={[Function]}
+    >
+      <SideEffect(FocusWatcher)
+        autoFocus={true}
+        disabled={false}
+        observed={
+          <div
+            data-focus-lock-disabled="false"
+          >
+            <div
+              class="md-overlay-wrapper"
+              data-color="primary"
+              data-fullscreen="false"
+            />
+          </div>
+        }
+        onActivation={[Function]}
+        onDeactivation={[Function]}
+        persistentFocus={false}
+        shards={Array []}
+      >
+        <FocusWatcher
+          autoFocus={true}
+          disabled={false}
+          observed={
+            <div
+              data-focus-lock-disabled="false"
+            >
+              <div
+                class="md-overlay-wrapper"
+                data-color="primary"
+                data-fullscreen="false"
+              />
+            </div>
+          }
+          onActivation={[Function]}
+          onDeactivation={[Function]}
+          persistentFocus={false}
+          shards={Array []}
+        />
+      </SideEffect(FocusWatcher)>
+      <div
+        className="md-overlay-wrapper"
+        data-color="primary"
+        data-fullscreen={false}
+      />
+    </div>
+    <div
+      data-focus-guard={true}
+      style={
+        Object {
+          "height": "0px",
+          "left": "1px",
+          "overflow": "hidden",
+          "padding": 0,
+          "position": "fixed",
+          "top": "1px",
+          "width": "1px",
+        }
+      }
+      tabIndex={0}
+    />
+  </FocusLock>
+</Overlay>
+`;
+
 exports[`<Overlay /> snapshot should match snapshot with fullscreen 1`] = `
 <Overlay
   fullscreen={true}

--- a/src/components/OverlayAlert/OverlayAlert.constants.ts
+++ b/src/components/OverlayAlert/OverlayAlert.constants.ts
@@ -7,6 +7,10 @@ const DEFAULTS = {
    * Default <Overlay /> color prop.
    */
   OVERLAY_COLOR: OVERLAY_CONSTANTS.COLORS.SECONDARY,
+  /**
+   * Default props for react focus lock, which will be passed to Overlay
+   */
+  FOCUS_LOCK_PROPS: { returnFocus: true },
 };
 
 const STYLE = {

--- a/src/components/OverlayAlert/OverlayAlert.tsx
+++ b/src/components/OverlayAlert/OverlayAlert.tsx
@@ -24,11 +24,17 @@ const OverlayAlert: FC<Props> = (props: Props) => {
     modalColor,
     overlayColor = DEFAULTS.OVERLAY_COLOR,
     title,
+    focusLockProps = DEFAULTS.FOCUS_LOCK_PROPS,
     ...other
   } = props;
 
   return (
-    <Overlay className={classnames(className, STYLE.wrapper)} color={overlayColor} {...other}>
+    <Overlay
+      focusLockProps={focusLockProps}
+      className={classnames(className, STYLE.wrapper)}
+      color={overlayColor}
+      {...other}
+    >
       <ModalContainer color={modalColor}>
         <div>
           <div className={classnames(STYLE.title)}>

--- a/src/components/OverlayAlert/OverlayAlert.types.ts
+++ b/src/components/OverlayAlert/OverlayAlert.types.ts
@@ -1,4 +1,5 @@
-import type { CSSProperties, ReactElement, ReactNode } from 'react';
+import type { CSSProperties, ReactElement, ReactNode, ComponentProps } from 'react';
+import FocusLock from 'react-focus-lock';
 
 import type { ButtonControlProps } from '../ButtonControl';
 import type { ButtonSimpleProps } from '../ButtonSimple';
@@ -59,4 +60,9 @@ export interface Props extends OverlayProps {
    * Title for this OverlayAlert.
    */
   title?: string;
+
+  /**
+   * Props to be passed to Overlay for FocusLock
+   */
+  focusLockProps?: Omit<ComponentProps<typeof FocusLock>, 'children'>;
 }

--- a/src/components/OverlayAlert/OverlayAlert.unit.test.tsx
+++ b/src/components/OverlayAlert/OverlayAlert.unit.test.tsx
@@ -7,6 +7,7 @@ import ModalContainer, { MODAL_CONTAINER_CONSTANTS } from '../ModalContainer';
 import Overlay, { OVERLAY_CONSTANTS } from '../Overlay';
 
 import OverlayAlert, { OVERLAY_ALERT_CONSTANTS as CONSTANTS, OVERLAY_ALERT_CONSTANTS } from './';
+import { STYLE as OVERLAY_STYLE } from '../Overlay/Overlay.constants';
 
 describe('<OverlayAlert />', () => {
   describe('snapshot', () => {
@@ -136,7 +137,7 @@ describe('<OverlayAlert />', () => {
       expect.assertions(1);
 
       const element = mount(<OverlayAlert />)
-        .find(OverlayAlert)
+        .find(`.${OVERLAY_STYLE.wrapper}`) // OverlayAlert passes its class names to Overlay
         .getDOMNode();
 
       expect(element.classList.contains(CONSTANTS.STYLE.wrapper)).toBe(true);
@@ -148,7 +149,7 @@ describe('<OverlayAlert />', () => {
       const className = 'example-class';
 
       const element = mount(<OverlayAlert className={className} />)
-        .find(OverlayAlert)
+        .find(`.${OVERLAY_STYLE.wrapper}`) // OverlayAlert passes its class names to Overlay
         .getDOMNode();
 
       expect(element.classList.contains(className)).toBe(true);
@@ -160,7 +161,7 @@ describe('<OverlayAlert />', () => {
       const id = 'example-id';
 
       const element = mount(<OverlayAlert id={id} />)
-        .find(OverlayAlert)
+        .find(`.${OVERLAY_STYLE.wrapper}`) // OverlayAlert passes other props to Overlay
         .getDOMNode();
 
       expect(element.id).toBe(id);
@@ -173,7 +174,7 @@ describe('<OverlayAlert />', () => {
       const styleString = 'color: pink;';
 
       const element = mount(<OverlayAlert style={style} />)
-        .find(OverlayAlert)
+        .find(`.${OVERLAY_STYLE.wrapper}`) // OverlayAlert passes other props to Overlay
         .getDOMNode();
 
       expect(element.getAttribute('style')).toBe(styleString);
@@ -240,7 +241,7 @@ describe('<OverlayAlert />', () => {
 
       const details = 'details-example';
 
-      const component = mount(<OverlayAlert details={details} />).find(OverlayAlert);
+      const component = mount(<OverlayAlert details={details} />).find(`.${OVERLAY_STYLE.wrapper}`);
 
       const target = component
         .getDOMNode()
@@ -254,7 +255,7 @@ describe('<OverlayAlert />', () => {
 
       const title = 'title-example';
 
-      const component = mount(<OverlayAlert title={title} />).find(OverlayAlert);
+      const component = mount(<OverlayAlert title={title} />).find(`.${OVERLAY_STYLE.wrapper}`);
 
       const target = component
         .getDOMNode()
@@ -266,7 +267,7 @@ describe('<OverlayAlert />', () => {
     it('should still render a empty div with the appropriate class when no title is provided', () => {
       expect.assertions(1);
 
-      const component = mount(<OverlayAlert />).find(OverlayAlert);
+      const component = mount(<OverlayAlert />).find(`.${OVERLAY_STYLE.wrapper}`);
 
       const target = component
         .getDOMNode()

--- a/src/components/OverlayAlert/OverlayAlert.unit.test.tsx.snap
+++ b/src/components/OverlayAlert/OverlayAlert.unit.test.tsx.snap
@@ -5,31 +5,172 @@ exports[`<OverlayAlert /> snapshot should match snapshot 1`] = `
   <Overlay
     className="md-overlay-alert-wrapper"
     color="secondary"
+    focusLockProps={
+      Object {
+        "returnFocus": true,
+      }
+    }
   >
-    <div
-      className="md-overlay-alert-wrapper md-overlay-wrapper"
-      data-color="secondary"
-      data-fullscreen={false}
+    <FocusLock
+      as="div"
+      autoFocus={true}
+      disabled={false}
+      lockProps={Object {}}
+      noFocusGuards={false}
+      persistentFocus={false}
+      returnFocus={true}
     >
-      <ModalContainer>
-        <div
-          className="md-modal-container-wrapper"
-          data-color="primary"
-          data-elevation={0}
-          data-padded={false}
-          data-round={0}
-        >
-          <div>
+      <div
+        data-focus-guard={true}
+        key="guard-first"
+        style={
+          Object {
+            "height": "0px",
+            "left": "1px",
+            "overflow": "hidden",
+            "padding": 0,
+            "position": "fixed",
+            "top": "1px",
+            "width": "1px",
+          }
+        }
+        tabIndex={0}
+      />
+      <div
+        data-focus-guard={true}
+        key="guard-nearest"
+        style={
+          Object {
+            "height": "0px",
+            "left": "1px",
+            "overflow": "hidden",
+            "padding": 0,
+            "position": "fixed",
+            "top": "1px",
+            "width": "1px",
+          }
+        }
+        tabIndex={1}
+      />
+      <div
+        data-focus-lock-disabled={false}
+        onBlur={[Function]}
+        onFocus={[Function]}
+      >
+        <SideEffect(FocusWatcher)
+          autoFocus={true}
+          disabled={false}
+          observed={
             <div
-              className="md-overlay-alert-title"
-            />
-            <div />
-          </div>
-          <div />
-          <div />
+              data-focus-lock-disabled="false"
+            >
+              <div
+                class="md-overlay-alert-wrapper md-overlay-wrapper"
+                data-color="secondary"
+                data-fullscreen="false"
+              >
+                <div
+                  class="md-modal-container-wrapper"
+                  data-color="primary"
+                  data-elevation="0"
+                  data-padded="false"
+                  data-round="0"
+                >
+                  <div>
+                    <div
+                      class="md-overlay-alert-title"
+                    />
+                    <div />
+                  </div>
+                  <div />
+                  <div />
+                </div>
+              </div>
+            </div>
+          }
+          onActivation={[Function]}
+          onDeactivation={[Function]}
+          persistentFocus={false}
+          shards={Array []}
+        >
+          <FocusWatcher
+            autoFocus={true}
+            disabled={false}
+            observed={
+              <div
+                data-focus-lock-disabled="false"
+              >
+                <div
+                  class="md-overlay-alert-wrapper md-overlay-wrapper"
+                  data-color="secondary"
+                  data-fullscreen="false"
+                >
+                  <div
+                    class="md-modal-container-wrapper"
+                    data-color="primary"
+                    data-elevation="0"
+                    data-padded="false"
+                    data-round="0"
+                  >
+                    <div>
+                      <div
+                        class="md-overlay-alert-title"
+                      />
+                      <div />
+                    </div>
+                    <div />
+                    <div />
+                  </div>
+                </div>
+              </div>
+            }
+            onActivation={[Function]}
+            onDeactivation={[Function]}
+            persistentFocus={false}
+            shards={Array []}
+          />
+        </SideEffect(FocusWatcher)>
+        <div
+          className="md-overlay-alert-wrapper md-overlay-wrapper"
+          data-color="secondary"
+          data-fullscreen={false}
+        >
+          <ModalContainer>
+            <div
+              className="md-modal-container-wrapper"
+              data-color="primary"
+              data-elevation={0}
+              data-padded={false}
+              data-round={0}
+            >
+              <div>
+                <div
+                  className="md-overlay-alert-title"
+                />
+                <div />
+              </div>
+              <div />
+              <div />
+            </div>
+          </ModalContainer>
         </div>
-      </ModalContainer>
-    </div>
+      </div>
+      <div
+        data-focus-guard={true}
+        style={
+          Object {
+            "height": "0px",
+            "left": "1px",
+            "overflow": "hidden",
+            "padding": 0,
+            "position": "fixed",
+            "top": "1px",
+            "width": "1px",
+          }
+        }
+        tabIndex={0}
+      />
+    </FocusLock>
   </Overlay>
 </OverlayAlert>
 `;
@@ -45,83 +186,258 @@ exports[`<OverlayAlert /> snapshot should match snapshot with actions 1`] = `
   <Overlay
     className="md-overlay-alert-wrapper"
     color="secondary"
+    focusLockProps={
+      Object {
+        "returnFocus": true,
+      }
+    }
   >
-    <div
-      className="md-overlay-alert-wrapper md-overlay-wrapper"
-      data-color="secondary"
-      data-fullscreen={false}
+    <FocusLock
+      as="div"
+      autoFocus={true}
+      disabled={false}
+      lockProps={Object {}}
+      noFocusGuards={false}
+      persistentFocus={false}
+      returnFocus={true}
     >
-      <ModalContainer>
-        <div
-          className="md-modal-container-wrapper"
-          data-color="primary"
-          data-elevation={0}
-          data-padded={false}
-          data-round={0}
-        >
-          <div>
+      <div
+        data-focus-guard={true}
+        key="guard-first"
+        style={
+          Object {
+            "height": "0px",
+            "left": "1px",
+            "overflow": "hidden",
+            "padding": 0,
+            "position": "fixed",
+            "top": "1px",
+            "width": "1px",
+          }
+        }
+        tabIndex={0}
+      />
+      <div
+        data-focus-guard={true}
+        key="guard-nearest"
+        style={
+          Object {
+            "height": "0px",
+            "left": "1px",
+            "overflow": "hidden",
+            "padding": 0,
+            "position": "fixed",
+            "top": "1px",
+            "width": "1px",
+          }
+        }
+        tabIndex={1}
+      />
+      <div
+        data-focus-lock-disabled={false}
+        onBlur={[Function]}
+        onFocus={[Function]}
+      >
+        <SideEffect(FocusWatcher)
+          autoFocus={true}
+          disabled={false}
+          observed={
             <div
-              className="md-overlay-alert-title"
-            />
-            <div />
-          </div>
-          <div />
-          <div>
-            <ButtonPill>
-              <ButtonSimple
-                className="md-button-pill-wrapper"
-                data-color="primary"
-                data-disabled={false}
-                data-ghost={false}
-                data-grown={false}
-                data-inverted={false}
-                data-outline={false}
-                data-shallow-disabled={false}
-                data-size={40}
+              data-focus-lock-disabled="false"
+            >
+              <div
+                class="md-overlay-alert-wrapper md-overlay-wrapper"
+                data-color="secondary"
+                data-fullscreen="false"
               >
-                <FocusRing>
-                  <FocusRing
-                    focusClass="md-focus-ring-wrapper children"
-                    focusRingClass="md-focus-ring-wrapper children"
-                  >
+                <div
+                  class="md-modal-container-wrapper"
+                  data-color="primary"
+                  data-elevation="0"
+                  data-padded="false"
+                  data-round="0"
+                >
+                  <div>
+                    <div
+                      class="md-overlay-alert-title"
+                    />
+                    <div />
+                  </div>
+                  <div />
+                  <div>
                     <button
-                      className="md-button-pill-wrapper md-button-simple-wrapper"
+                      class="md-button-pill-wrapper md-button-simple-wrapper"
                       data-color="primary"
-                      data-disabled={false}
-                      data-ghost={false}
-                      data-grown={false}
-                      data-inverted={false}
-                      data-outline={false}
-                      data-shallow-disabled={false}
-                      data-size={40}
-                      onBlur={[Function]}
-                      onClick={[Function]}
-                      onDragStart={[Function]}
-                      onFocus={[Function]}
-                      onKeyDown={[Function]}
-                      onKeyUp={[Function]}
-                      onMouseDown={[Function]}
-                      onMouseEnter={[Function]}
-                      onMouseLeave={[Function]}
-                      onMouseUp={[Function]}
-                      onTouchCancel={[Function]}
-                      onTouchEnd={[Function]}
-                      onTouchMove={[Function]}
-                      onTouchStart={[Function]}
+                      data-disabled="false"
+                      data-ghost="false"
+                      data-grown="false"
+                      data-inverted="false"
+                      data-outline="false"
+                      data-shallow-disabled="false"
+                      data-size="40"
                       type="button"
                     >
                       <span>
                         Button Pill
                       </span>
                     </button>
-                  </FocusRing>
-                </FocusRing>
-              </ButtonSimple>
-            </ButtonPill>
-          </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          }
+          onActivation={[Function]}
+          onDeactivation={[Function]}
+          persistentFocus={false}
+          shards={Array []}
+        >
+          <FocusWatcher
+            autoFocus={true}
+            disabled={false}
+            observed={
+              <div
+                data-focus-lock-disabled="false"
+              >
+                <div
+                  class="md-overlay-alert-wrapper md-overlay-wrapper"
+                  data-color="secondary"
+                  data-fullscreen="false"
+                >
+                  <div
+                    class="md-modal-container-wrapper"
+                    data-color="primary"
+                    data-elevation="0"
+                    data-padded="false"
+                    data-round="0"
+                  >
+                    <div>
+                      <div
+                        class="md-overlay-alert-title"
+                      />
+                      <div />
+                    </div>
+                    <div />
+                    <div>
+                      <button
+                        class="md-button-pill-wrapper md-button-simple-wrapper"
+                        data-color="primary"
+                        data-disabled="false"
+                        data-ghost="false"
+                        data-grown="false"
+                        data-inverted="false"
+                        data-outline="false"
+                        data-shallow-disabled="false"
+                        data-size="40"
+                        type="button"
+                      >
+                        <span>
+                          Button Pill
+                        </span>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            }
+            onActivation={[Function]}
+            onDeactivation={[Function]}
+            persistentFocus={false}
+            shards={Array []}
+          />
+        </SideEffect(FocusWatcher)>
+        <div
+          className="md-overlay-alert-wrapper md-overlay-wrapper"
+          data-color="secondary"
+          data-fullscreen={false}
+        >
+          <ModalContainer>
+            <div
+              className="md-modal-container-wrapper"
+              data-color="primary"
+              data-elevation={0}
+              data-padded={false}
+              data-round={0}
+            >
+              <div>
+                <div
+                  className="md-overlay-alert-title"
+                />
+                <div />
+              </div>
+              <div />
+              <div>
+                <ButtonPill>
+                  <ButtonSimple
+                    className="md-button-pill-wrapper"
+                    data-color="primary"
+                    data-disabled={false}
+                    data-ghost={false}
+                    data-grown={false}
+                    data-inverted={false}
+                    data-outline={false}
+                    data-shallow-disabled={false}
+                    data-size={40}
+                  >
+                    <FocusRing>
+                      <FocusRing
+                        focusClass="md-focus-ring-wrapper children"
+                        focusRingClass="md-focus-ring-wrapper children"
+                      >
+                        <button
+                          className="md-button-pill-wrapper md-button-simple-wrapper"
+                          data-color="primary"
+                          data-disabled={false}
+                          data-ghost={false}
+                          data-grown={false}
+                          data-inverted={false}
+                          data-outline={false}
+                          data-shallow-disabled={false}
+                          data-size={40}
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onDragStart={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onKeyUp={[Function]}
+                          onMouseDown={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseUp={[Function]}
+                          onTouchCancel={[Function]}
+                          onTouchEnd={[Function]}
+                          onTouchMove={[Function]}
+                          onTouchStart={[Function]}
+                          type="button"
+                        >
+                          <span>
+                            Button Pill
+                          </span>
+                        </button>
+                      </FocusRing>
+                    </FocusRing>
+                  </ButtonSimple>
+                </ButtonPill>
+              </div>
+            </div>
+          </ModalContainer>
         </div>
-      </ModalContainer>
-    </div>
+      </div>
+      <div
+        data-focus-guard={true}
+        style={
+          Object {
+            "height": "0px",
+            "left": "1px",
+            "overflow": "hidden",
+            "padding": 0,
+            "position": "fixed",
+            "top": "1px",
+            "width": "1px",
+          }
+        }
+        tabIndex={0}
+      />
+    </FocusLock>
   </Overlay>
 </OverlayAlert>
 `;
@@ -133,31 +449,172 @@ exports[`<OverlayAlert /> snapshot should match snapshot with className 1`] = `
   <Overlay
     className="example-class md-overlay-alert-wrapper"
     color="secondary"
+    focusLockProps={
+      Object {
+        "returnFocus": true,
+      }
+    }
   >
-    <div
-      className="example-class md-overlay-alert-wrapper md-overlay-wrapper"
-      data-color="secondary"
-      data-fullscreen={false}
+    <FocusLock
+      as="div"
+      autoFocus={true}
+      disabled={false}
+      lockProps={Object {}}
+      noFocusGuards={false}
+      persistentFocus={false}
+      returnFocus={true}
     >
-      <ModalContainer>
-        <div
-          className="md-modal-container-wrapper"
-          data-color="primary"
-          data-elevation={0}
-          data-padded={false}
-          data-round={0}
-        >
-          <div>
+      <div
+        data-focus-guard={true}
+        key="guard-first"
+        style={
+          Object {
+            "height": "0px",
+            "left": "1px",
+            "overflow": "hidden",
+            "padding": 0,
+            "position": "fixed",
+            "top": "1px",
+            "width": "1px",
+          }
+        }
+        tabIndex={0}
+      />
+      <div
+        data-focus-guard={true}
+        key="guard-nearest"
+        style={
+          Object {
+            "height": "0px",
+            "left": "1px",
+            "overflow": "hidden",
+            "padding": 0,
+            "position": "fixed",
+            "top": "1px",
+            "width": "1px",
+          }
+        }
+        tabIndex={1}
+      />
+      <div
+        data-focus-lock-disabled={false}
+        onBlur={[Function]}
+        onFocus={[Function]}
+      >
+        <SideEffect(FocusWatcher)
+          autoFocus={true}
+          disabled={false}
+          observed={
             <div
-              className="md-overlay-alert-title"
-            />
-            <div />
-          </div>
-          <div />
-          <div />
+              data-focus-lock-disabled="false"
+            >
+              <div
+                class="example-class md-overlay-alert-wrapper md-overlay-wrapper"
+                data-color="secondary"
+                data-fullscreen="false"
+              >
+                <div
+                  class="md-modal-container-wrapper"
+                  data-color="primary"
+                  data-elevation="0"
+                  data-padded="false"
+                  data-round="0"
+                >
+                  <div>
+                    <div
+                      class="md-overlay-alert-title"
+                    />
+                    <div />
+                  </div>
+                  <div />
+                  <div />
+                </div>
+              </div>
+            </div>
+          }
+          onActivation={[Function]}
+          onDeactivation={[Function]}
+          persistentFocus={false}
+          shards={Array []}
+        >
+          <FocusWatcher
+            autoFocus={true}
+            disabled={false}
+            observed={
+              <div
+                data-focus-lock-disabled="false"
+              >
+                <div
+                  class="example-class md-overlay-alert-wrapper md-overlay-wrapper"
+                  data-color="secondary"
+                  data-fullscreen="false"
+                >
+                  <div
+                    class="md-modal-container-wrapper"
+                    data-color="primary"
+                    data-elevation="0"
+                    data-padded="false"
+                    data-round="0"
+                  >
+                    <div>
+                      <div
+                        class="md-overlay-alert-title"
+                      />
+                      <div />
+                    </div>
+                    <div />
+                    <div />
+                  </div>
+                </div>
+              </div>
+            }
+            onActivation={[Function]}
+            onDeactivation={[Function]}
+            persistentFocus={false}
+            shards={Array []}
+          />
+        </SideEffect(FocusWatcher)>
+        <div
+          className="example-class md-overlay-alert-wrapper md-overlay-wrapper"
+          data-color="secondary"
+          data-fullscreen={false}
+        >
+          <ModalContainer>
+            <div
+              className="md-modal-container-wrapper"
+              data-color="primary"
+              data-elevation={0}
+              data-padded={false}
+              data-round={0}
+            >
+              <div>
+                <div
+                  className="md-overlay-alert-title"
+                />
+                <div />
+              </div>
+              <div />
+              <div />
+            </div>
+          </ModalContainer>
         </div>
-      </ModalContainer>
-    </div>
+      </div>
+      <div
+        data-focus-guard={true}
+        style={
+          Object {
+            "height": "0px",
+            "left": "1px",
+            "overflow": "hidden",
+            "padding": 0,
+            "position": "fixed",
+            "top": "1px",
+            "width": "1px",
+          }
+        }
+        tabIndex={0}
+      />
+    </FocusLock>
   </Overlay>
 </OverlayAlert>
 `;
@@ -173,71 +630,222 @@ exports[`<OverlayAlert /> snapshot should match snapshot with controls 1`] = `
   <Overlay
     className="md-overlay-alert-wrapper"
     color="secondary"
+    focusLockProps={
+      Object {
+        "returnFocus": true,
+      }
+    }
   >
-    <div
-      className="md-overlay-alert-wrapper md-overlay-wrapper"
-      data-color="secondary"
-      data-fullscreen={false}
+    <FocusLock
+      as="div"
+      autoFocus={true}
+      disabled={false}
+      lockProps={Object {}}
+      noFocusGuards={false}
+      persistentFocus={false}
+      returnFocus={true}
     >
-      <ModalContainer>
-        <div
-          className="md-modal-container-wrapper"
-          data-color="primary"
-          data-elevation={0}
-          data-padded={false}
-          data-round={0}
-        >
-          <div>
+      <div
+        data-focus-guard={true}
+        key="guard-first"
+        style={
+          Object {
+            "height": "0px",
+            "left": "1px",
+            "overflow": "hidden",
+            "padding": 0,
+            "position": "fixed",
+            "top": "1px",
+            "width": "1px",
+          }
+        }
+        tabIndex={0}
+      />
+      <div
+        data-focus-guard={true}
+        key="guard-nearest"
+        style={
+          Object {
+            "height": "0px",
+            "left": "1px",
+            "overflow": "hidden",
+            "padding": 0,
+            "position": "fixed",
+            "top": "1px",
+            "width": "1px",
+          }
+        }
+        tabIndex={1}
+      />
+      <div
+        data-focus-lock-disabled={false}
+        onBlur={[Function]}
+        onFocus={[Function]}
+      >
+        <SideEffect(FocusWatcher)
+          autoFocus={true}
+          disabled={false}
+          observed={
             <div
-              className="md-overlay-alert-title"
-            />
-            <div>
-              <ButtonControl
-                control="close"
+              data-focus-lock-disabled="false"
+            >
+              <div
+                class="md-overlay-alert-wrapper md-overlay-wrapper"
+                data-color="secondary"
+                data-fullscreen="false"
               >
-                <ButtonSimple
-                  className="md-button-control-wrapper"
+                <div
+                  class="md-modal-container-wrapper"
+                  data-color="primary"
+                  data-elevation="0"
+                  data-padded="false"
+                  data-round="0"
                 >
-                  <FocusRing>
-                    <FocusRing
-                      focusClass="md-focus-ring-wrapper children"
-                      focusRingClass="md-focus-ring-wrapper children"
-                    >
+                  <div>
+                    <div
+                      class="md-overlay-alert-title"
+                    />
+                    <div>
                       <button
-                        className="md-button-control-wrapper md-button-simple-wrapper"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onDragStart={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        onKeyUp={[Function]}
-                        onMouseDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                        onMouseUp={[Function]}
-                        onTouchCancel={[Function]}
-                        onTouchEnd={[Function]}
-                        onTouchMove={[Function]}
-                        onTouchStart={[Function]}
+                        class="md-button-control-wrapper md-button-simple-wrapper"
                         type="button"
-                      >
-                        <Icon
-                          autoScale={true}
-                          name="cancel"
-                          weight="bold"
-                        />
-                      </button>
-                    </FocusRing>
-                  </FocusRing>
-                </ButtonSimple>
-              </ButtonControl>
+                      />
+                    </div>
+                  </div>
+                  <div />
+                  <div />
+                </div>
+              </div>
             </div>
-          </div>
-          <div />
-          <div />
+          }
+          onActivation={[Function]}
+          onDeactivation={[Function]}
+          persistentFocus={false}
+          shards={Array []}
+        >
+          <FocusWatcher
+            autoFocus={true}
+            disabled={false}
+            observed={
+              <div
+                data-focus-lock-disabled="false"
+              >
+                <div
+                  class="md-overlay-alert-wrapper md-overlay-wrapper"
+                  data-color="secondary"
+                  data-fullscreen="false"
+                >
+                  <div
+                    class="md-modal-container-wrapper"
+                    data-color="primary"
+                    data-elevation="0"
+                    data-padded="false"
+                    data-round="0"
+                  >
+                    <div>
+                      <div
+                        class="md-overlay-alert-title"
+                      />
+                      <div>
+                        <button
+                          class="md-button-control-wrapper md-button-simple-wrapper"
+                          type="button"
+                        />
+                      </div>
+                    </div>
+                    <div />
+                    <div />
+                  </div>
+                </div>
+              </div>
+            }
+            onActivation={[Function]}
+            onDeactivation={[Function]}
+            persistentFocus={false}
+            shards={Array []}
+          />
+        </SideEffect(FocusWatcher)>
+        <div
+          className="md-overlay-alert-wrapper md-overlay-wrapper"
+          data-color="secondary"
+          data-fullscreen={false}
+        >
+          <ModalContainer>
+            <div
+              className="md-modal-container-wrapper"
+              data-color="primary"
+              data-elevation={0}
+              data-padded={false}
+              data-round={0}
+            >
+              <div>
+                <div
+                  className="md-overlay-alert-title"
+                />
+                <div>
+                  <ButtonControl
+                    control="close"
+                  >
+                    <ButtonSimple
+                      className="md-button-control-wrapper"
+                    >
+                      <FocusRing>
+                        <FocusRing
+                          focusClass="md-focus-ring-wrapper children"
+                          focusRingClass="md-focus-ring-wrapper children"
+                        >
+                          <button
+                            className="md-button-control-wrapper md-button-simple-wrapper"
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onDragStart={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            onKeyUp={[Function]}
+                            onMouseDown={[Function]}
+                            onMouseEnter={[Function]}
+                            onMouseLeave={[Function]}
+                            onMouseUp={[Function]}
+                            onTouchCancel={[Function]}
+                            onTouchEnd={[Function]}
+                            onTouchMove={[Function]}
+                            onTouchStart={[Function]}
+                            type="button"
+                          >
+                            <Icon
+                              autoScale={true}
+                              name="cancel"
+                              weight="bold"
+                            />
+                          </button>
+                        </FocusRing>
+                      </FocusRing>
+                    </ButtonSimple>
+                  </ButtonControl>
+                </div>
+              </div>
+              <div />
+              <div />
+            </div>
+          </ModalContainer>
         </div>
-      </ModalContainer>
-    </div>
+      </div>
+      <div
+        data-focus-guard={true}
+        style={
+          Object {
+            "height": "0px",
+            "left": "1px",
+            "overflow": "hidden",
+            "padding": 0,
+            "position": "fixed",
+            "top": "1px",
+            "width": "1px",
+          }
+        }
+        tabIndex={0}
+      />
+    </FocusLock>
   </Overlay>
 </OverlayAlert>
 `;
@@ -249,43 +857,198 @@ exports[`<OverlayAlert /> snapshot should match snapshot with details 1`] = `
   <Overlay
     className="md-overlay-alert-wrapper"
     color="secondary"
+    focusLockProps={
+      Object {
+        "returnFocus": true,
+      }
+    }
   >
-    <div
-      className="md-overlay-alert-wrapper md-overlay-wrapper"
-      data-color="secondary"
-      data-fullscreen={false}
+    <FocusLock
+      as="div"
+      autoFocus={true}
+      disabled={false}
+      lockProps={Object {}}
+      noFocusGuards={false}
+      persistentFocus={false}
+      returnFocus={true}
     >
-      <ModalContainer>
-        <div
-          className="md-modal-container-wrapper"
-          data-color="primary"
-          data-elevation={0}
-          data-padded={false}
-          data-round={0}
-        >
-          <div>
+      <div
+        data-focus-guard={true}
+        key="guard-first"
+        style={
+          Object {
+            "height": "0px",
+            "left": "1px",
+            "overflow": "hidden",
+            "padding": 0,
+            "position": "fixed",
+            "top": "1px",
+            "width": "1px",
+          }
+        }
+        tabIndex={0}
+      />
+      <div
+        data-focus-guard={true}
+        key="guard-nearest"
+        style={
+          Object {
+            "height": "0px",
+            "left": "1px",
+            "overflow": "hidden",
+            "padding": 0,
+            "position": "fixed",
+            "top": "1px",
+            "width": "1px",
+          }
+        }
+        tabIndex={1}
+      />
+      <div
+        data-focus-lock-disabled={false}
+        onBlur={[Function]}
+        onFocus={[Function]}
+      >
+        <SideEffect(FocusWatcher)
+          autoFocus={true}
+          disabled={false}
+          observed={
             <div
-              className="md-overlay-alert-title"
-            />
-            <div />
-          </div>
-          <div>
-            <Text
-              className="md-overlay-alert-details"
-              type="body-secondary"
+              data-focus-lock-disabled="false"
             >
-              <small
-                className="md-text-wrapper md-overlay-alert-details"
-                data-type="body-secondary"
+              <div
+                class="md-overlay-alert-wrapper md-overlay-wrapper"
+                data-color="secondary"
+                data-fullscreen="false"
               >
-                example-details
-              </small>
-            </Text>
-          </div>
-          <div />
+                <div
+                  class="md-modal-container-wrapper"
+                  data-color="primary"
+                  data-elevation="0"
+                  data-padded="false"
+                  data-round="0"
+                >
+                  <div>
+                    <div
+                      class="md-overlay-alert-title"
+                    />
+                    <div />
+                  </div>
+                  <div>
+                    <small
+                      class="md-text-wrapper md-overlay-alert-details"
+                      data-type="body-secondary"
+                    >
+                      example-details
+                    </small>
+                  </div>
+                  <div />
+                </div>
+              </div>
+            </div>
+          }
+          onActivation={[Function]}
+          onDeactivation={[Function]}
+          persistentFocus={false}
+          shards={Array []}
+        >
+          <FocusWatcher
+            autoFocus={true}
+            disabled={false}
+            observed={
+              <div
+                data-focus-lock-disabled="false"
+              >
+                <div
+                  class="md-overlay-alert-wrapper md-overlay-wrapper"
+                  data-color="secondary"
+                  data-fullscreen="false"
+                >
+                  <div
+                    class="md-modal-container-wrapper"
+                    data-color="primary"
+                    data-elevation="0"
+                    data-padded="false"
+                    data-round="0"
+                  >
+                    <div>
+                      <div
+                        class="md-overlay-alert-title"
+                      />
+                      <div />
+                    </div>
+                    <div>
+                      <small
+                        class="md-text-wrapper md-overlay-alert-details"
+                        data-type="body-secondary"
+                      >
+                        example-details
+                      </small>
+                    </div>
+                    <div />
+                  </div>
+                </div>
+              </div>
+            }
+            onActivation={[Function]}
+            onDeactivation={[Function]}
+            persistentFocus={false}
+            shards={Array []}
+          />
+        </SideEffect(FocusWatcher)>
+        <div
+          className="md-overlay-alert-wrapper md-overlay-wrapper"
+          data-color="secondary"
+          data-fullscreen={false}
+        >
+          <ModalContainer>
+            <div
+              className="md-modal-container-wrapper"
+              data-color="primary"
+              data-elevation={0}
+              data-padded={false}
+              data-round={0}
+            >
+              <div>
+                <div
+                  className="md-overlay-alert-title"
+                />
+                <div />
+              </div>
+              <div>
+                <Text
+                  className="md-overlay-alert-details"
+                  type="body-secondary"
+                >
+                  <small
+                    className="md-text-wrapper md-overlay-alert-details"
+                    data-type="body-secondary"
+                  >
+                    example-details
+                  </small>
+                </Text>
+              </div>
+              <div />
+            </div>
+          </ModalContainer>
         </div>
-      </ModalContainer>
-    </div>
+      </div>
+      <div
+        data-focus-guard={true}
+        style={
+          Object {
+            "height": "0px",
+            "left": "1px",
+            "overflow": "hidden",
+            "padding": 0,
+            "position": "fixed",
+            "top": "1px",
+            "width": "1px",
+          }
+        }
+        tabIndex={0}
+      />
+    </FocusLock>
   </Overlay>
 </OverlayAlert>
 `;
@@ -297,33 +1060,178 @@ exports[`<OverlayAlert /> snapshot should match snapshot with details and childr
   <Overlay
     className="md-overlay-alert-wrapper"
     color="secondary"
+    focusLockProps={
+      Object {
+        "returnFocus": true,
+      }
+    }
   >
-    <div
-      className="md-overlay-alert-wrapper md-overlay-wrapper"
-      data-color="secondary"
-      data-fullscreen={false}
+    <FocusLock
+      as="div"
+      autoFocus={true}
+      disabled={false}
+      lockProps={Object {}}
+      noFocusGuards={false}
+      persistentFocus={false}
+      returnFocus={true}
     >
-      <ModalContainer>
-        <div
-          className="md-modal-container-wrapper"
-          data-color="primary"
-          data-elevation={0}
-          data-padded={false}
-          data-round={0}
-        >
-          <div>
+      <div
+        data-focus-guard={true}
+        key="guard-first"
+        style={
+          Object {
+            "height": "0px",
+            "left": "1px",
+            "overflow": "hidden",
+            "padding": 0,
+            "position": "fixed",
+            "top": "1px",
+            "width": "1px",
+          }
+        }
+        tabIndex={0}
+      />
+      <div
+        data-focus-guard={true}
+        key="guard-nearest"
+        style={
+          Object {
+            "height": "0px",
+            "left": "1px",
+            "overflow": "hidden",
+            "padding": 0,
+            "position": "fixed",
+            "top": "1px",
+            "width": "1px",
+          }
+        }
+        tabIndex={1}
+      />
+      <div
+        data-focus-lock-disabled={false}
+        onBlur={[Function]}
+        onFocus={[Function]}
+      >
+        <SideEffect(FocusWatcher)
+          autoFocus={true}
+          disabled={false}
+          observed={
             <div
-              className="md-overlay-alert-title"
-            />
-            <div />
-          </div>
-          <div>
-            example-children
-          </div>
-          <div />
+              data-focus-lock-disabled="false"
+            >
+              <div
+                class="md-overlay-alert-wrapper md-overlay-wrapper"
+                data-color="secondary"
+                data-fullscreen="false"
+              >
+                <div
+                  class="md-modal-container-wrapper"
+                  data-color="primary"
+                  data-elevation="0"
+                  data-padded="false"
+                  data-round="0"
+                >
+                  <div>
+                    <div
+                      class="md-overlay-alert-title"
+                    />
+                    <div />
+                  </div>
+                  <div>
+                    example-children
+                  </div>
+                  <div />
+                </div>
+              </div>
+            </div>
+          }
+          onActivation={[Function]}
+          onDeactivation={[Function]}
+          persistentFocus={false}
+          shards={Array []}
+        >
+          <FocusWatcher
+            autoFocus={true}
+            disabled={false}
+            observed={
+              <div
+                data-focus-lock-disabled="false"
+              >
+                <div
+                  class="md-overlay-alert-wrapper md-overlay-wrapper"
+                  data-color="secondary"
+                  data-fullscreen="false"
+                >
+                  <div
+                    class="md-modal-container-wrapper"
+                    data-color="primary"
+                    data-elevation="0"
+                    data-padded="false"
+                    data-round="0"
+                  >
+                    <div>
+                      <div
+                        class="md-overlay-alert-title"
+                      />
+                      <div />
+                    </div>
+                    <div>
+                      example-children
+                    </div>
+                    <div />
+                  </div>
+                </div>
+              </div>
+            }
+            onActivation={[Function]}
+            onDeactivation={[Function]}
+            persistentFocus={false}
+            shards={Array []}
+          />
+        </SideEffect(FocusWatcher)>
+        <div
+          className="md-overlay-alert-wrapper md-overlay-wrapper"
+          data-color="secondary"
+          data-fullscreen={false}
+        >
+          <ModalContainer>
+            <div
+              className="md-modal-container-wrapper"
+              data-color="primary"
+              data-elevation={0}
+              data-padded={false}
+              data-round={0}
+            >
+              <div>
+                <div
+                  className="md-overlay-alert-title"
+                />
+                <div />
+              </div>
+              <div>
+                example-children
+              </div>
+              <div />
+            </div>
+          </ModalContainer>
         </div>
-      </ModalContainer>
-    </div>
+      </div>
+      <div
+        data-focus-guard={true}
+        style={
+          Object {
+            "height": "0px",
+            "left": "1px",
+            "overflow": "hidden",
+            "padding": 0,
+            "position": "fixed",
+            "top": "1px",
+            "width": "1px",
+          }
+        }
+        tabIndex={0}
+      />
+    </FocusLock>
   </Overlay>
 </OverlayAlert>
 `;
@@ -335,33 +1243,176 @@ exports[`<OverlayAlert /> snapshot should match snapshot with id 1`] = `
   <Overlay
     className="md-overlay-alert-wrapper"
     color="secondary"
+    focusLockProps={
+      Object {
+        "returnFocus": true,
+      }
+    }
     id="example-id"
   >
-    <div
-      className="md-overlay-alert-wrapper md-overlay-wrapper"
-      data-color="secondary"
-      data-fullscreen={false}
-      id="example-id"
+    <FocusLock
+      as="div"
+      autoFocus={true}
+      disabled={false}
+      lockProps={Object {}}
+      noFocusGuards={false}
+      persistentFocus={false}
+      returnFocus={true}
     >
-      <ModalContainer>
-        <div
-          className="md-modal-container-wrapper"
-          data-color="primary"
-          data-elevation={0}
-          data-padded={false}
-          data-round={0}
-        >
-          <div>
+      <div
+        data-focus-guard={true}
+        key="guard-first"
+        style={
+          Object {
+            "height": "0px",
+            "left": "1px",
+            "overflow": "hidden",
+            "padding": 0,
+            "position": "fixed",
+            "top": "1px",
+            "width": "1px",
+          }
+        }
+        tabIndex={0}
+      />
+      <div
+        data-focus-guard={true}
+        key="guard-nearest"
+        style={
+          Object {
+            "height": "0px",
+            "left": "1px",
+            "overflow": "hidden",
+            "padding": 0,
+            "position": "fixed",
+            "top": "1px",
+            "width": "1px",
+          }
+        }
+        tabIndex={1}
+      />
+      <div
+        data-focus-lock-disabled={false}
+        onBlur={[Function]}
+        onFocus={[Function]}
+      >
+        <SideEffect(FocusWatcher)
+          autoFocus={true}
+          disabled={false}
+          observed={
             <div
-              className="md-overlay-alert-title"
-            />
-            <div />
-          </div>
-          <div />
-          <div />
+              data-focus-lock-disabled="false"
+            >
+              <div
+                class="md-overlay-alert-wrapper md-overlay-wrapper"
+                data-color="secondary"
+                data-fullscreen="false"
+                id="example-id"
+              >
+                <div
+                  class="md-modal-container-wrapper"
+                  data-color="primary"
+                  data-elevation="0"
+                  data-padded="false"
+                  data-round="0"
+                >
+                  <div>
+                    <div
+                      class="md-overlay-alert-title"
+                    />
+                    <div />
+                  </div>
+                  <div />
+                  <div />
+                </div>
+              </div>
+            </div>
+          }
+          onActivation={[Function]}
+          onDeactivation={[Function]}
+          persistentFocus={false}
+          shards={Array []}
+        >
+          <FocusWatcher
+            autoFocus={true}
+            disabled={false}
+            observed={
+              <div
+                data-focus-lock-disabled="false"
+              >
+                <div
+                  class="md-overlay-alert-wrapper md-overlay-wrapper"
+                  data-color="secondary"
+                  data-fullscreen="false"
+                  id="example-id"
+                >
+                  <div
+                    class="md-modal-container-wrapper"
+                    data-color="primary"
+                    data-elevation="0"
+                    data-padded="false"
+                    data-round="0"
+                  >
+                    <div>
+                      <div
+                        class="md-overlay-alert-title"
+                      />
+                      <div />
+                    </div>
+                    <div />
+                    <div />
+                  </div>
+                </div>
+              </div>
+            }
+            onActivation={[Function]}
+            onDeactivation={[Function]}
+            persistentFocus={false}
+            shards={Array []}
+          />
+        </SideEffect(FocusWatcher)>
+        <div
+          className="md-overlay-alert-wrapper md-overlay-wrapper"
+          data-color="secondary"
+          data-fullscreen={false}
+          id="example-id"
+        >
+          <ModalContainer>
+            <div
+              className="md-modal-container-wrapper"
+              data-color="primary"
+              data-elevation={0}
+              data-padded={false}
+              data-round={0}
+            >
+              <div>
+                <div
+                  className="md-overlay-alert-title"
+                />
+                <div />
+              </div>
+              <div />
+              <div />
+            </div>
+          </ModalContainer>
         </div>
-      </ModalContainer>
-    </div>
+      </div>
+      <div
+        data-focus-guard={true}
+        style={
+          Object {
+            "height": "0px",
+            "left": "1px",
+            "overflow": "hidden",
+            "padding": 0,
+            "position": "fixed",
+            "top": "1px",
+            "width": "1px",
+          }
+        }
+        tabIndex={0}
+      />
+    </FocusLock>
   </Overlay>
 </OverlayAlert>
 `;
@@ -388,194 +1439,439 @@ exports[`<OverlayAlert /> snapshot should match snapshot with multiple actions 1
   <Overlay
     className="md-overlay-alert-wrapper"
     color="secondary"
+    focusLockProps={
+      Object {
+        "returnFocus": true,
+      }
+    }
   >
-    <div
-      className="md-overlay-alert-wrapper md-overlay-wrapper"
-      data-color="secondary"
-      data-fullscreen={false}
+    <FocusLock
+      as="div"
+      autoFocus={true}
+      disabled={false}
+      lockProps={Object {}}
+      noFocusGuards={false}
+      persistentFocus={false}
+      returnFocus={true}
     >
-      <ModalContainer>
-        <div
-          className="md-modal-container-wrapper"
-          data-color="primary"
-          data-elevation={0}
-          data-padded={false}
-          data-round={0}
-        >
-          <div>
+      <div
+        data-focus-guard={true}
+        key="guard-first"
+        style={
+          Object {
+            "height": "0px",
+            "left": "1px",
+            "overflow": "hidden",
+            "padding": 0,
+            "position": "fixed",
+            "top": "1px",
+            "width": "1px",
+          }
+        }
+        tabIndex={0}
+      />
+      <div
+        data-focus-guard={true}
+        key="guard-nearest"
+        style={
+          Object {
+            "height": "0px",
+            "left": "1px",
+            "overflow": "hidden",
+            "padding": 0,
+            "position": "fixed",
+            "top": "1px",
+            "width": "1px",
+          }
+        }
+        tabIndex={1}
+      />
+      <div
+        data-focus-lock-disabled={false}
+        onBlur={[Function]}
+        onFocus={[Function]}
+      >
+        <SideEffect(FocusWatcher)
+          autoFocus={true}
+          disabled={false}
+          observed={
             <div
-              className="md-overlay-alert-title"
-            />
-            <div />
-          </div>
-          <div />
-          <div>
-            <ButtonPill
-              key="0"
+              data-focus-lock-disabled="false"
             >
-              <ButtonSimple
-                className="md-button-pill-wrapper"
-                data-color="primary"
-                data-disabled={false}
-                data-ghost={false}
-                data-grown={false}
-                data-inverted={false}
-                data-outline={false}
-                data-shallow-disabled={false}
-                data-size={40}
+              <div
+                class="md-overlay-alert-wrapper md-overlay-wrapper"
+                data-color="secondary"
+                data-fullscreen="false"
               >
-                <FocusRing>
-                  <FocusRing
-                    focusClass="md-focus-ring-wrapper children"
-                    focusRingClass="md-focus-ring-wrapper children"
-                  >
+                <div
+                  class="md-modal-container-wrapper"
+                  data-color="primary"
+                  data-elevation="0"
+                  data-padded="false"
+                  data-round="0"
+                >
+                  <div>
+                    <div
+                      class="md-overlay-alert-title"
+                    />
+                    <div />
+                  </div>
+                  <div />
+                  <div>
                     <button
-                      className="md-button-pill-wrapper md-button-simple-wrapper"
+                      class="md-button-pill-wrapper md-button-simple-wrapper"
                       data-color="primary"
-                      data-disabled={false}
-                      data-ghost={false}
-                      data-grown={false}
-                      data-inverted={false}
-                      data-outline={false}
-                      data-shallow-disabled={false}
-                      data-size={40}
-                      onBlur={[Function]}
-                      onClick={[Function]}
-                      onDragStart={[Function]}
-                      onFocus={[Function]}
-                      onKeyDown={[Function]}
-                      onKeyUp={[Function]}
-                      onMouseDown={[Function]}
-                      onMouseEnter={[Function]}
-                      onMouseLeave={[Function]}
-                      onMouseUp={[Function]}
-                      onTouchCancel={[Function]}
-                      onTouchEnd={[Function]}
-                      onTouchMove={[Function]}
-                      onTouchStart={[Function]}
+                      data-disabled="false"
+                      data-ghost="false"
+                      data-grown="false"
+                      data-inverted="false"
+                      data-outline="false"
+                      data-shallow-disabled="false"
+                      data-size="40"
                       type="button"
                     >
                       <span>
                         Button Pill
                       </span>
                     </button>
-                  </FocusRing>
-                </FocusRing>
-              </ButtonSimple>
-            </ButtonPill>
-            ,
-            <ButtonPill
-              key="1"
-            >
-              <ButtonSimple
-                className="md-button-pill-wrapper"
-                data-color="primary"
-                data-disabled={false}
-                data-ghost={false}
-                data-grown={false}
-                data-inverted={false}
-                data-outline={false}
-                data-shallow-disabled={false}
-                data-size={40}
-              >
-                <FocusRing>
-                  <FocusRing
-                    focusClass="md-focus-ring-wrapper children"
-                    focusRingClass="md-focus-ring-wrapper children"
-                  >
+                    ,
                     <button
-                      className="md-button-pill-wrapper md-button-simple-wrapper"
+                      class="md-button-pill-wrapper md-button-simple-wrapper"
                       data-color="primary"
-                      data-disabled={false}
-                      data-ghost={false}
-                      data-grown={false}
-                      data-inverted={false}
-                      data-outline={false}
-                      data-shallow-disabled={false}
-                      data-size={40}
-                      onBlur={[Function]}
-                      onClick={[Function]}
-                      onDragStart={[Function]}
-                      onFocus={[Function]}
-                      onKeyDown={[Function]}
-                      onKeyUp={[Function]}
-                      onMouseDown={[Function]}
-                      onMouseEnter={[Function]}
-                      onMouseLeave={[Function]}
-                      onMouseUp={[Function]}
-                      onTouchCancel={[Function]}
-                      onTouchEnd={[Function]}
-                      onTouchMove={[Function]}
-                      onTouchStart={[Function]}
+                      data-disabled="false"
+                      data-ghost="false"
+                      data-grown="false"
+                      data-inverted="false"
+                      data-outline="false"
+                      data-shallow-disabled="false"
+                      data-size="40"
                       type="button"
                     >
                       <span>
                         Button Pill
                       </span>
                     </button>
-                  </FocusRing>
-                </FocusRing>
-              </ButtonSimple>
-            </ButtonPill>
-            ,
-            <ButtonPill
-              key="2"
-            >
-              <ButtonSimple
-                className="md-button-pill-wrapper"
-                data-color="primary"
-                data-disabled={false}
-                data-ghost={false}
-                data-grown={false}
-                data-inverted={false}
-                data-outline={false}
-                data-shallow-disabled={false}
-                data-size={40}
-              >
-                <FocusRing>
-                  <FocusRing
-                    focusClass="md-focus-ring-wrapper children"
-                    focusRingClass="md-focus-ring-wrapper children"
-                  >
+                    ,
                     <button
-                      className="md-button-pill-wrapper md-button-simple-wrapper"
+                      class="md-button-pill-wrapper md-button-simple-wrapper"
                       data-color="primary"
-                      data-disabled={false}
-                      data-ghost={false}
-                      data-grown={false}
-                      data-inverted={false}
-                      data-outline={false}
-                      data-shallow-disabled={false}
-                      data-size={40}
-                      onBlur={[Function]}
-                      onClick={[Function]}
-                      onDragStart={[Function]}
-                      onFocus={[Function]}
-                      onKeyDown={[Function]}
-                      onKeyUp={[Function]}
-                      onMouseDown={[Function]}
-                      onMouseEnter={[Function]}
-                      onMouseLeave={[Function]}
-                      onMouseUp={[Function]}
-                      onTouchCancel={[Function]}
-                      onTouchEnd={[Function]}
-                      onTouchMove={[Function]}
-                      onTouchStart={[Function]}
+                      data-disabled="false"
+                      data-ghost="false"
+                      data-grown="false"
+                      data-inverted="false"
+                      data-outline="false"
+                      data-shallow-disabled="false"
+                      data-size="40"
                       type="button"
                     >
                       <span>
                         Button Pill
                       </span>
                     </button>
-                  </FocusRing>
-                </FocusRing>
-              </ButtonSimple>
-            </ButtonPill>
-            ,
-          </div>
+                    ,
+                  </div>
+                </div>
+              </div>
+            </div>
+          }
+          onActivation={[Function]}
+          onDeactivation={[Function]}
+          persistentFocus={false}
+          shards={Array []}
+        >
+          <FocusWatcher
+            autoFocus={true}
+            disabled={false}
+            observed={
+              <div
+                data-focus-lock-disabled="false"
+              >
+                <div
+                  class="md-overlay-alert-wrapper md-overlay-wrapper"
+                  data-color="secondary"
+                  data-fullscreen="false"
+                >
+                  <div
+                    class="md-modal-container-wrapper"
+                    data-color="primary"
+                    data-elevation="0"
+                    data-padded="false"
+                    data-round="0"
+                  >
+                    <div>
+                      <div
+                        class="md-overlay-alert-title"
+                      />
+                      <div />
+                    </div>
+                    <div />
+                    <div>
+                      <button
+                        class="md-button-pill-wrapper md-button-simple-wrapper"
+                        data-color="primary"
+                        data-disabled="false"
+                        data-ghost="false"
+                        data-grown="false"
+                        data-inverted="false"
+                        data-outline="false"
+                        data-shallow-disabled="false"
+                        data-size="40"
+                        type="button"
+                      >
+                        <span>
+                          Button Pill
+                        </span>
+                      </button>
+                      ,
+                      <button
+                        class="md-button-pill-wrapper md-button-simple-wrapper"
+                        data-color="primary"
+                        data-disabled="false"
+                        data-ghost="false"
+                        data-grown="false"
+                        data-inverted="false"
+                        data-outline="false"
+                        data-shallow-disabled="false"
+                        data-size="40"
+                        type="button"
+                      >
+                        <span>
+                          Button Pill
+                        </span>
+                      </button>
+                      ,
+                      <button
+                        class="md-button-pill-wrapper md-button-simple-wrapper"
+                        data-color="primary"
+                        data-disabled="false"
+                        data-ghost="false"
+                        data-grown="false"
+                        data-inverted="false"
+                        data-outline="false"
+                        data-shallow-disabled="false"
+                        data-size="40"
+                        type="button"
+                      >
+                        <span>
+                          Button Pill
+                        </span>
+                      </button>
+                      ,
+                    </div>
+                  </div>
+                </div>
+              </div>
+            }
+            onActivation={[Function]}
+            onDeactivation={[Function]}
+            persistentFocus={false}
+            shards={Array []}
+          />
+        </SideEffect(FocusWatcher)>
+        <div
+          className="md-overlay-alert-wrapper md-overlay-wrapper"
+          data-color="secondary"
+          data-fullscreen={false}
+        >
+          <ModalContainer>
+            <div
+              className="md-modal-container-wrapper"
+              data-color="primary"
+              data-elevation={0}
+              data-padded={false}
+              data-round={0}
+            >
+              <div>
+                <div
+                  className="md-overlay-alert-title"
+                />
+                <div />
+              </div>
+              <div />
+              <div>
+                <ButtonPill
+                  key="0"
+                >
+                  <ButtonSimple
+                    className="md-button-pill-wrapper"
+                    data-color="primary"
+                    data-disabled={false}
+                    data-ghost={false}
+                    data-grown={false}
+                    data-inverted={false}
+                    data-outline={false}
+                    data-shallow-disabled={false}
+                    data-size={40}
+                  >
+                    <FocusRing>
+                      <FocusRing
+                        focusClass="md-focus-ring-wrapper children"
+                        focusRingClass="md-focus-ring-wrapper children"
+                      >
+                        <button
+                          className="md-button-pill-wrapper md-button-simple-wrapper"
+                          data-color="primary"
+                          data-disabled={false}
+                          data-ghost={false}
+                          data-grown={false}
+                          data-inverted={false}
+                          data-outline={false}
+                          data-shallow-disabled={false}
+                          data-size={40}
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onDragStart={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onKeyUp={[Function]}
+                          onMouseDown={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseUp={[Function]}
+                          onTouchCancel={[Function]}
+                          onTouchEnd={[Function]}
+                          onTouchMove={[Function]}
+                          onTouchStart={[Function]}
+                          type="button"
+                        >
+                          <span>
+                            Button Pill
+                          </span>
+                        </button>
+                      </FocusRing>
+                    </FocusRing>
+                  </ButtonSimple>
+                </ButtonPill>
+                ,
+                <ButtonPill
+                  key="1"
+                >
+                  <ButtonSimple
+                    className="md-button-pill-wrapper"
+                    data-color="primary"
+                    data-disabled={false}
+                    data-ghost={false}
+                    data-grown={false}
+                    data-inverted={false}
+                    data-outline={false}
+                    data-shallow-disabled={false}
+                    data-size={40}
+                  >
+                    <FocusRing>
+                      <FocusRing
+                        focusClass="md-focus-ring-wrapper children"
+                        focusRingClass="md-focus-ring-wrapper children"
+                      >
+                        <button
+                          className="md-button-pill-wrapper md-button-simple-wrapper"
+                          data-color="primary"
+                          data-disabled={false}
+                          data-ghost={false}
+                          data-grown={false}
+                          data-inverted={false}
+                          data-outline={false}
+                          data-shallow-disabled={false}
+                          data-size={40}
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onDragStart={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onKeyUp={[Function]}
+                          onMouseDown={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseUp={[Function]}
+                          onTouchCancel={[Function]}
+                          onTouchEnd={[Function]}
+                          onTouchMove={[Function]}
+                          onTouchStart={[Function]}
+                          type="button"
+                        >
+                          <span>
+                            Button Pill
+                          </span>
+                        </button>
+                      </FocusRing>
+                    </FocusRing>
+                  </ButtonSimple>
+                </ButtonPill>
+                ,
+                <ButtonPill
+                  key="2"
+                >
+                  <ButtonSimple
+                    className="md-button-pill-wrapper"
+                    data-color="primary"
+                    data-disabled={false}
+                    data-ghost={false}
+                    data-grown={false}
+                    data-inverted={false}
+                    data-outline={false}
+                    data-shallow-disabled={false}
+                    data-size={40}
+                  >
+                    <FocusRing>
+                      <FocusRing
+                        focusClass="md-focus-ring-wrapper children"
+                        focusRingClass="md-focus-ring-wrapper children"
+                      >
+                        <button
+                          className="md-button-pill-wrapper md-button-simple-wrapper"
+                          data-color="primary"
+                          data-disabled={false}
+                          data-ghost={false}
+                          data-grown={false}
+                          data-inverted={false}
+                          data-outline={false}
+                          data-shallow-disabled={false}
+                          data-size={40}
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onDragStart={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onKeyUp={[Function]}
+                          onMouseDown={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseUp={[Function]}
+                          onTouchCancel={[Function]}
+                          onTouchEnd={[Function]}
+                          onTouchMove={[Function]}
+                          onTouchStart={[Function]}
+                          type="button"
+                        >
+                          <span>
+                            Button Pill
+                          </span>
+                        </button>
+                      </FocusRing>
+                    </FocusRing>
+                  </ButtonSimple>
+                </ButtonPill>
+                ,
+              </div>
+            </div>
+          </ModalContainer>
         </div>
-      </ModalContainer>
-    </div>
+      </div>
+      <div
+        data-focus-guard={true}
+        style={
+          Object {
+            "height": "0px",
+            "left": "1px",
+            "overflow": "hidden",
+            "padding": 0,
+            "position": "fixed",
+            "top": "1px",
+            "width": "1px",
+          }
+        }
+        tabIndex={0}
+      />
+    </FocusLock>
   </Overlay>
 </OverlayAlert>
 `;
@@ -602,156 +1898,329 @@ exports[`<OverlayAlert /> snapshot should match snapshot with multiple controls 
   <Overlay
     className="md-overlay-alert-wrapper"
     color="secondary"
+    focusLockProps={
+      Object {
+        "returnFocus": true,
+      }
+    }
   >
-    <div
-      className="md-overlay-alert-wrapper md-overlay-wrapper"
-      data-color="secondary"
-      data-fullscreen={false}
+    <FocusLock
+      as="div"
+      autoFocus={true}
+      disabled={false}
+      lockProps={Object {}}
+      noFocusGuards={false}
+      persistentFocus={false}
+      returnFocus={true}
     >
-      <ModalContainer>
-        <div
-          className="md-modal-container-wrapper"
-          data-color="primary"
-          data-elevation={0}
-          data-padded={false}
-          data-round={0}
-        >
-          <div>
+      <div
+        data-focus-guard={true}
+        key="guard-first"
+        style={
+          Object {
+            "height": "0px",
+            "left": "1px",
+            "overflow": "hidden",
+            "padding": 0,
+            "position": "fixed",
+            "top": "1px",
+            "width": "1px",
+          }
+        }
+        tabIndex={0}
+      />
+      <div
+        data-focus-guard={true}
+        key="guard-nearest"
+        style={
+          Object {
+            "height": "0px",
+            "left": "1px",
+            "overflow": "hidden",
+            "padding": 0,
+            "position": "fixed",
+            "top": "1px",
+            "width": "1px",
+          }
+        }
+        tabIndex={1}
+      />
+      <div
+        data-focus-lock-disabled={false}
+        onBlur={[Function]}
+        onFocus={[Function]}
+      >
+        <SideEffect(FocusWatcher)
+          autoFocus={true}
+          disabled={false}
+          observed={
             <div
-              className="md-overlay-alert-title"
-            />
-            <div>
-              <ButtonControl
-                control="close"
-                key="0"
+              data-focus-lock-disabled="false"
+            >
+              <div
+                class="md-overlay-alert-wrapper md-overlay-wrapper"
+                data-color="secondary"
+                data-fullscreen="false"
               >
-                <ButtonSimple
-                  className="md-button-control-wrapper"
+                <div
+                  class="md-modal-container-wrapper"
+                  data-color="primary"
+                  data-elevation="0"
+                  data-padded="false"
+                  data-round="0"
                 >
-                  <FocusRing>
-                    <FocusRing
-                      focusClass="md-focus-ring-wrapper children"
-                      focusRingClass="md-focus-ring-wrapper children"
-                    >
+                  <div>
+                    <div
+                      class="md-overlay-alert-title"
+                    />
+                    <div>
                       <button
-                        className="md-button-control-wrapper md-button-simple-wrapper"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onDragStart={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        onKeyUp={[Function]}
-                        onMouseDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                        onMouseUp={[Function]}
-                        onTouchCancel={[Function]}
-                        onTouchEnd={[Function]}
-                        onTouchMove={[Function]}
-                        onTouchStart={[Function]}
+                        class="md-button-control-wrapper md-button-simple-wrapper"
                         type="button"
-                      >
-                        <Icon
-                          autoScale={true}
-                          name="cancel"
-                          weight="bold"
-                        />
-                      </button>
-                    </FocusRing>
-                  </FocusRing>
-                </ButtonSimple>
-              </ButtonControl>
-              ,
-              <ButtonControl
-                control="favorite"
-                key="1"
-              >
-                <ButtonSimple
-                  className="md-button-control-wrapper"
-                >
-                  <FocusRing>
-                    <FocusRing
-                      focusClass="md-focus-ring-wrapper children"
-                      focusRingClass="md-focus-ring-wrapper children"
-                    >
+                      />
+                      ,
                       <button
-                        className="md-button-control-wrapper md-button-simple-wrapper"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onDragStart={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        onKeyUp={[Function]}
-                        onMouseDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                        onMouseUp={[Function]}
-                        onTouchCancel={[Function]}
-                        onTouchEnd={[Function]}
-                        onTouchMove={[Function]}
-                        onTouchStart={[Function]}
+                        class="md-button-control-wrapper md-button-simple-wrapper"
                         type="button"
-                      >
-                        <Icon
-                          autoScale={true}
-                          color="var(--mds-color-theme-text-warning-normal)"
-                          name="favorite"
-                          weight="filled"
-                        />
-                      </button>
-                    </FocusRing>
-                  </FocusRing>
-                </ButtonSimple>
-              </ButtonControl>
-              ,
-              <ButtonControl
-                control="maximize"
-                key="2"
-              >
-                <ButtonSimple
-                  className="md-button-control-wrapper"
-                >
-                  <FocusRing>
-                    <FocusRing
-                      focusClass="md-focus-ring-wrapper children"
-                      focusRingClass="md-focus-ring-wrapper children"
-                    >
+                      />
+                      ,
                       <button
-                        className="md-button-control-wrapper md-button-simple-wrapper"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onDragStart={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        onKeyUp={[Function]}
-                        onMouseDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                        onMouseUp={[Function]}
-                        onTouchCancel={[Function]}
-                        onTouchEnd={[Function]}
-                        onTouchMove={[Function]}
-                        onTouchStart={[Function]}
+                        class="md-button-control-wrapper md-button-simple-wrapper"
                         type="button"
-                      >
-                        <Icon
-                          autoScale={true}
-                          name="arrow-up"
-                          weight="bold"
-                        />
-                      </button>
-                    </FocusRing>
-                  </FocusRing>
-                </ButtonSimple>
-              </ButtonControl>
-              ,
+                      />
+                      ,
+                    </div>
+                  </div>
+                  <div />
+                  <div />
+                </div>
+              </div>
             </div>
-          </div>
-          <div />
-          <div />
+          }
+          onActivation={[Function]}
+          onDeactivation={[Function]}
+          persistentFocus={false}
+          shards={Array []}
+        >
+          <FocusWatcher
+            autoFocus={true}
+            disabled={false}
+            observed={
+              <div
+                data-focus-lock-disabled="false"
+              >
+                <div
+                  class="md-overlay-alert-wrapper md-overlay-wrapper"
+                  data-color="secondary"
+                  data-fullscreen="false"
+                >
+                  <div
+                    class="md-modal-container-wrapper"
+                    data-color="primary"
+                    data-elevation="0"
+                    data-padded="false"
+                    data-round="0"
+                  >
+                    <div>
+                      <div
+                        class="md-overlay-alert-title"
+                      />
+                      <div>
+                        <button
+                          class="md-button-control-wrapper md-button-simple-wrapper"
+                          type="button"
+                        />
+                        ,
+                        <button
+                          class="md-button-control-wrapper md-button-simple-wrapper"
+                          type="button"
+                        />
+                        ,
+                        <button
+                          class="md-button-control-wrapper md-button-simple-wrapper"
+                          type="button"
+                        />
+                        ,
+                      </div>
+                    </div>
+                    <div />
+                    <div />
+                  </div>
+                </div>
+              </div>
+            }
+            onActivation={[Function]}
+            onDeactivation={[Function]}
+            persistentFocus={false}
+            shards={Array []}
+          />
+        </SideEffect(FocusWatcher)>
+        <div
+          className="md-overlay-alert-wrapper md-overlay-wrapper"
+          data-color="secondary"
+          data-fullscreen={false}
+        >
+          <ModalContainer>
+            <div
+              className="md-modal-container-wrapper"
+              data-color="primary"
+              data-elevation={0}
+              data-padded={false}
+              data-round={0}
+            >
+              <div>
+                <div
+                  className="md-overlay-alert-title"
+                />
+                <div>
+                  <ButtonControl
+                    control="close"
+                    key="0"
+                  >
+                    <ButtonSimple
+                      className="md-button-control-wrapper"
+                    >
+                      <FocusRing>
+                        <FocusRing
+                          focusClass="md-focus-ring-wrapper children"
+                          focusRingClass="md-focus-ring-wrapper children"
+                        >
+                          <button
+                            className="md-button-control-wrapper md-button-simple-wrapper"
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onDragStart={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            onKeyUp={[Function]}
+                            onMouseDown={[Function]}
+                            onMouseEnter={[Function]}
+                            onMouseLeave={[Function]}
+                            onMouseUp={[Function]}
+                            onTouchCancel={[Function]}
+                            onTouchEnd={[Function]}
+                            onTouchMove={[Function]}
+                            onTouchStart={[Function]}
+                            type="button"
+                          >
+                            <Icon
+                              autoScale={true}
+                              name="cancel"
+                              weight="bold"
+                            />
+                          </button>
+                        </FocusRing>
+                      </FocusRing>
+                    </ButtonSimple>
+                  </ButtonControl>
+                  ,
+                  <ButtonControl
+                    control="favorite"
+                    key="1"
+                  >
+                    <ButtonSimple
+                      className="md-button-control-wrapper"
+                    >
+                      <FocusRing>
+                        <FocusRing
+                          focusClass="md-focus-ring-wrapper children"
+                          focusRingClass="md-focus-ring-wrapper children"
+                        >
+                          <button
+                            className="md-button-control-wrapper md-button-simple-wrapper"
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onDragStart={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            onKeyUp={[Function]}
+                            onMouseDown={[Function]}
+                            onMouseEnter={[Function]}
+                            onMouseLeave={[Function]}
+                            onMouseUp={[Function]}
+                            onTouchCancel={[Function]}
+                            onTouchEnd={[Function]}
+                            onTouchMove={[Function]}
+                            onTouchStart={[Function]}
+                            type="button"
+                          >
+                            <Icon
+                              autoScale={true}
+                              color="var(--mds-color-theme-text-warning-normal)"
+                              name="favorite"
+                              weight="filled"
+                            />
+                          </button>
+                        </FocusRing>
+                      </FocusRing>
+                    </ButtonSimple>
+                  </ButtonControl>
+                  ,
+                  <ButtonControl
+                    control="maximize"
+                    key="2"
+                  >
+                    <ButtonSimple
+                      className="md-button-control-wrapper"
+                    >
+                      <FocusRing>
+                        <FocusRing
+                          focusClass="md-focus-ring-wrapper children"
+                          focusRingClass="md-focus-ring-wrapper children"
+                        >
+                          <button
+                            className="md-button-control-wrapper md-button-simple-wrapper"
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onDragStart={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            onKeyUp={[Function]}
+                            onMouseDown={[Function]}
+                            onMouseEnter={[Function]}
+                            onMouseLeave={[Function]}
+                            onMouseUp={[Function]}
+                            onTouchCancel={[Function]}
+                            onTouchEnd={[Function]}
+                            onTouchMove={[Function]}
+                            onTouchStart={[Function]}
+                            type="button"
+                          >
+                            <Icon
+                              autoScale={true}
+                              name="arrow-up"
+                              weight="bold"
+                            />
+                          </button>
+                        </FocusRing>
+                      </FocusRing>
+                    </ButtonSimple>
+                  </ButtonControl>
+                  ,
+                </div>
+              </div>
+              <div />
+              <div />
+            </div>
+          </ModalContainer>
         </div>
-      </ModalContainer>
-    </div>
+      </div>
+      <div
+        data-focus-guard={true}
+        style={
+          Object {
+            "height": "0px",
+            "left": "1px",
+            "overflow": "hidden",
+            "padding": 0,
+            "position": "fixed",
+            "top": "1px",
+            "width": "1px",
+          }
+        }
+        tabIndex={0}
+      />
+    </FocusLock>
   </Overlay>
 </OverlayAlert>
 `;
@@ -767,41 +2236,184 @@ exports[`<OverlayAlert /> snapshot should match snapshot with style 1`] = `
   <Overlay
     className="md-overlay-alert-wrapper"
     color="secondary"
+    focusLockProps={
+      Object {
+        "returnFocus": true,
+      }
+    }
     style={
       Object {
         "color": "pink",
       }
     }
   >
-    <div
-      className="md-overlay-alert-wrapper md-overlay-wrapper"
-      data-color="secondary"
-      data-fullscreen={false}
-      style={
-        Object {
-          "color": "pink",
-        }
-      }
+    <FocusLock
+      as="div"
+      autoFocus={true}
+      disabled={false}
+      lockProps={Object {}}
+      noFocusGuards={false}
+      persistentFocus={false}
+      returnFocus={true}
     >
-      <ModalContainer>
-        <div
-          className="md-modal-container-wrapper"
-          data-color="primary"
-          data-elevation={0}
-          data-padded={false}
-          data-round={0}
-        >
-          <div>
+      <div
+        data-focus-guard={true}
+        key="guard-first"
+        style={
+          Object {
+            "height": "0px",
+            "left": "1px",
+            "overflow": "hidden",
+            "padding": 0,
+            "position": "fixed",
+            "top": "1px",
+            "width": "1px",
+          }
+        }
+        tabIndex={0}
+      />
+      <div
+        data-focus-guard={true}
+        key="guard-nearest"
+        style={
+          Object {
+            "height": "0px",
+            "left": "1px",
+            "overflow": "hidden",
+            "padding": 0,
+            "position": "fixed",
+            "top": "1px",
+            "width": "1px",
+          }
+        }
+        tabIndex={1}
+      />
+      <div
+        data-focus-lock-disabled={false}
+        onBlur={[Function]}
+        onFocus={[Function]}
+      >
+        <SideEffect(FocusWatcher)
+          autoFocus={true}
+          disabled={false}
+          observed={
             <div
-              className="md-overlay-alert-title"
-            />
-            <div />
-          </div>
-          <div />
-          <div />
+              data-focus-lock-disabled="false"
+            >
+              <div
+                class="md-overlay-alert-wrapper md-overlay-wrapper"
+                data-color="secondary"
+                data-fullscreen="false"
+                style="color: pink;"
+              >
+                <div
+                  class="md-modal-container-wrapper"
+                  data-color="primary"
+                  data-elevation="0"
+                  data-padded="false"
+                  data-round="0"
+                >
+                  <div>
+                    <div
+                      class="md-overlay-alert-title"
+                    />
+                    <div />
+                  </div>
+                  <div />
+                  <div />
+                </div>
+              </div>
+            </div>
+          }
+          onActivation={[Function]}
+          onDeactivation={[Function]}
+          persistentFocus={false}
+          shards={Array []}
+        >
+          <FocusWatcher
+            autoFocus={true}
+            disabled={false}
+            observed={
+              <div
+                data-focus-lock-disabled="false"
+              >
+                <div
+                  class="md-overlay-alert-wrapper md-overlay-wrapper"
+                  data-color="secondary"
+                  data-fullscreen="false"
+                  style="color: pink;"
+                >
+                  <div
+                    class="md-modal-container-wrapper"
+                    data-color="primary"
+                    data-elevation="0"
+                    data-padded="false"
+                    data-round="0"
+                  >
+                    <div>
+                      <div
+                        class="md-overlay-alert-title"
+                      />
+                      <div />
+                    </div>
+                    <div />
+                    <div />
+                  </div>
+                </div>
+              </div>
+            }
+            onActivation={[Function]}
+            onDeactivation={[Function]}
+            persistentFocus={false}
+            shards={Array []}
+          />
+        </SideEffect(FocusWatcher)>
+        <div
+          className="md-overlay-alert-wrapper md-overlay-wrapper"
+          data-color="secondary"
+          data-fullscreen={false}
+          style={
+            Object {
+              "color": "pink",
+            }
+          }
+        >
+          <ModalContainer>
+            <div
+              className="md-modal-container-wrapper"
+              data-color="primary"
+              data-elevation={0}
+              data-padded={false}
+              data-round={0}
+            >
+              <div>
+                <div
+                  className="md-overlay-alert-title"
+                />
+                <div />
+              </div>
+              <div />
+              <div />
+            </div>
+          </ModalContainer>
         </div>
-      </ModalContainer>
-    </div>
+      </div>
+      <div
+        data-focus-guard={true}
+        style={
+          Object {
+            "height": "0px",
+            "left": "1px",
+            "overflow": "hidden",
+            "padding": 0,
+            "position": "fixed",
+            "top": "1px",
+            "width": "1px",
+          }
+        }
+        tabIndex={0}
+      />
+    </FocusLock>
   </Overlay>
 </OverlayAlert>
 `;
@@ -813,43 +2425,198 @@ exports[`<OverlayAlert /> snapshot should match snapshot with title 1`] = `
   <Overlay
     className="md-overlay-alert-wrapper"
     color="secondary"
+    focusLockProps={
+      Object {
+        "returnFocus": true,
+      }
+    }
   >
-    <div
-      className="md-overlay-alert-wrapper md-overlay-wrapper"
-      data-color="secondary"
-      data-fullscreen={false}
+    <FocusLock
+      as="div"
+      autoFocus={true}
+      disabled={false}
+      lockProps={Object {}}
+      noFocusGuards={false}
+      persistentFocus={false}
+      returnFocus={true}
     >
-      <ModalContainer>
-        <div
-          className="md-modal-container-wrapper"
-          data-color="primary"
-          data-elevation={0}
-          data-padded={false}
-          data-round={0}
-        >
-          <div>
+      <div
+        data-focus-guard={true}
+        key="guard-first"
+        style={
+          Object {
+            "height": "0px",
+            "left": "1px",
+            "overflow": "hidden",
+            "padding": 0,
+            "position": "fixed",
+            "top": "1px",
+            "width": "1px",
+          }
+        }
+        tabIndex={0}
+      />
+      <div
+        data-focus-guard={true}
+        key="guard-nearest"
+        style={
+          Object {
+            "height": "0px",
+            "left": "1px",
+            "overflow": "hidden",
+            "padding": 0,
+            "position": "fixed",
+            "top": "1px",
+            "width": "1px",
+          }
+        }
+        tabIndex={1}
+      />
+      <div
+        data-focus-lock-disabled={false}
+        onBlur={[Function]}
+        onFocus={[Function]}
+      >
+        <SideEffect(FocusWatcher)
+          autoFocus={true}
+          disabled={false}
+          observed={
             <div
-              className="md-overlay-alert-title"
+              data-focus-lock-disabled="false"
             >
-              <Text
-                className="md-overlay-alert-title"
-                type="header-primary"
+              <div
+                class="md-overlay-alert-wrapper md-overlay-wrapper"
+                data-color="secondary"
+                data-fullscreen="false"
               >
-                <h3
-                  className="md-text-wrapper md-overlay-alert-title"
-                  data-type="header-primary"
+                <div
+                  class="md-modal-container-wrapper"
+                  data-color="primary"
+                  data-elevation="0"
+                  data-padded="false"
+                  data-round="0"
                 >
-                  example-title
-                </h3>
-              </Text>
+                  <div>
+                    <div
+                      class="md-overlay-alert-title"
+                    >
+                      <h3
+                        class="md-text-wrapper md-overlay-alert-title"
+                        data-type="header-primary"
+                      >
+                        example-title
+                      </h3>
+                    </div>
+                    <div />
+                  </div>
+                  <div />
+                  <div />
+                </div>
+              </div>
             </div>
-            <div />
-          </div>
-          <div />
-          <div />
+          }
+          onActivation={[Function]}
+          onDeactivation={[Function]}
+          persistentFocus={false}
+          shards={Array []}
+        >
+          <FocusWatcher
+            autoFocus={true}
+            disabled={false}
+            observed={
+              <div
+                data-focus-lock-disabled="false"
+              >
+                <div
+                  class="md-overlay-alert-wrapper md-overlay-wrapper"
+                  data-color="secondary"
+                  data-fullscreen="false"
+                >
+                  <div
+                    class="md-modal-container-wrapper"
+                    data-color="primary"
+                    data-elevation="0"
+                    data-padded="false"
+                    data-round="0"
+                  >
+                    <div>
+                      <div
+                        class="md-overlay-alert-title"
+                      >
+                        <h3
+                          class="md-text-wrapper md-overlay-alert-title"
+                          data-type="header-primary"
+                        >
+                          example-title
+                        </h3>
+                      </div>
+                      <div />
+                    </div>
+                    <div />
+                    <div />
+                  </div>
+                </div>
+              </div>
+            }
+            onActivation={[Function]}
+            onDeactivation={[Function]}
+            persistentFocus={false}
+            shards={Array []}
+          />
+        </SideEffect(FocusWatcher)>
+        <div
+          className="md-overlay-alert-wrapper md-overlay-wrapper"
+          data-color="secondary"
+          data-fullscreen={false}
+        >
+          <ModalContainer>
+            <div
+              className="md-modal-container-wrapper"
+              data-color="primary"
+              data-elevation={0}
+              data-padded={false}
+              data-round={0}
+            >
+              <div>
+                <div
+                  className="md-overlay-alert-title"
+                >
+                  <Text
+                    className="md-overlay-alert-title"
+                    type="header-primary"
+                  >
+                    <h3
+                      className="md-text-wrapper md-overlay-alert-title"
+                      data-type="header-primary"
+                    >
+                      example-title
+                    </h3>
+                  </Text>
+                </div>
+                <div />
+              </div>
+              <div />
+              <div />
+            </div>
+          </ModalContainer>
         </div>
-      </ModalContainer>
-    </div>
+      </div>
+      <div
+        data-focus-guard={true}
+        style={
+          Object {
+            "height": "0px",
+            "left": "1px",
+            "overflow": "hidden",
+            "padding": 0,
+            "position": "fixed",
+            "top": "1px",
+            "width": "1px",
+          }
+        }
+        tabIndex={0}
+      />
+    </FocusLock>
   </Overlay>
 </OverlayAlert>
 `;


### PR DESCRIPTION
# Description

- Added focusLockProps to Overlay. If present, the overlay will render inside a FocusLock
- Used these focusLockProps for OverlayAlert. OverlayAlert can still be configured to use different focusLockProps but the default is to returnFocus

Why didn't I just put the FocusLock in OverlayAlert? Because, like with legacy overlay component, overlays naturally want to restrict the focus to what they show in front of them and not behind them. I left this configurable in case there are exceptions to that.
