### PR TITLE
fix(overlay-alert): fix spacing and corners of overlay alert

### DIFF
--- a/src/components/OverlayAlert/OverlayAlert.stories.tsx
+++ b/src/components/OverlayAlert/OverlayAlert.stories.tsx
@@ -134,4 +134,56 @@ WithoutTitle.parameters = {
 
 WithoutTitle.args = { ...{ details: coreArgs.details } };
 
-export { Example, WithoutActions, WithoutControls, WithoutTitle };
+const FigmaExample: Story<OverlayAlertProps> = (args: OverlayAlertProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const open = () => {
+    setIsOpen(true);
+  };
+
+  const close = () => {
+    setIsOpen(false);
+  };
+
+  const actions = [
+    <ButtonPill key={0} outline inverted onPress={close} size={32}>
+      Secondary
+    </ButtonPill>,
+    <ButtonPill key={1} onPress={close} size={32}>
+      Primary
+    </ButtonPill>,
+  ];
+
+  const controls = [<ButtonControl key={2} onPress={close} control="close" />];
+
+  return (
+    <div
+      style={{
+        alignItems: 'center',
+        backgroundColor: 'var(--mds-color-theme-background-solid-primary-normal)',
+        border:
+          '1px var(--md-globals-border-style-solid) var(--mds-color-theme-outline-secondary-normal)',
+        display: 'flex',
+        height: '80%',
+        paddingLeft: '4rem',
+        position: 'relative',
+        width: '80%',
+      }}
+    >
+      <ButtonPill onPress={open}>Open</ButtonPill>
+      {isOpen && (
+        <OverlayAlert
+          details="In ultrices dapibus tortor in posuere. Sed rhoncus mi sem."
+          title="Title"
+          actions={<>{actions}</>}
+          controls={<>{controls}</>}
+          {...args}
+        />
+      )}
+    </div>
+  );
+};
+
+FigmaExample.argTypes = { ...argTypes };
+
+export { Example, WithoutActions, WithoutControls, WithoutTitle, FigmaExample };

--- a/src/components/OverlayAlert/OverlayAlert.stories.tsx
+++ b/src/components/OverlayAlert/OverlayAlert.stories.tsx
@@ -66,7 +66,8 @@ function Template(): Story<OverlayAlertProps> {
         style={{
           alignItems: 'center',
           backgroundColor: 'var(--mds-color-theme-background-solid-primary-normal)',
-          border: '1px var(--md-globals-border-style-solid) var(--mds-color-theme-outline-secondary-normal)',
+          border:
+            '1px var(--md-globals-border-style-solid) var(--mds-color-theme-outline-secondary-normal)',
           display: 'flex',
           height: '80%',
           paddingLeft: '4rem',
@@ -122,4 +123,15 @@ WithoutControls.parameters = {
 
 WithoutControls.args = { ...coreArgs };
 
-export { Example, WithoutActions, WithoutControls };
+const WithoutTitle = Template().bind({});
+
+WithoutTitle.argTypes = { ...argTypes };
+
+WithoutTitle.parameters = {
+  hasActions: true,
+  hasControls: true,
+};
+
+WithoutTitle.args = { ...{ details: coreArgs.details } };
+
+export { Example, WithoutActions, WithoutControls, WithoutTitle };

--- a/src/components/OverlayAlert/OverlayAlert.style.scss
+++ b/src/components/OverlayAlert/OverlayAlert.style.scss
@@ -24,6 +24,7 @@
       > .md-overlay-alert-details {
         display: block;
         line-height: 1.25rem;
+        color: var(--mds-color-theme-text-secondary-normal);
       }
     }
 

--- a/src/components/OverlayAlert/OverlayAlert.style.scss
+++ b/src/components/OverlayAlert/OverlayAlert.style.scss
@@ -4,9 +4,6 @@
     min-width: 20rem;
 
     > :first-child {
-      align-items: flex-end;
-      display: flex;
-      justify-content: space-between;
       width: 100%;
 
       > .md-overlay-alert-title {

--- a/src/components/OverlayAlert/OverlayAlert.style.scss
+++ b/src/components/OverlayAlert/OverlayAlert.style.scss
@@ -1,6 +1,6 @@
 .md-overlay-alert-wrapper {
   > :first-child {
-    max-width: 32rem;
+    max-width: 25rem;
     min-width: 20rem;
 
     > :first-child {
@@ -18,7 +18,7 @@
     }
 
     > :not(:first-child):not(:last-child) {
-      padding: 0.5rem 1rem 0;
+      padding: 0.5rem 1.25rem 0;
       width: 100%;
 
       > .md-overlay-alert-details {
@@ -30,7 +30,7 @@
     > :last-child {
       display: flex;
       justify-content: flex-end;
-      padding: 1rem 1.5rem;
+      padding: 1.25rem 1.25rem;
       width: 100%;
 
       > * {

--- a/src/components/OverlayAlert/OverlayAlert.tsx
+++ b/src/components/OverlayAlert/OverlayAlert.tsx
@@ -50,7 +50,7 @@ const OverlayAlert: FC<Props> = (props: Props) => {
           {children
             ? children
             : !!details && (
-                <Text className={classnames(STYLE.details)} type="body-secondary">
+                <Text className={classnames(STYLE.details)} type="body-primary">
                   {details}
                 </Text>
               )}

--- a/src/components/OverlayAlert/OverlayAlert.tsx
+++ b/src/components/OverlayAlert/OverlayAlert.tsx
@@ -35,17 +35,17 @@ const OverlayAlert: FC<Props> = (props: Props) => {
       color={overlayColor}
       {...other}
     >
-      <ModalContainer color={modalColor}>
+      <ModalContainer round={75} color={modalColor}>
         <div>
-          <div className={classnames(STYLE.title)}>
-            {!!title && (
-              <Text className={classnames(STYLE.title)} type="header-primary">
-                {title}
-              </Text>
-            )}
-          </div>
           <div>{controls}</div>
         </div>
+        {!!title && (
+          <div className={classnames(STYLE.title)}>
+            <Text className={classnames(STYLE.title)} type="header-primary">
+              {title}
+            </Text>
+          </div>
+        )}
         <div>
           {children
             ? children

--- a/src/components/OverlayAlert/OverlayAlert.unit.test.tsx
+++ b/src/components/OverlayAlert/OverlayAlert.unit.test.tsx
@@ -264,7 +264,7 @@ describe('<OverlayAlert />', () => {
       expect(target.innerHTML.includes(title)).toBe(true);
     });
 
-    it('should still render a empty div with the appropriate class when no title is provided', () => {
+    it('should not render an empty div when no title is provided', () => {
       expect.assertions(1);
 
       const component = mount(<OverlayAlert />).find(`.${OVERLAY_STYLE.wrapper}`);
@@ -273,7 +273,7 @@ describe('<OverlayAlert />', () => {
         .getDOMNode()
         .getElementsByClassName(OVERLAY_ALERT_CONSTANTS.STYLE.title)[0];
 
-      expect(target.classList.contains(OVERLAY_ALERT_CONSTANTS.STYLE.title)).toBe(true);
+      expect(target).toBeUndefined();
     });
 
     it('should have provided children when details and children are provided', () => {

--- a/src/components/OverlayAlert/OverlayAlert.unit.test.tsx.snap
+++ b/src/components/OverlayAlert/OverlayAlert.unit.test.tsx.snap
@@ -74,12 +74,9 @@ exports[`<OverlayAlert /> snapshot should match snapshot 1`] = `
                   data-color="primary"
                   data-elevation="0"
                   data-padded="false"
-                  data-round="0"
+                  data-round="75"
                 >
                   <div>
-                    <div
-                      class="md-overlay-alert-title"
-                    />
                     <div />
                   </div>
                   <div />
@@ -110,12 +107,9 @@ exports[`<OverlayAlert /> snapshot should match snapshot 1`] = `
                     data-color="primary"
                     data-elevation="0"
                     data-padded="false"
-                    data-round="0"
+                    data-round="75"
                   >
                     <div>
-                      <div
-                        class="md-overlay-alert-title"
-                      />
                       <div />
                     </div>
                     <div />
@@ -135,18 +129,17 @@ exports[`<OverlayAlert /> snapshot should match snapshot 1`] = `
           data-color="secondary"
           data-fullscreen={false}
         >
-          <ModalContainer>
+          <ModalContainer
+            round={75}
+          >
             <div
               className="md-modal-container-wrapper"
               data-color="primary"
               data-elevation={0}
               data-padded={false}
-              data-round={0}
+              data-round={75}
             >
               <div>
-                <div
-                  className="md-overlay-alert-title"
-                />
                 <div />
               </div>
               <div />
@@ -255,12 +248,9 @@ exports[`<OverlayAlert /> snapshot should match snapshot with actions 1`] = `
                   data-color="primary"
                   data-elevation="0"
                   data-padded="false"
-                  data-round="0"
+                  data-round="75"
                 >
                   <div>
-                    <div
-                      class="md-overlay-alert-title"
-                    />
                     <div />
                   </div>
                   <div />
@@ -308,12 +298,9 @@ exports[`<OverlayAlert /> snapshot should match snapshot with actions 1`] = `
                     data-color="primary"
                     data-elevation="0"
                     data-padded="false"
-                    data-round="0"
+                    data-round="75"
                   >
                     <div>
-                      <div
-                        class="md-overlay-alert-title"
-                      />
                       <div />
                     </div>
                     <div />
@@ -350,18 +337,17 @@ exports[`<OverlayAlert /> snapshot should match snapshot with actions 1`] = `
           data-color="secondary"
           data-fullscreen={false}
         >
-          <ModalContainer>
+          <ModalContainer
+            round={75}
+          >
             <div
               className="md-modal-container-wrapper"
               data-color="primary"
               data-elevation={0}
               data-padded={false}
-              data-round={0}
+              data-round={75}
             >
               <div>
-                <div
-                  className="md-overlay-alert-title"
-                />
                 <div />
               </div>
               <div />
@@ -518,12 +504,9 @@ exports[`<OverlayAlert /> snapshot should match snapshot with className 1`] = `
                   data-color="primary"
                   data-elevation="0"
                   data-padded="false"
-                  data-round="0"
+                  data-round="75"
                 >
                   <div>
-                    <div
-                      class="md-overlay-alert-title"
-                    />
                     <div />
                   </div>
                   <div />
@@ -554,12 +537,9 @@ exports[`<OverlayAlert /> snapshot should match snapshot with className 1`] = `
                     data-color="primary"
                     data-elevation="0"
                     data-padded="false"
-                    data-round="0"
+                    data-round="75"
                   >
                     <div>
-                      <div
-                        class="md-overlay-alert-title"
-                      />
                       <div />
                     </div>
                     <div />
@@ -579,18 +559,17 @@ exports[`<OverlayAlert /> snapshot should match snapshot with className 1`] = `
           data-color="secondary"
           data-fullscreen={false}
         >
-          <ModalContainer>
+          <ModalContainer
+            round={75}
+          >
             <div
               className="md-modal-container-wrapper"
               data-color="primary"
               data-elevation={0}
               data-padded={false}
-              data-round={0}
+              data-round={75}
             >
               <div>
-                <div
-                  className="md-overlay-alert-title"
-                />
                 <div />
               </div>
               <div />
@@ -699,12 +678,9 @@ exports[`<OverlayAlert /> snapshot should match snapshot with controls 1`] = `
                   data-color="primary"
                   data-elevation="0"
                   data-padded="false"
-                  data-round="0"
+                  data-round="75"
                 >
                   <div>
-                    <div
-                      class="md-overlay-alert-title"
-                    />
                     <div>
                       <button
                         class="md-button-control-wrapper md-button-simple-wrapper"
@@ -740,12 +716,9 @@ exports[`<OverlayAlert /> snapshot should match snapshot with controls 1`] = `
                     data-color="primary"
                     data-elevation="0"
                     data-padded="false"
-                    data-round="0"
+                    data-round="75"
                   >
                     <div>
-                      <div
-                        class="md-overlay-alert-title"
-                      />
                       <div>
                         <button
                           class="md-button-control-wrapper md-button-simple-wrapper"
@@ -770,18 +743,17 @@ exports[`<OverlayAlert /> snapshot should match snapshot with controls 1`] = `
           data-color="secondary"
           data-fullscreen={false}
         >
-          <ModalContainer>
+          <ModalContainer
+            round={75}
+          >
             <div
               className="md-modal-container-wrapper"
               data-color="primary"
               data-elevation={0}
               data-padded={false}
-              data-round={0}
+              data-round={75}
             >
               <div>
-                <div
-                  className="md-overlay-alert-title"
-                />
                 <div>
                   <ButtonControl
                     control="close"
@@ -926,12 +898,9 @@ exports[`<OverlayAlert /> snapshot should match snapshot with details 1`] = `
                   data-color="primary"
                   data-elevation="0"
                   data-padded="false"
-                  data-round="0"
+                  data-round="75"
                 >
                   <div>
-                    <div
-                      class="md-overlay-alert-title"
-                    />
                     <div />
                   </div>
                   <div>
@@ -969,12 +938,9 @@ exports[`<OverlayAlert /> snapshot should match snapshot with details 1`] = `
                     data-color="primary"
                     data-elevation="0"
                     data-padded="false"
-                    data-round="0"
+                    data-round="75"
                   >
                     <div>
-                      <div
-                        class="md-overlay-alert-title"
-                      />
                       <div />
                     </div>
                     <div>
@@ -1001,18 +967,17 @@ exports[`<OverlayAlert /> snapshot should match snapshot with details 1`] = `
           data-color="secondary"
           data-fullscreen={false}
         >
-          <ModalContainer>
+          <ModalContainer
+            round={75}
+          >
             <div
               className="md-modal-container-wrapper"
               data-color="primary"
               data-elevation={0}
               data-padded={false}
-              data-round={0}
+              data-round={75}
             >
               <div>
-                <div
-                  className="md-overlay-alert-title"
-                />
                 <div />
               </div>
               <div>
@@ -1129,12 +1094,9 @@ exports[`<OverlayAlert /> snapshot should match snapshot with details and childr
                   data-color="primary"
                   data-elevation="0"
                   data-padded="false"
-                  data-round="0"
+                  data-round="75"
                 >
                   <div>
-                    <div
-                      class="md-overlay-alert-title"
-                    />
                     <div />
                   </div>
                   <div>
@@ -1167,12 +1129,9 @@ exports[`<OverlayAlert /> snapshot should match snapshot with details and childr
                     data-color="primary"
                     data-elevation="0"
                     data-padded="false"
-                    data-round="0"
+                    data-round="75"
                   >
                     <div>
-                      <div
-                        class="md-overlay-alert-title"
-                      />
                       <div />
                     </div>
                     <div>
@@ -1194,18 +1153,17 @@ exports[`<OverlayAlert /> snapshot should match snapshot with details and childr
           data-color="secondary"
           data-fullscreen={false}
         >
-          <ModalContainer>
+          <ModalContainer
+            round={75}
+          >
             <div
               className="md-modal-container-wrapper"
               data-color="primary"
               data-elevation={0}
               data-padded={false}
-              data-round={0}
+              data-round={75}
             >
               <div>
-                <div
-                  className="md-overlay-alert-title"
-                />
                 <div />
               </div>
               <div>
@@ -1314,12 +1272,9 @@ exports[`<OverlayAlert /> snapshot should match snapshot with id 1`] = `
                   data-color="primary"
                   data-elevation="0"
                   data-padded="false"
-                  data-round="0"
+                  data-round="75"
                 >
                   <div>
-                    <div
-                      class="md-overlay-alert-title"
-                    />
                     <div />
                   </div>
                   <div />
@@ -1351,12 +1306,9 @@ exports[`<OverlayAlert /> snapshot should match snapshot with id 1`] = `
                     data-color="primary"
                     data-elevation="0"
                     data-padded="false"
-                    data-round="0"
+                    data-round="75"
                   >
                     <div>
-                      <div
-                        class="md-overlay-alert-title"
-                      />
                       <div />
                     </div>
                     <div />
@@ -1377,18 +1329,17 @@ exports[`<OverlayAlert /> snapshot should match snapshot with id 1`] = `
           data-fullscreen={false}
           id="example-id"
         >
-          <ModalContainer>
+          <ModalContainer
+            round={75}
+          >
             <div
               className="md-modal-container-wrapper"
               data-color="primary"
               data-elevation={0}
               data-padded={false}
-              data-round={0}
+              data-round={75}
             >
               <div>
-                <div
-                  className="md-overlay-alert-title"
-                />
                 <div />
               </div>
               <div />
@@ -1508,12 +1459,9 @@ exports[`<OverlayAlert /> snapshot should match snapshot with multiple actions 1
                   data-color="primary"
                   data-elevation="0"
                   data-padded="false"
-                  data-round="0"
+                  data-round="75"
                 >
                   <div>
-                    <div
-                      class="md-overlay-alert-title"
-                    />
                     <div />
                   </div>
                   <div />
@@ -1596,12 +1544,9 @@ exports[`<OverlayAlert /> snapshot should match snapshot with multiple actions 1
                     data-color="primary"
                     data-elevation="0"
                     data-padded="false"
-                    data-round="0"
+                    data-round="75"
                   >
                     <div>
-                      <div
-                        class="md-overlay-alert-title"
-                      />
                       <div />
                     </div>
                     <div />
@@ -1673,18 +1618,17 @@ exports[`<OverlayAlert /> snapshot should match snapshot with multiple actions 1
           data-color="secondary"
           data-fullscreen={false}
         >
-          <ModalContainer>
+          <ModalContainer
+            round={75}
+          >
             <div
               className="md-modal-container-wrapper"
               data-color="primary"
               data-elevation={0}
               data-padded={false}
-              data-round={0}
+              data-round={75}
             >
               <div>
-                <div
-                  className="md-overlay-alert-title"
-                />
                 <div />
               </div>
               <div />
@@ -1967,12 +1911,9 @@ exports[`<OverlayAlert /> snapshot should match snapshot with multiple controls 
                   data-color="primary"
                   data-elevation="0"
                   data-padded="false"
-                  data-round="0"
+                  data-round="75"
                 >
                   <div>
-                    <div
-                      class="md-overlay-alert-title"
-                    />
                     <div>
                       <button
                         class="md-button-control-wrapper md-button-simple-wrapper"
@@ -2019,12 +1960,9 @@ exports[`<OverlayAlert /> snapshot should match snapshot with multiple controls 
                     data-color="primary"
                     data-elevation="0"
                     data-padded="false"
-                    data-round="0"
+                    data-round="75"
                   >
                     <div>
-                      <div
-                        class="md-overlay-alert-title"
-                      />
                       <div>
                         <button
                           class="md-button-control-wrapper md-button-simple-wrapper"
@@ -2060,18 +1998,17 @@ exports[`<OverlayAlert /> snapshot should match snapshot with multiple controls 
           data-color="secondary"
           data-fullscreen={false}
         >
-          <ModalContainer>
+          <ModalContainer
+            round={75}
+          >
             <div
               className="md-modal-container-wrapper"
               data-color="primary"
               data-elevation={0}
               data-padded={false}
-              data-round={0}
+              data-round={75}
             >
               <div>
-                <div
-                  className="md-overlay-alert-title"
-                />
                 <div>
                   <ButtonControl
                     control="close"
@@ -2311,12 +2248,9 @@ exports[`<OverlayAlert /> snapshot should match snapshot with style 1`] = `
                   data-color="primary"
                   data-elevation="0"
                   data-padded="false"
-                  data-round="0"
+                  data-round="75"
                 >
                   <div>
-                    <div
-                      class="md-overlay-alert-title"
-                    />
                     <div />
                   </div>
                   <div />
@@ -2348,12 +2282,9 @@ exports[`<OverlayAlert /> snapshot should match snapshot with style 1`] = `
                     data-color="primary"
                     data-elevation="0"
                     data-padded="false"
-                    data-round="0"
+                    data-round="75"
                   >
                     <div>
-                      <div
-                        class="md-overlay-alert-title"
-                      />
                       <div />
                     </div>
                     <div />
@@ -2378,18 +2309,17 @@ exports[`<OverlayAlert /> snapshot should match snapshot with style 1`] = `
             }
           }
         >
-          <ModalContainer>
+          <ModalContainer
+            round={75}
+          >
             <div
               className="md-modal-container-wrapper"
               data-color="primary"
               data-elevation={0}
               data-padded={false}
-              data-round={0}
+              data-round={75}
             >
               <div>
-                <div
-                  className="md-overlay-alert-title"
-                />
                 <div />
               </div>
               <div />
@@ -2494,20 +2424,20 @@ exports[`<OverlayAlert /> snapshot should match snapshot with title 1`] = `
                   data-color="primary"
                   data-elevation="0"
                   data-padded="false"
-                  data-round="0"
+                  data-round="75"
                 >
                   <div>
-                    <div
-                      class="md-overlay-alert-title"
-                    >
-                      <h3
-                        class="md-text-wrapper md-overlay-alert-title"
-                        data-type="header-primary"
-                      >
-                        example-title
-                      </h3>
-                    </div>
                     <div />
+                  </div>
+                  <div
+                    class="md-overlay-alert-title"
+                  >
+                    <h3
+                      class="md-text-wrapper md-overlay-alert-title"
+                      data-type="header-primary"
+                    >
+                      example-title
+                    </h3>
                   </div>
                   <div />
                   <div />
@@ -2537,20 +2467,20 @@ exports[`<OverlayAlert /> snapshot should match snapshot with title 1`] = `
                     data-color="primary"
                     data-elevation="0"
                     data-padded="false"
-                    data-round="0"
+                    data-round="75"
                   >
                     <div>
-                      <div
-                        class="md-overlay-alert-title"
-                      >
-                        <h3
-                          class="md-text-wrapper md-overlay-alert-title"
-                          data-type="header-primary"
-                        >
-                          example-title
-                        </h3>
-                      </div>
                       <div />
+                    </div>
+                    <div
+                      class="md-overlay-alert-title"
+                    >
+                      <h3
+                        class="md-text-wrapper md-overlay-alert-title"
+                        data-type="header-primary"
+                      >
+                        example-title
+                      </h3>
                     </div>
                     <div />
                     <div />
@@ -2569,31 +2499,33 @@ exports[`<OverlayAlert /> snapshot should match snapshot with title 1`] = `
           data-color="secondary"
           data-fullscreen={false}
         >
-          <ModalContainer>
+          <ModalContainer
+            round={75}
+          >
             <div
               className="md-modal-container-wrapper"
               data-color="primary"
               data-elevation={0}
               data-padded={false}
-              data-round={0}
+              data-round={75}
             >
               <div>
-                <div
-                  className="md-overlay-alert-title"
-                >
-                  <Text
-                    className="md-overlay-alert-title"
-                    type="header-primary"
-                  >
-                    <h3
-                      className="md-text-wrapper md-overlay-alert-title"
-                      data-type="header-primary"
-                    >
-                      example-title
-                    </h3>
-                  </Text>
-                </div>
                 <div />
+              </div>
+              <div
+                className="md-overlay-alert-title"
+              >
+                <Text
+                  className="md-overlay-alert-title"
+                  type="header-primary"
+                >
+                  <h3
+                    className="md-text-wrapper md-overlay-alert-title"
+                    data-type="header-primary"
+                  >
+                    example-title
+                  </h3>
+                </Text>
               </div>
               <div />
               <div />

--- a/src/components/OverlayAlert/OverlayAlert.unit.test.tsx.snap
+++ b/src/components/OverlayAlert/OverlayAlert.unit.test.tsx.snap
@@ -904,12 +904,12 @@ exports[`<OverlayAlert /> snapshot should match snapshot with details 1`] = `
                     <div />
                   </div>
                   <div>
-                    <small
+                    <p
                       class="md-text-wrapper md-overlay-alert-details"
-                      data-type="body-secondary"
+                      data-type="body-primary"
                     >
                       example-details
-                    </small>
+                    </p>
                   </div>
                   <div />
                 </div>
@@ -944,12 +944,12 @@ exports[`<OverlayAlert /> snapshot should match snapshot with details 1`] = `
                       <div />
                     </div>
                     <div>
-                      <small
+                      <p
                         class="md-text-wrapper md-overlay-alert-details"
-                        data-type="body-secondary"
+                        data-type="body-primary"
                       >
                         example-details
-                      </small>
+                      </p>
                     </div>
                     <div />
                   </div>
@@ -983,14 +983,14 @@ exports[`<OverlayAlert /> snapshot should match snapshot with details 1`] = `
               <div>
                 <Text
                   className="md-overlay-alert-details"
-                  type="body-secondary"
+                  type="body-primary"
                 >
-                  <small
+                  <p
                     className="md-text-wrapper md-overlay-alert-details"
-                    data-type="body-secondary"
+                    data-type="body-primary"
                   >
                     example-details
-                  </small>
+                  </p>
                 </Text>
               </div>
               <div />


### PR DESCRIPTION
# Description

Update the overlay alert to be in line with the latest UX figma

Before
![overlay_alert_before](https://github.com/momentum-design/momentum-react-v2/assets/3998548/6553a34c-3b64-45db-b27d-b63323b82ff8)

After
![alert_example](https://github.com/momentum-design/momentum-react-v2/assets/3998548/59c5c9dc-2f33-4c72-af46-8f298176aa5e)

Figma Design
![figma_overlay_alert](https://github.com/momentum-design/momentum-react-v2/assets/3998548/a517e820-097c-4308-8d7c-bfb2ee1252bd)

Figma storybook example
![Screenshot 2023-10-03 104838](https://github.com/momentum-design/momentum-react-v2/assets/3998548/6bb36e6f-c897-4619-96a0-74b719216939)

