### PR TITLE
feat: popover forward ref

### DIFF
--- a/src/components/Popover/Popover.stories.tsx
+++ b/src/components/Popover/Popover.stories.tsx
@@ -155,6 +155,32 @@ Offset.args = {
   ),
 };
 
+const MultiplePopovers = Template<PopoverProps>(Popover).bind({});
+
+MultiplePopovers.argTypes = { ...argTypes };
+
+MultiplePopovers.args = {
+  trigger: 'click',
+  placement: PLACEMENTS.TOP,
+  showArrow: true,
+  interactive: true,
+  children: 'Interactive content on click',
+  triggerComponent: (
+    <Popover
+      trigger="mouseenter"
+      placement={PLACEMENTS.BOTTOM}
+      showArrow
+      triggerComponent={
+        <ButtonSimple style={{ margin: '10rem auto', display: 'flex' }}>
+          Hover or click me!
+        </ButtonSimple>
+      }
+    >
+      Description tooltip on hover
+    </Popover>
+  ),
+};
+
 const Common = MultiTemplate<PopoverProps>(Popover).bind({});
 
 Common.argTypes = { ...argTypes };
@@ -208,4 +234,12 @@ Common.parameters = {
   ],
 };
 
-export { Example, InteractiveContent, InteractiveFocus, WithCloseButton, Offset, Common };
+export {
+  Example,
+  InteractiveContent,
+  InteractiveFocus,
+  WithCloseButton,
+  Offset,
+  MultiplePopovers,
+  Common,
+};

--- a/src/utils/applyRef.ts
+++ b/src/utils/applyRef.ts
@@ -1,0 +1,13 @@
+import { ForwardedRef } from 'react';
+
+export const applyRef = (ref: ForwardedRef<HTMLElement>, node: HTMLElement): void => {
+  if (!ref) {
+    return;
+  }
+
+  if (typeof ref === 'function') {
+    ref(node);
+  } else if (Object.prototype.hasOwnProperty.call(ref, 'current')) {
+    ref.current = node;
+  }
+};

--- a/src/utils/applyRef.unit.test.ts
+++ b/src/utils/applyRef.unit.test.ts
@@ -1,0 +1,23 @@
+import { applyRef } from './applyRef';
+
+describe('applyRef', () => {
+  const node = document.createElement('div');
+
+  it('does nothing when ref is provided as null', () => {
+    expect(applyRef(null, node)).toBeUndefined();
+  });
+
+  it('calls the callback when ref is provided as a callback', () => {
+    const callback = jest.fn();
+
+    expect(applyRef(callback, node)).toBeUndefined();
+    expect(callback).toBeCalledWith(node);
+  });
+
+  it('sets the current property when ref is provided as a mutable', () => {
+    const mutable = { current: null };
+
+    expect(applyRef(mutable, node)).toBeUndefined();
+    expect(mutable).toStrictEqual({ current: node });
+  });
+});

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,2 @@
+export { applyRef } from './applyRef';
 export { PrimitiveConverter } from './component-conversions';


### PR DESCRIPTION
# Description

Allow the `Popover` component to forward refs provided to it to the trigger component, via the tippy react component. This allows for `Popover`s to be used as trigger components themselves, which allows for multiple popovers to be applied to a single trigger. 

This enables consumers to add popovers with different triggers on them without needing to wrap the popover in a span / div / etc. A common use case for this is where a button needs to have a tooltip displayed on hover, but also to display some interactive content on click. A storybook example has been added for this common use case.
