### PR TITLE
fix: overlayalert to pass in onClose and escape

### DIFF
--- a/src/components/Overlay/Overlay.tsx
+++ b/src/components/Overlay/Overlay.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/no-static-element-interactions */
 import React, { FC } from 'react';
 import classnames from 'classnames';
 import FocusLock from 'react-focus-lock';
@@ -18,6 +19,8 @@ const Overlay: FC<Props> = (props: Props) => {
     id,
     style,
     focusLockProps,
+    onKeyDown,
+    ...other
   } = props;
 
   const content = (
@@ -27,6 +30,8 @@ const Overlay: FC<Props> = (props: Props) => {
       data-fullscreen={fullscreen}
       id={id}
       style={style}
+      onKeyDown={onKeyDown}
+      {...other}
     >
       {children}
     </div>

--- a/src/components/Overlay/Overlay.types.ts
+++ b/src/components/Overlay/Overlay.types.ts
@@ -38,4 +38,10 @@ export interface Props {
    * Props to be passed to FocusLock
    */
   focusLockProps?: Omit<ComponentProps<typeof FocusLock>, 'children'>;
+
+  /**
+   * Callback function for when the escape key is pressed on the container div
+   * @param event - React Keyboard Event
+   */
+  onKeyDown?: (event: React.KeyboardEvent) => void;
 }

--- a/src/components/OverlayAlert/OverlayAlert.stories.tsx
+++ b/src/components/OverlayAlert/OverlayAlert.stories.tsx
@@ -92,7 +92,7 @@ const coreArgs = {
 
 const Example = Template().bind({});
 
-Example.argTypes = { ...argTypes };
+Example.argTypes = { ...argTypes, onClose: { action: 'closed' } };
 
 Example.parameters = {
   hasActions: true,

--- a/src/components/OverlayAlert/OverlayAlert.tsx
+++ b/src/components/OverlayAlert/OverlayAlert.tsx
@@ -25,14 +25,22 @@ const OverlayAlert: FC<Props> = (props: Props) => {
     overlayColor = DEFAULTS.OVERLAY_COLOR,
     title,
     focusLockProps = DEFAULTS.FOCUS_LOCK_PROPS,
+    onClose,
     ...other
   } = props;
+
+  const onKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key === 'Escape') {
+      onClose?.();
+    }
+  };
 
   return (
     <Overlay
       focusLockProps={focusLockProps}
       className={classnames(className, STYLE.wrapper)}
       color={overlayColor}
+      onKeyDown={onKeyDown}
       {...other}
     >
       <ModalContainer round={75} color={modalColor}>

--- a/src/components/OverlayAlert/OverlayAlert.types.ts
+++ b/src/components/OverlayAlert/OverlayAlert.types.ts
@@ -65,4 +65,9 @@ export interface Props extends OverlayProps {
    * Props to be passed to Overlay for FocusLock
    */
   focusLockProps?: Omit<ComponentProps<typeof FocusLock>, 'children'>;
+
+  /**
+   * Callback function to be fired when Escape key is pressed.
+   */
+  onClose?: () => void;
 }

--- a/src/components/OverlayAlert/OverlayAlert.unit.test.tsx
+++ b/src/components/OverlayAlert/OverlayAlert.unit.test.tsx
@@ -5,6 +5,8 @@ import ButtonControl from '../ButtonControl';
 import ButtonPill from '../ButtonPill';
 import ModalContainer, { MODAL_CONTAINER_CONSTANTS } from '../ModalContainer';
 import Overlay, { OVERLAY_CONSTANTS } from '../Overlay';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import OverlayAlert, { OVERLAY_ALERT_CONSTANTS as CONSTANTS, OVERLAY_ALERT_CONSTANTS } from './';
 import { STYLE as OVERLAY_STYLE } from '../Overlay/Overlay.constants';
@@ -288,6 +290,24 @@ describe('<OverlayAlert />', () => {
 
       expect(tree.includes(children)).toBe(true);
       expect(tree.includes(details)).toBe(false);
+    });
+  });
+
+  describe('actions', () => {
+    it('should fire onClose if Escape is pressed', async () => {
+      const onCloseFn = jest.fn();
+      const contentText = 'test 123';
+
+      const user = userEvent.setup();
+
+      render(
+        <OverlayAlert onClose={onCloseFn}>
+          <button>{contentText}</button>
+        </OverlayAlert>
+      );
+      await user.keyboard('{Escape}');
+
+      expect(onCloseFn).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/components/OverlayAlert/OverlayAlert.unit.test.tsx.snap
+++ b/src/components/OverlayAlert/OverlayAlert.unit.test.tsx.snap
@@ -10,6 +10,7 @@ exports[`<OverlayAlert /> snapshot should match snapshot 1`] = `
         "returnFocus": true,
       }
     }
+    onKeyDown={[Function]}
   >
     <FocusLock
       as="div"
@@ -128,6 +129,7 @@ exports[`<OverlayAlert /> snapshot should match snapshot 1`] = `
           className="md-overlay-alert-wrapper md-overlay-wrapper"
           data-color="secondary"
           data-fullscreen={false}
+          onKeyDown={[Function]}
         >
           <ModalContainer
             round={75}
@@ -184,6 +186,7 @@ exports[`<OverlayAlert /> snapshot should match snapshot with actions 1`] = `
         "returnFocus": true,
       }
     }
+    onKeyDown={[Function]}
   >
     <FocusLock
       as="div"
@@ -336,6 +339,7 @@ exports[`<OverlayAlert /> snapshot should match snapshot with actions 1`] = `
           className="md-overlay-alert-wrapper md-overlay-wrapper"
           data-color="secondary"
           data-fullscreen={false}
+          onKeyDown={[Function]}
         >
           <ModalContainer
             round={75}
@@ -440,6 +444,7 @@ exports[`<OverlayAlert /> snapshot should match snapshot with className 1`] = `
         "returnFocus": true,
       }
     }
+    onKeyDown={[Function]}
   >
     <FocusLock
       as="div"
@@ -558,6 +563,7 @@ exports[`<OverlayAlert /> snapshot should match snapshot with className 1`] = `
           className="example-class md-overlay-alert-wrapper md-overlay-wrapper"
           data-color="secondary"
           data-fullscreen={false}
+          onKeyDown={[Function]}
         >
           <ModalContainer
             round={75}
@@ -614,6 +620,7 @@ exports[`<OverlayAlert /> snapshot should match snapshot with controls 1`] = `
         "returnFocus": true,
       }
     }
+    onKeyDown={[Function]}
   >
     <FocusLock
       as="div"
@@ -742,6 +749,7 @@ exports[`<OverlayAlert /> snapshot should match snapshot with controls 1`] = `
           className="md-overlay-alert-wrapper md-overlay-wrapper"
           data-color="secondary"
           data-fullscreen={false}
+          onKeyDown={[Function]}
         >
           <ModalContainer
             round={75}
@@ -834,6 +842,7 @@ exports[`<OverlayAlert /> snapshot should match snapshot with details 1`] = `
         "returnFocus": true,
       }
     }
+    onKeyDown={[Function]}
   >
     <FocusLock
       as="div"
@@ -966,6 +975,7 @@ exports[`<OverlayAlert /> snapshot should match snapshot with details 1`] = `
           className="md-overlay-alert-wrapper md-overlay-wrapper"
           data-color="secondary"
           data-fullscreen={false}
+          onKeyDown={[Function]}
         >
           <ModalContainer
             round={75}
@@ -1030,6 +1040,7 @@ exports[`<OverlayAlert /> snapshot should match snapshot with details and childr
         "returnFocus": true,
       }
     }
+    onKeyDown={[Function]}
   >
     <FocusLock
       as="div"
@@ -1152,6 +1163,7 @@ exports[`<OverlayAlert /> snapshot should match snapshot with details and childr
           className="md-overlay-alert-wrapper md-overlay-wrapper"
           data-color="secondary"
           data-fullscreen={false}
+          onKeyDown={[Function]}
         >
           <ModalContainer
             round={75}
@@ -1207,6 +1219,7 @@ exports[`<OverlayAlert /> snapshot should match snapshot with id 1`] = `
       }
     }
     id="example-id"
+    onKeyDown={[Function]}
   >
     <FocusLock
       as="div"
@@ -1328,6 +1341,7 @@ exports[`<OverlayAlert /> snapshot should match snapshot with id 1`] = `
           data-color="secondary"
           data-fullscreen={false}
           id="example-id"
+          onKeyDown={[Function]}
         >
           <ModalContainer
             round={75}
@@ -1395,6 +1409,7 @@ exports[`<OverlayAlert /> snapshot should match snapshot with multiple actions 1
         "returnFocus": true,
       }
     }
+    onKeyDown={[Function]}
   >
     <FocusLock
       as="div"
@@ -1617,6 +1632,7 @@ exports[`<OverlayAlert /> snapshot should match snapshot with multiple actions 1
           className="md-overlay-alert-wrapper md-overlay-wrapper"
           data-color="secondary"
           data-fullscreen={false}
+          onKeyDown={[Function]}
         >
           <ModalContainer
             round={75}
@@ -1847,6 +1863,7 @@ exports[`<OverlayAlert /> snapshot should match snapshot with multiple controls 
         "returnFocus": true,
       }
     }
+    onKeyDown={[Function]}
   >
     <FocusLock
       as="div"
@@ -1997,6 +2014,7 @@ exports[`<OverlayAlert /> snapshot should match snapshot with multiple controls 
           className="md-overlay-alert-wrapper md-overlay-wrapper"
           data-color="secondary"
           data-fullscreen={false}
+          onKeyDown={[Function]}
         >
           <ModalContainer
             round={75}
@@ -2178,6 +2196,7 @@ exports[`<OverlayAlert /> snapshot should match snapshot with style 1`] = `
         "returnFocus": true,
       }
     }
+    onKeyDown={[Function]}
     style={
       Object {
         "color": "pink",
@@ -2303,6 +2322,7 @@ exports[`<OverlayAlert /> snapshot should match snapshot with style 1`] = `
           className="md-overlay-alert-wrapper md-overlay-wrapper"
           data-color="secondary"
           data-fullscreen={false}
+          onKeyDown={[Function]}
           style={
             Object {
               "color": "pink",
@@ -2360,6 +2380,7 @@ exports[`<OverlayAlert /> snapshot should match snapshot with title 1`] = `
         "returnFocus": true,
       }
     }
+    onKeyDown={[Function]}
   >
     <FocusLock
       as="div"
@@ -2498,6 +2519,7 @@ exports[`<OverlayAlert /> snapshot should match snapshot with title 1`] = `
           className="md-overlay-alert-wrapper md-overlay-wrapper"
           data-color="secondary"
           data-fullscreen={false}
+          onKeyDown={[Function]}
         >
           <ModalContainer
             round={75}


### PR DESCRIPTION
# Description

- Change the Overlayalert to allow for a onClose prop, which will be fired when Escape is pressed
- Allow the Overlay component to pass through `...other` props
- Added unit tests
