### PR TITLE
feat(toast-notification): remove default label of close button

### DIFF
--- a/src/components/NotificationSystem/NotificationSystem.unit.test.tsx.snap
+++ b/src/components/NotificationSystem/NotificationSystem.unit.test.tsx.snap
@@ -67,7 +67,6 @@ exports[`<NotificationSystem /> snapshot should match snapshot 1`] = `
                     class="md-toast-notification-close-button"
                   >
                     <button
-                      aria-label="Close notification"
                       class="md-button-circle-wrapper md-button-simple-wrapper"
                       data-color="primary"
                       data-disabled="false"
@@ -179,7 +178,6 @@ exports[`<NotificationSystem /> snapshot should match snapshot if notification c
                     class="md-toast-notification-close-button"
                   >
                     <button
-                      aria-label="Close notification"
                       class="md-button-circle-wrapper md-button-simple-wrapper"
                       data-color="primary"
                       data-disabled="false"
@@ -292,7 +290,6 @@ exports[`<NotificationSystem /> snapshot should match snapshot if notification c
                     class="md-toast-notification-close-button"
                   >
                     <button
-                      aria-label="Close notification"
                       class="md-button-circle-wrapper md-button-simple-wrapper"
                       data-color="primary"
                       data-disabled="false"
@@ -405,7 +402,6 @@ exports[`<NotificationSystem /> snapshot should match snapshot when limit is set
                     class="md-toast-notification-close-button"
                   >
                     <button
-                      aria-label="Close notification"
                       class="md-button-circle-wrapper md-button-simple-wrapper"
                       data-color="primary"
                       data-disabled="false"
@@ -518,7 +514,6 @@ exports[`<NotificationSystem /> snapshot should match snapshot with body class n
                     class="md-toast-notification-close-button"
                   >
                     <button
-                      aria-label="Close notification"
                       class="md-button-circle-wrapper md-button-simple-wrapper"
                       data-color="primary"
                       data-disabled="false"
@@ -631,7 +626,6 @@ exports[`<NotificationSystem /> snapshot should match snapshot with className 1`
                     class="md-toast-notification-close-button"
                   >
                     <button
-                      aria-label="Close notification"
                       class="md-button-circle-wrapper md-button-simple-wrapper"
                       data-color="primary"
                       data-disabled="false"
@@ -744,7 +738,6 @@ exports[`<NotificationSystem /> snapshot should match snapshot with container cl
                     class="md-toast-notification-close-button"
                   >
                     <button
-                      aria-label="Close notification"
                       class="md-button-circle-wrapper md-button-simple-wrapper"
                       data-color="primary"
                       data-disabled="false"
@@ -853,7 +846,6 @@ exports[`<NotificationSystem /> snapshot should match snapshot with different at
                     class="md-toast-notification-close-button"
                   >
                     <button
-                      aria-label="Close notification"
                       class="md-button-circle-wrapper md-button-simple-wrapper"
                       data-color="primary"
                       data-disabled="false"
@@ -959,7 +951,6 @@ exports[`<NotificationSystem /> snapshot should match snapshot with different po
                     class="md-toast-notification-close-button"
                   >
                     <button
-                      aria-label="Close notification"
                       class="md-button-circle-wrapper md-button-simple-wrapper"
                       data-color="primary"
                       data-disabled="false"
@@ -1076,7 +1067,6 @@ exports[`<NotificationSystem /> snapshot should match snapshot with different zI
                     class="md-toast-notification-close-button"
                   >
                     <button
-                      aria-label="Close notification"
                       class="md-button-circle-wrapper md-button-simple-wrapper"
                       data-color="primary"
                       data-disabled="false"
@@ -1189,7 +1179,6 @@ exports[`<NotificationSystem /> snapshot should match snapshot with enter animat
                     class="md-toast-notification-close-button"
                   >
                     <button
-                      aria-label="Close notification"
                       class="md-button-circle-wrapper md-button-simple-wrapper"
                       data-color="primary"
                       data-disabled="false"
@@ -1302,7 +1291,6 @@ exports[`<NotificationSystem /> snapshot should match snapshot with id 1`] = `
                     class="md-toast-notification-close-button"
                   >
                     <button
-                      aria-label="Close notification"
                       class="md-button-circle-wrapper md-button-simple-wrapper"
                       data-color="primary"
                       data-disabled="false"
@@ -1415,7 +1403,6 @@ exports[`<NotificationSystem /> snapshot should match snapshot with newest on to
                     class="md-toast-notification-close-button"
                   >
                     <button
-                      aria-label="Close notification"
                       class="md-button-circle-wrapper md-button-simple-wrapper"
                       data-color="primary"
                       data-disabled="false"
@@ -1528,7 +1515,6 @@ exports[`<NotificationSystem /> snapshot should match snapshot with style 1`] = 
                     class="md-toast-notification-close-button"
                   >
                     <button
-                      aria-label="Close notification"
                       class="md-button-circle-wrapper md-button-simple-wrapper"
                       data-color="primary"
                       data-disabled="false"
@@ -1641,7 +1627,6 @@ exports[`<NotificationSystem /> snapshot should match snapshot with toast class 
                     class="md-toast-notification-close-button"
                   >
                     <button
-                      aria-label="Close notification"
                       class="md-button-circle-wrapper md-button-simple-wrapper"
                       data-color="primary"
                       data-disabled="false"

--- a/src/components/ToastNotification/ToastNotification.constants.ts
+++ b/src/components/ToastNotification/ToastNotification.constants.ts
@@ -1,9 +1,5 @@
 const CLASS_PREFIX = 'md-toast-notification';
 
-const DEFAULTS = {
-  CLOSE_BUTTON_LABEL: 'Close notification',
-};
-
 const STYLE = {
   wrapper: `${CLASS_PREFIX}-wrapper`,
   body: `${CLASS_PREFIX}-body`,
@@ -13,4 +9,4 @@ const STYLE = {
   buttonGroup: `${CLASS_PREFIX}-button-group`,
 };
 
-export { CLASS_PREFIX, DEFAULTS, STYLE };
+export { CLASS_PREFIX, STYLE };

--- a/src/components/ToastNotification/ToastNotification.tsx
+++ b/src/components/ToastNotification/ToastNotification.tsx
@@ -5,7 +5,7 @@ import ModalContainer from '../ModalContainer';
 import ButtonCircle from '../ButtonCircle';
 import Icon from '../Icon';
 
-import { STYLE, DEFAULTS } from './ToastNotification.constants';
+import { STYLE } from './ToastNotification.constants';
 import { Props } from './ToastNotification.types';
 import './ToastNotification.style.scss';
 import Text from '../Text';
@@ -14,16 +14,8 @@ import Text from '../Text';
  * The ToastNotification component.
  */
 const ToastNotification: FC<Props> = (props: Props) => {
-  const {
-    className,
-    id,
-    style,
-    content,
-    leadingVisual,
-    buttonGroup,
-    onClose,
-    closeButtonLabel = DEFAULTS.CLOSE_BUTTON_LABEL,
-  } = props;
+  const { className, id, style, content, leadingVisual, buttonGroup, onClose, closeButtonLabel } =
+    props;
 
   return (
     <ModalContainer

--- a/src/components/ToastNotification/ToastNotification.types.ts
+++ b/src/components/ToastNotification/ToastNotification.types.ts
@@ -41,7 +41,7 @@ export interface Props {
   style?: CSSProperties;
 
   /**
-   * Callback when user clicks on the close button.
+   * Callback when user clicks on the close button. If defined, please also pass closeButtonLabel property.
    */
   onClose?: (event: PressEvent) => void;
 

--- a/src/components/ToastNotification/ToastNotification.unit.test.tsx
+++ b/src/components/ToastNotification/ToastNotification.unit.test.tsx
@@ -13,6 +13,7 @@ describe('<ToastNotification />', () => {
   let buttonGroup: ReactElement<ButtonPillProps>;
   let onClose;
   const exampleContent = 'Example text';
+  const closeButtonLabel = 'Close toast';
 
   beforeEach(() => {
     leadingVisual = <Icon name="help-circle" scale={24} weight="bold" />;
@@ -109,6 +110,20 @@ describe('<ToastNotification />', () => {
 
       expect(container).toMatchSnapshot();
     });
+
+    it('should match snapshot with onClose and closeButtonLabel', async () => {
+      expect.assertions(1);
+
+      const container = await mountAndWait(
+        <ToastNotification
+          content={exampleContent}
+          onClose={onClose}
+          closeButtonLabel={closeButtonLabel}
+        />
+      );
+
+      expect(container).toMatchSnapshot();
+    });
   });
 
   describe('attributes', () => {
@@ -159,7 +174,7 @@ describe('<ToastNotification />', () => {
       expect(element.getAttribute('style')).toBe(styleString);
     });
 
-    it('should wrap the onClose inside when onClose is provided', async () => {
+    it('should wrap the onClose inside when onClose is provided and closeButtonLabel is undefined', async () => {
       expect.assertions(2);
 
       const wrapper = await mountAndWait(
@@ -169,7 +184,7 @@ describe('<ToastNotification />', () => {
       const button = wrapper.find('.md-toast-notification-close-button button');
 
       expect(element).toBeDefined();
-      expect(button.props()['aria-label']).toBe(CONSTANTS.DEFAULTS.CLOSE_BUTTON_LABEL);
+      expect(button.props()['aria-label']).toBe(undefined);
     });
 
     it('should have label of the close button when both onClose and closeButtonLabel defined', async () => {

--- a/src/components/ToastNotification/ToastNotification.unit.test.tsx.snap
+++ b/src/components/ToastNotification/ToastNotification.unit.test.tsx.snap
@@ -378,6 +378,125 @@ exports[`<ToastNotification /> snapshot should match snapshot with non string co
 </ToastNotification>
 `;
 
+exports[`<ToastNotification /> snapshot should match snapshot with onClose and closeButtonLabel 1`] = `
+<ToastNotification
+  closeButtonLabel="Close toast"
+  content="Example text"
+  onClose={[Function]}
+>
+  <ModalContainer
+    className="md-toast-notification-wrapper"
+    isPadded={true}
+    round={50}
+  >
+    <div
+      className="md-toast-notification-wrapper md-modal-container-wrapper"
+      data-color="primary"
+      data-elevation={0}
+      data-padded={true}
+      data-round={50}
+    >
+      <div
+        className="md-toast-notification-body"
+      >
+        <Text
+          className="md-toast-notification-content"
+          type="body-primary"
+        >
+          <p
+            className="md-text-wrapper md-toast-notification-content"
+            data-type="body-primary"
+          >
+            Example text
+          </p>
+        </Text>
+        <div
+          className="md-toast-notification-close-button"
+        >
+          <ButtonCircle
+            aria-label="Close toast"
+            ghost={true}
+            onPress={[Function]}
+            size={20}
+          >
+            <ButtonSimple
+              aria-label="Close toast"
+              className="md-button-circle-wrapper"
+              data-color="primary"
+              data-disabled={false}
+              data-ghost={true}
+              data-inverted={false}
+              data-multiple-children={false}
+              data-outline={false}
+              data-shallow-disabled={false}
+              data-size={20}
+              onPress={[Function]}
+            >
+              <FocusRing>
+                <FocusRing
+                  focusClass="md-focus-ring-wrapper children"
+                  focusRingClass="md-focus-ring-wrapper children"
+                >
+                  <button
+                    aria-label="Close toast"
+                    className="md-button-circle-wrapper md-button-simple-wrapper"
+                    data-color="primary"
+                    data-disabled={false}
+                    data-ghost={true}
+                    data-inverted={false}
+                    data-multiple-children={false}
+                    data-outline={false}
+                    data-shallow-disabled={false}
+                    data-size={20}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onDragStart={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchCancel={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchMove={[Function]}
+                    onTouchStart={[Function]}
+                    type="button"
+                  >
+                    <Icon
+                      name="cancel"
+                      scale={16}
+                      weight="bold"
+                    >
+                      <div
+                        className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                      >
+                        <svg
+                          className=""
+                          data-autoscale={false}
+                          data-scale={16}
+                          data-test="cancel"
+                          fill="currentColor"
+                          height="100%"
+                          style={Object {}}
+                          viewBox="0, 0, 32, 32"
+                          width="100%"
+                        />
+                      </div>
+                    </Icon>
+                  </button>
+                </FocusRing>
+              </FocusRing>
+            </ButtonSimple>
+          </ButtonCircle>
+        </div>
+      </div>
+    </div>
+  </ModalContainer>
+</ToastNotification>
+`;
+
 exports[`<ToastNotification /> snapshot should match snapshot with string content 1`] = `
 <ToastNotification
   content="Example text"


### PR DESCRIPTION
# Description

Removing a default label which I suggested in https://github.com/momentum-design/momentum-react-v2/pull/462/files as a string would not be translated in MRV2, so the default cannot exist on this repo.  
