### PR TITLE
Fix(SearchInput): Fix tab navigation to close button in SearchInput component

### DIFF
--- a/src/components/SearchInput/SearchInput.tsx
+++ b/src/components/SearchInput/SearchInput.tsx
@@ -77,6 +77,8 @@ const SearchInput = (props: Props, ref: RefObject<HTMLInputElement>): ReactEleme
           className={STYLE.clear}
           {...clearButtonProps}
           aria-label={clearButtonAriaLabel}
+          excludeFromTabOrder={false}
+          useNativeKeyDown={true}
         >
           <Icon weight="bold" scale={ICON_HEIGHT_MAPPING[height]} name="cancel" />
         </ButtonSimple>

--- a/src/components/SearchInput/SearchInput.unit.test.tsx
+++ b/src/components/SearchInput/SearchInput.unit.test.tsx
@@ -5,6 +5,7 @@ import { mountAndWait } from '../../../test/utils';
 import Icon from '../Icon';
 import SearchInput, { SEARCH_INPUT_CONSTANTS as CONSTANTS } from '.';
 import { act } from 'react-dom/test-utils';
+import ButtonSimple from '../ButtonSimple';
 
 const testTranslations = {
   empty: 'empty',
@@ -214,6 +215,34 @@ describe('<SearchInput />', () => {
     it('should work with autofocus', async () => {
       // eslint-disable-next-line jsx-a11y/no-autofocus
       await mountAndWait(<SearchInput autoFocus aria-label="search" value="test" />);
+    });
+
+    it('should not render ButtonSimple if there is no value', async () => {
+      const container = await mountAndWait(<SearchInput autoFocus aria-label="search" value="" isDisabled={false} clearButtonAriaLabel="clear search"/>);
+
+      expect(container.find(ButtonSimple).exists()).toBe(false);
+    });
+
+    it('should not render ButtonSimple if isDisabled is false', async () => {
+      const container = await mountAndWait(<SearchInput autoFocus aria-label="search" value="test" isDisabled={true} clearButtonAriaLabel="clear search"/>);
+
+      expect(container.find(ButtonSimple).exists()).toBe(false);
+    });
+
+    it('should render ButtonSimple if there is a value and isDisabled is false', async () => {
+      const container = await mountAndWait(<SearchInput autoFocus aria-label="search" value="test" isDisabled={false} clearButtonAriaLabel="clear search" />);
+
+      expect(container.find(ButtonSimple).exists()).toBe(true);
+
+      expect(container.find(ButtonSimple).props()).toMatchObject({
+        className: 'md-search-input-clear',
+        'aria-label': 'clear search',
+        excludeFromTabOrder: false,
+        preventFocusOnPress: true,
+        onPress: expect.any(Function),
+        onPressStart: expect.any(Function),
+        useNativeKeyDown: true,
+      })
     });
   });
 

--- a/src/components/SearchInput/SearchInput.unit.test.tsx
+++ b/src/components/SearchInput/SearchInput.unit.test.tsx
@@ -218,19 +218,19 @@ describe('<SearchInput />', () => {
     });
 
     it('should not render ButtonSimple if there is no value', async () => {
-      const container = await mountAndWait(<SearchInput autoFocus aria-label="search" value="" isDisabled={false} clearButtonAriaLabel="clear search"/>);
+      const container = await mountAndWait(<SearchInput aria-label="search" value="" isDisabled={false} clearButtonAriaLabel="clear search"/>);
 
       expect(container.find(ButtonSimple).exists()).toBe(false);
     });
 
     it('should not render ButtonSimple if isDisabled is false', async () => {
-      const container = await mountAndWait(<SearchInput autoFocus aria-label="search" value="test" isDisabled={true} clearButtonAriaLabel="clear search"/>);
+      const container = await mountAndWait(<SearchInput aria-label="search" value="test" isDisabled={true} clearButtonAriaLabel="clear search"/>);
 
       expect(container.find(ButtonSimple).exists()).toBe(false);
     });
 
     it('should render ButtonSimple if there is a value and isDisabled is false', async () => {
-      const container = await mountAndWait(<SearchInput autoFocus aria-label="search" value="test" isDisabled={false} clearButtonAriaLabel="clear search" />);
+      const container = await mountAndWait(<SearchInput aria-label="search" value="test" isDisabled={false} clearButtonAriaLabel="clear search" />);
 
       expect(container.find(ButtonSimple).exists()).toBe(true);
 

--- a/src/components/SearchInput/SearchInput.unit.test.tsx.snap
+++ b/src/components/SearchInput/SearchInput.unit.test.tsx.snap
@@ -157,10 +157,11 @@ exports[`<SearchInput /> snapshot should match snapshot when filters are set 1`]
       </div>
       <ButtonSimple
         className="md-search-input-clear"
-        excludeFromTabOrder={true}
+        excludeFromTabOrder={false}
         onPress={[Function]}
         onPressStart={[Function]}
         preventFocusOnPress={true}
+        useNativeKeyDown={true}
       >
         <FocusRing>
           <FocusRing
@@ -173,7 +174,6 @@ exports[`<SearchInput /> snapshot should match snapshot when filters are set 1`]
               onClick={[Function]}
               onDragStart={[Function]}
               onFocus={[Function]}
-              onKeyDown={[Function]}
               onKeyUp={[Function]}
               onMouseDown={[Function]}
               onMouseEnter={[Function]}
@@ -183,7 +183,6 @@ exports[`<SearchInput /> snapshot should match snapshot when filters are set 1`]
               onTouchEnd={[Function]}
               onTouchMove={[Function]}
               onTouchStart={[Function]}
-              tabIndex={-1}
               type="button"
             >
               <Icon


### PR DESCRIPTION
# Description
This pull request addresses the bug where pressing the Tab key was not navigating to the "X" button on the Search textbox. Added the following props to `<ButtonSimple />` inside `<SearchInput />`
- Updated event listener to handle Tab key press by setting `useNativeKeyDown` to true
- Implemented logic to focus on the "X" button when Tab key is pressed by setting `excludeFromTabOrder` to false 

# Links
Press Tab to navigate to the “X” button on the Search textbox [SPARK-522081](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-522081)
