### PR TITLE
fix(codeInput): adding ariaLabel to input

### DIFF
--- a/src/components/CodeInput/CodeInput.tsx
+++ b/src/components/CodeInput/CodeInput.tsx
@@ -20,6 +20,7 @@ const CodeInput: React.FC<Props> = (props: Props): ReactElement => {
     messageArr = [],
     disabled = false,
     className,
+    visibleLabelId,
   } = props;
 
   const [internalMessageArray, setInternalMessageArray] = useState(messageArr);
@@ -48,7 +49,7 @@ const CodeInput: React.FC<Props> = (props: Props): ReactElement => {
   return (
     <div className={classnames(STYLE.wrapper, className)} data-level={messageType}>
       <VerificationInput
-        inputProps={{ 'aria-label': ariaLabel, disabled }}
+        inputProps={{ 'aria-label': ariaLabel, name: visibleLabelId, disabled }}
         length={numDigits}
         onChange={setValue}
         onFocus={() => {

--- a/src/components/CodeInput/CodeInput.types.ts
+++ b/src/components/CodeInput/CodeInput.types.ts
@@ -29,4 +29,8 @@ export interface Props {
    * disabled: whether code input is disabled
    */
   disabled?: boolean;
+  /**
+   * visibleLabelId: the name field to be passed through to the input
+   */
+  visibleLabelId?: string;
 }

--- a/src/components/CodeInput/CodeInput.unit.test.tsx
+++ b/src/components/CodeInput/CodeInput.unit.test.tsx
@@ -34,6 +34,14 @@ describe('CodeInput', () => {
       expect(component.find('input').props().disabled).toBeTruthy();
     });
 
+    it('input accepts prop aria-label', () => {
+      const component = mount(<CodeInput numDigits={6} ariaLabel="enter 6 digit code" />).childAt(
+        0
+      );
+      expect(component.find('input').prop('aria-label')).toBeDefined();
+      expect(component.find('input').prop('aria-label')).toBe('enter 6 digit code');
+    });
+
     it('when a message array is passing in messages should be displayed', async () => {
       let component;
       await act(async () => {

--- a/src/components/CodeInput/CodeInput.unit.test.tsx.snap
+++ b/src/components/CodeInput/CodeInput.unit.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`CodeInput snapshot should match snapshot 1`] = `
         Object {
           "aria-label": undefined,
           "disabled": false,
+          "name": undefined,
         }
       }
       length={6}


### PR DESCRIPTION
# IMPORTANT

**Currently, this project is closed to any external contributions. Any pull request made against this project from external sources will likely be closed. If you would like to make changes to this project, please fork this project.**

# Guide

**This "Help" section can be deleted before submitting this pull request.**

*Update the name of this pull request to reflect the following shape:*

```
{type}/{scope?}/{message}
```

* **type** - A [conventional commit type](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional#type-enum) **REQUIRED**
* **scope** - The kabab-case scope of the changes in this request
* **message** - A short, kebab-case statement describing the changes **REQUIRED**

*Provide a general summary of the scope of the changes in this pull request.*

* [Readme](https://github.com/momentum-design/momentum-react-v2/blob/master/README.md)
* [Getting Started Guide](https://github.com/momentum-design/momentum-react-v2/blob/master/GETTING_STARTED.md)
* [Contributing Guide](https://github.com/momentum-design/momentum-react-v2/blob/master/CONTRIBUTING.md)

# Description

added aria-label to the input fields in codeInput to announce add six digit confirmation code when focus moved to first field input.

# Links

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-367530
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-505989
