### PR TITLE
fix(list-item-base): make non-interactive list items have tabIndex -1

### DIFF
--- a/src/components/ListHeader/ListHeader.unit.test.tsx.snap
+++ b/src/components/ListHeader/ListHeader.unit.test.tsx.snap
@@ -49,7 +49,7 @@ exports[`<ListHeader /> snapshot should match snapshot 1`] = `
           onTouchMove={[Function]}
           onTouchStart={[Function]}
           role="separator"
-          tabIndex={0}
+          tabIndex={-1}
         />
       </FocusRing>
     </FocusRing>
@@ -109,7 +109,7 @@ exports[`<ListHeader /> snapshot should match snapshot with bold 1`] = `
           onTouchMove={[Function]}
           onTouchStart={[Function]}
           role="separator"
-          tabIndex={0}
+          tabIndex={-1}
         />
       </FocusRing>
     </FocusRing>
@@ -168,7 +168,7 @@ exports[`<ListHeader /> snapshot should match snapshot with className 1`] = `
           onTouchMove={[Function]}
           onTouchStart={[Function]}
           role="separator"
-          tabIndex={0}
+          tabIndex={-1}
         />
       </FocusRing>
     </FocusRing>
@@ -229,7 +229,7 @@ exports[`<ListHeader /> snapshot should match snapshot with id 1`] = `
           onTouchMove={[Function]}
           onTouchStart={[Function]}
           role="separator"
-          tabIndex={0}
+          tabIndex={-1}
         />
       </FocusRing>
     </FocusRing>
@@ -288,7 +288,7 @@ exports[`<ListHeader /> snapshot should match snapshot with outline 1`] = `
           onTouchMove={[Function]}
           onTouchStart={[Function]}
           role="separator"
-          tabIndex={0}
+          tabIndex={-1}
         />
       </FocusRing>
     </FocusRing>
@@ -348,7 +348,7 @@ exports[`<ListHeader /> snapshot should match snapshot with outlineColor 1`] = `
           onTouchMove={[Function]}
           onTouchStart={[Function]}
           role="separator"
-          tabIndex={0}
+          tabIndex={-1}
         />
       </FocusRing>
     </FocusRing>
@@ -408,7 +408,7 @@ exports[`<ListHeader /> snapshot should match snapshot with outlinePosition 1`] 
           onTouchMove={[Function]}
           onTouchStart={[Function]}
           role="separator"
-          tabIndex={0}
+          tabIndex={-1}
         />
       </FocusRing>
     </FocusRing>
@@ -468,7 +468,7 @@ exports[`<ListHeader /> snapshot should match snapshot with outlinePosition 2`] 
           onTouchMove={[Function]}
           onTouchStart={[Function]}
           role="separator"
-          tabIndex={0}
+          tabIndex={-1}
         />
       </FocusRing>
     </FocusRing>
@@ -541,7 +541,7 @@ exports[`<ListHeader /> snapshot should match snapshot with style 1`] = `
               "color": "pink",
             }
           }
-          tabIndex={0}
+          tabIndex={-1}
         />
       </FocusRing>
     </FocusRing>

--- a/src/components/ListItemBase/ListItemBase.test.tsx
+++ b/src/components/ListItemBase/ListItemBase.test.tsx
@@ -112,6 +112,16 @@ describe('ListItemBase', () => {
 
       expect(container).toMatchSnapshot();
     });
+
+    it('should match snapshot with interactive=false', () => {
+      expect.assertions(1);
+
+      const interactive = false;
+
+      container = mount(<ListItemBase interactive={interactive}>Test</ListItemBase>);
+
+      expect(container).toMatchSnapshot();
+    });
   });
 
   describe('attributes', () => {
@@ -233,7 +243,7 @@ describe('ListItemBase', () => {
     });
 
     it('should have provided data-interactive when interactive is provided', () => {
-      expect.assertions(1);
+      expect.assertions(2);
 
       const interactive = false;
 
@@ -242,6 +252,7 @@ describe('ListItemBase', () => {
       const element = container.find(ListItemBase).getDOMNode();
 
       expect(element.getAttribute('data-interactive')).toBe(`${interactive}`);
+      expect(element.getAttribute('tabIndex')).toBe('-1');
     });
   });
 

--- a/src/components/ListItemBase/ListItemBase.test.tsx.snap
+++ b/src/components/ListItemBase/ListItemBase.test.tsx.snap
@@ -128,6 +128,49 @@ exports[`ListItemBase snapshot should match snapshot with id 1`] = `
 </ListItemBase>
 `;
 
+exports[`ListItemBase snapshot should match snapshot with interactive=false 1`] = `
+<ListItemBase
+  interactive={false}
+>
+  <FocusRing
+    isInset={false}
+  >
+    <FocusRing
+      focusClass="md-focus-ring-wrapper children"
+      focusRingClass="md-focus-ring-wrapper children"
+      isInset={false}
+    >
+      <li
+        className="md-list-item-base-wrapper"
+        data-disabled={false}
+        data-interactive={false}
+        data-padded={false}
+        data-shape="rectangle"
+        data-size={40}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onDragStart={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        onTouchCancel={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
+        role="listitem"
+        tabIndex={-1}
+      >
+        Test
+      </li>
+    </FocusRing>
+  </FocusRing>
+</ListItemBase>
+`;
+
 exports[`ListItemBase snapshot should match snapshot with isDisabled 1`] = `
 <ListItemBase
   isDisabled={true}

--- a/src/components/ListItemBase/ListItemBase.tsx
+++ b/src/components/ListItemBase/ListItemBase.tsx
@@ -23,6 +23,7 @@ import ButtonSimple from '../ButtonSimple';
 import Text from '../Text';
 import {
   getKeyboardFocusableElements,
+  getListItemBaseTabIndex,
   handleLeftRightArrowNavigation,
   useDidUpdateEffect,
 } from './ListItemBase.utils';
@@ -127,6 +128,8 @@ const ListItemBase = (props: Props, providedRef: RefObject<HTMLLIElement>) => {
   const shouldFocusOnPress = listContext?.shouldFocusOnPress || false;
   const shouldItemFocusBeInset =
     listContext?.shouldItemFocusBeInset || DEFAULTS.SHOULD_ITEM_FOCUS_BE_INSET;
+
+  const listItemTabIndex = getListItemBaseTabIndex({ interactive, listContext, focus });
 
   // makes sure that whenever an item is pressed, the list focus state gets updated as well
   useEffect(() => {
@@ -250,7 +253,7 @@ const ListItemBase = (props: Props, providedRef: RefObject<HTMLLIElement>) => {
   return (
     <FocusRing isInset={shouldItemFocusBeInset}>
       <li
-        tabIndex={listContext ? (focus ? 0 : -1) : 0}
+        tabIndex={listItemTabIndex}
         style={style}
         ref={ref}
         data-size={size}

--- a/src/components/ListItemBase/ListItemBase.utils.test.tsx
+++ b/src/components/ListItemBase/ListItemBase.utils.test.tsx
@@ -1,6 +1,7 @@
 import { renderHook } from '@testing-library/react-hooks';
 import {
   getKeyboardFocusableElements,
+  getListItemBaseTabIndex,
   handleLeftRightArrowNavigation,
   useDidUpdateEffect,
 } from './ListItemBase.utils';
@@ -169,4 +170,26 @@ describe('handleLeftRightArrowNavigation', () => {
     );
     checkFocus(focusSpies[2]);
   });
+});
+
+describe('getListItemBaseTabIndex', () => {
+  const listContextWellDefined = { currentFocus: 1 };
+
+  it.each`
+    interactive | listContext               | focus    | expected
+    ${false}    | ${undefined}              | ${true}  | ${-1}
+    ${false}    | ${undefined}              | ${false} | ${-1}
+    ${false}    | ${listContextWellDefined} | ${true}  | ${-1}
+    ${false}    | ${listContextWellDefined} | ${false} | ${-1}
+    ${true}     | ${undefined}              | ${true}  | ${0}
+    ${true}     | ${undefined}              | ${false} | ${0}
+    ${true}     | ${listContextWellDefined} | ${true}  | ${0}
+    ${true}     | ${listContextWellDefined} | ${false} | ${-1}
+  `(
+    'returns $expected when interactive is $interactive, listContext is $listContext and focus is $focus',
+    ({ interactive, listContext, focus, expected }) => {
+      const tabIndex = getListItemBaseTabIndex({ interactive, listContext, focus });
+      expect(tabIndex).toBe(expected);
+    }
+  );
 });

--- a/src/components/ListItemBase/ListItemBase.utils.tsx
+++ b/src/components/ListItemBase/ListItemBase.utils.tsx
@@ -1,5 +1,6 @@
 import { DependencyList, EffectCallback, useEffect, useRef } from 'react';
 import { KEYS } from './ListItemBase.constants';
+import { ListContextValue } from '../List/List.types';
 
 /**
  * Returns all focusable child elements as an Element Array
@@ -76,5 +77,24 @@ export const handleLeftRightArrowNavigation = (
     event.preventDefault();
     event.stopPropagation();
     newTarget.focus();
+  }
+};
+
+/**
+ * Returns the intended tabIndex for the ListItemBase
+ */
+export const getListItemBaseTabIndex = ({
+  interactive,
+  listContext,
+  focus,
+}: {
+  interactive: boolean;
+  listContext?: ListContextValue;
+  focus: boolean;
+}): number => {
+  if (!interactive || (listContext && !focus)) {
+    return -1;
+  } else {
+    return 0;
   }
 };


### PR DESCRIPTION
# Description

Currently if a ListHeader is used outside of a ListNext context then it is included in the tab order of the page despite it not being interactive. This change makes it so that interactive=false implies tabIndex=-1 in ListItemBase

# Links

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-471953
