### PR TITLE
fix(csp): use lottie-light to avoid eval()

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true,
+    "source.fixAll.eslint": "explicit"
   }
 }

--- a/src/components/Reaction/Reaction.tsx
+++ b/src/components/Reaction/Reaction.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useRef, useEffect } from 'react';
 import classnames from 'classnames';
-import lottie, { AnimationItem } from 'lottie-web';
+import lottie, { AnimationItem } from 'lottie-web/build/player/lottie_light';
 import { useDynamicJSONImport } from '../../hooks/useDynamicJSONImport';
 
 import { DEFAULTS, STYLE } from './Reaction.constants';

--- a/src/components/Reaction/Reaction.unit.test.tsx
+++ b/src/components/Reaction/Reaction.unit.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { mountAndWait } from '../../../test/utils';
 
 import Reaction, { REACTION_CONSTANTS as CONSTANTS } from './';
-import lottie from 'lottie-web';
+import lottie from 'lottie-web/build/player/lottie_light';
 import * as jsonImport from '../../hooks/useDynamicJSONImport';
 import { REACTIONS, STYLE } from './Reaction.constants';
 import { GLYPH_NOT_FOUND } from '../Icon/Icon.constants';


### PR DESCRIPTION
# IMPORTANT

**Currently, this project is closed to any external contributions. Any pull request made against this project from external sources will likely be closed. If you would like to make changes to this project, please fork this project.**

# Guide

**This "Help" section can be deleted before submitting this pull request.**

*Update the name of this pull request to reflect the following shape:*

```
{type}/{scope?}/{message}
```

* **type** - A [conventional commit type](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional#type-enum) **REQUIRED**
* **scope** - The kabab-case scope of the changes in this request
* **message** - A short, kebab-case statement describing the changes **REQUIRED**

*Provide a general summary of the scope of the changes in this pull request.*

* [Readme](https://github.com/momentum-design/momentum-react-v2/blob/master/README.md)
* [Getting Started Guide](https://github.com/momentum-design/momentum-react-v2/blob/master/GETTING_STARTED.md)
* [Contributing Guide](https://github.com/momentum-design/momentum-react-v2/blob/master/CONTRIBUTING.md)

# Description
lottie uses `eval()` which is not considered secure and will cause issues with CSP. it uses this to evaluate expressions on animations. i don't believe we use any of that functionality and lottie-light does not use eval()

# Links
https://github.com/airbnb/lottie-web/issues/2173