### PR TITLE
fix(list-item-base): update navigable children when children change

### DIFF
--- a/src/components/ListItemBase/ListItemBase.stories.tsx
+++ b/src/components/ListItemBase/ListItemBase.stories.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/display-name */
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 
 import ListItemBase from '.';
 
@@ -20,6 +20,10 @@ import ButtonPill from '../ButtonPill';
 import Avatar from '../Avatar';
 import { PresenceType } from '../Avatar/Avatar.types';
 import argTypes from './ListItemBase.stories.args';
+import ButtonSimple from '../ButtonSimple';
+import Text from '../Text';
+import ButtonCircle from '../ButtonCircle';
+import Popover from '../Popover';
 
 export default {
   title: 'Momentum UI/ListItemBase',
@@ -214,4 +218,83 @@ Shapes.parameters = {
   ],
 };
 
-export { Example, Sizes, Shapes, Common };
+const ListItemWithChangingContent = () => {
+  const [showButtonSimple, setShowButtonSimple] = useState<boolean>(false);
+  const [removeButton, setRemoveButton] = useState<boolean>(false);
+  const [showText, setShowText] = useState<boolean>(false);
+
+  const handleChange = useCallback(() => {
+    setShowButtonSimple((curr) => !curr);
+  }, []);
+
+  const handleRemove = useCallback(() => {
+    setRemoveButton((curr) => !curr);
+  }, []);
+
+  const handleShowTextInstead = useCallback(() => {
+    setShowText((curr) => !curr);
+  }, []);
+
+  return (
+    <div
+      style={{
+        width: '40rem',
+        height: '4rem',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        alignItems: 'center',
+        gap: '0.5rem',
+      }}
+    >
+      <Text>Example with changing context - try it out!</Text>
+      <ListItemBase size={40} isPadded>
+        <div
+          style={{
+            width: '40rem',
+            height: '4rem',
+            display: 'grid',
+            gridTemplateColumns: 'repeat(4, 1fr)',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+          }}
+        >
+          {removeButton && (
+            <Popover
+              trigger="mouseenter"
+              placement="bottom"
+              triggerComponent={
+                <ButtonCircle size={20} ghost outline onPress={handleShowTextInstead}>
+                  <Icon name="plus" weight="bold" scale={16} />
+                </ButtonCircle>
+              }
+            >
+              Extra button to toggle text
+            </Popover>
+          )}
+          {showButtonSimple ? (
+            <div>
+              <div>
+                <ButtonSimple onPress={handleRemove}>Toggle extra button</ButtonSimple>
+              </div>
+            </div>
+          ) : (
+            <ButtonPill size={20} ghost outline onPress={handleShowTextInstead}>
+              Toggle text
+            </ButtonPill>
+          )}
+          {showText && <Text>Unfocusable text</Text>}
+          <ButtonPill size={20} ghost outline onPress={handleChange}>
+            Change button
+          </ButtonPill>
+        </div>
+      </ListItemBase>
+    </div>
+  );
+};
+
+const ChangingContent = Template(ListItemWithChangingContent).bind({});
+
+ChangingContent.argTypes = { ...argTypes };
+
+export { Example, Sizes, Shapes, Common, ChangingContent };

--- a/src/components/ListItemBase/ListItemBase.tsx
+++ b/src/components/ListItemBase/ListItemBase.tsx
@@ -94,6 +94,13 @@ const ListItemBase = (props: Props, providedRef: RefObject<HTMLLIElement>) => {
     ...rest,
   });
 
+  // Update navigableChildren if children change
+  useEffect(() => {
+    if (children) {
+      navigableChildren.current = getKeyboardFocusableElements(ref.current, false);
+    }
+  }, [ref, children]);
+
   // Prevent list item update because it can cause state lost in the focused component e.g. Menu
   const listItemPressProps = {
     ...pressProps,


### PR DESCRIPTION
# Description

Currently if the children of a list item base change (e.g one changes from button pill to button simple) then it is no longer navigable by keyboard. This change updates the navigable children when children changes.

I haven't added tests for this but I've added a storybook to demo the fix

# Links

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-471568
