### PR TITLE
feat(text-input): add max len property

### DIFF
--- a/src/components/TextInput/TextInput.stories.tsx
+++ b/src/components/TextInput/TextInput.stories.tsx
@@ -39,6 +39,10 @@ export default {
       description: 'The label for the input',
       control: { type: 'text' },
     },
+    inputMaxLen: {
+      description: 'The max amount of characters that this input should allow',
+      control: { type: 'number' },
+    },
     className: {
       description:
         'If present, the class name will be added to the underlying component. Used to override styles by consumers.',

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -23,6 +23,7 @@ const TextInput = (props: Props, ref: RefObject<HTMLInputElement>): ReactElement
     isDisabled,
     style,
     id,
+    inputMaxLen,
   } = props;
 
   const componentRef = React.useRef<HTMLInputElement>();
@@ -73,6 +74,7 @@ const TextInput = (props: Props, ref: RefObject<HTMLInputElement>): ReactElement
           {...focusProps}
           className={inputClassName}
           ref={inputRef}
+          maxLength={inputMaxLen}
         />
         {!!state.value && (
           <ButtonSimple

--- a/src/components/TextInput/TextInput.types.ts
+++ b/src/components/TextInput/TextInput.types.ts
@@ -35,4 +35,8 @@ export interface Props extends Omit<AriaTextFieldProps, 'errorMessage'> {
    * Array of Messages with message and type to display below the input
    */
   messageArr?: Message[];
+  /**
+   * Max amount of characters the input should allow
+   */
+  inputMaxLen?: number;
 }

--- a/src/components/TextInput/TextInput.unit.test.tsx
+++ b/src/components/TextInput/TextInput.unit.test.tsx
@@ -74,6 +74,14 @@ describe('<TextInput/>', () => {
 
       expect(container).toMatchSnapshot();
     });
+
+    it('should match snapshot with inputMaxLen', async () => {
+      expect.assertions(1);
+
+      const container = await mountComponent(<TextInput aria-label="text-input" inputMaxLen={4} />);
+
+      expect(container).toMatchSnapshot();
+    });
   });
 
   describe('attributes', () => {
@@ -124,6 +132,27 @@ describe('<TextInput/>', () => {
         .getDOMNode();
 
       expect(element.getAttribute('style')).toBe(styleString);
+    });
+
+    it('should have provided inputMaxLen when inputMaxLen is provided', async () => {
+      expect.assertions(1);
+
+      const inputMaxLen = 8;
+      const inputClassName = 'fake-class-name';
+
+      const element = (
+        await mountAndWait(
+          <TextInput
+            aria-label="text-input"
+            inputMaxLen={inputMaxLen}
+            inputClassName={inputClassName}
+          />
+        )
+      )
+        .find(`.${inputClassName}`)
+        .getDOMNode();
+
+      expect(element.getAttribute('maxLength')).toBe(`${inputMaxLen}`);
     });
   });
 

--- a/src/components/TextInput/TextInput.unit.test.tsx.snap
+++ b/src/components/TextInput/TextInput.unit.test.tsx.snap
@@ -252,6 +252,38 @@ exports[`<TextInput/> snapshot should match snapshot with id 1`] = `
 </SSRProvider>
 `;
 
+exports[`<TextInput/> snapshot should match snapshot with inputMaxLen 1`] = `
+<SSRProvider>
+  <TextInput
+    aria-label="text-input"
+    inputMaxLen={4}
+  >
+    <div
+      className="md-text-input-wrapper"
+      data-focus={false}
+      data-level="none"
+      onClick={[Function]}
+    >
+      <div
+        className="md-text-input-container"
+      >
+        <input
+          aria-label="text-input"
+          disabled={false}
+          id="test-ID"
+          maxLength={4}
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          readOnly={false}
+          type="text"
+        />
+      </div>
+    </div>
+  </TextInput>
+</SSRProvider>
+`;
+
 exports[`<TextInput/> snapshot should match snapshot with style 1`] = `
 <SSRProvider>
   <TextInput


### PR DESCRIPTION
# Description

To address, [SPARK-488197](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-488197), I added a inputMaxLen optional property to TextInput to allow consume to specify tha max amount of chars the UI should allow the user to input. 
