### PR TITLE
fix(lightbox): change title to h2, add aria-labelledby and id for title

### DIFF
--- a/src/legacy/Lightbox/index.js
+++ b/src/legacy/Lightbox/index.js
@@ -4,8 +4,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Modal from 'react-aria-modal';
 import { Spinner, Tooltip, Icon } from '@momentum-ui/react-collaboration';
+import { v4 as uuidv4 } from 'uuid';
 
 class Lightbox extends React.Component {
+  constructor(props) {
+    super(props);
+    this.nameId = uuidv4();
+  }
+
   state = {
     viewportDimensions: {
       width: 600,
@@ -485,6 +491,7 @@ class Lightbox extends React.Component {
         titleId="md-lightbox"
         dialogClass="md-lightbox"
         underlayClass="md-lightbox__container"
+        aria-labelledby={this.nameId}
       >
         <div className="md-lightbox__header" ref={(ref) => (this.lightBox = ref)}>
           <div className="md-lightbox__header-item--left">
@@ -494,7 +501,7 @@ class Lightbox extends React.Component {
             </div>
           </div>
           <div className="md-lightbox__header-item--center">
-            <div className="md-lightbox__header-name">{name}</div>
+            <h2 className="md-lightbox__header-name" id={this.nameId}>{name}</h2>
           </div>
           <div className="md-lightbox__header-item--right">
             <Tooltip popoverProps={popoverProps} tooltip={tooltips.exit}>

--- a/src/legacy/Lightbox/tests/index.spec.js
+++ b/src/legacy/Lightbox/tests/index.spec.js
@@ -2,6 +2,12 @@ import React from 'react';
 import { shallow, mount } from 'enzyme';
 import { Lightbox } from '@momentum-ui/react-collaboration';
 
+jest.mock('uuid', () => {
+  return {
+    v4: () => 'test-ID',
+  };
+});
+
 describe('tests for <Lightbox />', () => {
   it('should match SnapShot', () => {
     const container = mount(
@@ -125,6 +131,8 @@ describe('tests for <Lightbox />', () => {
     const sharedBy = container.find('.md-lightbox__header-sharer');
     const timestamp = container.find('.md-lightbox__header-timestamp');
     const name = container.find('.md-lightbox__header-name');
+    expect(container.props()['aria-labelledby']).toStrictEqual(name.props().id);
+    expect(name.type()).toEqual('h2');
     expect(name.text()).toEqual('test');
     expect(timestamp.text()).toEqual('At 4/17/2018, 10:02 AM');
     expect(sharedBy.text()).toEqual('Shared by abcd');

--- a/src/legacy/Lightbox/tests/index.spec.js.snap
+++ b/src/legacy/Lightbox/tests/index.spec.js.snap
@@ -43,6 +43,7 @@ exports[`tests for <Lightbox /> should match SnapShot 1`] = `
   width={100}
 >
   <Displaced
+    aria-labelledby="test-ID"
     dialogClass="md-lightbox"
     focusDialog={true}
     getApplicationNode={[Function]}
@@ -60,7 +61,7 @@ exports[`tests for <Lightbox /> should match SnapShot 1`] = `
               class="md-lightbox__container"
             >
               <div
-                aria-labelledby="md-lightbox"
+                aria-labelledby="test-ID"
                 class="md-lightbox"
                 id="react-aria-modal-dialog"
                 role="dialog"
@@ -86,11 +87,12 @@ exports[`tests for <Lightbox /> should match SnapShot 1`] = `
                   <div
                     class="md-lightbox__header-item--center"
                   >
-                    <div
+                    <h2
                       class="md-lightbox__header-name"
+                      id="test-ID"
                     >
                       test
-                    </div>
+                    </h2>
                   </div>
                   <div
                     class="md-lightbox__header-item--right"
@@ -204,6 +206,7 @@ exports[`tests for <Lightbox /> should match SnapShot 1`] = `
       }
     >
       <Modal
+        aria-labelledby="test-ID"
         dialogClass="md-lightbox"
         dialogId="react-aria-modal-dialog"
         escapeExits={true}
@@ -239,7 +242,7 @@ exports[`tests for <Lightbox /> should match SnapShot 1`] = `
               style={Object {}}
             >
               <div
-                aria-labelledby="md-lightbox"
+                aria-labelledby="test-ID"
                 className="md-lightbox"
                 id="react-aria-modal-dialog"
                 key="b"
@@ -267,11 +270,12 @@ exports[`tests for <Lightbox /> should match SnapShot 1`] = `
                   <div
                     className="md-lightbox__header-item--center"
                   >
-                    <div
+                    <h2
                       className="md-lightbox__header-name"
+                      id="test-ID"
                     >
                       test
-                    </div>
+                    </h2>
                   </div>
                   <div
                     className="md-lightbox__header-item--right"


### PR DESCRIPTION
# Description

Making changes to a legacy component to fix accessibility.

Changed the title to be h2
Added id to title and aria-labelledby to modal

|Before|After|
|---|---|
|![Screenshot 2024-05-22 at 13 15 07](https://github.com/momentum-design/momentum-react-v2/assets/86778628/d3f98fe4-731b-469b-a161-e066a4022337)|![Screenshot 2024-05-22 at 13 15 05](https://github.com/momentum-design/momentum-react-v2/assets/86778628/fd7737ba-a1d1-4710-b0e3-03f7584ceefe)|


# Links


https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-526931
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-503204

