### PR TITLE
fix(fonts): safari support for inter

### DIFF
--- a/src/components/ThemeProvider/ThemeProvider.style.scss
+++ b/src/components/ThemeProvider/ThemeProvider.style.scss
@@ -4,6 +4,7 @@
   src: url('../../fonts/Inter.var.woff2') format('woff2');
   font-style: normal;
   font-display: swap;
+  font-weight: 1 1000; /* Required for Safari support */
 }
 
 .md-theme-provider-wrapper {


### PR DESCRIPTION
# Description

The scope of the changes in this pull request are to fix Safari support for the provided Inter font. Without specifying the scope of a font-face, such as our `inter` font, safari only respects the default font size for a specific font (normal).

To reproduce this, open the *storybook* and browse to `text`. From `text`, add `font-weight` to the style of `750` while using the Safari browser.

# Links

* [Task](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-464615)

# Screenshots

## Safari Before

![Screenshot 2023-11-20 at 11 12 36](https://github.com/momentum-design/momentum-react-v2/assets/14828820/a27d718b-7c3c-4b20-995f-458ad8f95915)

## Safari After

![Screenshot 2023-11-20 at 11 12 19](https://github.com/momentum-design/momentum-react-v2/assets/14828820/8c75edc0-746f-4c75-8406-051640b85809)

## Chrome Before

![Screenshot 2023-11-20 at 11 15 17](https://github.com/momentum-design/momentum-react-v2/assets/14828820/6d910461-2f87-4a24-9942-77b89272fcb4)

## Chrome After

![Screenshot 2023-11-20 at 11 14 06](https://github.com/momentum-design/momentum-react-v2/assets/14828820/95692e98-cedf-4a1f-803d-afc08ac13815)