### PR TITLE
fix: allow non-button child in buttongroup

### DIFF
--- a/src/components/ButtonGroup/ButtonGroup.stories.args.ts
+++ b/src/components/ButtonGroup/ButtonGroup.stories.args.ts
@@ -6,13 +6,15 @@ export default {
   ...commonStyles,
   children: {
     defaultValue: undefined,
-    description: 'Provides the SupportedButton child nodes for this component.',
+    description:
+      'Provides the SupportedButton child nodes for this component. Elements, which wrap the Button, could also be passed in, with `data-childof="button-group"` to be set and using the same `fontSize` as the Button it is wrapping.',
     control: {
       type: 'none',
     },
     table: {
       type: {
-        summary: 'ReactElement<SupportedComponents> | Array<ReactElement<SupportedComponents>>',
+        summary:
+          'ReactElement<SupportedComponents> | Array<ReactElement<SupportedComponents>> | Array<HTMLElement>',
       },
       defaultValue: {
         summary: 'undefined',

--- a/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -350,6 +350,40 @@ Common.parameters = {
         backgroundColor: 'Chocolate',
       },
     },
+    {
+      children: [
+        <div key="0" data-childof="button-group" style={{ fontSize: '0.8rem' }}>
+          <ButtonCircle ghost size={32}>
+            <Icon name="camera-presence" autoScale={150} />
+          </ButtonCircle>
+        </div>,
+        <div key="1" data-childof="button-group" style={{ fontSize: '0.8rem' }}>
+          <ButtonCircle ghost size={32}>
+            <Icon name="quiet-hours-presence" autoScale={150} />
+          </ButtonCircle>
+        </div>,
+        <div key="2" data-childof="button-group" style={{ fontSize: '0.8rem' }}>
+          <ButtonCircle ghost size={32}>
+            <Icon name="handset" autoScale={150} />
+          </ButtonCircle>
+        </div>,
+        <div key="3" data-childof="button-group" style={{ fontSize: '0.8rem' }}>
+          <ButtonCircle ghost size={32}>
+            <Icon name="meetings-presence" autoScale={150} />
+          </ButtonCircle>
+        </div>,
+        <div key="4" data-childof="button-group" style={{ fontSize: '0.8rem' }}>
+          <ButtonCircle ghost size={32}>
+            <Icon name="pto-presence" autoScale={150} />
+          </ButtonCircle>
+        </div>,
+      ],
+      round: true,
+      spaced: true,
+      style: {
+        backgroundColor: 'Chocolate',
+      },
+    },
   ],
 };
 

--- a/src/components/ButtonGroup/ButtonGroup.style.scss
+++ b/src/components/ButtonGroup/ButtonGroup.style.scss
@@ -39,7 +39,8 @@
     &[data-orientation='horizontal'] {
       &[data-compressed='false'] {
         &[data-separator='true'] {
-          > button {
+          > button,
+          [data-childof='button-group'] {
             &:not(:first-of-type) {
               border-image: -webkit-linear-gradient(
                   top,
@@ -59,7 +60,8 @@
     &[data-orientation='vertical'] {
       &[data-compressed='false'] {
         &[data-separator='true'] {
-          > button {
+          > button,
+          [data-childof='button-group'] {
             &:not(:first-of-type) {
               border-image: -webkit-linear-gradient(
                   left,
@@ -82,7 +84,8 @@
       border-radius: 100vh;
 
       &[data-spaced='false'] {
-        > button {
+        > button,
+        [data-childof='button-group'] {
           &:first-of-type {
             border-top-left-radius: 100vh;
             border-bottom-left-radius: 100vh;
@@ -95,7 +98,8 @@
         }
 
         &[data-compressed='true'] {
-          > button {
+          > button,
+          [data-childof='button-group'] {
             &:not(:first-of-type) {
               border-left: none;
               padding-left: 0.2rem;
@@ -116,7 +120,8 @@
       border-radius: 100vh;
 
       &[data-spaced='false'] {
-        > button {
+        > button,
+        [data-childof='button-group'] {
           &:first-of-type {
             border-top-left-radius: 100vh;
             border-top-right-radius: 100vh;
@@ -129,7 +134,8 @@
         }
 
         &[data-compressed='true'] {
-          > button {
+          > button,
+          [data-childof='button-group'] {
             &:not(:first-of-type) {
               border-top: none;
               padding-top: 0.2rem;
@@ -147,7 +153,8 @@
 
   &[data-round='false'] {
     &[data-compressed='true'] {
-      > button {
+      > button,
+      [data-childof='button-group'] {
         &:not(:first-of-type) {
           border-left: none;
         }

--- a/src/components/ButtonGroup/ButtonGroup.types.ts
+++ b/src/components/ButtonGroup/ButtonGroup.types.ts
@@ -9,8 +9,15 @@ export type ButtonGroupOrientation = 'horizontal' | 'vertical';
 export interface Props {
   /**
    * Button shaped components.
+   *
+   * NOTE: if passing in wrapper around buttons (using a HTMLElement),
+   * each wrapper needs to have `data-childof="button-group"` to be set and
+   * using the same `fontSize` as the Button it is wrapping.
    */
-  children?: ReactElement<SupportedComponents> | Array<ReactElement<SupportedComponents>>;
+  children?:
+    | ReactElement<SupportedComponents>
+    | Array<ReactElement<SupportedComponents>>
+    | Array<HTMLElement>;
 
   /**
    * Custom class for overriding this component's CSS.


### PR DESCRIPTION
# Description

- Extend the Buttongroup component by allowing non-button children to be passed in.
- Updated documentation to make consumers aware.

Note: this is necessary to allow usage of nested popovers.

