### PR TITLE
Fix(NavigationTab): Updated height and tab count positioning in expanded state

### DIFF
--- a/src/components/NavigationTab/NavigationTab.style.scss
+++ b/src/components/NavigationTab/NavigationTab.style.scss
@@ -117,7 +117,7 @@
   }
 
   &[data-size='200'] {
-    height: 3rem;
+    height: 2.5rem;
     width: 100%;
 
     > .md-navigation-tab-icon {
@@ -127,7 +127,6 @@
     > .md-navigation-tab-count {
       position: absolute;
       right: 0.75rem;
-      top: 0.75rem;
     }
   }
 }


### PR DESCRIPTION
# IMPORTANT

**Currently, this project is closed to any external contributions. Any pull request made against this project from external sources will likely be closed. If you would like to make changes to this project, please fork this project.**

# Guide

**This "Help" section can be deleted before submitting this pull request.**

*Update the name of this pull request to reflect the following shape:*

```
{type}/{scope?}/{message}
```

* **type** - A [conventional commit type](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional#type-enum) **REQUIRED**
* **scope** - The kabab-case scope of the changes in this request
* **message** - A short, kebab-case statement describing the changes **REQUIRED**

*Provide a general summary of the scope of the changes in this pull request.*

* [Readme](https://github.com/momentum-design/momentum-react-v2/blob/master/README.md)
* [Getting Started Guide](https://github.com/momentum-design/momentum-react-v2/blob/master/GETTING_STARTED.md)
* [Contributing Guide](https://github.com/momentum-design/momentum-react-v2/blob/master/CONTRIBUTING.md)

# Description
NavigationTab size needs to be altered when in expanded state especially height and tab-count position.

# Links
[
*Links to relevent resources.*](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-472770)
