### PR TITLE
fix(overlay-alert): add ariaLabel prop, add aria-labelledby to ModalContainer and id to title text and change title from h3 to h2

### DIFF
--- a/src/components/OverlayAlert/OverlayAlert.stories.args.ts
+++ b/src/components/OverlayAlert/OverlayAlert.stories.args.ts
@@ -95,6 +95,18 @@ const overlayAlertArgTypes = {
       },
     },
   },
+  ariaLabel: {
+    description: 'Provides the ariaLabel within this component as a `string`.',
+    control: { type: 'text' },
+    table: {
+      type: {
+        summary: 'string',
+      },
+      defaultValue: {
+        summary: 'undefined',
+      },
+    },
+  },
 };
 
 export { overlayAlertArgTypes };

--- a/src/components/OverlayAlert/OverlayAlert.stories.docs.mdx
+++ b/src/components/OverlayAlert/OverlayAlert.stories.docs.mdx
@@ -4,6 +4,8 @@ Note that the render state of this component must be managed manually from withi
 
 The default `z-index` for this component is `1000`.
 
+Accessibility Note: If you provide a `title` to `<OverlayAlert />` we will provide the necessary `aria-labelledby` and `id` props for screen reader accessibility. If `title` is not provided, consider providing an `ariaLabel` prop with a meaningful label to ensure your component is accessible to screen reader users.
+
 Example:
 
 ```jsx

--- a/src/components/OverlayAlert/OverlayAlert.tsx
+++ b/src/components/OverlayAlert/OverlayAlert.tsx
@@ -8,6 +8,7 @@ import Text from '../Text';
 import { DEFAULTS, STYLE } from './OverlayAlert.constants';
 import { Props } from './OverlayAlert.types';
 import './OverlayAlert.style.scss';
+import { useId } from 'react-aria';
 
 /**
  * The OverlayAlert component.
@@ -26,8 +27,11 @@ const OverlayAlert: FC<Props> = (props: Props) => {
     title,
     focusLockProps = DEFAULTS.FOCUS_LOCK_PROPS,
     onClose,
+    ariaLabel,
     ...other
   } = props;
+
+  const id = useId();
 
   const onKeyDown = (event: React.KeyboardEvent) => {
     if (event.key === 'Escape') {
@@ -43,13 +47,13 @@ const OverlayAlert: FC<Props> = (props: Props) => {
       onKeyDown={onKeyDown}
       {...other}
     >
-      <ModalContainer round={75} color={modalColor}>
+      <ModalContainer round={75} color={modalColor} aria-label={ariaLabel} aria-labelledby={title ? id : undefined}>
         <div>
           <div>{controls}</div>
         </div>
         {!!title && (
           <div className={classnames(STYLE.title)}>
-            <Text className={classnames(STYLE.title)} type="header-primary">
+            <Text className={classnames(STYLE.title)} type="title" id={id}>
               {title}
             </Text>
           </div>

--- a/src/components/OverlayAlert/OverlayAlert.tsx
+++ b/src/components/OverlayAlert/OverlayAlert.tsx
@@ -8,7 +8,7 @@ import Text from '../Text';
 import { DEFAULTS, STYLE } from './OverlayAlert.constants';
 import { Props } from './OverlayAlert.types';
 import './OverlayAlert.style.scss';
-import { useId } from 'react-aria';
+import { v4 as uuidV4 } from 'uuid';
 
 /**
  * The OverlayAlert component.
@@ -31,7 +31,7 @@ const OverlayAlert: FC<Props> = (props: Props) => {
     ...other
   } = props;
 
-  const id = useId();
+  const id = uuidV4();
 
   const onKeyDown = (event: React.KeyboardEvent) => {
     if (event.key === 'Escape') {

--- a/src/components/OverlayAlert/OverlayAlert.types.ts
+++ b/src/components/OverlayAlert/OverlayAlert.types.ts
@@ -70,4 +70,9 @@ export interface Props extends OverlayProps {
    * Callback function to be fired when Escape key is pressed.
    */
   onClose?: () => void;
+
+  /**
+   * ariaLabel for this OverlayAlert which will be passed onto ModalContainer.
+   */
+  ariaLabel?: string;
 }

--- a/src/components/OverlayAlert/OverlayAlert.unit.test.tsx
+++ b/src/components/OverlayAlert/OverlayAlert.unit.test.tsx
@@ -10,6 +10,7 @@ import userEvent from '@testing-library/user-event';
 
 import OverlayAlert, { OVERLAY_ALERT_CONSTANTS as CONSTANTS, OVERLAY_ALERT_CONSTANTS } from './';
 import { STYLE as OVERLAY_STYLE } from '../Overlay/Overlay.constants';
+import Text from '../Text';
 
 describe('<OverlayAlert />', () => {
   describe('snapshot', () => {
@@ -129,6 +130,17 @@ describe('<OverlayAlert />', () => {
       const children = 'example-children';
 
       const container = mount(<OverlayAlert details={details}>{children}</OverlayAlert>);
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match snapshot with ariaLabel', () => {
+      expect.assertions(1);
+
+      const ariaLabel = 'test-aria-label';
+      const children = 'example-children';
+
+      const container = mount(<OverlayAlert ariaLabel={ariaLabel}>{children}</OverlayAlert>);
 
       expect(container).toMatchSnapshot();
     });
@@ -264,6 +276,55 @@ describe('<OverlayAlert />', () => {
         .getElementsByClassName(OVERLAY_ALERT_CONSTANTS.STYLE.title)[0];
 
       expect(target.innerHTML.includes(title)).toBe(true);
+    });
+
+    it('should have correct text type for title when title provided', () => {
+      expect.assertions(1);
+
+      const title = 'title-example';
+
+      const component = mount(<OverlayAlert title={title} />).find(`.${OVERLAY_STYLE.wrapper}`);
+
+      const titleComponent = component.find(Text).filter({className: OVERLAY_ALERT_CONSTANTS.STYLE.title});
+
+      expect(titleComponent.props().type).toStrictEqual('title');
+    });
+
+    it('should have aria-labelledby and id when title is provided', () => {
+      expect.assertions(2);
+
+      const title = 'title-example';
+
+      const component = mount(<OverlayAlert title={title} />).find(`.${OVERLAY_STYLE.wrapper}`);
+
+      const titleComponent = component.find(Text).filter({type: 'title'});
+
+      const modalContainerComponent = component.find(ModalContainer);
+
+      expect(titleComponent.props().id).toStrictEqual('test-ID');
+      expect(modalContainerComponent.props()['aria-labelledby']).toStrictEqual('test-ID');
+    });
+
+    it('should not have aria-labelledby when title is not provided', () => {
+      expect.assertions(1);
+
+      const component = mount(<OverlayAlert />).find(`.${OVERLAY_STYLE.wrapper}`);
+
+      const modalContainerComponent = component.find(ModalContainer);
+
+      expect(modalContainerComponent.props()['aria-labelledby']).toBe(undefined);
+    });
+
+    it('should pass aria-label through to ModalContiner when ariaLabel is provided', () => {
+      expect.assertions(1);
+
+      const ariaLabel = 'test-aria-label'
+
+      const component = mount(<OverlayAlert ariaLabel={ariaLabel}/>).find(`.${OVERLAY_STYLE.wrapper}`);
+
+      const modalContainerComponent = component.find(ModalContainer);
+
+      expect(modalContainerComponent.props()['aria-label']).toBe(ariaLabel);
     });
 
     it('should not render an empty div when no title is provided', () => {

--- a/src/components/OverlayAlert/OverlayAlert.unit.test.tsx
+++ b/src/components/OverlayAlert/OverlayAlert.unit.test.tsx
@@ -12,6 +12,12 @@ import OverlayAlert, { OVERLAY_ALERT_CONSTANTS as CONSTANTS, OVERLAY_ALERT_CONST
 import { STYLE as OVERLAY_STYLE } from '../Overlay/Overlay.constants';
 import Text from '../Text';
 
+jest.mock('uuid', () => {
+  return {
+    v4: () => 'test-ID',
+  };
+});
+
 describe('<OverlayAlert />', () => {
   describe('snapshot', () => {
     it('should match snapshot', () => {
@@ -318,7 +324,7 @@ describe('<OverlayAlert />', () => {
     it('should pass aria-label through to ModalContiner when ariaLabel is provided', () => {
       expect.assertions(1);
 
-      const ariaLabel = 'test-aria-label'
+      const ariaLabel = 'test-aria-label';
 
       const component = mount(<OverlayAlert ariaLabel={ariaLabel}/>).find(`.${OVERLAY_STYLE.wrapper}`);
 

--- a/src/components/OverlayAlert/OverlayAlert.unit.test.tsx.snap
+++ b/src/components/OverlayAlert/OverlayAlert.unit.test.tsx.snap
@@ -432,6 +432,188 @@ exports[`<OverlayAlert /> snapshot should match snapshot with actions 1`] = `
 </OverlayAlert>
 `;
 
+exports[`<OverlayAlert /> snapshot should match snapshot with ariaLabel 1`] = `
+<OverlayAlert
+  ariaLabel="test-aria-label"
+>
+  <Overlay
+    className="md-overlay-alert-wrapper"
+    color="secondary"
+    focusLockProps={
+      Object {
+        "returnFocus": true,
+      }
+    }
+    onKeyDown={[Function]}
+  >
+    <FocusLock
+      as="div"
+      autoFocus={true}
+      disabled={false}
+      lockProps={Object {}}
+      noFocusGuards={false}
+      persistentFocus={false}
+      returnFocus={true}
+    >
+      <div
+        data-focus-guard={true}
+        key="guard-first"
+        style={
+          Object {
+            "height": "0px",
+            "left": "1px",
+            "overflow": "hidden",
+            "padding": 0,
+            "position": "fixed",
+            "top": "1px",
+            "width": "1px",
+          }
+        }
+        tabIndex={0}
+      />
+      <div
+        data-focus-guard={true}
+        key="guard-nearest"
+        style={
+          Object {
+            "height": "0px",
+            "left": "1px",
+            "overflow": "hidden",
+            "padding": 0,
+            "position": "fixed",
+            "top": "1px",
+            "width": "1px",
+          }
+        }
+        tabIndex={1}
+      />
+      <div
+        data-focus-lock-disabled={false}
+        onBlur={[Function]}
+        onFocus={[Function]}
+      >
+        <SideEffect(FocusWatcher)
+          autoFocus={true}
+          disabled={false}
+          observed={
+            <div
+              data-focus-lock-disabled="false"
+            >
+              <div
+                class="md-overlay-alert-wrapper md-overlay-wrapper"
+                data-color="secondary"
+                data-fullscreen="false"
+              >
+                <div
+                  aria-label="test-aria-label"
+                  class="md-modal-container-wrapper"
+                  data-color="primary"
+                  data-elevation="0"
+                  data-padded="false"
+                  data-round="75"
+                >
+                  <div>
+                    <div />
+                  </div>
+                  <div>
+                    example-children
+                  </div>
+                  <div />
+                </div>
+              </div>
+            </div>
+          }
+          onActivation={[Function]}
+          onDeactivation={[Function]}
+          persistentFocus={false}
+          shards={Array []}
+        >
+          <FocusWatcher
+            autoFocus={true}
+            disabled={false}
+            observed={
+              <div
+                data-focus-lock-disabled="false"
+              >
+                <div
+                  class="md-overlay-alert-wrapper md-overlay-wrapper"
+                  data-color="secondary"
+                  data-fullscreen="false"
+                >
+                  <div
+                    aria-label="test-aria-label"
+                    class="md-modal-container-wrapper"
+                    data-color="primary"
+                    data-elevation="0"
+                    data-padded="false"
+                    data-round="75"
+                  >
+                    <div>
+                      <div />
+                    </div>
+                    <div>
+                      example-children
+                    </div>
+                    <div />
+                  </div>
+                </div>
+              </div>
+            }
+            onActivation={[Function]}
+            onDeactivation={[Function]}
+            persistentFocus={false}
+            shards={Array []}
+          />
+        </SideEffect(FocusWatcher)>
+        <div
+          className="md-overlay-alert-wrapper md-overlay-wrapper"
+          data-color="secondary"
+          data-fullscreen={false}
+          onKeyDown={[Function]}
+        >
+          <ModalContainer
+            aria-label="test-aria-label"
+            round={75}
+          >
+            <div
+              aria-label="test-aria-label"
+              className="md-modal-container-wrapper"
+              data-color="primary"
+              data-elevation={0}
+              data-padded={false}
+              data-round={75}
+            >
+              <div>
+                <div />
+              </div>
+              <div>
+                example-children
+              </div>
+              <div />
+            </div>
+          </ModalContainer>
+        </div>
+      </div>
+      <div
+        data-focus-guard={true}
+        style={
+          Object {
+            "height": "0px",
+            "left": "1px",
+            "overflow": "hidden",
+            "padding": 0,
+            "position": "fixed",
+            "top": "1px",
+            "width": "1px",
+          }
+        }
+        tabIndex={0}
+      />
+    </FocusLock>
+  </Overlay>
+</OverlayAlert>
+`;
+
 exports[`<OverlayAlert /> snapshot should match snapshot with className 1`] = `
 <OverlayAlert
   className="example-class"

--- a/src/components/OverlayAlert/OverlayAlert.unit.test.tsx.snap
+++ b/src/components/OverlayAlert/OverlayAlert.unit.test.tsx.snap
@@ -2441,6 +2441,7 @@ exports[`<OverlayAlert /> snapshot should match snapshot with title 1`] = `
                 data-fullscreen="false"
               >
                 <div
+                  aria-labelledby="test-ID"
                   class="md-modal-container-wrapper"
                   data-color="primary"
                   data-elevation="0"
@@ -2453,12 +2454,13 @@ exports[`<OverlayAlert /> snapshot should match snapshot with title 1`] = `
                   <div
                     class="md-overlay-alert-title"
                   >
-                    <h3
+                    <h2
                       class="md-text-wrapper md-overlay-alert-title"
-                      data-type="header-primary"
+                      data-type="title"
+                      id="test-ID"
                     >
                       example-title
-                    </h3>
+                    </h2>
                   </div>
                   <div />
                   <div />
@@ -2484,6 +2486,7 @@ exports[`<OverlayAlert /> snapshot should match snapshot with title 1`] = `
                   data-fullscreen="false"
                 >
                   <div
+                    aria-labelledby="test-ID"
                     class="md-modal-container-wrapper"
                     data-color="primary"
                     data-elevation="0"
@@ -2496,12 +2499,13 @@ exports[`<OverlayAlert /> snapshot should match snapshot with title 1`] = `
                     <div
                       class="md-overlay-alert-title"
                     >
-                      <h3
+                      <h2
                         class="md-text-wrapper md-overlay-alert-title"
-                        data-type="header-primary"
+                        data-type="title"
+                        id="test-ID"
                       >
                         example-title
-                      </h3>
+                      </h2>
                     </div>
                     <div />
                     <div />
@@ -2522,9 +2526,11 @@ exports[`<OverlayAlert /> snapshot should match snapshot with title 1`] = `
           onKeyDown={[Function]}
         >
           <ModalContainer
+            aria-labelledby="test-ID"
             round={75}
           >
             <div
+              aria-labelledby="test-ID"
               className="md-modal-container-wrapper"
               data-color="primary"
               data-elevation={0}
@@ -2539,14 +2545,16 @@ exports[`<OverlayAlert /> snapshot should match snapshot with title 1`] = `
               >
                 <Text
                   className="md-overlay-alert-title"
-                  type="header-primary"
+                  id="test-ID"
+                  type="title"
                 >
-                  <h3
+                  <h2
                     className="md-text-wrapper md-overlay-alert-title"
-                    data-type="header-primary"
+                    data-type="title"
+                    id="test-ID"
                   >
                     example-title
-                  </h3>
+                  </h2>
                 </Text>
               </div>
               <div />


### PR DESCRIPTION
# Description

- Add ability to pass aria-label through to ModalContainer

- Add aria-labelledby to ModalContainer

- Apply this Id to title component

- Change header type to "title"


# Links

[SPARK-525340](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-525340)
[Tech Breakdown](https://confluence-eng-gpk2.cisco.com/conf/display/WTWC/Bucket+Breakdown+-+SPARK-522085+Overlays)
