### PR TITLE
feat(icons): add ariaLabel props to icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "@babel/runtime": "^7.0.0",
     "@momentum-design/animations": "^0.0.4",
     "@momentum-design/icons": "0.0.68",
-    "@momentum-design/tokens": "^0.0.44",
+    "@momentum-design/tokens": "^0.0.51",
     "@momentum-ui/design-tokens": "^0.0.63",
     "@momentum-ui/icons": "8.28.4",
     "@momentum-ui/tokens": "^1.7.1",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "@babel/runtime": "^7.0.0",
     "@momentum-design/animations": "^0.0.4",
     "@momentum-design/icons": "0.0.68",
-    "@momentum-design/tokens": "^0.0.51",
+    "@momentum-design/tokens": "^0.0.44",
     "@momentum-ui/design-tokens": "^0.0.63",
     "@momentum-ui/icons": "8.28.4",
     "@momentum-ui/tokens": "^1.7.1",

--- a/src/components/AddReactionButton/AddReactionButton.unit.test.tsx.snap
+++ b/src/components/AddReactionButton/AddReactionButton.unit.test.tsx.snap
@@ -53,9 +53,12 @@ exports[`<AddReactionButton /> snapshot should match snapshot 1`] = `
               scale={12}
             >
               <div
+                aria-hidden="true"
                 className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                role="img"
               >
                 <svg
+                  aria-hidden="true"
                   className=""
                   data-autoscale={false}
                   data-scale={12}
@@ -131,9 +134,12 @@ exports[`<AddReactionButton /> snapshot should match snapshot with className 1`]
               scale={12}
             >
               <div
+                aria-hidden="true"
                 className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                role="img"
               >
                 <svg
+                  aria-hidden="true"
                   className=""
                   data-autoscale={false}
                   data-scale={12}
@@ -212,9 +218,12 @@ exports[`<AddReactionButton /> snapshot should match snapshot with id 1`] = `
               scale={12}
             >
               <div
+                aria-hidden="true"
                 className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                role="img"
               >
                 <svg
+                  aria-hidden="true"
                   className=""
                   data-autoscale={false}
                   data-scale={12}
@@ -309,9 +318,12 @@ exports[`<AddReactionButton /> snapshot should match snapshot with style 1`] = `
               scale={12}
             >
               <div
+                aria-hidden="true"
                 className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                role="img"
               >
                 <svg
+                  aria-hidden="true"
                   className=""
                   data-autoscale={false}
                   data-scale={12}

--- a/src/components/Avatar/Avatar.unit.test.tsx.snap
+++ b/src/components/Avatar/Avatar.unit.test.tsx.snap
@@ -65,9 +65,12 @@ exports[`Avatar snapshot should match snapshot with failureBadge 1`] = `
           weight="filled"
         >
           <div
+            aria-hidden="true"
             className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+            role="img"
           >
             <svg
+              aria-hidden="true"
               className=""
               data-autoscale={false}
               data-scale={14}
@@ -132,9 +135,12 @@ exports[`Avatar snapshot should match snapshot with icon 1`] = `
       weight="bold"
     >
       <div
+        aria-hidden="true"
         className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-avatar-wrapper-children md-avatar-icon-wrapper md-icon-no-shrink"
+        role="img"
       >
         <svg
+          aria-hidden="true"
           className=""
           data-autoscale={false}
           data-scale={16}
@@ -355,9 +361,12 @@ exports[`Avatar snapshot should match snapshot with presence 1`] = `
             weight="filled"
           >
             <div
+              aria-hidden="true"
               className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+              role="img"
             >
               <svg
+                aria-hidden="true"
                 className=""
                 data-autoscale={false}
                 data-scale={14}
@@ -418,9 +427,12 @@ exports[`Avatar snapshot should match snapshot with presence 1`] = `
             weight="filled"
           >
             <div
+              aria-hidden="true"
               className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+              role="img"
             >
               <svg
+                aria-hidden="true"
                 className=""
                 data-autoscale={false}
                 data-scale={14}
@@ -481,9 +493,12 @@ exports[`Avatar snapshot should match snapshot with presence 1`] = `
             weight="filled"
           >
             <div
+              aria-hidden="true"
               className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+              role="img"
             >
               <svg
+                aria-hidden="true"
                 className=""
                 data-autoscale={false}
                 data-scale={14}
@@ -544,9 +559,12 @@ exports[`Avatar snapshot should match snapshot with presence 1`] = `
             weight="filled"
           >
             <div
+              aria-hidden="true"
               className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+              role="img"
             >
               <svg
+                aria-hidden="true"
                 className=""
                 data-autoscale={false}
                 data-scale={14}
@@ -607,9 +625,12 @@ exports[`Avatar snapshot should match snapshot with presence 1`] = `
             weight="filled"
           >
             <div
+              aria-hidden="true"
               className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+              role="img"
             >
               <svg
+                aria-hidden="true"
                 className=""
                 data-autoscale={false}
                 data-scale={14}
@@ -670,9 +691,12 @@ exports[`Avatar snapshot should match snapshot with presence 1`] = `
             weight="filled"
           >
             <div
+              aria-hidden="true"
               className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+              role="img"
             >
               <svg
+                aria-hidden="true"
                 className=""
                 data-autoscale={false}
                 data-scale={14}
@@ -733,9 +757,12 @@ exports[`Avatar snapshot should match snapshot with presence 1`] = `
             weight="filled"
           >
             <div
+              aria-hidden="true"
               className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+              role="img"
             >
               <svg
+                aria-hidden="true"
                 className=""
                 data-autoscale={false}
                 data-scale={14}
@@ -796,9 +823,12 @@ exports[`Avatar snapshot should match snapshot with presence 1`] = `
             weight="filled"
           >
             <div
+              aria-hidden="true"
               className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+              role="img"
             >
               <svg
+                aria-hidden="true"
                 className=""
                 data-autoscale={false}
                 data-scale={14}
@@ -859,9 +889,12 @@ exports[`Avatar snapshot should match snapshot with presence 1`] = `
             weight="filled"
           >
             <div
+              aria-hidden="true"
               className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+              role="img"
             >
               <svg
+                aria-hidden="true"
                 className=""
                 data-autoscale={false}
                 data-scale={14}
@@ -922,9 +955,12 @@ exports[`Avatar snapshot should match snapshot with presence 1`] = `
             weight="bold"
           >
             <div
+              aria-hidden="true"
               className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+              role="img"
             >
               <svg
+                aria-hidden="true"
                 className=""
                 data-autoscale={false}
                 data-scale={14}
@@ -985,9 +1021,12 @@ exports[`Avatar snapshot should match snapshot with presence 1`] = `
             weight="filled"
           >
             <div
+              aria-hidden="true"
               className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+              role="img"
             >
               <svg
+                aria-hidden="true"
                 className=""
                 data-autoscale={false}
                 data-scale={14}
@@ -1048,9 +1087,12 @@ exports[`Avatar snapshot should match snapshot with presence 1`] = `
             weight="filled"
           >
             <div
+              aria-hidden="true"
               className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+              role="img"
             >
               <svg
+                aria-hidden="true"
                 className=""
                 data-autoscale={false}
                 data-scale={14}
@@ -1111,9 +1153,12 @@ exports[`Avatar snapshot should match snapshot with presence 1`] = `
             weight="filled"
           >
             <div
+              aria-hidden="true"
               className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+              role="img"
             >
               <svg
+                aria-hidden="true"
                 className=""
                 data-autoscale={false}
                 data-scale={14}

--- a/src/components/AvatarMeetingsListItem/AvatarMeetingsListItem.unit.test.tsx.snap
+++ b/src/components/AvatarMeetingsListItem/AvatarMeetingsListItem.unit.test.tsx.snap
@@ -204,9 +204,12 @@ exports[`<AvatarMeetingsListItem /> snapshot should match snapshot with avatarPr
                         weight="filled"
                       >
                         <div
+                          aria-hidden="true"
                           className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                          role="img"
                         >
                           <svg
+                            aria-hidden="true"
                             className=""
                             data-autoscale={false}
                             data-scale={14}
@@ -535,9 +538,12 @@ exports[`<AvatarMeetingsListItem /> snapshot should match snapshot with displayM
                           weight="bold"
                         >
                           <div
+                            aria-hidden="true"
                             className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                            role="img"
                           >
                             <svg
+                              aria-hidden="true"
                               className=""
                               data-autoscale={false}
                               data-scale={16}
@@ -726,9 +732,12 @@ exports[`<AvatarMeetingsListItem /> snapshot should match snapshot with displayM
                           weight="bold"
                         >
                           <div
+                            aria-hidden="true"
                             className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                            role="img"
                           >
                             <svg
+                              aria-hidden="true"
                               className=""
                               data-autoscale={false}
                               data-scale={16}
@@ -920,9 +929,12 @@ exports[`<AvatarMeetingsListItem /> snapshot should match snapshot with displayM
                           weight="bold"
                         >
                           <div
+                            aria-hidden="true"
                             className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                            role="img"
                           >
                             <svg
+                              aria-hidden="true"
                               className=""
                               data-autoscale={false}
                               data-scale={16}
@@ -1270,9 +1282,12 @@ exports[`<AvatarMeetingsListItem /> snapshot should match snapshot with schedule
                 weight="bold"
               >
                 <div
+                  aria-hidden="true"
                   className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                  role="img"
                 >
                   <svg
+                    aria-hidden="true"
                     className=""
                     data-autoscale={false}
                     data-scale={16}
@@ -1408,9 +1423,12 @@ exports[`<AvatarMeetingsListItem /> snapshot should match snapshot with schedule
                 weight="bold"
               >
                 <div
+                  aria-hidden="true"
                   className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                  role="img"
                 >
                   <svg
+                    aria-hidden="true"
                     className=""
                     data-autoscale={false}
                     data-scale={16}
@@ -1546,9 +1564,12 @@ exports[`<AvatarMeetingsListItem /> snapshot should match snapshot with schedule
                 weight="bold"
               >
                 <div
+                  aria-hidden="true"
                   className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                  role="img"
                 >
                   <svg
+                    aria-hidden="true"
                     className=""
                     data-autoscale={false}
                     data-scale={16}
@@ -1684,9 +1705,12 @@ exports[`<AvatarMeetingsListItem /> snapshot should match snapshot with schedule
                 weight="bold"
               >
                 <div
+                  aria-hidden="true"
                   className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                  role="img"
                 >
                   <svg
+                    aria-hidden="true"
                     className=""
                     data-autoscale={false}
                     data-scale={16}

--- a/src/components/Banner/Banner.unit.test.tsx.snap
+++ b/src/components/Banner/Banner.unit.test.tsx.snap
@@ -167,9 +167,12 @@ exports[`<Banner /> snapshot should match a complex snapshot 1`] = `
                       name="camera"
                     >
                       <div
+                        aria-hidden="true"
                         className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+                        role="img"
                       >
                         <svg
+                          aria-hidden="true"
                           className=""
                           data-autoscale={125}
                           data-scale={false}
@@ -237,9 +240,12 @@ exports[`<Banner /> snapshot should match a complex snapshot 1`] = `
                       name="cancel"
                     >
                       <div
+                        aria-hidden="true"
                         className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+                        role="img"
                       >
                         <svg
+                          aria-hidden="true"
                           className=""
                           data-autoscale={125}
                           data-scale={false}
@@ -433,9 +439,12 @@ exports[`<Banner /> snapshot should match snapshot with actions 1`] = `
                       name="camera"
                     >
                       <div
+                        aria-hidden="true"
                         className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+                        role="img"
                       >
                         <svg
+                          aria-hidden="true"
                           className=""
                           data-autoscale={125}
                           data-scale={false}
@@ -503,9 +512,12 @@ exports[`<Banner /> snapshot should match snapshot with actions 1`] = `
                       name="cancel"
                     >
                       <div
+                        aria-hidden="true"
                         className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+                        role="img"
                       >
                         <svg
+                          aria-hidden="true"
                           className=""
                           data-autoscale={125}
                           data-scale={false}

--- a/src/components/ButtonControl/ButtonControl.unit.test.tsx.snap
+++ b/src/components/ButtonControl/ButtonControl.unit.test.tsx.snap
@@ -36,9 +36,12 @@ exports[`<ButtonControl /> snapshot should match snapshot 1`] = `
             weight="bold"
           >
             <div
+              aria-hidden="true"
               className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+              role="img"
             >
               <svg
+                aria-hidden="true"
                 className=""
                 data-autoscale={true}
                 data-scale={false}
@@ -95,9 +98,12 @@ exports[`<ButtonControl /> snapshot should match snapshot with className 1`] = `
             weight="bold"
           >
             <div
+              aria-hidden="true"
               className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+              role="img"
             >
               <svg
+                aria-hidden="true"
                 className=""
                 data-autoscale={true}
                 data-scale={false}
@@ -156,9 +162,12 @@ exports[`<ButtonControl /> snapshot should match snapshot with id 1`] = `
             weight="bold"
           >
             <div
+              aria-hidden="true"
               className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+              role="img"
             >
               <svg
+                aria-hidden="true"
                 className=""
                 data-autoscale={true}
                 data-scale={false}
@@ -217,9 +226,12 @@ exports[`<ButtonControl /> snapshot should match snapshot with isCircular 1`] = 
             weight="bold"
           >
             <div
+              aria-hidden="true"
               className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+              role="img"
             >
               <svg
+                aria-hidden="true"
                 className=""
                 data-autoscale={true}
                 data-scale={false}
@@ -283,9 +295,12 @@ exports[`<ButtonControl /> snapshot should match snapshot with isDisabled 1`] = 
             weight="bold"
           >
             <div
+              aria-hidden="true"
               className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+              role="img"
             >
               <svg
+                aria-hidden="true"
                 className=""
                 data-autoscale={true}
                 data-scale={false}
@@ -356,9 +371,12 @@ exports[`<ButtonControl /> snapshot should match snapshot with style 1`] = `
             weight="bold"
           >
             <div
+              aria-hidden="true"
               className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+              role="img"
             >
               <svg
+                aria-hidden="true"
                 className=""
                 data-autoscale={true}
                 data-scale={false}

--- a/src/components/Checkbox/Checkbox.unit.test.tsx.snap
+++ b/src/components/Checkbox/Checkbox.unit.test.tsx.snap
@@ -278,9 +278,12 @@ exports[`<Checkbox /> snapshot should match snapshot with indeterminate checkbox
         weight="bold"
       >
         <div
+          aria-hidden="true"
           className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-checkbox-icon md-icon-no-shrink"
+          role="img"
         >
           <svg
+            aria-hidden="true"
             className=""
             data-autoscale={false}
             data-scale={12}
@@ -468,9 +471,12 @@ exports[`<Checkbox /> snapshot should match snapshot with selected checkbox 1`] 
         weight="bold"
       >
         <div
+          aria-hidden="true"
           className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-checkbox-icon md-icon-no-shrink"
+          role="img"
         >
           <svg
+            aria-hidden="true"
             className=""
             data-autoscale={false}
             data-scale={12}

--- a/src/components/Coachmark/Coachmark.unit.test.tsx.snap
+++ b/src/components/Coachmark/Coachmark.unit.test.tsx.snap
@@ -27,9 +27,12 @@ exports[`<Coachmark /> snapshot should match snapshot with header 1`] = `
           class="md-coachmark-header"
         >
           <div
+            aria-hidden="true"
             class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+            role="img"
           >
             <svg
+              aria-hidden="true"
               class=""
               data-autoscale="false"
               data-scale="18"
@@ -61,9 +64,12 @@ exports[`<Coachmark /> snapshot should match snapshot with header 1`] = `
               type="button"
             >
               <div
+                aria-hidden="true"
                 class="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+                role="img"
               >
                 <svg
+                  aria-hidden="true"
                   class=""
                   data-autoscale="true"
                   data-scale="false"
@@ -256,9 +262,12 @@ exports[`<Coachmark /> snapshot should match snapshot without header 1`] = `
             type="button"
           >
             <div
+              aria-hidden="true"
               class="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+              role="img"
             >
               <svg
+                aria-hidden="true"
                 class=""
                 data-autoscale="true"
                 data-scale="false"

--- a/src/components/ComboBox/ComboBox.unit.test.tsx.snap
+++ b/src/components/ComboBox/ComboBox.unit.test.tsx.snap
@@ -146,9 +146,12 @@ exports[`ComboBox snapshot should match snapshot label 1`] = `
                   weight="filled"
                 >
                   <div
+                    aria-hidden="true"
                     className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-combo-box-arrow-icon md-icon-no-shrink"
+                    role="img"
                   >
                     <svg
+                      aria-hidden="true"
                       className=""
                       data-autoscale={false}
                       data-scale={12}
@@ -312,9 +315,12 @@ exports[`ComboBox snapshot should match snapshot with className 1`] = `
                   weight="filled"
                 >
                   <div
+                    aria-hidden="true"
                     className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-combo-box-arrow-icon md-icon-no-shrink"
+                    role="img"
                   >
                     <svg
+                      aria-hidden="true"
                       className=""
                       data-autoscale={false}
                       data-scale={12}
@@ -478,9 +484,12 @@ exports[`ComboBox snapshot should match snapshot with noResultText 1`] = `
                   weight="filled"
                 >
                   <div
+                    aria-hidden="true"
                     className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-combo-box-arrow-icon md-icon-no-shrink"
+                    role="img"
                   >
                     <svg
+                      aria-hidden="true"
                       className=""
                       data-autoscale={false}
                       data-scale={12}
@@ -644,9 +653,12 @@ exports[`ComboBox snapshot should match snapshot with placeholder 1`] = `
                   weight="filled"
                 >
                   <div
+                    aria-hidden="true"
                     className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-combo-box-arrow-icon md-icon-no-shrink"
+                    role="img"
                   >
                     <svg
+                      aria-hidden="true"
                       className=""
                       data-autoscale={false}
                       data-scale={12}
@@ -815,9 +827,12 @@ exports[`ComboBox snapshot should match snapshot with style 1`] = `
                   weight="filled"
                 >
                   <div
+                    aria-hidden="true"
                     className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-combo-box-arrow-icon md-icon-no-shrink"
+                    role="img"
                   >
                     <svg
+                      aria-hidden="true"
                       className=""
                       data-autoscale={false}
                       data-scale={12}
@@ -981,9 +996,12 @@ exports[`ComboBox snapshot should match snapshot with width 1`] = `
                   weight="filled"
                 >
                   <div
+                    aria-hidden="true"
                     className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-combo-box-arrow-icon md-icon-no-shrink"
+                    role="img"
                   >
                     <svg
+                      aria-hidden="true"
                       className=""
                       data-autoscale={false}
                       data-scale={12}
@@ -1160,9 +1178,12 @@ exports[`ComboBox snapshot should match snapshot withSection 1`] = `
                   weight="filled"
                 >
                   <div
+                    aria-hidden="true"
                     className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-combo-box-arrow-icon md-icon-no-shrink"
+                    role="img"
                   >
                     <svg
+                      aria-hidden="true"
                       className=""
                       data-autoscale={false}
                       data-scale={12}

--- a/src/components/GlobalSearchInput/GlobalSearchInput.unit.test.tsx.snap
+++ b/src/components/GlobalSearchInput/GlobalSearchInput.unit.test.tsx.snap
@@ -22,9 +22,12 @@ exports[`<GlobalSearchInput /> snapshot should match snapshot 1`] = `
           weight="light"
         >
           <div
+            aria-hidden="true"
             className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-global-search-input-search md-icon-no-shrink"
+            role="img"
           >
             <svg
+              aria-hidden="true"
               className=""
               data-autoscale={false}
               data-scale={18}
@@ -114,9 +117,12 @@ exports[`<GlobalSearchInput /> snapshot should match snapshot when filters are s
           weight="light"
         >
           <div
+            aria-hidden="true"
             className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-global-search-input-search md-icon-no-shrink"
+            role="img"
           >
             <svg
+              aria-hidden="true"
               className=""
               data-autoscale={false}
               data-scale={18}
@@ -203,9 +209,12 @@ exports[`<GlobalSearchInput /> snapshot should match snapshot when filters are s
                 scale={18}
               >
                 <div
+                  aria-hidden="true"
                   className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                  role="img"
                 >
                   <svg
+                    aria-hidden="true"
                     className=""
                     data-autoscale={false}
                     data-scale={18}
@@ -250,9 +259,12 @@ exports[`<GlobalSearchInput /> snapshot should match snapshot when searching 1`]
           weight="light"
         >
           <div
+            aria-hidden="true"
             className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-global-search-input-search md-icon-no-shrink"
+            role="img"
           >
             <svg
+              aria-hidden="true"
               className=""
               data-autoscale={false}
               data-scale={18}
@@ -314,9 +326,12 @@ exports[`<GlobalSearchInput /> snapshot should match snapshot with className 1`]
           weight="light"
         >
           <div
+            aria-hidden="true"
             className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-global-search-input-search md-icon-no-shrink"
+            role="img"
           >
             <svg
+              aria-hidden="true"
               className=""
               data-autoscale={false}
               data-scale={18}
@@ -379,9 +394,12 @@ exports[`<GlobalSearchInput /> snapshot should match snapshot with id 1`] = `
           weight="light"
         >
           <div
+            aria-hidden="true"
             className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-global-search-input-search md-icon-no-shrink"
+            role="img"
           >
             <svg
+              aria-hidden="true"
               className=""
               data-autoscale={false}
               data-scale={18}
@@ -452,9 +470,12 @@ exports[`<GlobalSearchInput /> snapshot should match snapshot with style 1`] = `
           weight="light"
         >
           <div
+            aria-hidden="true"
             className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-global-search-input-search md-icon-no-shrink"
+            role="img"
           >
             <svg
+              aria-hidden="true"
               className=""
               data-autoscale={false}
               data-scale={18}

--- a/src/components/Icon/Icon.stories.args.ts
+++ b/src/components/Icon/Icon.stories.args.ts
@@ -111,4 +111,31 @@ export default {
       },
     },
   },
+  title: {
+    defaultValue: '',
+    description: 'Visible accessibility label when icon is hovered',
+    control: { type: 'text' },
+    table: {
+      type: {
+        summary: 'string',
+      },
+      defaultValue: {
+        summary: undefined,
+      },
+    },
+  },
+  ariaLabel: {
+    defaultValue: '',
+    description:
+      'Accessible name of the icon for screen reader in case icon is informative (not decorative)',
+    control: { type: 'text' },
+    table: {
+      type: {
+        summary: 'string',
+      },
+      defaultValue: {
+        summary: undefined,
+      },
+    },
+  },
 };

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -30,6 +30,7 @@ const Icon: React.FC<Props> = (props: Props) => {
     title,
     weight,
     weightless = DEFAULTS.WEIGHTLESS,
+    ariaLabel,
     ...otherProps
   } = props;
   const resolvedSVGName = getResolvedSVGName(name, weight, weightless);
@@ -80,6 +81,8 @@ const Icon: React.FC<Props> = (props: Props) => {
 
   const { inheritedColors, styleColors } = getColors();
 
+  const accessibleName = ariaLabel || title;
+
   if (SvgIcon) {
     return (
       <div
@@ -89,11 +92,15 @@ const Icon: React.FC<Props> = (props: Props) => {
         id={id}
         style={style}
         title={title}
+        role="img"
+        aria-label={accessibleName}
+        aria-hidden={accessibleName ? 'false' : 'true'}
       >
         <SvgIcon
           // coloured class is added to avoid theming the fixed colours inside coloured icons
           data-test={name}
           className={classnames({ [STYLE.coloured]: isColoredIcon })}
+          aria-hidden="true"
           style={{ ...styleColors }}
           {...inheritedColors}
           viewBox={

--- a/src/components/Icon/Icon.types.ts
+++ b/src/components/Icon/Icon.types.ts
@@ -78,9 +78,16 @@ export interface Props {
   style?: CSSProperties;
 
   /**
-   * Provides accessibility label when icon is hovered
+   * Provides visible accessibility label when icon is hovered
    */
   title?: string;
+
+  /**
+   * Provides the accessible name of the icon
+   * Only needed if icon has an informative non-redundant meaning.
+   * Reference: https://www.w3.org/WAI/tutorials/images/decision-tree/
+   */
+  ariaLabel?: string;
 
   /**
    * Represents the style of the icon.

--- a/src/components/Icon/Icon.unit.test.tsx
+++ b/src/components/Icon/Icon.unit.test.tsx
@@ -56,6 +56,16 @@ describe('<Icon />', () => {
       expect(container).toMatchSnapshot();
     });
 
+    it('should match snapshot with ariaLabel', async () => {
+      expect.assertions(1);
+
+      const ariaLabel = 'This participant is muted';
+
+      container = await mountAndWait(<Icon name="draft-indicator-bold" ariaLabel={ariaLabel} />);
+
+      expect(container).toMatchSnapshot();
+    });
+
     it('should match snapshot with scale', async () => {
       expect.assertions(1);
 
@@ -190,6 +200,20 @@ describe('<Icon />', () => {
       expect(element.getAttribute('title')).toBe(title);
     });
 
+    it('should have ariaLabel when ariaLabel is provided', async () => {
+      expect.assertions(2);
+
+      const ariaLabel = 'This participant is muted';
+
+      const wrapper = await mountAndWait(
+        <Icon name="draft-indicator-bold" ariaLabel={ariaLabel} />
+      );
+      const element = wrapper.find(Icon).getDOMNode();
+
+      expect(element.getAttribute('aria-label')).toBe(ariaLabel);
+      expect(element.getAttribute('aria-hidden')).toBe('false');
+    });
+
     it('should pass scale prop', async () => {
       const scale = 16;
 
@@ -204,6 +228,50 @@ describe('<Icon />', () => {
         'md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink'
       );
     });
+
+    it.each([
+      {
+        title: 'fake title',
+        ariaLabel: 'fake aria label',
+        expectedAriaLabel: 'fake aria label',
+        expectedAriaHidden: 'false',
+      },
+      {
+        title: 'fake title',
+        ariaLabel: undefined,
+        expectedAriaLabel: 'fake title',
+        expectedAriaHidden: 'false',
+      },
+      {
+        title: undefined,
+        ariaLabel: 'fake aria label',
+        expectedAriaLabel: 'fake aria label',
+        expectedAriaHidden: 'false',
+      },
+      {
+        title: undefined,
+        ariaLabel: undefined,
+        expectedAriaLabel: undefined,
+        expectedAriaHidden: 'true',
+      },
+    ])(
+      'should pass title and ariaLabel prop when %s',
+      async ({ title, ariaLabel, expectedAriaHidden, expectedAriaLabel }) => {
+        const wrapper = await mountAndWait(
+          <Icon name={'accessibility'} title={title} id={'fake-id'} ariaLabel={ariaLabel} />
+        );
+        const icon = wrapper.find('svg').getDOMNode();
+        const div = wrapper.find('div').filter({ id: 'fake-id' });
+
+        expect(div.props().className).toBe('md-icon-wrapper md-icon-auto-scales md-icon-scales');
+        expect(div.props().title).toBe(title);
+        expect(div.props().role).toBe('img');
+        expect(div.props()['aria-label']).toBe(expectedAriaLabel);
+        expect(div.props()['aria-hidden']).toBe(expectedAriaHidden);
+
+        expect(icon.getAttribute('aria-hidden')).toBe('true');
+      }
+    );
 
     it('should pass autoScale prop and disable scale prop', async () => {
       const autoScale = true;

--- a/src/components/Icon/Icon.unit.test.tsx.snap
+++ b/src/components/Icon/Icon.unit.test.tsx.snap
@@ -5,13 +5,43 @@ exports[`<Icon /> snapshot should match snapshot 1`] = `
   name="accessibility"
 >
   <div
+    aria-hidden="true"
     className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+    role="img"
   >
     <svg
+      aria-hidden="true"
       className=""
       data-autoscale={false}
       data-scale={32}
       data-test="accessibility"
+      fill="currentColor"
+      height="100%"
+      style={Object {}}
+      viewBox="0, 0, 32, 32"
+      width="100%"
+    />
+  </div>
+</Icon>
+`;
+
+exports[`<Icon /> snapshot should match snapshot with ariaLabel 1`] = `
+<Icon
+  ariaLabel="This participant is muted"
+  name="draft-indicator-bold"
+>
+  <div
+    aria-hidden="false"
+    aria-label="This participant is muted"
+    className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+    role="img"
+  >
+    <svg
+      aria-hidden="true"
+      className=""
+      data-autoscale={false}
+      data-scale={32}
+      data-test="draft-indicator-bold"
       fill="currentColor"
       height="100%"
       style={Object {}}
@@ -28,9 +58,12 @@ exports[`<Icon /> snapshot should match snapshot with autoScale set to 'true' 1`
   name="accessibility"
 >
   <div
+    aria-hidden="true"
     className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+    role="img"
   >
     <svg
+      aria-hidden="true"
       className=""
       data-autoscale={true}
       data-scale={false}
@@ -51,9 +84,12 @@ exports[`<Icon /> snapshot should match snapshot with autoScale set to a percent
   name="accessibility"
 >
   <div
+    aria-hidden="true"
     className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+    role="img"
   >
     <svg
+      aria-hidden="true"
       className=""
       data-autoscale={150}
       data-scale={false}
@@ -74,9 +110,12 @@ exports[`<Icon /> snapshot should match snapshot with className 1`] = `
   name="accessibility"
 >
   <div
+    aria-hidden="true"
     className="md-icon-wrapper md-icon-auto-scales md-icon-scales example-class"
+    role="img"
   >
     <svg
+      aria-hidden="true"
       className=""
       data-autoscale={false}
       data-scale={32}
@@ -97,9 +136,12 @@ exports[`<Icon /> snapshot should match snapshot with color 1`] = `
   name="accessibility"
 >
   <div
+    aria-hidden="true"
     className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+    role="img"
   >
     <svg
+      aria-hidden="true"
       className=""
       data-autoscale={false}
       data-scale={32}
@@ -124,9 +166,12 @@ exports[`<Icon /> snapshot should match snapshot with fillColor 1`] = `
   name="accessibility"
 >
   <div
+    aria-hidden="true"
     className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+    role="img"
   >
     <svg
+      aria-hidden="true"
       className=""
       data-autoscale={false}
       data-scale={32}
@@ -150,10 +195,13 @@ exports[`<Icon /> snapshot should match snapshot with id 1`] = `
   name="accessibility"
 >
   <div
+    aria-hidden="true"
     className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
     id="example-id"
+    role="img"
   >
     <svg
+      aria-hidden="true"
       className=""
       data-autoscale={false}
       data-scale={32}
@@ -192,9 +240,12 @@ exports[`<Icon /> snapshot should match snapshot with scale 1`] = `
   scale={16}
 >
   <div
+    aria-hidden="true"
     className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+    role="img"
   >
     <svg
+      aria-hidden="true"
       className=""
       data-autoscale={false}
       data-scale={16}
@@ -215,9 +266,12 @@ exports[`<Icon /> snapshot should match snapshot with small icons 1`] = `
   scale={14}
 >
   <div
+    aria-hidden="true"
     className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+    role="img"
   >
     <svg
+      aria-hidden="true"
       className=""
       data-autoscale={false}
       data-scale={14}
@@ -238,9 +292,12 @@ exports[`<Icon /> snapshot should match snapshot with strokeColor 1`] = `
   strokeColor="red"
 >
   <div
+    aria-hidden="true"
     className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+    role="img"
   >
     <svg
+      aria-hidden="true"
       className=""
       data-autoscale={false}
       data-scale={32}
@@ -269,7 +326,9 @@ exports[`<Icon /> snapshot should match snapshot with style 1`] = `
   }
 >
   <div
+    aria-hidden="true"
     className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+    role="img"
     style={
       Object {
         "color": "pink",
@@ -277,6 +336,7 @@ exports[`<Icon /> snapshot should match snapshot with style 1`] = `
     }
   >
     <svg
+      aria-hidden="true"
       className=""
       data-autoscale={false}
       data-scale={32}
@@ -297,10 +357,14 @@ exports[`<Icon /> snapshot should match snapshot with title 1`] = `
   title="You have a draft message"
 >
   <div
+    aria-hidden="false"
+    aria-label="You have a draft message"
     className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+    role="img"
     title="You have a draft message"
   >
     <svg
+      aria-hidden="true"
       className=""
       data-autoscale={false}
       data-scale={32}
@@ -321,9 +385,12 @@ exports[`<Icon /> snapshot should match snapshot with weight 1`] = `
   weight="light"
 >
   <div
+    aria-hidden="true"
     className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+    role="img"
   >
     <svg
+      aria-hidden="true"
       className=""
       data-autoscale={false}
       data-scale={32}

--- a/src/components/InputMessage/InputMessage.unit.test.tsx.snap
+++ b/src/components/InputMessage/InputMessage.unit.test.tsx.snap
@@ -23,9 +23,12 @@ exports[`InputMessage snapshot should match snapshot 1`] = `
           weight="bold"
         >
           <div
+            aria-hidden="true"
             className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+            role="img"
           >
             <svg
+              aria-hidden="true"
               className=""
               data-autoscale={false}
               data-scale={16}

--- a/src/components/LoadingSpinner/LoadingSpinner.unit.test.tsx.snap
+++ b/src/components/LoadingSpinner/LoadingSpinner.unit.test.tsx.snap
@@ -11,9 +11,12 @@ exports[`<LoadingSpinner /> snapshot should match snapshot 1`] = `
       weight="regular"
     >
       <div
+        aria-hidden="true"
         className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+        role="img"
       >
         <svg
+          aria-hidden="true"
           className=""
           data-autoscale={false}
           data-scale={24}
@@ -33,9 +36,12 @@ exports[`<LoadingSpinner /> snapshot should match snapshot 1`] = `
       weight="regular"
     >
       <div
+        aria-hidden="true"
         className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-loading-spinner-arch md-icon-no-shrink"
+        role="img"
       >
         <svg
+          aria-hidden="true"
           className=""
           data-autoscale={false}
           data-scale={24}
@@ -65,9 +71,12 @@ exports[`<LoadingSpinner /> snapshot should match snapshot with className 1`] = 
       weight="regular"
     >
       <div
+        aria-hidden="true"
         className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+        role="img"
       >
         <svg
+          aria-hidden="true"
           className=""
           data-autoscale={false}
           data-scale={24}
@@ -87,9 +96,12 @@ exports[`<LoadingSpinner /> snapshot should match snapshot with className 1`] = 
       weight="regular"
     >
       <div
+        aria-hidden="true"
         className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-loading-spinner-arch md-icon-no-shrink"
+        role="img"
       >
         <svg
+          aria-hidden="true"
           className=""
           data-autoscale={false}
           data-scale={24}
@@ -120,9 +132,12 @@ exports[`<LoadingSpinner /> snapshot should match snapshot with id 1`] = `
       weight="regular"
     >
       <div
+        aria-hidden="true"
         className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+        role="img"
       >
         <svg
+          aria-hidden="true"
           className=""
           data-autoscale={false}
           data-scale={24}
@@ -142,9 +157,12 @@ exports[`<LoadingSpinner /> snapshot should match snapshot with id 1`] = `
       weight="regular"
     >
       <div
+        aria-hidden="true"
         className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-loading-spinner-arch md-icon-no-shrink"
+        role="img"
       >
         <svg
+          aria-hidden="true"
           className=""
           data-autoscale={false}
           data-scale={24}
@@ -174,9 +192,12 @@ exports[`<LoadingSpinner /> snapshot should match snapshot with scale 1`] = `
       weight="regular"
     >
       <div
+        aria-hidden="true"
         className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+        role="img"
       >
         <svg
+          aria-hidden="true"
           className=""
           data-autoscale={false}
           data-scale={32}
@@ -196,9 +217,12 @@ exports[`<LoadingSpinner /> snapshot should match snapshot with scale 1`] = `
       weight="regular"
     >
       <div
+        aria-hidden="true"
         className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-loading-spinner-arch md-icon-no-shrink"
+        role="img"
       >
         <svg
+          aria-hidden="true"
           className=""
           data-autoscale={false}
           data-scale={32}
@@ -237,9 +261,12 @@ exports[`<LoadingSpinner /> snapshot should match snapshot with style 1`] = `
       weight="regular"
     >
       <div
+        aria-hidden="true"
         className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+        role="img"
       >
         <svg
+          aria-hidden="true"
           className=""
           data-autoscale={false}
           data-scale={24}
@@ -259,9 +286,12 @@ exports[`<LoadingSpinner /> snapshot should match snapshot with style 1`] = `
       weight="regular"
     >
       <div
+        aria-hidden="true"
         className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-loading-spinner-arch md-icon-no-shrink"
+        role="img"
       >
         <svg
+          aria-hidden="true"
           className=""
           data-autoscale={false}
           data-scale={24}

--- a/src/components/MeetingListItem/MeetingListItem.unit.test.tsx.snap
+++ b/src/components/MeetingListItem/MeetingListItem.unit.test.tsx.snap
@@ -451,9 +451,12 @@ exports[`<MeetingListItem /> snapshot should match snapshot with image 1`] = `
                 weight="bold"
               >
                 <div
+                  aria-hidden="true"
                   className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                  role="img"
                 >
                   <svg
+                    aria-hidden="true"
                     className=""
                     data-autoscale={false}
                     data-scale={12}

--- a/src/components/NavigationTab/NavigationTab.unit.test.tsx.snap
+++ b/src/components/NavigationTab/NavigationTab.unit.test.tsx.snap
@@ -255,9 +255,12 @@ exports[`<NavigationTab /> snapshot should match snapshot with icon 1`] = `
                 weight="filled"
               >
                 <div
+                  aria-hidden="true"
                   className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-navigation-tab-icon md-icon-no-shrink"
+                  role="img"
                 >
                   <svg
+                    aria-hidden="true"
                     className=""
                     data-autoscale={false}
                     data-scale={24}
@@ -580,9 +583,12 @@ exports[`<NavigationTab /> snapshot should match snapshot with size, label, icon
                 weight="filled"
               >
                 <div
+                  aria-hidden="true"
                   className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-navigation-tab-icon md-icon-no-shrink"
+                  role="img"
                 >
                   <svg
+                    aria-hidden="true"
                     className=""
                     data-autoscale={false}
                     data-scale={24}
@@ -661,9 +667,12 @@ exports[`<NavigationTab /> snapshot should match snapshot with size, label, icon
                 weight="filled"
               >
                 <div
+                  aria-hidden="true"
                   className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-navigation-tab-icon md-icon-no-shrink"
+                  role="img"
                 >
                   <svg
+                    aria-hidden="true"
                     className=""
                     data-autoscale={false}
                     data-scale={24}

--- a/src/components/NotificationSystem/NotificationSystem.unit.test.tsx.snap
+++ b/src/components/NotificationSystem/NotificationSystem.unit.test.tsx.snap
@@ -42,9 +42,12 @@ exports[`<NotificationSystem /> snapshot should match snapshot 1`] = `
                     class="md-toast-notification-leading-visual"
                   >
                     <div
+                      aria-hidden="true"
                       class="md-icon-wrapper md-icon-auto-scales md-icon-scales icon md-icon-no-shrink"
+                      role="img"
                     >
                       <svg
+                        aria-hidden="true"
                         class=""
                         data-autoscale="false"
                         data-scale="24"
@@ -79,9 +82,12 @@ exports[`<NotificationSystem /> snapshot should match snapshot 1`] = `
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                        role="img"
                       >
                         <svg
+                          aria-hidden="true"
                           class=""
                           data-autoscale="false"
                           data-scale="16"
@@ -154,9 +160,12 @@ exports[`<NotificationSystem /> snapshot should match snapshot if notification c
                     class="md-toast-notification-leading-visual"
                   >
                     <div
+                      aria-hidden="true"
                       class="md-icon-wrapper md-icon-auto-scales md-icon-scales icon md-icon-no-shrink"
+                      role="img"
                     >
                       <svg
+                        aria-hidden="true"
                         class=""
                         data-autoscale="false"
                         data-scale="24"
@@ -190,9 +199,12 @@ exports[`<NotificationSystem /> snapshot should match snapshot if notification c
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                        role="img"
                       >
                         <svg
+                          aria-hidden="true"
                           class=""
                           data-autoscale="false"
                           data-scale="16"
@@ -265,9 +277,12 @@ exports[`<NotificationSystem /> snapshot should match snapshot if notification c
                     class="md-toast-notification-leading-visual"
                   >
                     <div
+                      aria-hidden="true"
                       class="md-icon-wrapper md-icon-auto-scales md-icon-scales icon md-icon-no-shrink"
+                      role="img"
                     >
                       <svg
+                        aria-hidden="true"
                         class=""
                         data-autoscale="false"
                         data-scale="24"
@@ -302,9 +317,12 @@ exports[`<NotificationSystem /> snapshot should match snapshot if notification c
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                        role="img"
                       >
                         <svg
+                          aria-hidden="true"
                           class=""
                           data-autoscale="false"
                           data-scale="16"
@@ -377,9 +395,12 @@ exports[`<NotificationSystem /> snapshot should match snapshot when limit is set
                     class="md-toast-notification-leading-visual"
                   >
                     <div
+                      aria-hidden="true"
                       class="md-icon-wrapper md-icon-auto-scales md-icon-scales icon md-icon-no-shrink"
+                      role="img"
                     >
                       <svg
+                        aria-hidden="true"
                         class=""
                         data-autoscale="false"
                         data-scale="24"
@@ -414,9 +435,12 @@ exports[`<NotificationSystem /> snapshot should match snapshot when limit is set
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                        role="img"
                       >
                         <svg
+                          aria-hidden="true"
                           class=""
                           data-autoscale="false"
                           data-scale="16"
@@ -489,9 +513,12 @@ exports[`<NotificationSystem /> snapshot should match snapshot with body class n
                     class="md-toast-notification-leading-visual"
                   >
                     <div
+                      aria-hidden="true"
                       class="md-icon-wrapper md-icon-auto-scales md-icon-scales icon md-icon-no-shrink"
+                      role="img"
                     >
                       <svg
+                        aria-hidden="true"
                         class=""
                         data-autoscale="false"
                         data-scale="24"
@@ -526,9 +553,12 @@ exports[`<NotificationSystem /> snapshot should match snapshot with body class n
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                        role="img"
                       >
                         <svg
+                          aria-hidden="true"
                           class=""
                           data-autoscale="false"
                           data-scale="16"
@@ -601,9 +631,12 @@ exports[`<NotificationSystem /> snapshot should match snapshot with className 1`
                     class="md-toast-notification-leading-visual"
                   >
                     <div
+                      aria-hidden="true"
                       class="md-icon-wrapper md-icon-auto-scales md-icon-scales icon md-icon-no-shrink"
+                      role="img"
                     >
                       <svg
+                        aria-hidden="true"
                         class=""
                         data-autoscale="false"
                         data-scale="24"
@@ -638,9 +671,12 @@ exports[`<NotificationSystem /> snapshot should match snapshot with className 1`
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                        role="img"
                       >
                         <svg
+                          aria-hidden="true"
                           class=""
                           data-autoscale="false"
                           data-scale="16"
@@ -713,9 +749,12 @@ exports[`<NotificationSystem /> snapshot should match snapshot with container cl
                     class="md-toast-notification-leading-visual"
                   >
                     <div
+                      aria-hidden="true"
                       class="md-icon-wrapper md-icon-auto-scales md-icon-scales icon md-icon-no-shrink"
+                      role="img"
                     >
                       <svg
+                        aria-hidden="true"
                         class=""
                         data-autoscale="false"
                         data-scale="24"
@@ -750,9 +789,12 @@ exports[`<NotificationSystem /> snapshot should match snapshot with container cl
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                        role="img"
                       >
                         <svg
+                          aria-hidden="true"
                           class=""
                           data-autoscale="false"
                           data-scale="16"
@@ -821,9 +863,12 @@ exports[`<NotificationSystem /> snapshot should match snapshot with different at
                     class="md-toast-notification-leading-visual"
                   >
                     <div
+                      aria-hidden="true"
                       class="md-icon-wrapper md-icon-auto-scales md-icon-scales icon md-icon-no-shrink"
+                      role="img"
                     >
                       <svg
+                        aria-hidden="true"
                         class=""
                         data-autoscale="false"
                         data-scale="24"
@@ -858,9 +903,12 @@ exports[`<NotificationSystem /> snapshot should match snapshot with different at
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                        role="img"
                       >
                         <svg
+                          aria-hidden="true"
                           class=""
                           data-autoscale="false"
                           data-scale="16"
@@ -926,9 +974,12 @@ exports[`<NotificationSystem /> snapshot should match snapshot with different po
                     class="md-toast-notification-leading-visual"
                   >
                     <div
+                      aria-hidden="true"
                       class="md-icon-wrapper md-icon-auto-scales md-icon-scales icon md-icon-no-shrink"
+                      role="img"
                     >
                       <svg
+                        aria-hidden="true"
                         class=""
                         data-autoscale="false"
                         data-scale="24"
@@ -963,9 +1014,12 @@ exports[`<NotificationSystem /> snapshot should match snapshot with different po
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                        role="img"
                       >
                         <svg
+                          aria-hidden="true"
                           class=""
                           data-autoscale="false"
                           data-scale="16"
@@ -1042,9 +1096,12 @@ exports[`<NotificationSystem /> snapshot should match snapshot with different zI
                     class="md-toast-notification-leading-visual"
                   >
                     <div
+                      aria-hidden="true"
                       class="md-icon-wrapper md-icon-auto-scales md-icon-scales icon md-icon-no-shrink"
+                      role="img"
                     >
                       <svg
+                        aria-hidden="true"
                         class=""
                         data-autoscale="false"
                         data-scale="24"
@@ -1079,9 +1136,12 @@ exports[`<NotificationSystem /> snapshot should match snapshot with different zI
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                        role="img"
                       >
                         <svg
+                          aria-hidden="true"
                           class=""
                           data-autoscale="false"
                           data-scale="16"
@@ -1154,9 +1214,12 @@ exports[`<NotificationSystem /> snapshot should match snapshot with enter animat
                     class="md-toast-notification-leading-visual"
                   >
                     <div
+                      aria-hidden="true"
                       class="md-icon-wrapper md-icon-auto-scales md-icon-scales icon md-icon-no-shrink"
+                      role="img"
                     >
                       <svg
+                        aria-hidden="true"
                         class=""
                         data-autoscale="false"
                         data-scale="24"
@@ -1191,9 +1254,12 @@ exports[`<NotificationSystem /> snapshot should match snapshot with enter animat
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                        role="img"
                       >
                         <svg
+                          aria-hidden="true"
                           class=""
                           data-autoscale="false"
                           data-scale="16"
@@ -1266,9 +1332,12 @@ exports[`<NotificationSystem /> snapshot should match snapshot with id 1`] = `
                     class="md-toast-notification-leading-visual"
                   >
                     <div
+                      aria-hidden="true"
                       class="md-icon-wrapper md-icon-auto-scales md-icon-scales icon md-icon-no-shrink"
+                      role="img"
                     >
                       <svg
+                        aria-hidden="true"
                         class=""
                         data-autoscale="false"
                         data-scale="24"
@@ -1303,9 +1372,12 @@ exports[`<NotificationSystem /> snapshot should match snapshot with id 1`] = `
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                        role="img"
                       >
                         <svg
+                          aria-hidden="true"
                           class=""
                           data-autoscale="false"
                           data-scale="16"
@@ -1378,9 +1450,12 @@ exports[`<NotificationSystem /> snapshot should match snapshot with newest on to
                     class="md-toast-notification-leading-visual"
                   >
                     <div
+                      aria-hidden="true"
                       class="md-icon-wrapper md-icon-auto-scales md-icon-scales icon md-icon-no-shrink"
+                      role="img"
                     >
                       <svg
+                        aria-hidden="true"
                         class=""
                         data-autoscale="false"
                         data-scale="24"
@@ -1415,9 +1490,12 @@ exports[`<NotificationSystem /> snapshot should match snapshot with newest on to
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                        role="img"
                       >
                         <svg
+                          aria-hidden="true"
                           class=""
                           data-autoscale="false"
                           data-scale="16"
@@ -1490,9 +1568,12 @@ exports[`<NotificationSystem /> snapshot should match snapshot with style 1`] = 
                     class="md-toast-notification-leading-visual"
                   >
                     <div
+                      aria-hidden="true"
                       class="md-icon-wrapper md-icon-auto-scales md-icon-scales icon md-icon-no-shrink"
+                      role="img"
                     >
                       <svg
+                        aria-hidden="true"
                         class=""
                         data-autoscale="false"
                         data-scale="24"
@@ -1527,9 +1608,12 @@ exports[`<NotificationSystem /> snapshot should match snapshot with style 1`] = 
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                        role="img"
                       >
                         <svg
+                          aria-hidden="true"
                           class=""
                           data-autoscale="false"
                           data-scale="16"
@@ -1602,9 +1686,12 @@ exports[`<NotificationSystem /> snapshot should match snapshot with toast class 
                     class="md-toast-notification-leading-visual"
                   >
                     <div
+                      aria-hidden="true"
                       class="md-icon-wrapper md-icon-auto-scales md-icon-scales icon md-icon-no-shrink"
+                      role="img"
                     >
                       <svg
+                        aria-hidden="true"
                         class=""
                         data-autoscale="false"
                         data-scale="24"
@@ -1639,9 +1726,12 @@ exports[`<NotificationSystem /> snapshot should match snapshot with toast class 
                       type="button"
                     >
                       <div
+                        aria-hidden="true"
                         class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                        role="img"
                       >
                         <svg
+                          aria-hidden="true"
                           class=""
                           data-autoscale="false"
                           data-scale="16"

--- a/src/components/Popover/Popover.unit.test.tsx.snap
+++ b/src/components/Popover/Popover.unit.test.tsx.snap
@@ -633,9 +633,12 @@ exports[`<Popover /> snapshot should match snapshot with closeButtonPlacement 2`
         type="button"
       >
         <div
+          aria-hidden="true"
           class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+          role="img"
         >
           <svg
+            aria-hidden="true"
             class=""
             data-autoscale="false"
             data-scale="16"

--- a/src/components/Reaction/Reaction.unit.test.tsx.snap
+++ b/src/components/Reaction/Reaction.unit.test.tsx.snap
@@ -467,9 +467,12 @@ exports[`<Reaction/> snapshot should match snapshot with spinner while animation
         weight="regular"
       >
         <div
+          aria-hidden="true"
           className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+          role="img"
         >
           <svg
+            aria-hidden="true"
             className=""
             data-autoscale={false}
             data-scale={16}
@@ -489,9 +492,12 @@ exports[`<Reaction/> snapshot should match snapshot with spinner while animation
         weight="regular"
       >
         <div
+          aria-hidden="true"
           className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-loading-spinner-arch md-icon-no-shrink"
+          role="img"
         >
           <svg
+            aria-hidden="true"
             className=""
             data-autoscale={false}
             data-scale={16}

--- a/src/components/SearchInput/SearchInput.unit.test.tsx.snap
+++ b/src/components/SearchInput/SearchInput.unit.test.tsx.snap
@@ -19,9 +19,12 @@ exports[`<SearchInput /> snapshot should match snapshot 1`] = `
           weight="bold"
         >
           <div
+            aria-hidden="true"
             className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-search-input-search md-icon-no-shrink"
+            role="img"
           >
             <svg
+              aria-hidden="true"
               className=""
               data-autoscale={false}
               data-scale={16}
@@ -123,9 +126,12 @@ exports[`<SearchInput /> snapshot should match snapshot when filters are set 1`]
           weight="bold"
         >
           <div
+            aria-hidden="true"
             className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-search-input-search md-icon-no-shrink"
+            role="img"
           >
             <svg
+              aria-hidden="true"
               className=""
               data-autoscale={false}
               data-scale={16}
@@ -191,9 +197,12 @@ exports[`<SearchInput /> snapshot should match snapshot when filters are set 1`]
                 weight="bold"
               >
                 <div
+                  aria-hidden="true"
                   className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                  role="img"
                 >
                   <svg
+                    aria-hidden="true"
                     className=""
                     data-autoscale={false}
                     data-scale={16}
@@ -262,9 +271,12 @@ exports[`<SearchInput /> snapshot should match snapshot when searching 1`] = `
               weight="regular"
             >
               <div
+                aria-hidden="true"
                 className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                role="img"
               >
                 <svg
+                  aria-hidden="true"
                   className=""
                   data-autoscale={false}
                   data-scale={16}
@@ -284,9 +296,12 @@ exports[`<SearchInput /> snapshot should match snapshot when searching 1`] = `
               weight="regular"
             >
               <div
+                aria-hidden="true"
                 className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-loading-spinner-arch md-icon-no-shrink"
+                role="img"
               >
                 <svg
+                  aria-hidden="true"
                   className=""
                   data-autoscale={false}
                   data-scale={16}
@@ -370,9 +385,12 @@ exports[`<SearchInput /> snapshot should match snapshot with a label 1`] = `
           weight="bold"
         >
           <div
+            aria-hidden="true"
             className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-search-input-search md-icon-no-shrink"
+            role="img"
           >
             <svg
+              aria-hidden="true"
               className=""
               data-autoscale={false}
               data-scale={16}
@@ -449,9 +467,12 @@ exports[`<SearchInput /> snapshot should match snapshot with className 1`] = `
           weight="bold"
         >
           <div
+            aria-hidden="true"
             className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-search-input-search md-icon-no-shrink"
+            role="img"
           >
             <svg
+              aria-hidden="true"
               className=""
               data-autoscale={false}
               data-scale={16}
@@ -527,9 +548,12 @@ exports[`<SearchInput /> snapshot should match snapshot with height 1`] = `
           weight="bold"
         >
           <div
+            aria-hidden="true"
             className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-search-input-search md-icon-no-shrink"
+            role="img"
           >
             <svg
+              aria-hidden="true"
               className=""
               data-autoscale={false}
               data-scale={12}
@@ -606,9 +630,12 @@ exports[`<SearchInput /> snapshot should match snapshot with id 1`] = `
           weight="bold"
         >
           <div
+            aria-hidden="true"
             className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-search-input-search md-icon-no-shrink"
+            role="img"
           >
             <svg
+              aria-hidden="true"
               className=""
               data-autoscale={false}
               data-scale={16}
@@ -693,9 +720,12 @@ exports[`<SearchInput /> snapshot should match snapshot with style 1`] = `
           weight="bold"
         >
           <div
+            aria-hidden="true"
             className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-search-input-search md-icon-no-shrink"
+            role="img"
           >
             <svg
+              aria-hidden="true"
               className=""
               data-autoscale={false}
               data-scale={16}

--- a/src/components/Select/Select.unit.test.tsx.snap
+++ b/src/components/Select/Select.unit.test.tsx.snap
@@ -185,9 +185,12 @@ exports[`Select snapshot should match snapshot 1`] = `
               class="md-select-icon-wrapper"
             >
               <div
+                aria-hidden="true"
                 class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                role="img"
               >
                 <svg
+                  aria-hidden="true"
                   class=""
                   data-autoscale="false"
                   data-scale="16"
@@ -507,9 +510,12 @@ exports[`Select snapshot should match snapshot 1`] = `
                   weight="bold"
                 >
                   <div
+                    aria-hidden="true"
                     className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                    role="img"
                   >
                     <svg
+                      aria-hidden="true"
                       className=""
                       data-autoscale={false}
                       data-scale={16}
@@ -728,9 +734,12 @@ exports[`Select snapshot should match snapshot before and after opening select d
               class="md-select-icon-wrapper"
             >
               <div
+                aria-hidden="true"
                 class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                role="img"
               >
                 <svg
+                  aria-hidden="true"
                   class=""
                   data-autoscale="false"
                   data-scale="16"
@@ -1050,9 +1059,12 @@ exports[`Select snapshot should match snapshot before and after opening select d
                   weight="bold"
                 >
                   <div
+                    aria-hidden="true"
                     className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                    role="img"
                   >
                     <svg
+                      aria-hidden="true"
                       className=""
                       data-autoscale={false}
                       data-scale={16}
@@ -1272,9 +1284,12 @@ exports[`Select snapshot should match snapshot before and after opening select d
               class="md-select-icon-wrapper"
             >
               <div
+                aria-hidden="true"
                 class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                role="img"
               >
                 <svg
+                  aria-hidden="true"
                   class=""
                   data-autoscale="false"
                   data-scale="16"
@@ -1594,9 +1609,12 @@ exports[`Select snapshot should match snapshot before and after opening select d
                   weight="bold"
                 >
                   <div
+                    aria-hidden="true"
                     className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                    role="img"
                   >
                     <svg
+                      aria-hidden="true"
                       className=""
                       data-autoscale={false}
                       data-scale={16}
@@ -2327,9 +2345,12 @@ exports[`Select snapshot should match snapshot with border 1`] = `
               class="md-select-icon-wrapper"
             >
               <div
+                aria-hidden="true"
                 class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                role="img"
               >
                 <svg
+                  aria-hidden="true"
                   class=""
                   data-autoscale="false"
                   data-scale="16"
@@ -2649,9 +2670,12 @@ exports[`Select snapshot should match snapshot with border 1`] = `
                   weight="bold"
                 >
                   <div
+                    aria-hidden="true"
                     className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                    role="img"
                   >
                     <svg
+                      aria-hidden="true"
                       className=""
                       data-autoscale={false}
                       data-scale={16}
@@ -2871,9 +2895,12 @@ exports[`Select snapshot should match snapshot with className 1`] = `
               class="md-select-icon-wrapper"
             >
               <div
+                aria-hidden="true"
                 class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                role="img"
               >
                 <svg
+                  aria-hidden="true"
                   class=""
                   data-autoscale="false"
                   data-scale="16"
@@ -3193,9 +3220,12 @@ exports[`Select snapshot should match snapshot with className 1`] = `
                   weight="bold"
                 >
                   <div
+                    aria-hidden="true"
                     className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                    role="img"
                   >
                     <svg
+                      aria-hidden="true"
                       className=""
                       data-autoscale={false}
                       data-scale={16}
@@ -3415,9 +3445,12 @@ exports[`Select snapshot should match snapshot with direction 1`] = `
               class="md-select-icon-wrapper"
             >
               <div
+                aria-hidden="true"
                 class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                role="img"
               >
                 <svg
+                  aria-hidden="true"
                   class=""
                   data-autoscale="false"
                   data-scale="16"
@@ -3737,9 +3770,12 @@ exports[`Select snapshot should match snapshot with direction 1`] = `
                   weight="bold"
                 >
                   <div
+                    aria-hidden="true"
                     className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                    role="img"
                   >
                     <svg
+                      aria-hidden="true"
                       className=""
                       data-autoscale={false}
                       data-scale={16}
@@ -3969,9 +4005,12 @@ exports[`Select snapshot should match snapshot with disabled option 1`] = `
               class="md-select-icon-wrapper"
             >
               <div
+                aria-hidden="true"
                 class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                role="img"
               >
                 <svg
+                  aria-hidden="true"
                   class=""
                   data-autoscale="false"
                   data-scale="16"
@@ -4291,9 +4330,12 @@ exports[`Select snapshot should match snapshot with disabled option 1`] = `
                   weight="bold"
                 >
                   <div
+                    aria-hidden="true"
                     className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                    role="img"
                   >
                     <svg
+                      aria-hidden="true"
                       className=""
                       data-autoscale={false}
                       data-scale={16}
@@ -5027,9 +5069,12 @@ exports[`Select snapshot should match snapshot with id 1`] = `
               class="md-select-icon-wrapper"
             >
               <div
+                aria-hidden="true"
                 class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                role="img"
               >
                 <svg
+                  aria-hidden="true"
                   class=""
                   data-autoscale="false"
                   data-scale="16"
@@ -5349,9 +5394,12 @@ exports[`Select snapshot should match snapshot with id 1`] = `
                   weight="bold"
                 >
                   <div
+                    aria-hidden="true"
                     className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                    role="img"
                   >
                     <svg
+                      aria-hidden="true"
                       className=""
                       data-autoscale={false}
                       data-scale={16}
@@ -5663,9 +5711,12 @@ exports[`Select snapshot should match snapshot with isInForm = false 1`] = `
                   weight="bold"
                 >
                   <div
+                    aria-hidden="true"
                     className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                    role="img"
                   >
                     <svg
+                      aria-hidden="true"
                       className=""
                       data-autoscale={false}
                       data-scale={16}
@@ -5886,9 +5937,12 @@ exports[`Select snapshot should match snapshot with listbox opened 1`] = `
               class="md-select-icon-wrapper"
             >
               <div
+                aria-hidden="true"
                 class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                role="img"
               >
                 <svg
+                  aria-hidden="true"
                   class=""
                   data-autoscale="false"
                   data-scale="16"
@@ -6208,9 +6262,12 @@ exports[`Select snapshot should match snapshot with listbox opened 1`] = `
                   weight="bold"
                 >
                   <div
+                    aria-hidden="true"
                     className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                    role="img"
                   >
                     <svg
+                      aria-hidden="true"
                       className=""
                       data-autoscale={false}
                       data-scale={16}
@@ -6941,9 +6998,12 @@ exports[`Select snapshot should match snapshot with listboxMaxHeight 1`] = `
               class="md-select-icon-wrapper"
             >
               <div
+                aria-hidden="true"
                 class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                role="img"
               >
                 <svg
+                  aria-hidden="true"
                   class=""
                   data-autoscale="false"
                   data-scale="16"
@@ -7263,9 +7323,12 @@ exports[`Select snapshot should match snapshot with listboxMaxHeight 1`] = `
                   weight="bold"
                 >
                   <div
+                    aria-hidden="true"
                     className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                    role="img"
                   >
                     <svg
+                      aria-hidden="true"
                       className=""
                       data-autoscale={false}
                       data-scale={16}
@@ -7996,9 +8059,12 @@ exports[`Select snapshot should match snapshot with listboxWidth 1`] = `
               class="md-select-icon-wrapper"
             >
               <div
+                aria-hidden="true"
                 class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                role="img"
               >
                 <svg
+                  aria-hidden="true"
                   class=""
                   data-autoscale="false"
                   data-scale="16"
@@ -8318,9 +8384,12 @@ exports[`Select snapshot should match snapshot with listboxWidth 1`] = `
                   weight="bold"
                 >
                   <div
+                    aria-hidden="true"
                     className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                    role="img"
                   >
                     <svg
+                      aria-hidden="true"
                       className=""
                       data-autoscale={false}
                       data-scale={16}
@@ -9053,9 +9122,12 @@ exports[`Select snapshot should match snapshot with placeholder 1`] = `
               class="md-select-icon-wrapper"
             >
               <div
+                aria-hidden="true"
                 class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                role="img"
               >
                 <svg
+                  aria-hidden="true"
                   class=""
                   data-autoscale="false"
                   data-scale="16"
@@ -9379,9 +9451,12 @@ exports[`Select snapshot should match snapshot with placeholder 1`] = `
                   weight="bold"
                 >
                   <div
+                    aria-hidden="true"
                     className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                    role="img"
                   >
                     <svg
+                      aria-hidden="true"
                       className=""
                       data-autoscale={false}
                       data-scale={16}
@@ -9627,9 +9702,12 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
               class="md-select-icon-wrapper"
             >
               <div
+                aria-hidden="true"
                 class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                role="img"
               >
                 <svg
+                  aria-hidden="true"
                   class=""
                   data-autoscale="false"
                   data-scale="16"
@@ -9955,9 +10033,12 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
                   weight="bold"
                 >
                   <div
+                    aria-hidden="true"
                     className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                    role="img"
                   >
                     <svg
+                      aria-hidden="true"
                       className=""
                       data-autoscale={false}
                       data-scale={16}
@@ -10205,9 +10286,12 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
               class="md-select-icon-wrapper"
             >
               <div
+                aria-hidden="true"
                 class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                role="img"
               >
                 <svg
+                  aria-hidden="true"
                   class=""
                   data-autoscale="false"
                   data-scale="16"
@@ -10533,9 +10617,12 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
                   weight="bold"
                 >
                   <div
+                    aria-hidden="true"
                     className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                    role="img"
                   >
                     <svg
+                      aria-hidden="true"
                       className=""
                       data-autoscale={false}
                       data-scale={16}
@@ -10603,9 +10690,12 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
                           data-position="end"
                         >
                           <div
+                            aria-hidden="true"
                             class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-list-box-item-tick-icon md-icon-no-shrink"
+                            role="img"
                           >
                             <svg
+                              aria-hidden="true"
                               class=""
                               data-autoscale="false"
                               data-scale="16"
@@ -11003,9 +11093,12 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
                                               weight="bold"
                                             >
                                               <div
+                                                aria-hidden="true"
                                                 className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-list-box-item-tick-icon md-icon-no-shrink"
+                                                role="img"
                                               >
                                                 <svg
+                                                  aria-hidden="true"
                                                   className=""
                                                   data-autoscale={false}
                                                   data-scale={16}
@@ -11348,9 +11441,12 @@ exports[`Select snapshot should match snapshot with style 1`] = `
               class="md-select-icon-wrapper"
             >
               <div
+                aria-hidden="true"
                 class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                role="img"
               >
                 <svg
+                  aria-hidden="true"
                   class=""
                   data-autoscale="false"
                   data-scale="16"
@@ -11670,9 +11766,12 @@ exports[`Select snapshot should match snapshot with style 1`] = `
                   weight="bold"
                 >
                   <div
+                    aria-hidden="true"
                     className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                    role="img"
                   >
                     <svg
+                      aria-hidden="true"
                       className=""
                       data-autoscale={false}
                       data-scale={16}
@@ -11891,9 +11990,12 @@ exports[`Select snapshot should match snapshot with title 1`] = `
               class="md-select-icon-wrapper"
             >
               <div
+                aria-hidden="true"
                 class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                role="img"
               >
                 <svg
+                  aria-hidden="true"
                   class=""
                   data-autoscale="false"
                   data-scale="16"
@@ -12215,9 +12317,12 @@ exports[`Select snapshot should match snapshot with title 1`] = `
                   weight="bold"
                 >
                   <div
+                    aria-hidden="true"
                     className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                    role="img"
                   >
                     <svg
+                      aria-hidden="true"
                       className=""
                       data-autoscale={false}
                       data-scale={16}

--- a/src/components/SpaceListItem/SpaceListItem.unit.test.tsx.snap
+++ b/src/components/SpaceListItem/SpaceListItem.unit.test.tsx.snap
@@ -645,9 +645,12 @@ exports[`<SpaceListItem /> snapshot should match snapshot with isAlert 1`] = `
                 weight="bold"
               >
                 <div
+                  aria-hidden="true"
                   className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                  role="img"
                 >
                   <svg
+                    aria-hidden="true"
                     className=""
                     data-autoscale={false}
                     data-scale={14}
@@ -758,9 +761,12 @@ exports[`<SpaceListItem /> snapshot should match snapshot with isAlertMuted 1`] 
                 weight="bold"
               >
                 <div
+                  aria-hidden="true"
                   className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                  role="img"
                 >
                   <svg
+                    aria-hidden="true"
                     className=""
                     data-autoscale={false}
                     data-scale={14}
@@ -956,9 +962,12 @@ exports[`<SpaceListItem /> snapshot should match snapshot with isEnterRoom 1`] =
                 weight="bold"
               >
                 <div
+                  aria-hidden="true"
                   className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                  role="img"
                 >
                   <svg
+                    aria-hidden="true"
                     className=""
                     data-autoscale={false}
                     data-scale={14}
@@ -1069,9 +1078,12 @@ exports[`<SpaceListItem /> snapshot should match snapshot with isError 1`] = `
                 weight="filled"
               >
                 <div
+                  aria-hidden="true"
                   className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                  role="img"
                 >
                   <svg
+                    aria-hidden="true"
                     className=""
                     data-autoscale={false}
                     data-scale={14}
@@ -1182,9 +1194,12 @@ exports[`<SpaceListItem /> snapshot should match snapshot with isMention 1`] = `
                 weight="bold"
               >
                 <div
+                  aria-hidden="true"
                   className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                  role="img"
                 >
                   <svg
+                    aria-hidden="true"
                     className=""
                     data-autoscale={false}
                     data-scale={14}
@@ -1468,9 +1483,12 @@ exports[`<SpaceListItem /> snapshot should match snapshot with isSelected and dr
                 weight="bold"
               >
                 <div
+                  aria-hidden="true"
                   className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                  role="img"
                 >
                   <svg
+                    aria-hidden="true"
                     className=""
                     data-autoscale={false}
                     data-scale={14}
@@ -1581,9 +1599,12 @@ exports[`<SpaceListItem /> snapshot should match snapshot with isUnread 1`] = `
                 weight="bold"
               >
                 <div
+                  aria-hidden="true"
                   className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                  role="img"
                 >
                   <svg
+                    aria-hidden="true"
                     className=""
                     data-autoscale={false}
                     data-scale={14}

--- a/src/components/Tab/Tab.unit.test.tsx.snap
+++ b/src/components/Tab/Tab.unit.test.tsx.snap
@@ -365,9 +365,12 @@ exports[`<Tab /> snapshot Icon children should match snapshot 1`] = `
             weight="bold"
           >
             <div
+              aria-hidden="true"
               className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+              role="img"
             >
               <svg
+                aria-hidden="true"
                 className=""
                 data-autoscale={false}
                 data-scale={12}
@@ -428,9 +431,12 @@ exports[`<Tab /> snapshot Icon children should match snapshot with active 1`] = 
             weight="bold"
           >
             <div
+              aria-hidden="true"
               className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+              role="img"
             >
               <svg
+                aria-hidden="true"
                 className=""
                 data-autoscale={false}
                 data-scale={12}
@@ -491,9 +497,12 @@ exports[`<Tab /> snapshot Icon children should match snapshot with className 1`]
             weight="bold"
           >
             <div
+              aria-hidden="true"
               className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+              role="img"
             >
               <svg
+                aria-hidden="true"
                 className=""
                 data-autoscale={false}
                 data-scale={12}
@@ -554,9 +563,12 @@ exports[`<Tab /> snapshot Icon children should match snapshot with disabled 1`] 
             weight="bold"
           >
             <div
+              aria-hidden="true"
               className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+              role="img"
             >
               <svg
+                aria-hidden="true"
                 className=""
                 data-autoscale={false}
                 data-scale={12}
@@ -619,9 +631,12 @@ exports[`<Tab /> snapshot Icon children should match snapshot with id 1`] = `
             weight="bold"
           >
             <div
+              aria-hidden="true"
               className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+              role="img"
             >
               <svg
+                aria-hidden="true"
                 className=""
                 data-autoscale={false}
                 data-scale={12}
@@ -696,9 +711,12 @@ exports[`<Tab /> snapshot Icon children should match snapshot with style 1`] = `
             weight="bold"
           >
             <div
+              aria-hidden="true"
               className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+              role="img"
             >
               <svg
+                aria-hidden="true"
                 className=""
                 data-autoscale={false}
                 data-scale={12}

--- a/src/components/TextInput/TextInput.unit.test.tsx.snap
+++ b/src/components/TextInput/TextInput.unit.test.tsx.snap
@@ -181,9 +181,12 @@ exports[`<TextInput/> snapshot should match snapshot with error text 1`] = `
                   weight="bold"
                 >
                   <div
+                    aria-hidden="true"
                     className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                    role="img"
                   >
                     <svg
+                      aria-hidden="true"
                       className=""
                       data-autoscale={false}
                       data-scale={16}

--- a/src/components/TextToast/TextToast.unit.test.tsx.snap
+++ b/src/components/TextToast/TextToast.unit.test.tsx.snap
@@ -64,9 +64,12 @@ exports[`<TextToast /> snapshot should match snapshot with icon 1`] = `
       name="noise-removal"
     >
       <div
+        aria-hidden="true"
         className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+        role="img"
       >
         <svg
+          aria-hidden="true"
           className=""
           data-autoscale={false}
           data-scale={32}

--- a/src/components/Toast/Toast.unit.test.tsx.snap
+++ b/src/components/Toast/Toast.unit.test.tsx.snap
@@ -188,9 +188,12 @@ exports[`<Toast /> snapshot should match snapshot 1`] = `
                       weight="bold"
                     >
                       <div
+                        aria-hidden="true"
                         className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+                        role="img"
                       >
                         <svg
+                          aria-hidden="true"
                           className=""
                           data-autoscale={true}
                           data-scale={false}
@@ -247,9 +250,12 @@ exports[`<Toast /> snapshot should match snapshot 1`] = `
                       weight="bold"
                     >
                       <div
+                        aria-hidden="true"
                         className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+                        role="img"
                       >
                         <svg
+                          aria-hidden="true"
                           className=""
                           data-autoscale={true}
                           data-scale={false}
@@ -306,9 +312,12 @@ exports[`<Toast /> snapshot should match snapshot 1`] = `
                       weight="bold"
                     >
                       <div
+                        aria-hidden="true"
                         className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+                        role="img"
                       >
                         <svg
+                          aria-hidden="true"
                           className=""
                           data-autoscale={true}
                           data-scale={false}
@@ -456,9 +465,12 @@ exports[`<Toast /> snapshot should match snapshot 1`] = `
                         weight="bold"
                       >
                         <div
+                          aria-hidden="true"
                           className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+                          role="img"
                         >
                           <svg
+                            aria-hidden="true"
                             className=""
                             data-autoscale={125}
                             data-scale={false}
@@ -836,9 +848,12 @@ exports[`<Toast /> snapshot should match snapshot with aria-live 1`] = `
                       weight="bold"
                     >
                       <div
+                        aria-hidden="true"
                         className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+                        role="img"
                       >
                         <svg
+                          aria-hidden="true"
                           className=""
                           data-autoscale={true}
                           data-scale={false}
@@ -895,9 +910,12 @@ exports[`<Toast /> snapshot should match snapshot with aria-live 1`] = `
                       weight="bold"
                     >
                       <div
+                        aria-hidden="true"
                         className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+                        role="img"
                       >
                         <svg
+                          aria-hidden="true"
                           className=""
                           data-autoscale={true}
                           data-scale={false}
@@ -954,9 +972,12 @@ exports[`<Toast /> snapshot should match snapshot with aria-live 1`] = `
                       weight="bold"
                     >
                       <div
+                        aria-hidden="true"
                         className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+                        role="img"
                       >
                         <svg
+                          aria-hidden="true"
                           className=""
                           data-autoscale={true}
                           data-scale={false}
@@ -1104,9 +1125,12 @@ exports[`<Toast /> snapshot should match snapshot with aria-live 1`] = `
                         weight="bold"
                       >
                         <div
+                          aria-hidden="true"
                           className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+                          role="img"
                         >
                           <svg
+                            aria-hidden="true"
                             className=""
                             data-autoscale={125}
                             data-scale={false}
@@ -1483,9 +1507,12 @@ exports[`<Toast /> snapshot should match snapshot with className 1`] = `
                       weight="bold"
                     >
                       <div
+                        aria-hidden="true"
                         className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+                        role="img"
                       >
                         <svg
+                          aria-hidden="true"
                           className=""
                           data-autoscale={true}
                           data-scale={false}
@@ -1542,9 +1569,12 @@ exports[`<Toast /> snapshot should match snapshot with className 1`] = `
                       weight="bold"
                     >
                       <div
+                        aria-hidden="true"
                         className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+                        role="img"
                       >
                         <svg
+                          aria-hidden="true"
                           className=""
                           data-autoscale={true}
                           data-scale={false}
@@ -1601,9 +1631,12 @@ exports[`<Toast /> snapshot should match snapshot with className 1`] = `
                       weight="bold"
                     >
                       <div
+                        aria-hidden="true"
                         className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+                        role="img"
                       >
                         <svg
+                          aria-hidden="true"
                           className=""
                           data-autoscale={true}
                           data-scale={false}
@@ -1751,9 +1784,12 @@ exports[`<Toast /> snapshot should match snapshot with className 1`] = `
                         weight="bold"
                       >
                         <div
+                          aria-hidden="true"
                           className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+                          role="img"
                         >
                           <svg
+                            aria-hidden="true"
                             className=""
                             data-autoscale={125}
                             data-scale={false}
@@ -2086,9 +2122,12 @@ exports[`<Toast /> snapshot should match snapshot with content children and deta
                       weight="bold"
                     >
                       <div
+                        aria-hidden="true"
                         className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+                        role="img"
                       >
                         <svg
+                          aria-hidden="true"
                           className=""
                           data-autoscale={true}
                           data-scale={false}
@@ -2145,9 +2184,12 @@ exports[`<Toast /> snapshot should match snapshot with content children and deta
                       weight="bold"
                     >
                       <div
+                        aria-hidden="true"
                         className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+                        role="img"
                       >
                         <svg
+                          aria-hidden="true"
                           className=""
                           data-autoscale={true}
                           data-scale={false}
@@ -2204,9 +2246,12 @@ exports[`<Toast /> snapshot should match snapshot with content children and deta
                       weight="bold"
                     >
                       <div
+                        aria-hidden="true"
                         className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+                        role="img"
                       >
                         <svg
+                          aria-hidden="true"
                           className=""
                           data-autoscale={true}
                           data-scale={false}
@@ -2355,9 +2400,12 @@ exports[`<Toast /> snapshot should match snapshot with content children and deta
                         weight="bold"
                       >
                         <div
+                          aria-hidden="true"
                           className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+                          role="img"
                         >
                           <svg
+                            aria-hidden="true"
                             className=""
                             data-autoscale={125}
                             data-scale={false}
@@ -2677,9 +2725,12 @@ exports[`<Toast /> snapshot should match snapshot with details and content child
                       weight="bold"
                     >
                       <div
+                        aria-hidden="true"
                         className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+                        role="img"
                       >
                         <svg
+                          aria-hidden="true"
                           className=""
                           data-autoscale={true}
                           data-scale={false}
@@ -2736,9 +2787,12 @@ exports[`<Toast /> snapshot should match snapshot with details and content child
                       weight="bold"
                     >
                       <div
+                        aria-hidden="true"
                         className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+                        role="img"
                       >
                         <svg
+                          aria-hidden="true"
                           className=""
                           data-autoscale={true}
                           data-scale={false}
@@ -2795,9 +2849,12 @@ exports[`<Toast /> snapshot should match snapshot with details and content child
                       weight="bold"
                     >
                       <div
+                        aria-hidden="true"
                         className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+                        role="img"
                       >
                         <svg
+                          aria-hidden="true"
                           className=""
                           data-autoscale={true}
                           data-scale={false}
@@ -2946,9 +3003,12 @@ exports[`<Toast /> snapshot should match snapshot with details and content child
                         weight="bold"
                       >
                         <div
+                          aria-hidden="true"
                           className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+                          role="img"
                         >
                           <svg
+                            aria-hidden="true"
                             className=""
                             data-autoscale={125}
                             data-scale={false}
@@ -3311,9 +3371,12 @@ exports[`<Toast /> snapshot should match snapshot with details children and cont
                       weight="bold"
                     >
                       <div
+                        aria-hidden="true"
                         className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+                        role="img"
                       >
                         <svg
+                          aria-hidden="true"
                           className=""
                           data-autoscale={true}
                           data-scale={false}
@@ -3370,9 +3433,12 @@ exports[`<Toast /> snapshot should match snapshot with details children and cont
                       weight="bold"
                     >
                       <div
+                        aria-hidden="true"
                         className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+                        role="img"
                       >
                         <svg
+                          aria-hidden="true"
                           className=""
                           data-autoscale={true}
                           data-scale={false}
@@ -3429,9 +3495,12 @@ exports[`<Toast /> snapshot should match snapshot with details children and cont
                       weight="bold"
                     >
                       <div
+                        aria-hidden="true"
                         className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+                        role="img"
                       >
                         <svg
+                          aria-hidden="true"
                           className=""
                           data-autoscale={true}
                           data-scale={false}
@@ -3579,9 +3648,12 @@ exports[`<Toast /> snapshot should match snapshot with details children and cont
                         weight="bold"
                       >
                         <div
+                          aria-hidden="true"
                           className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+                          role="img"
                         >
                           <svg
+                            aria-hidden="true"
                             className=""
                             data-autoscale={125}
                             data-scale={false}
@@ -3959,9 +4031,12 @@ exports[`<Toast /> snapshot should match snapshot with id 1`] = `
                       weight="bold"
                     >
                       <div
+                        aria-hidden="true"
                         className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+                        role="img"
                       >
                         <svg
+                          aria-hidden="true"
                           className=""
                           data-autoscale={true}
                           data-scale={false}
@@ -4018,9 +4093,12 @@ exports[`<Toast /> snapshot should match snapshot with id 1`] = `
                       weight="bold"
                     >
                       <div
+                        aria-hidden="true"
                         className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+                        role="img"
                       >
                         <svg
+                          aria-hidden="true"
                           className=""
                           data-autoscale={true}
                           data-scale={false}
@@ -4077,9 +4155,12 @@ exports[`<Toast /> snapshot should match snapshot with id 1`] = `
                       weight="bold"
                     >
                       <div
+                        aria-hidden="true"
                         className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+                        role="img"
                       >
                         <svg
+                          aria-hidden="true"
                           className=""
                           data-autoscale={true}
                           data-scale={false}
@@ -4227,9 +4308,12 @@ exports[`<Toast /> snapshot should match snapshot with id 1`] = `
                         weight="bold"
                       >
                         <div
+                          aria-hidden="true"
                           className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+                          role="img"
                         >
                           <svg
+                            aria-hidden="true"
                             className=""
                             data-autoscale={125}
                             data-scale={false}
@@ -4615,9 +4699,12 @@ exports[`<Toast /> snapshot should match snapshot with style 1`] = `
                       weight="bold"
                     >
                       <div
+                        aria-hidden="true"
                         className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+                        role="img"
                       >
                         <svg
+                          aria-hidden="true"
                           className=""
                           data-autoscale={true}
                           data-scale={false}
@@ -4674,9 +4761,12 @@ exports[`<Toast /> snapshot should match snapshot with style 1`] = `
                       weight="bold"
                     >
                       <div
+                        aria-hidden="true"
                         className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+                        role="img"
                       >
                         <svg
+                          aria-hidden="true"
                           className=""
                           data-autoscale={true}
                           data-scale={false}
@@ -4733,9 +4823,12 @@ exports[`<Toast /> snapshot should match snapshot with style 1`] = `
                       weight="bold"
                     >
                       <div
+                        aria-hidden="true"
                         className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+                        role="img"
                       >
                         <svg
+                          aria-hidden="true"
                           className=""
                           data-autoscale={true}
                           data-scale={false}
@@ -4883,9 +4976,12 @@ exports[`<Toast /> snapshot should match snapshot with style 1`] = `
                         weight="bold"
                       >
                         <div
+                          aria-hidden="true"
                           className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+                          role="img"
                         >
                           <svg
+                            aria-hidden="true"
                             className=""
                             data-autoscale={125}
                             data-scale={false}
@@ -5197,9 +5293,12 @@ exports[`<Toast /> snapshot should match snapshot with title 1`] = `
                     weight="bold"
                   >
                     <div
+                      aria-hidden="true"
                       className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+                      role="img"
                     >
                       <svg
+                        aria-hidden="true"
                         className=""
                         data-autoscale={true}
                         data-scale={false}
@@ -5253,9 +5352,12 @@ exports[`<Toast /> snapshot should match snapshot with title 1`] = `
                     weight="bold"
                   >
                     <div
+                      aria-hidden="true"
                       className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+                      role="img"
                     >
                       <svg
+                        aria-hidden="true"
                         className=""
                         data-autoscale={true}
                         data-scale={false}
@@ -5309,9 +5411,12 @@ exports[`<Toast /> snapshot should match snapshot with title 1`] = `
                     weight="bold"
                   >
                     <div
+                      aria-hidden="true"
                       className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+                      role="img"
                     >
                       <svg
+                        aria-hidden="true"
                         className=""
                         data-autoscale={true}
                         data-scale={false}
@@ -5517,9 +5622,12 @@ exports[`<Toast /> snapshot should match snapshot with title 1`] = `
                         weight="bold"
                       >
                         <div
+                          aria-hidden="true"
                           className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+                          role="img"
                         >
                           <svg
+                            aria-hidden="true"
                             className=""
                             data-autoscale={125}
                             data-scale={false}

--- a/src/components/ToastDetails/ToastDetails.unit.test.tsx.snap
+++ b/src/components/ToastDetails/ToastDetails.unit.test.tsx.snap
@@ -330,9 +330,12 @@ exports[`<ToastDetails /> snapshot should match snapshot with complete props 1`]
                   weight="bold"
                 >
                   <div
+                    aria-hidden="true"
                     className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+                    role="img"
                   >
                     <svg
+                      aria-hidden="true"
                       className=""
                       data-autoscale={true}
                       data-scale={false}
@@ -389,9 +392,12 @@ exports[`<ToastDetails /> snapshot should match snapshot with complete props 1`]
                   weight="bold"
                 >
                   <div
+                    aria-hidden="true"
                     className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+                    role="img"
                   >
                     <svg
+                      aria-hidden="true"
                       className=""
                       data-autoscale={true}
                       data-scale={false}
@@ -449,9 +455,12 @@ exports[`<ToastDetails /> snapshot should match snapshot with complete props 1`]
                   weight="filled"
                 >
                   <div
+                    aria-hidden="true"
                     className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+                    role="img"
                   >
                     <svg
+                      aria-hidden="true"
                       className=""
                       data-autoscale={true}
                       data-scale={false}
@@ -608,9 +617,12 @@ exports[`<ToastDetails /> snapshot should match snapshot with complete props and
                   weight="bold"
                 >
                   <div
+                    aria-hidden="true"
                     className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+                    role="img"
                   >
                     <svg
+                      aria-hidden="true"
                       className=""
                       data-autoscale={true}
                       data-scale={false}
@@ -667,9 +679,12 @@ exports[`<ToastDetails /> snapshot should match snapshot with complete props and
                   weight="bold"
                 >
                   <div
+                    aria-hidden="true"
                     className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+                    role="img"
                   >
                     <svg
+                      aria-hidden="true"
                       className=""
                       data-autoscale={true}
                       data-scale={false}
@@ -727,9 +742,12 @@ exports[`<ToastDetails /> snapshot should match snapshot with complete props and
                   weight="filled"
                 >
                   <div
+                    aria-hidden="true"
                     className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+                    role="img"
                   >
                     <svg
+                      aria-hidden="true"
                       className=""
                       data-autoscale={true}
                       data-scale={false}
@@ -853,9 +871,12 @@ exports[`<ToastDetails /> snapshot should match snapshot with controls 1`] = `
                   weight="bold"
                 >
                   <div
+                    aria-hidden="true"
                     className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+                    role="img"
                   >
                     <svg
+                      aria-hidden="true"
                       className=""
                       data-autoscale={true}
                       data-scale={false}
@@ -912,9 +933,12 @@ exports[`<ToastDetails /> snapshot should match snapshot with controls 1`] = `
                   weight="bold"
                 >
                   <div
+                    aria-hidden="true"
                     className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+                    role="img"
                   >
                     <svg
+                      aria-hidden="true"
                       className=""
                       data-autoscale={true}
                       data-scale={false}
@@ -972,9 +996,12 @@ exports[`<ToastDetails /> snapshot should match snapshot with controls 1`] = `
                   weight="filled"
                 >
                   <div
+                    aria-hidden="true"
                     className="md-icon-wrapper md-icon-auto-scales md-icon-scales"
+                    role="img"
                   >
                     <svg
+                      aria-hidden="true"
                       className=""
                       data-autoscale={true}
                       data-scale={false}

--- a/src/components/ToastNotification/ToastNotification.unit.test.tsx.snap
+++ b/src/components/ToastNotification/ToastNotification.unit.test.tsx.snap
@@ -309,9 +309,12 @@ exports[`<ToastNotification /> snapshot should match snapshot with leading visua
             weight="bold"
           >
             <div
+              aria-hidden="true"
               className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+              role="img"
             >
               <svg
+                aria-hidden="true"
                 className=""
                 data-autoscale={false}
                 data-scale={24}
@@ -470,9 +473,12 @@ exports[`<ToastNotification /> snapshot should match snapshot with onClose and c
                       weight="bold"
                     >
                       <div
+                        aria-hidden="true"
                         className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                        role="img"
                       >
                         <svg
+                          aria-hidden="true"
                           className=""
                           data-autoscale={false}
                           data-scale={16}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2451,10 +2451,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@momentum-design/tokens@npm:^0.0.51":
-  version: 0.0.51
-  resolution: "@momentum-design/tokens@npm:0.0.51"
-  checksum: e555c18094a4a122825131d0a0eaddda87d07e8655f924588649c92044e65206e78245953ecb392b8756220ef58e16848395811b2adc2757c5aaf8dd2d3b2974
+"@momentum-design/tokens@npm:^0.0.44":
+  version: 0.0.44
+  resolution: "@momentum-design/tokens@npm:0.0.44"
+  checksum: 4e76dae4211c2ca7d74b5c4e1a1363f9861a1ee2a0354bdf06762e7ecbc32ac857d93cb3b746e9b813d9065f36591387afc5d96cfd8c98b7a3f6bd6a9e74b27a
   languageName: node
   linkType: hard
 
@@ -2496,7 +2496,7 @@ __metadata:
     "@hot-loader/react-dom": ~16.8.0
     "@momentum-design/animations": ^0.0.4
     "@momentum-design/icons": 0.0.68
-    "@momentum-design/tokens": ^0.0.51
+    "@momentum-design/tokens": ^0.0.44
     "@momentum-ui/design-tokens": ^0.0.63
     "@momentum-ui/icons": 8.28.4
     "@momentum-ui/tokens": ^1.7.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -2451,10 +2451,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@momentum-design/tokens@npm:^0.0.44":
-  version: 0.0.44
-  resolution: "@momentum-design/tokens@npm:0.0.44"
-  checksum: 4e76dae4211c2ca7d74b5c4e1a1363f9861a1ee2a0354bdf06762e7ecbc32ac857d93cb3b746e9b813d9065f36591387afc5d96cfd8c98b7a3f6bd6a9e74b27a
+"@momentum-design/tokens@npm:^0.0.51":
+  version: 0.0.51
+  resolution: "@momentum-design/tokens@npm:0.0.51"
+  checksum: e555c18094a4a122825131d0a0eaddda87d07e8655f924588649c92044e65206e78245953ecb392b8756220ef58e16848395811b2adc2757c5aaf8dd2d3b2974
   languageName: node
   linkType: hard
 
@@ -2496,7 +2496,7 @@ __metadata:
     "@hot-loader/react-dom": ~16.8.0
     "@momentum-design/animations": ^0.0.4
     "@momentum-design/icons": 0.0.68
-    "@momentum-design/tokens": ^0.0.44
+    "@momentum-design/tokens": ^0.0.51
     "@momentum-ui/design-tokens": ^0.0.63
     "@momentum-ui/icons": 8.28.4
     "@momentum-ui/tokens": ^1.7.1


### PR DESCRIPTION
# Description

Adding ariaLabel props to Icons to be able to add a text that explains the meaning of the icon in case it is informative and not decorative.

Accessibility references recommend adding a <title> as a child of the <svg /> tag. However, we receive the svg directly from momentum-design/icons, and it would be an over-do if we transform the element we get to add the title.

Screen readers only need to:
1. In case the icon has decorative meaning, they they should not access it (aria-hidden)
2. In case the icon has informative meaning, they should be able to access it and read the aria-label provided to it.

# Links

*Links to relevent resources.*
