### PR TITLE
feat: better handling of tippy instances

### DIFF
--- a/src/components/MenuTrigger/MenuTrigger.unit.test.tsx.snap
+++ b/src/components/MenuTrigger/MenuTrigger.unit.test.tsx.snap
@@ -81,6 +81,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot 1`] = `
         }
       }
       render={[Function]}
+      setInstance={[Function]}
       trigger="click"
     >
       <ForwardRef(TippyWrapper)
@@ -99,6 +100,9 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot 1`] = `
         placement="bottom-start"
         plugins={
           Array [
+            Object {
+              "fn": [Function],
+            },
             Object {
               "fn": [Function],
             },
@@ -150,6 +154,9 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot 1`] = `
           placement="bottom-start"
           plugins={
             Array [
+              Object {
+                "fn": [Function],
+              },
               Object {
                 "fn": [Function],
               },
@@ -2316,6 +2323,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with className 
         }
       }
       render={[Function]}
+      setInstance={[Function]}
       trigger="click"
     >
       <ForwardRef(TippyWrapper)
@@ -2334,6 +2342,9 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with className 
         placement="bottom-start"
         plugins={
           Array [
+            Object {
+              "fn": [Function],
+            },
             Object {
               "fn": [Function],
             },
@@ -2385,6 +2396,9 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with className 
           placement="bottom-start"
           plugins={
             Array [
+              Object {
+                "fn": [Function],
+              },
               Object {
                 "fn": [Function],
               },
@@ -4551,6 +4565,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with color 1`] 
         }
       }
       render={[Function]}
+      setInstance={[Function]}
       trigger="click"
     >
       <ForwardRef(TippyWrapper)
@@ -4569,6 +4584,9 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with color 1`] 
         placement="bottom-start"
         plugins={
           Array [
+            Object {
+              "fn": [Function],
+            },
             Object {
               "fn": [Function],
             },
@@ -4620,6 +4638,9 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with color 1`] 
           placement="bottom-start"
           plugins={
             Array [
+              Object {
+                "fn": [Function],
+              },
               Object {
                 "fn": [Function],
               },
@@ -6787,6 +6808,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with id 1`] = `
         }
       }
       render={[Function]}
+      setInstance={[Function]}
       trigger="click"
     >
       <ForwardRef(TippyWrapper)
@@ -6805,6 +6827,9 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with id 1`] = `
         placement="bottom-start"
         plugins={
           Array [
+            Object {
+              "fn": [Function],
+            },
             Object {
               "fn": [Function],
             },
@@ -6856,6 +6881,9 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with id 1`] = `
           placement="bottom-start"
           plugins={
             Array [
+              Object {
+                "fn": [Function],
+              },
               Object {
                 "fn": [Function],
               },
@@ -9025,6 +9053,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with placement 
         }
       }
       render={[Function]}
+      setInstance={[Function]}
       trigger="click"
     >
       <ForwardRef(TippyWrapper)
@@ -9043,6 +9072,9 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with placement 
         placement="top"
         plugins={
           Array [
+            Object {
+              "fn": [Function],
+            },
             Object {
               "fn": [Function],
             },
@@ -9094,6 +9126,9 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with placement 
           placement="top"
           plugins={
             Array [
+              Object {
+                "fn": [Function],
+              },
               Object {
                 "fn": [Function],
               },
@@ -11260,6 +11295,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with showArrow 
         }
       }
       render={[Function]}
+      setInstance={[Function]}
       trigger="click"
     >
       <ForwardRef(TippyWrapper)
@@ -11278,6 +11314,9 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with showArrow 
         placement="bottom-start"
         plugins={
           Array [
+            Object {
+              "fn": [Function],
+            },
             Object {
               "fn": [Function],
             },
@@ -11329,6 +11368,9 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with showArrow 
           placement="bottom-start"
           plugins={
             Array [
+              Object {
+                "fn": [Function],
+              },
               Object {
                 "fn": [Function],
               },
@@ -13568,6 +13610,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with style 1`] 
         }
       }
       render={[Function]}
+      setInstance={[Function]}
       trigger="click"
     >
       <ForwardRef(TippyWrapper)
@@ -13586,6 +13629,9 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with style 1`] 
         placement="bottom-start"
         plugins={
           Array [
+            Object {
+              "fn": [Function],
+            },
             Object {
               "fn": [Function],
             },
@@ -13637,6 +13683,9 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with style 1`] 
           placement="bottom-start"
           plugins={
             Array [
+              Object {
+                "fn": [Function],
+              },
               Object {
                 "fn": [Function],
               },
@@ -15814,6 +15863,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with variant 1`
         }
       }
       render={[Function]}
+      setInstance={[Function]}
       trigger="click"
     >
       <ForwardRef(TippyWrapper)
@@ -15832,6 +15882,9 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with variant 1`
         placement="bottom-start"
         plugins={
           Array [
+            Object {
+              "fn": [Function],
+            },
             Object {
               "fn": [Function],
             },
@@ -15883,6 +15936,9 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with variant 1`
           placement="bottom-start"
           plugins={
             Array [
+              Object {
+                "fn": [Function],
+              },
               Object {
                 "fn": [Function],
               },

--- a/src/components/Popover/LazyTippy.tsx
+++ b/src/components/Popover/LazyTippy.tsx
@@ -1,8 +1,9 @@
-import React, { FC } from 'react';
+import React, { FC, useMemo } from 'react';
+import type { Instance as TippyInstance } from 'tippy.js';
 
 import Tippy, { TippyProps } from '@tippyjs/react';
 
-export type LazyTippyProps = TippyProps;
+export type LazyTippyProps = TippyProps & { setInstance?: (instance?: TippyInstance) => void };
 
 /**
  * The LazyTippy component is used to "lazify" the Popover.
@@ -10,27 +11,39 @@ export type LazyTippyProps = TippyProps;
  * (which means that it could, if its used a lot, polute the DOM tree). Therefore the Popover has to be
  * lazified so that it will only be mounted to the DOM, whenever it is triggered to do so.
  */
-export const LazyTippy: FC<LazyTippyProps> = React.forwardRef((props: LazyTippyProps, ref) => {
-  const [mounted, setMounted] = React.useState(false);
+export const LazyTippy: FC<LazyTippyProps> = React.forwardRef(
+  ({ setInstance, ...props }: LazyTippyProps, ref) => {
+    const [mounted, setMounted] = React.useState(false);
 
-  const lazyPlugin = {
-    fn: () => ({
-      onMount: () => setMounted(true),
-      onHidden: () => setMounted(false),
-    }),
-  };
+    const lazyPlugin = {
+      fn: () => ({
+        onMount: () => setMounted(true),
+        onHidden: () => setMounted(false),
+      }),
+    };
 
-  const computedProps = { ...props };
+    const instancePlugin = useMemo(
+      () => ({
+        fn: (instance: TippyInstance) => ({
+          onCreate: () => setInstance?.(instance),
+          onDestroy: () => setInstance?.(undefined),
+        }),
+      }),
+      []
+    );
 
-  computedProps.plugins = [lazyPlugin, ...(props.plugins || [])];
+    const computedProps = { ...props };
 
-  if (props.render) {
-    computedProps.render = (...args) => (mounted ? props.render(...args) : '');
-  } else {
-    computedProps.content = mounted ? props.content : '';
+    computedProps.plugins = [instancePlugin, lazyPlugin, ...(props.plugins || [])];
+
+    if (props.render) {
+      computedProps.render = (...args) => (mounted ? props.render(...args) : '');
+    } else {
+      computedProps.content = mounted ? props.content : '';
+    }
+
+    return <Tippy ref={ref} {...computedProps} />;
   }
-
-  return <Tippy ref={ref} {...computedProps} />;
-});
+);
 
 LazyTippy.displayName = 'LazyTippy';

--- a/src/components/Select/Select.unit.test.tsx.snap
+++ b/src/components/Select/Select.unit.test.tsx.snap
@@ -352,6 +352,7 @@ exports[`Select snapshot should match snapshot 1`] = `
           }
         }
         render={[Function]}
+        setInstance={[Function]}
         trigger="manual"
       >
         <ForwardRef(TippyWrapper)
@@ -370,6 +371,9 @@ exports[`Select snapshot should match snapshot 1`] = `
           placement="bottom"
           plugins={
             Array [
+              Object {
+                "fn": [Function],
+              },
               Object {
                 "fn": [Function],
               },
@@ -421,6 +425,9 @@ exports[`Select snapshot should match snapshot 1`] = `
             placement="bottom"
             plugins={
               Array [
+                Object {
+                  "fn": [Function],
+                },
                 Object {
                   "fn": [Function],
                 },
@@ -881,6 +888,7 @@ exports[`Select snapshot should match snapshot before and after opening select d
           }
         }
         render={[Function]}
+        setInstance={[Function]}
         trigger="manual"
       >
         <ForwardRef(TippyWrapper)
@@ -899,6 +907,9 @@ exports[`Select snapshot should match snapshot before and after opening select d
           placement="bottom"
           plugins={
             Array [
+              Object {
+                "fn": [Function],
+              },
               Object {
                 "fn": [Function],
               },
@@ -950,6 +961,9 @@ exports[`Select snapshot should match snapshot before and after opening select d
             placement="bottom"
             plugins={
               Array [
+                Object {
+                  "fn": [Function],
+                },
                 Object {
                   "fn": [Function],
                 },
@@ -1411,6 +1425,7 @@ exports[`Select snapshot should match snapshot before and after opening select d
           }
         }
         render={[Function]}
+        setInstance={[Function]}
         trigger="manual"
       >
         <ForwardRef(TippyWrapper)
@@ -1429,6 +1444,9 @@ exports[`Select snapshot should match snapshot before and after opening select d
           placement="bottom"
           plugins={
             Array [
+              Object {
+                "fn": [Function],
+              },
               Object {
                 "fn": [Function],
               },
@@ -1480,6 +1498,9 @@ exports[`Select snapshot should match snapshot before and after opening select d
             placement="bottom"
             plugins={
               Array [
+                Object {
+                  "fn": [Function],
+                },
                 Object {
                   "fn": [Function],
                 },
@@ -2452,6 +2473,7 @@ exports[`Select snapshot should match snapshot with border 1`] = `
           }
         }
         render={[Function]}
+        setInstance={[Function]}
         trigger="manual"
       >
         <ForwardRef(TippyWrapper)
@@ -2470,6 +2492,9 @@ exports[`Select snapshot should match snapshot with border 1`] = `
           placement="bottom"
           plugins={
             Array [
+              Object {
+                "fn": [Function],
+              },
               Object {
                 "fn": [Function],
               },
@@ -2521,6 +2546,9 @@ exports[`Select snapshot should match snapshot with border 1`] = `
             placement="bottom"
             plugins={
               Array [
+                Object {
+                  "fn": [Function],
+                },
                 Object {
                   "fn": [Function],
                 },
@@ -2982,6 +3010,7 @@ exports[`Select snapshot should match snapshot with className 1`] = `
           }
         }
         render={[Function]}
+        setInstance={[Function]}
         trigger="manual"
       >
         <ForwardRef(TippyWrapper)
@@ -3000,6 +3029,9 @@ exports[`Select snapshot should match snapshot with className 1`] = `
           placement="bottom"
           plugins={
             Array [
+              Object {
+                "fn": [Function],
+              },
               Object {
                 "fn": [Function],
               },
@@ -3051,6 +3083,9 @@ exports[`Select snapshot should match snapshot with className 1`] = `
             placement="bottom"
             plugins={
               Array [
+                Object {
+                  "fn": [Function],
+                },
                 Object {
                   "fn": [Function],
                 },
@@ -3512,6 +3547,7 @@ exports[`Select snapshot should match snapshot with direction 1`] = `
           }
         }
         render={[Function]}
+        setInstance={[Function]}
         trigger="manual"
       >
         <ForwardRef(TippyWrapper)
@@ -3530,6 +3566,9 @@ exports[`Select snapshot should match snapshot with direction 1`] = `
           placement="top"
           plugins={
             Array [
+              Object {
+                "fn": [Function],
+              },
               Object {
                 "fn": [Function],
               },
@@ -3581,6 +3620,9 @@ exports[`Select snapshot should match snapshot with direction 1`] = `
             placement="top"
             plugins={
               Array [
+                Object {
+                  "fn": [Function],
+                },
                 Object {
                   "fn": [Function],
                 },
@@ -4052,6 +4094,7 @@ exports[`Select snapshot should match snapshot with disabled option 1`] = `
           }
         }
         render={[Function]}
+        setInstance={[Function]}
         trigger="manual"
       >
         <ForwardRef(TippyWrapper)
@@ -4070,6 +4113,9 @@ exports[`Select snapshot should match snapshot with disabled option 1`] = `
           placement="bottom"
           plugins={
             Array [
+              Object {
+                "fn": [Function],
+              },
               Object {
                 "fn": [Function],
               },
@@ -4121,6 +4167,9 @@ exports[`Select snapshot should match snapshot with disabled option 1`] = `
             placement="bottom"
             plugins={
               Array [
+                Object {
+                  "fn": [Function],
+                },
                 Object {
                   "fn": [Function],
                 },
@@ -5096,6 +5145,7 @@ exports[`Select snapshot should match snapshot with id 1`] = `
           }
         }
         render={[Function]}
+        setInstance={[Function]}
         trigger="manual"
       >
         <ForwardRef(TippyWrapper)
@@ -5114,6 +5164,9 @@ exports[`Select snapshot should match snapshot with id 1`] = `
           placement="bottom"
           plugins={
             Array [
+              Object {
+                "fn": [Function],
+              },
               Object {
                 "fn": [Function],
               },
@@ -5165,6 +5218,9 @@ exports[`Select snapshot should match snapshot with id 1`] = `
             placement="bottom"
             plugins={
               Array [
+                Object {
+                  "fn": [Function],
+                },
                 Object {
                   "fn": [Function],
                 },
@@ -5627,6 +5683,7 @@ exports[`Select snapshot should match snapshot with listbox opened 1`] = `
           }
         }
         render={[Function]}
+        setInstance={[Function]}
         trigger="manual"
       >
         <ForwardRef(TippyWrapper)
@@ -5645,6 +5702,9 @@ exports[`Select snapshot should match snapshot with listbox opened 1`] = `
           placement="bottom"
           plugins={
             Array [
+              Object {
+                "fn": [Function],
+              },
               Object {
                 "fn": [Function],
               },
@@ -5696,6 +5756,9 @@ exports[`Select snapshot should match snapshot with listbox opened 1`] = `
             placement="bottom"
             plugins={
               Array [
+                Object {
+                  "fn": [Function],
+                },
                 Object {
                   "fn": [Function],
                 },
@@ -6668,6 +6731,7 @@ exports[`Select snapshot should match snapshot with listboxMaxHeight 1`] = `
           }
         }
         render={[Function]}
+        setInstance={[Function]}
         trigger="manual"
       >
         <ForwardRef(TippyWrapper)
@@ -6686,6 +6750,9 @@ exports[`Select snapshot should match snapshot with listboxMaxHeight 1`] = `
           placement="bottom"
           plugins={
             Array [
+              Object {
+                "fn": [Function],
+              },
               Object {
                 "fn": [Function],
               },
@@ -6737,6 +6804,9 @@ exports[`Select snapshot should match snapshot with listboxMaxHeight 1`] = `
             placement="bottom"
             plugins={
               Array [
+                Object {
+                  "fn": [Function],
+                },
                 Object {
                   "fn": [Function],
                 },
@@ -7713,6 +7783,7 @@ exports[`Select snapshot should match snapshot with placeholder 1`] = `
           }
         }
         render={[Function]}
+        setInstance={[Function]}
         trigger="manual"
       >
         <ForwardRef(TippyWrapper)
@@ -7731,6 +7802,9 @@ exports[`Select snapshot should match snapshot with placeholder 1`] = `
           placement="bottom"
           plugins={
             Array [
+              Object {
+                "fn": [Function],
+              },
               Object {
                 "fn": [Function],
               },
@@ -7782,6 +7856,9 @@ exports[`Select snapshot should match snapshot with placeholder 1`] = `
             placement="bottom"
             plugins={
               Array [
+                Object {
+                  "fn": [Function],
+                },
                 Object {
                   "fn": [Function],
                 },
@@ -8274,6 +8351,7 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
           }
         }
         render={[Function]}
+        setInstance={[Function]}
         trigger="manual"
       >
         <ForwardRef(TippyWrapper)
@@ -8292,6 +8370,9 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
           placement="bottom"
           plugins={
             Array [
+              Object {
+                "fn": [Function],
+              },
               Object {
                 "fn": [Function],
               },
@@ -8343,6 +8424,9 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
             placement="bottom"
             plugins={
               Array [
+                Object {
+                  "fn": [Function],
+                },
                 Object {
                   "fn": [Function],
                 },
@@ -8838,6 +8922,7 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
           }
         }
         render={[Function]}
+        setInstance={[Function]}
         trigger="manual"
       >
         <ForwardRef(TippyWrapper)
@@ -8856,6 +8941,9 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
           placement="bottom"
           plugins={
             Array [
+              Object {
+                "fn": [Function],
+              },
               Object {
                 "fn": [Function],
               },
@@ -8907,6 +8995,9 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
             placement="bottom"
             plugins={
               Array [
+                Object {
+                  "fn": [Function],
+                },
                 Object {
                   "fn": [Function],
                 },
@@ -9968,6 +10059,7 @@ exports[`Select snapshot should match snapshot with style 1`] = `
           }
         }
         render={[Function]}
+        setInstance={[Function]}
         trigger="manual"
       >
         <ForwardRef(TippyWrapper)
@@ -9986,6 +10078,9 @@ exports[`Select snapshot should match snapshot with style 1`] = `
           placement="bottom"
           plugins={
             Array [
+              Object {
+                "fn": [Function],
+              },
               Object {
                 "fn": [Function],
               },
@@ -10037,6 +10132,9 @@ exports[`Select snapshot should match snapshot with style 1`] = `
             placement="bottom"
             plugins={
               Array [
+                Object {
+                  "fn": [Function],
+                },
                 Object {
                   "fn": [Function],
                 },
@@ -10498,6 +10596,7 @@ exports[`Select snapshot should match snapshot with title 1`] = `
           }
         }
         render={[Function]}
+        setInstance={[Function]}
         trigger="manual"
       >
         <ForwardRef(TippyWrapper)
@@ -10516,6 +10615,9 @@ exports[`Select snapshot should match snapshot with title 1`] = `
           placement="bottom"
           plugins={
             Array [
+              Object {
+                "fn": [Function],
+              },
               Object {
                 "fn": [Function],
               },
@@ -10567,6 +10669,9 @@ exports[`Select snapshot should match snapshot with title 1`] = `
             placement="bottom"
             plugins={
               Array [
+                Object {
+                  "fn": [Function],
+                },
                 Object {
                   "fn": [Function],
                 },


### PR DESCRIPTION
# Description

This change improves tippy instance handling (specifically via the `setInstance` prop) of popovers so that it no longer relies on accessing a DOM node in order to retrieve the current tippy instance. This means that nested popovers now (correctly) get their own instance, and much of the popover internals are simplified with regards to refs.

Note that I haven't yet added any tests for this. Since this is not a new behaviour (rather a refactor of an old one), I expect the existing set of tests should cover the changes. I am, of course, happy to add tests if wanted.

This change also makes the `applyRef` utility function unused, however I have left this in as it may have use in future. Again if this should be removed I am happy to do so.
