### PR TITLE
fix: add close button accessible name props to ToastNotification

### DIFF
--- a/src/components/NotificationSystem/NotificationSystem.unit.test.tsx.snap
+++ b/src/components/NotificationSystem/NotificationSystem.unit.test.tsx.snap
@@ -67,6 +67,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot 1`] = `
                     class="md-toast-notification-close-button"
                   >
                     <button
+                      aria-label="Close notification"
                       class="md-button-circle-wrapper md-button-simple-wrapper"
                       data-color="primary"
                       data-disabled="false"
@@ -178,6 +179,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot if notification c
                     class="md-toast-notification-close-button"
                   >
                     <button
+                      aria-label="Close notification"
                       class="md-button-circle-wrapper md-button-simple-wrapper"
                       data-color="primary"
                       data-disabled="false"
@@ -290,6 +292,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot if notification c
                     class="md-toast-notification-close-button"
                   >
                     <button
+                      aria-label="Close notification"
                       class="md-button-circle-wrapper md-button-simple-wrapper"
                       data-color="primary"
                       data-disabled="false"
@@ -402,6 +405,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot when limit is set
                     class="md-toast-notification-close-button"
                   >
                     <button
+                      aria-label="Close notification"
                       class="md-button-circle-wrapper md-button-simple-wrapper"
                       data-color="primary"
                       data-disabled="false"
@@ -514,6 +518,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with body class n
                     class="md-toast-notification-close-button"
                   >
                     <button
+                      aria-label="Close notification"
                       class="md-button-circle-wrapper md-button-simple-wrapper"
                       data-color="primary"
                       data-disabled="false"
@@ -626,6 +631,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with className 1`
                     class="md-toast-notification-close-button"
                   >
                     <button
+                      aria-label="Close notification"
                       class="md-button-circle-wrapper md-button-simple-wrapper"
                       data-color="primary"
                       data-disabled="false"
@@ -738,6 +744,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with container cl
                     class="md-toast-notification-close-button"
                   >
                     <button
+                      aria-label="Close notification"
                       class="md-button-circle-wrapper md-button-simple-wrapper"
                       data-color="primary"
                       data-disabled="false"
@@ -846,6 +853,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with different at
                     class="md-toast-notification-close-button"
                   >
                     <button
+                      aria-label="Close notification"
                       class="md-button-circle-wrapper md-button-simple-wrapper"
                       data-color="primary"
                       data-disabled="false"
@@ -951,6 +959,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with different po
                     class="md-toast-notification-close-button"
                   >
                     <button
+                      aria-label="Close notification"
                       class="md-button-circle-wrapper md-button-simple-wrapper"
                       data-color="primary"
                       data-disabled="false"
@@ -1067,6 +1076,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with different zI
                     class="md-toast-notification-close-button"
                   >
                     <button
+                      aria-label="Close notification"
                       class="md-button-circle-wrapper md-button-simple-wrapper"
                       data-color="primary"
                       data-disabled="false"
@@ -1179,6 +1189,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with enter animat
                     class="md-toast-notification-close-button"
                   >
                     <button
+                      aria-label="Close notification"
                       class="md-button-circle-wrapper md-button-simple-wrapper"
                       data-color="primary"
                       data-disabled="false"
@@ -1291,6 +1302,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with id 1`] = `
                     class="md-toast-notification-close-button"
                   >
                     <button
+                      aria-label="Close notification"
                       class="md-button-circle-wrapper md-button-simple-wrapper"
                       data-color="primary"
                       data-disabled="false"
@@ -1403,6 +1415,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with newest on to
                     class="md-toast-notification-close-button"
                   >
                     <button
+                      aria-label="Close notification"
                       class="md-button-circle-wrapper md-button-simple-wrapper"
                       data-color="primary"
                       data-disabled="false"
@@ -1515,6 +1528,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with style 1`] = 
                     class="md-toast-notification-close-button"
                   >
                     <button
+                      aria-label="Close notification"
                       class="md-button-circle-wrapper md-button-simple-wrapper"
                       data-color="primary"
                       data-disabled="false"
@@ -1627,6 +1641,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with toast class 
                     class="md-toast-notification-close-button"
                   >
                     <button
+                      aria-label="Close notification"
                       class="md-button-circle-wrapper md-button-simple-wrapper"
                       data-color="primary"
                       data-disabled="false"

--- a/src/components/ToastNotification/ToastNotification.constants.ts
+++ b/src/components/ToastNotification/ToastNotification.constants.ts
@@ -1,6 +1,8 @@
 const CLASS_PREFIX = 'md-toast-notification';
 
-const DEFAULTS = {};
+const DEFAULTS = {
+  CLOSE_BUTTON_LABEL: 'Close notification',
+};
 
 const STYLE = {
   wrapper: `${CLASS_PREFIX}-wrapper`,

--- a/src/components/ToastNotification/ToastNotification.stories.args.ts
+++ b/src/components/ToastNotification/ToastNotification.stories.args.ts
@@ -13,6 +13,18 @@ const toastNotificationArgTypes = {
       },
     },
   },
+  closeButtonLabel: {
+    description: 'Accessible name of the close button',
+    control: { type: 'text' },
+    table: {
+      type: {
+        summary: 'string',
+      },
+      defaultValue: {
+        summary: 'undefined',
+      },
+    },
+  },
 };
 
 export { toastNotificationArgTypes };

--- a/src/components/ToastNotification/ToastNotification.tsx
+++ b/src/components/ToastNotification/ToastNotification.tsx
@@ -14,7 +14,8 @@ import Text from '../Text';
  * The ToastNotification component.
  */
 const ToastNotification: FC<Props> = (props: Props) => {
-  const { className, id, style, content, leadingVisual, buttonGroup, onClose } = props;
+  const { className, id, style, content, leadingVisual, buttonGroup, onClose, closeButtonLabel } =
+    props;
 
   return (
     <ModalContainer
@@ -37,7 +38,7 @@ const ToastNotification: FC<Props> = (props: Props) => {
         )}
         {onClose && (
           <div className={classnames(className, STYLE.closeButton)}>
-            <ButtonCircle size={20} ghost onPress={onClose}>
+            <ButtonCircle size={20} ghost onPress={onClose} aria-label={closeButtonLabel}>
               <Icon name="cancel" weight="bold" scale={16} />
             </ButtonCircle>
           </div>

--- a/src/components/ToastNotification/ToastNotification.tsx
+++ b/src/components/ToastNotification/ToastNotification.tsx
@@ -5,7 +5,7 @@ import ModalContainer from '../ModalContainer';
 import ButtonCircle from '../ButtonCircle';
 import Icon from '../Icon';
 
-import { STYLE } from './ToastNotification.constants';
+import { STYLE, DEFAULTS } from './ToastNotification.constants';
 import { Props } from './ToastNotification.types';
 import './ToastNotification.style.scss';
 import Text from '../Text';
@@ -14,8 +14,16 @@ import Text from '../Text';
  * The ToastNotification component.
  */
 const ToastNotification: FC<Props> = (props: Props) => {
-  const { className, id, style, content, leadingVisual, buttonGroup, onClose, closeButtonLabel } =
-    props;
+  const {
+    className,
+    id,
+    style,
+    content,
+    leadingVisual,
+    buttonGroup,
+    onClose,
+    closeButtonLabel = DEFAULTS.CLOSE_BUTTON_LABEL,
+  } = props;
 
   return (
     <ModalContainer

--- a/src/components/ToastNotification/ToastNotification.types.ts
+++ b/src/components/ToastNotification/ToastNotification.types.ts
@@ -44,4 +44,9 @@ export interface Props {
    * Callback when user clicks on the close button.
    */
   onClose?: (event: PressEvent) => void;
+
+  /**
+   * Close button's aria-label
+   */
+  closeButtonLabel?: string;
 }

--- a/src/components/ToastNotification/ToastNotification.unit.test.tsx
+++ b/src/components/ToastNotification/ToastNotification.unit.test.tsx
@@ -169,7 +169,7 @@ describe('<ToastNotification />', () => {
       const button = wrapper.find('.md-toast-notification-close-button button');
 
       expect(element).toBeDefined();
-      expect(button.props()['aria-label']).toBe(undefined);
+      expect(button.props()['aria-label']).toBe(CONSTANTS.DEFAULTS.CLOSE_BUTTON_LABEL);
     });
 
     it('should have label of the close button when both onClose and closeButtonLabel defined', async () => {

--- a/src/components/ToastNotification/ToastNotification.unit.test.tsx
+++ b/src/components/ToastNotification/ToastNotification.unit.test.tsx
@@ -65,7 +65,9 @@ describe('<ToastNotification />', () => {
 
       const style = { color: 'pink' };
 
-      const container = await mountAndWait(<ToastNotification style={style} content={exampleContent} />);
+      const container = await mountAndWait(
+        <ToastNotification style={style} content={exampleContent} />
+      );
 
       expect(container).toMatchSnapshot();
     });
@@ -158,14 +160,29 @@ describe('<ToastNotification />', () => {
     });
 
     it('should wrap the onClose inside when onClose is provided', async () => {
-      expect.assertions(1);
+      expect.assertions(2);
 
       const wrapper = await mountAndWait(
         <ToastNotification onClose={onClose} content={exampleContent} />
       );
       const element = wrapper.find('.md-toast-notification-close-button').getDOMNode();
+      const button = wrapper.find('.md-toast-notification-close-button button');
 
       expect(element).toBeDefined();
+      expect(button.props()['aria-label']).toBe(undefined);
+    });
+
+    it('should have label of the close button when both onClose and closeButtonLabel defined', async () => {
+      expect.assertions(2);
+
+      const wrapper = await mountAndWait(
+        <ToastNotification onClose={onClose} closeButtonLabel={'close'} content={exampleContent} />
+      );
+      const element = wrapper.find('.md-toast-notification-close-button').getDOMNode();
+      const button = wrapper.find('.md-toast-notification-close-button button');
+
+      expect(element).toBeDefined();
+      expect(button.props()['aria-label']).toBe('close');
     });
 
     it('should wrap Icon inside leadingVisual when Icon is provided', async () => {


### PR DESCRIPTION
# Description

Add new prop to ToastNotification to fix the missing accessible label on the close button

# Links

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-505339