### PR TITLE
fix(selectNext): adding aria-label as prop

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -39,6 +39,7 @@ function Select<T extends object>(props: Props<T>, ref: RefObject<HTMLDivElement
     listboxMaxHeight,
     isInForm = DEFAULTS.IS_IN_FORM,
     listboxWidth,
+    ariaLabel,
   } = props;
   const [popoverInstance, setPopoverInstance] = useState<PopoverInstance>();
   const hasBeenOpened = useRef<boolean>(false);
@@ -48,9 +49,15 @@ function Select<T extends object>(props: Props<T>, ref: RefObject<HTMLDivElement
 
   const state = useSelectState(props);
   const { labelProps, triggerProps, valueProps, menuProps } = useSelect(props, state, selectRef);
-  const { buttonProps } = useButton({ ...triggerProps, isDisabled }, selectRef);
+  const { buttonProps } = useButton(
+    { ...triggerProps, isDisabled, 'aria-label': ariaLabel },
+    selectRef
+  );
   delete buttonProps.color;
   delete buttonProps.onKeyDown;
+  // with aria-labelledby likned to the ID for the <label> below - SR announces frst selection as the label for the dropdown.
+  // aria-labelledby overrides aria-label so if custom aria-label needs to be passed thru cantina aria-labelledby needs to be deleted.
+  delete buttonProps['aria-labelledby'];
 
   const getArrowIcon = (isOpen: boolean) => (isOpen ? 'arrow-up' : 'arrow-down');
 

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -94,10 +94,9 @@ function Select<T extends object>(props: Props<T>, ref: RefObject<HTMLDivElement
    */
   const onKeyDown = useCallback((e) => {
     switch (e.key) {
-      case 'Enter':
-      case ' ':
-      case 'ArrowDown':
+      // useButton already provides Keyboard event support for Enter and Space
       case 'ArrowUp':
+      case 'ArrowDown':
         e.preventDefault();
         state.open();
         break;
@@ -108,6 +107,9 @@ function Select<T extends object>(props: Props<T>, ref: RefObject<HTMLDivElement
     <button
       id={name}
       {...buttonProps}
+      role="combobox"
+      aria-expanded={!!state.isOpen}
+      aria-controls={id}
       className={classnames(
         STYLE.dropdownInput,
         { [STYLE.selected]: state.selectedItem },

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -39,7 +39,6 @@ function Select<T extends object>(props: Props<T>, ref: RefObject<HTMLDivElement
     listboxMaxHeight,
     isInForm = DEFAULTS.IS_IN_FORM,
     listboxWidth,
-    ariaLabel,
   } = props;
   const [popoverInstance, setPopoverInstance] = useState<PopoverInstance>();
   const hasBeenOpened = useRef<boolean>(false);
@@ -49,15 +48,9 @@ function Select<T extends object>(props: Props<T>, ref: RefObject<HTMLDivElement
 
   const state = useSelectState(props);
   const { labelProps, triggerProps, valueProps, menuProps } = useSelect(props, state, selectRef);
-  const { buttonProps } = useButton(
-    { ...triggerProps, isDisabled, 'aria-label': ariaLabel },
-    selectRef
-  );
+  const { buttonProps } = useButton({ ...triggerProps, isDisabled }, selectRef);
   delete buttonProps.color;
   delete buttonProps.onKeyDown;
-  // with aria-labelledby likned to the ID for the <label> below - SR announces frst selection as the label for the dropdown.
-  // aria-labelledby overrides aria-label so if custom aria-label needs to be passed thru cantina aria-labelledby needs to be deleted.
-  delete buttonProps['aria-labelledby'];
 
   const getArrowIcon = (isOpen: boolean) => (isOpen ? 'arrow-up' : 'arrow-down');
 

--- a/src/components/Select/Select.types.ts
+++ b/src/components/Select/Select.types.ts
@@ -58,9 +58,4 @@ export interface Props<T> extends AriaSelectProps<T> {
    * NOTE: if set, the popover strategy will be set to 'fixed'
    */
   listboxWidth?: string;
-
-  /**
-   * aria-label to pass to this component.
-   */
-  ariaLabel?: string;
 }

--- a/src/components/Select/Select.types.ts
+++ b/src/components/Select/Select.types.ts
@@ -58,4 +58,9 @@ export interface Props<T> extends AriaSelectProps<T> {
    * NOTE: if set, the popover strategy will be set to 'fixed'
    */
   listboxWidth?: string;
+
+  /**
+   * aria-label to pass to this component.
+   */
+  ariaLabel?: string;
 }

--- a/src/components/Select/Select.unit.test.tsx
+++ b/src/components/Select/Select.unit.test.tsx
@@ -196,6 +196,21 @@ describe('Select', () => {
       expect(container).toMatchSnapshot();
     });
 
+    it('should match snapshot with aria-label', async () => {
+      expect.assertions(1);
+
+      const ariaLabel = 'test-aria-label';
+
+      container = await mountAndWait(
+        <Select ariaLabel={ariaLabel} label="test">
+          <Item>Item 1</Item>
+          <Item>Item 2</Item>
+        </Select>
+      );
+
+      expect(container).toMatchSnapshot();
+    });
+
     it('should match snapshot with title', async () => {
       expect.assertions(1);
 
@@ -298,6 +313,22 @@ describe('Select', () => {
       const element = wrapper.find(Select).getDOMNode();
 
       expect(element.id).toBe(id);
+    });
+
+    it('should have provided aria-label on button when ariaLabel is provided', async () => {
+      expect.assertions(1);
+
+      const ariaLabel = 'example-aira-label';
+
+      const container = await mountAndWait(
+        <Select ariaLabel={ariaLabel} label="test">
+          <Item>Item 1</Item>
+          <Item>Item 2</Item>
+        </Select>
+      );
+      const button = container.find('.md-select-dropdown-input').getDOMNode();
+
+      expect(button.getAttribute('aria-label')).toBe('example-aira-label');
     });
 
     it('should have provided style when style is provided', async () => {
@@ -432,7 +463,7 @@ describe('Select', () => {
       const user = userEvent.setup();
 
       render(
-        <Select id="test-id" label="test">
+        <Select id="test-id" ariaLabel="test-aria-label" label="test">
           <Item>Item 1</Item>
           <Item>Item 2</Item>
         </Select>
@@ -443,7 +474,7 @@ describe('Select', () => {
       expect(listbox).not.toBeInTheDocument();
 
       // list box should be shown after clicking on button
-      await user.click(screen.getByRole('button', { name: 'test' }));
+      await user.click(screen.getByRole('button', { name: 'test-aria-label' }));
       expect(screen.getByRole('listbox')).toBeVisible();
     });
 
@@ -451,7 +482,7 @@ describe('Select', () => {
       const user = userEvent.setup();
 
       render(
-        <Select id="test-id" label="test">
+        <Select id="test-id" ariaLabel="test-aria-label" label="test">
           <Item>Item 1</Item>
           <Item>Item 2</Item>
         </Select>
@@ -461,7 +492,7 @@ describe('Select', () => {
       const listbox = screen.queryByRole('listbox');
       expect(listbox).not.toBeInTheDocument();
 
-      const button = screen.getByRole('button', { name: 'test' });
+      const button = screen.getByRole('button', { name: 'test-aria-label' });
       button.focus();
       expect(button).toHaveFocus();
 
@@ -474,7 +505,7 @@ describe('Select', () => {
       const user = userEvent.setup();
 
       render(
-        <Select id="test-id" label="test">
+        <Select id="test-id" ariaLabel="test-aria-label" label="test">
           <Item>Item 1</Item>
           <Item>Item 2</Item>
         </Select>
@@ -484,7 +515,7 @@ describe('Select', () => {
       const listbox = screen.queryByRole('listbox');
       expect(listbox).not.toBeInTheDocument();
 
-      const button = screen.getByRole('button', { name: 'test' });
+      const button = screen.getByRole('button', { name: 'test-aria-label' });
       button.focus();
       expect(button).toHaveFocus();
 
@@ -497,7 +528,7 @@ describe('Select', () => {
       const user = userEvent.setup();
 
       render(
-        <Select id="test-id" label="test">
+        <Select id="test-id" ariaLabel="test-aria-label" label="test">
           <Item>Item 1</Item>
           <Item>Item 2</Item>
         </Select>
@@ -507,7 +538,7 @@ describe('Select', () => {
       const listbox = screen.queryByRole('listbox');
       expect(listbox).not.toBeInTheDocument();
 
-      const button = screen.getByRole('button', { name: 'test' });
+      const button = screen.getByRole('button', { name: 'test-aria-label' });
       button.focus();
       expect(button).toHaveFocus();
 
@@ -520,7 +551,7 @@ describe('Select', () => {
       const user = userEvent.setup();
 
       render(
-        <Select id="test-id" label="test">
+        <Select id="test-id" ariaLabel="test-aria-label" label="test">
           <Item>Item 1</Item>
           <Item>Item 2</Item>
         </Select>
@@ -530,7 +561,7 @@ describe('Select', () => {
       const listbox = screen.queryByRole('listbox');
       expect(listbox).not.toBeInTheDocument();
 
-      const button = screen.getByRole('button', { name: 'test' });
+      const button = screen.getByRole('button', { name: 'test-aria-label' });
       button.focus();
       expect(button).toHaveFocus();
 
@@ -544,7 +575,7 @@ describe('Select', () => {
 
       render(
         <>
-          <Select id="test-id" label="test">
+          <Select id="test-id" ariaLabel="test-aria-label" label="test">
             <Item>Item 1</Item>
             <Item>Item 2</Item>
           </Select>
@@ -553,7 +584,7 @@ describe('Select', () => {
       );
 
       // open listbox
-      await user.click(screen.getByRole('button', { name: 'test' }));
+      await user.click(screen.getByRole('button', { name: 'test-aria-label' }));
       expect(screen.getByRole('listbox')).toBeVisible();
 
       // close listbox by clicking outside
@@ -567,14 +598,14 @@ describe('Select', () => {
       const user = userEvent.setup();
 
       render(
-        <Select id="test-id" label="test">
+        <Select id="test-id" ariaLabel="test-aria-label" label="test">
           <Item>Item 1</Item>
           <Item>Item 2</Item>
         </Select>
       );
 
       // open listbox
-      await user.click(screen.getByRole('button', { name: 'test' }));
+      await user.click(screen.getByRole('button', { name: 'test-aria-label' }));
       expect(screen.getByRole('listbox')).toBeVisible();
 
       // close listbox by pressing escape
@@ -588,14 +619,14 @@ describe('Select', () => {
       const user = userEvent.setup();
 
       render(
-        <Select id="test-id" label="test">
+        <Select id="test-id" ariaLabel="test-aria-label" label="test">
           <Item>Item 1</Item>
           <Item>Item 2</Item>
         </Select>
       );
 
       // open listbox
-      await user.click(screen.getByRole('button', { name: 'test' }));
+      await user.click(screen.getByRole('button', { name: 'test-aria-label' }));
       expect(screen.getByRole('listbox')).toBeVisible();
 
       // choose first value and close listbox by pressing enter
@@ -606,21 +637,21 @@ describe('Select', () => {
         expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
       });
       // first item should be selected
-      expect(screen.getByRole('button', { name: 'test' }).textContent).toBe('Item 1');
+      expect(screen.getByRole('button', { name: 'test-aria-label' }).textContent).toBe('Item 1');
     });
 
     it('should select second option when pressing arrow-down & enter after opening', async () => {
       const user = userEvent.setup();
 
       render(
-        <Select id="test-id" label="test">
+        <Select id="test-id" ariaLabel="test-aria-label" label="test">
           <Item>Item 1</Item>
           <Item>Item 2</Item>
         </Select>
       );
 
       // open listbox
-      await user.click(screen.getByRole('button', { name: 'test' }));
+      await user.click(screen.getByRole('button', { name: 'test-aria-label' }));
       expect(screen.getByRole('listbox')).toBeVisible();
 
       // choose second value and close listbox by pressing arrow-down and enter
@@ -632,14 +663,14 @@ describe('Select', () => {
         expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
       });
       // second item should be selected
-      expect(screen.getByRole('button', { name: 'test' }).textContent).toBe('Item 2');
+      expect(screen.getByRole('button', { name: 'test-aria-label' }).textContent).toBe('Item 2');
     });
 
     it('should select third option when clicking on it after opening', async () => {
       const user = userEvent.setup();
 
       render(
-        <Select id="test-id" label="test">
+        <Select id="test-id" ariaLabel="test-aria-label" label="test">
           <Item>Item 1</Item>
           <Item>Item 2</Item>
           <Item>Item 3</Item>
@@ -647,7 +678,7 @@ describe('Select', () => {
       );
 
       // open listbox
-      await user.click(screen.getByRole('button', { name: 'test' }));
+      await user.click(screen.getByRole('button', { name: 'test-aria-label' }));
       expect(screen.getByRole('listbox')).toBeVisible();
 
       // choose third value and close listbox by clicking on it
@@ -658,21 +689,22 @@ describe('Select', () => {
         expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
       });
       // second item should be selected
-      expect(screen.getByRole('button', { name: 'test' }).textContent).toBe('Item 3');
+      expect(screen.getByRole('button', { name: 'test-aria-label' }).textContent).toBe('Item 3');
     });
 
     it('should focus on 2nd option after opening if first option is disabled', async () => {
       const user = userEvent.setup();
 
       render(
-        <Select id="test-id" label="test" disabledKeys={['1']}>
+        <Select id="test-id" ariaLabel="test-aria-label" label="test" disabledKeys={['1']}>
           <Item key="1">Item 1</Item>
           <Item key="2">Item 2</Item>
         </Select>
       );
 
       // open listbox
-      await user.click(screen.getByRole('button', { name: 'test' }));
+      await user.click(screen.getByRole('button', { name: 'test-aria-label' }));
+
       expect(screen.getByRole('listbox')).toBeVisible();
 
       // choose second value and close listbox by pressing enter
@@ -683,7 +715,7 @@ describe('Select', () => {
         expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
       });
       // second item should be selected
-      expect(screen.getByRole('button', { name: 'test' }).textContent).toBe('Item 2');
+      expect(screen.getByRole('button', { name: 'test-aria-label' }).textContent).toBe('Item 2');
     });
   });
 });

--- a/src/components/Select/Select.unit.test.tsx
+++ b/src/components/Select/Select.unit.test.tsx
@@ -315,6 +315,22 @@ describe('Select', () => {
       expect(element.id).toBe(id);
     });
 
+    it('should have role as combobox', async () => {
+      expect.assertions(1);
+
+      const id = 'example-id';
+
+      const container = await mountAndWait(
+        <Select id={id} label="test">
+          <Item>Item 1</Item>
+          <Item>Item 2</Item>
+        </Select>
+      );
+      const button = container.find('.md-select-dropdown-input').getDOMNode();
+
+      expect(button.getAttribute('role')).toBe('combobox');
+    });
+
     it('should have provided aria-label on button when ariaLabel is provided', async () => {
       expect.assertions(1);
 
@@ -474,53 +490,7 @@ describe('Select', () => {
       expect(listbox).not.toBeInTheDocument();
 
       // list box should be shown after clicking on button
-      await user.click(screen.getByRole('button', { name: 'test-aria-label' }));
-      expect(screen.getByRole('listbox')).toBeVisible();
-    });
-
-    it('should show Listbox when focused and pressing enter', async () => {
-      const user = userEvent.setup();
-
-      render(
-        <Select id="test-id" ariaLabel="test-aria-label" label="test">
-          <Item>Item 1</Item>
-          <Item>Item 2</Item>
-        </Select>
-      );
-
-      // list box shouldn't be shown initially
-      const listbox = screen.queryByRole('listbox');
-      expect(listbox).not.toBeInTheDocument();
-
-      const button = screen.getByRole('button', { name: 'test-aria-label' });
-      button.focus();
-      expect(button).toHaveFocus();
-
-      await user.keyboard('{Enter}');
-      // list box should be shown after focus and pressing enter
-      expect(screen.getByRole('listbox')).toBeVisible();
-    });
-
-    it('should show Listbox when focused and pressing space', async () => {
-      const user = userEvent.setup();
-
-      render(
-        <Select id="test-id" ariaLabel="test-aria-label" label="test">
-          <Item>Item 1</Item>
-          <Item>Item 2</Item>
-        </Select>
-      );
-
-      // list box shouldn't be shown initially
-      const listbox = screen.queryByRole('listbox');
-      expect(listbox).not.toBeInTheDocument();
-
-      const button = screen.getByRole('button', { name: 'test-aria-label' });
-      button.focus();
-      expect(button).toHaveFocus();
-
-      await user.keyboard('{ }');
-      // list box should be shown after focus and pressing space
+      await user.click(screen.getByRole('combobox', { name: 'test-aria-label' }));
       expect(screen.getByRole('listbox')).toBeVisible();
     });
 
@@ -538,7 +508,7 @@ describe('Select', () => {
       const listbox = screen.queryByRole('listbox');
       expect(listbox).not.toBeInTheDocument();
 
-      const button = screen.getByRole('button', { name: 'test-aria-label' });
+      const button = screen.getByRole('combobox', { name: 'test-aria-label' });
       button.focus();
       expect(button).toHaveFocus();
 
@@ -561,7 +531,7 @@ describe('Select', () => {
       const listbox = screen.queryByRole('listbox');
       expect(listbox).not.toBeInTheDocument();
 
-      const button = screen.getByRole('button', { name: 'test-aria-label' });
+      const button = screen.getByRole('combobox', { name: 'test-aria-label' });
       button.focus();
       expect(button).toHaveFocus();
 
@@ -584,7 +554,7 @@ describe('Select', () => {
       );
 
       // open listbox
-      await user.click(screen.getByRole('button', { name: 'test-aria-label' }));
+      await user.click(screen.getByRole('combobox', { name: 'test-aria-label' }));
       expect(screen.getByRole('listbox')).toBeVisible();
 
       // close listbox by clicking outside
@@ -605,7 +575,7 @@ describe('Select', () => {
       );
 
       // open listbox
-      await user.click(screen.getByRole('button', { name: 'test-aria-label' }));
+      await user.click(screen.getByRole('combobox', { name: 'test-aria-label' }));
       expect(screen.getByRole('listbox')).toBeVisible();
 
       // close listbox by pressing escape
@@ -626,7 +596,7 @@ describe('Select', () => {
       );
 
       // open listbox
-      await user.click(screen.getByRole('button', { name: 'test-aria-label' }));
+      await user.click(screen.getByRole('combobox', { name: 'test-aria-label' }));
       expect(screen.getByRole('listbox')).toBeVisible();
 
       // choose first value and close listbox by pressing enter
@@ -637,7 +607,7 @@ describe('Select', () => {
         expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
       });
       // first item should be selected
-      expect(screen.getByRole('button', { name: 'test-aria-label' }).textContent).toBe('Item 1');
+      expect(screen.getByRole('combobox', { name: 'test-aria-label' }).textContent).toBe('Item 1');
     });
 
     it('should select second option when pressing arrow-down & enter after opening', async () => {
@@ -651,7 +621,7 @@ describe('Select', () => {
       );
 
       // open listbox
-      await user.click(screen.getByRole('button', { name: 'test-aria-label' }));
+      await user.click(screen.getByRole('combobox', { name: 'test-aria-label' }));
       expect(screen.getByRole('listbox')).toBeVisible();
 
       // choose second value and close listbox by pressing arrow-down and enter
@@ -663,7 +633,7 @@ describe('Select', () => {
         expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
       });
       // second item should be selected
-      expect(screen.getByRole('button', { name: 'test-aria-label' }).textContent).toBe('Item 2');
+      expect(screen.getByRole('combobox', { name: 'test-aria-label' }).textContent).toBe('Item 2');
     });
 
     it('should select third option when clicking on it after opening', async () => {
@@ -678,7 +648,7 @@ describe('Select', () => {
       );
 
       // open listbox
-      await user.click(screen.getByRole('button', { name: 'test-aria-label' }));
+      await user.click(screen.getByRole('combobox', { name: 'test-aria-label' }));
       expect(screen.getByRole('listbox')).toBeVisible();
 
       // choose third value and close listbox by clicking on it
@@ -689,7 +659,7 @@ describe('Select', () => {
         expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
       });
       // second item should be selected
-      expect(screen.getByRole('button', { name: 'test-aria-label' }).textContent).toBe('Item 3');
+      expect(screen.getByRole('combobox', { name: 'test-aria-label' }).textContent).toBe('Item 3');
     });
 
     it('should focus on 2nd option after opening if first option is disabled', async () => {
@@ -703,7 +673,7 @@ describe('Select', () => {
       );
 
       // open listbox
-      await user.click(screen.getByRole('button', { name: 'test-aria-label' }));
+      await user.click(screen.getByRole('combobox', { name: 'test-aria-label' }));
 
       expect(screen.getByRole('listbox')).toBeVisible();
 
@@ -715,7 +685,7 @@ describe('Select', () => {
         expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
       });
       // second item should be selected
-      expect(screen.getByRole('button', { name: 'test-aria-label' }).textContent).toBe('Item 2');
+      expect(screen.getByRole('combobox', { name: 'test-aria-label' }).textContent).toBe('Item 2');
     });
   });
 });

--- a/src/components/Select/Select.unit.test.tsx
+++ b/src/components/Select/Select.unit.test.tsx
@@ -196,21 +196,6 @@ describe('Select', () => {
       expect(container).toMatchSnapshot();
     });
 
-    it('should match snapshot with aria-label', async () => {
-      expect.assertions(1);
-
-      const ariaLabel = 'test-aria-label';
-
-      container = await mountAndWait(
-        <Select ariaLabel={ariaLabel} label="test">
-          <Item>Item 1</Item>
-          <Item>Item 2</Item>
-        </Select>
-      );
-
-      expect(container).toMatchSnapshot();
-    });
-
     it('should match snapshot with title', async () => {
       expect.assertions(1);
 
@@ -329,22 +314,6 @@ describe('Select', () => {
       const button = container.find('.md-select-dropdown-input').getDOMNode();
 
       expect(button.getAttribute('role')).toBe('combobox');
-    });
-
-    it('should have provided aria-label on button when ariaLabel is provided', async () => {
-      expect.assertions(1);
-
-      const ariaLabel = 'example-aira-label';
-
-      const container = await mountAndWait(
-        <Select ariaLabel={ariaLabel} label="test">
-          <Item>Item 1</Item>
-          <Item>Item 2</Item>
-        </Select>
-      );
-      const button = container.find('.md-select-dropdown-input').getDOMNode();
-
-      expect(button.getAttribute('aria-label')).toBe('example-aira-label');
     });
 
     it('should have provided style when style is provided', async () => {
@@ -479,7 +448,7 @@ describe('Select', () => {
       const user = userEvent.setup();
 
       render(
-        <Select id="test-id" ariaLabel="test-aria-label" label="test">
+        <Select id="test-id" label="test">
           <Item>Item 1</Item>
           <Item>Item 2</Item>
         </Select>
@@ -490,7 +459,7 @@ describe('Select', () => {
       expect(listbox).not.toBeInTheDocument();
 
       // list box should be shown after clicking on button
-      await user.click(screen.getByRole('combobox', { name: 'test-aria-label' }));
+      await user.click(screen.getByRole('combobox', { name: 'test' }));
       expect(screen.getByRole('listbox')).toBeVisible();
     });
 
@@ -498,7 +467,7 @@ describe('Select', () => {
       const user = userEvent.setup();
 
       render(
-        <Select id="test-id" ariaLabel="test-aria-label" label="test">
+        <Select id="test-id" label="test">
           <Item>Item 1</Item>
           <Item>Item 2</Item>
         </Select>
@@ -508,7 +477,7 @@ describe('Select', () => {
       const listbox = screen.queryByRole('listbox');
       expect(listbox).not.toBeInTheDocument();
 
-      const button = screen.getByRole('combobox', { name: 'test-aria-label' });
+      const button = screen.getByRole('combobox', { name: 'test' });
       button.focus();
       expect(button).toHaveFocus();
 
@@ -521,7 +490,7 @@ describe('Select', () => {
       const user = userEvent.setup();
 
       render(
-        <Select id="test-id" ariaLabel="test-aria-label" label="test">
+        <Select id="test-id" label="test">
           <Item>Item 1</Item>
           <Item>Item 2</Item>
         </Select>
@@ -531,7 +500,7 @@ describe('Select', () => {
       const listbox = screen.queryByRole('listbox');
       expect(listbox).not.toBeInTheDocument();
 
-      const button = screen.getByRole('combobox', { name: 'test-aria-label' });
+      const button = screen.getByRole('combobox', { name: 'test' });
       button.focus();
       expect(button).toHaveFocus();
 
@@ -545,7 +514,7 @@ describe('Select', () => {
 
       render(
         <>
-          <Select id="test-id" ariaLabel="test-aria-label" label="test">
+          <Select id="test-id" label="test">
             <Item>Item 1</Item>
             <Item>Item 2</Item>
           </Select>
@@ -554,7 +523,7 @@ describe('Select', () => {
       );
 
       // open listbox
-      await user.click(screen.getByRole('combobox', { name: 'test-aria-label' }));
+      await user.click(screen.getByRole('combobox', { name: 'test' }));
       expect(screen.getByRole('listbox')).toBeVisible();
 
       // close listbox by clicking outside
@@ -568,14 +537,14 @@ describe('Select', () => {
       const user = userEvent.setup();
 
       render(
-        <Select id="test-id" ariaLabel="test-aria-label" label="test">
+        <Select id="test-id" label="test">
           <Item>Item 1</Item>
           <Item>Item 2</Item>
         </Select>
       );
 
       // open listbox
-      await user.click(screen.getByRole('combobox', { name: 'test-aria-label' }));
+      await user.click(screen.getByRole('combobox', { name: 'test' }));
       expect(screen.getByRole('listbox')).toBeVisible();
 
       // close listbox by pressing escape
@@ -589,14 +558,14 @@ describe('Select', () => {
       const user = userEvent.setup();
 
       render(
-        <Select id="test-id" ariaLabel="test-aria-label" label="test">
+        <Select id="test-id" label="test">
           <Item>Item 1</Item>
           <Item>Item 2</Item>
         </Select>
       );
 
       // open listbox
-      await user.click(screen.getByRole('combobox', { name: 'test-aria-label' }));
+      await user.click(screen.getByRole('combobox', { name: 'test' }));
       expect(screen.getByRole('listbox')).toBeVisible();
 
       // choose first value and close listbox by pressing enter
@@ -607,21 +576,21 @@ describe('Select', () => {
         expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
       });
       // first item should be selected
-      expect(screen.getByRole('combobox', { name: 'test-aria-label' }).textContent).toBe('Item 1');
+      expect(screen.getByRole('combobox', { name: 'test' }).textContent).toBe('Item 1');
     });
 
     it('should select second option when pressing arrow-down & enter after opening', async () => {
       const user = userEvent.setup();
 
       render(
-        <Select id="test-id" ariaLabel="test-aria-label" label="test">
+        <Select id="test-id" label="test">
           <Item>Item 1</Item>
           <Item>Item 2</Item>
         </Select>
       );
 
       // open listbox
-      await user.click(screen.getByRole('combobox', { name: 'test-aria-label' }));
+      await user.click(screen.getByRole('combobox', { name: 'test' }));
       expect(screen.getByRole('listbox')).toBeVisible();
 
       // choose second value and close listbox by pressing arrow-down and enter
@@ -633,14 +602,14 @@ describe('Select', () => {
         expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
       });
       // second item should be selected
-      expect(screen.getByRole('combobox', { name: 'test-aria-label' }).textContent).toBe('Item 2');
+      expect(screen.getByRole('combobox', { name: 'test' }).textContent).toBe('Item 2');
     });
 
     it('should select third option when clicking on it after opening', async () => {
       const user = userEvent.setup();
 
       render(
-        <Select id="test-id" ariaLabel="test-aria-label" label="test">
+        <Select id="test-id" label="test">
           <Item>Item 1</Item>
           <Item>Item 2</Item>
           <Item>Item 3</Item>
@@ -648,7 +617,7 @@ describe('Select', () => {
       );
 
       // open listbox
-      await user.click(screen.getByRole('combobox', { name: 'test-aria-label' }));
+      await user.click(screen.getByRole('combobox', { name: 'test' }));
       expect(screen.getByRole('listbox')).toBeVisible();
 
       // choose third value and close listbox by clicking on it
@@ -659,21 +628,21 @@ describe('Select', () => {
         expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
       });
       // second item should be selected
-      expect(screen.getByRole('combobox', { name: 'test-aria-label' }).textContent).toBe('Item 3');
+      expect(screen.getByRole('combobox', { name: 'test' }).textContent).toBe('Item 3');
     });
 
     it('should focus on 2nd option after opening if first option is disabled', async () => {
       const user = userEvent.setup();
 
       render(
-        <Select id="test-id" ariaLabel="test-aria-label" label="test" disabledKeys={['1']}>
+        <Select id="test-id" label="test" disabledKeys={['1']}>
           <Item key="1">Item 1</Item>
           <Item key="2">Item 2</Item>
         </Select>
       );
 
       // open listbox
-      await user.click(screen.getByRole('combobox', { name: 'test-aria-label' }));
+      await user.click(screen.getByRole('combobox', { name: 'test' }));
 
       expect(screen.getByRole('listbox')).toBeVisible();
 
@@ -685,7 +654,7 @@ describe('Select', () => {
         expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
       });
       // second item should be selected
-      expect(screen.getByRole('combobox', { name: 'test-aria-label' }).textContent).toBe('Item 2');
+      expect(screen.getByRole('combobox', { name: 'test' }).textContent).toBe('Item 2');
     });
   });
 });

--- a/src/components/Select/Select.unit.test.tsx.snap
+++ b/src/components/Select/Select.unit.test.tsx.snap
@@ -171,7 +171,6 @@ exports[`Select snapshot should match snapshot 1`] = `
           "current": <button
             aria-expanded="false"
             aria-haspopup="listbox"
-            aria-labelledby="test-ID test-ID"
             class="md-select-dropdown-input"
             id="test-id"
             type="button"
@@ -280,7 +279,6 @@ exports[`Select snapshot should match snapshot 1`] = `
           aria-controls={null}
           aria-expanded={false}
           aria-haspopup="listbox"
-          aria-labelledby="test-ID test-ID"
           className="md-select-dropdown-input"
           id="test-id"
           onBlur={[Function]}
@@ -477,7 +475,6 @@ exports[`Select snapshot should match snapshot 1`] = `
               aria-controls={null}
               aria-expanded={false}
               aria-haspopup="listbox"
-              aria-labelledby="test-ID test-ID"
               className="md-select-dropdown-input"
               id="test-id"
               onBlur={[Function]}
@@ -720,7 +717,6 @@ exports[`Select snapshot should match snapshot before and after opening select d
           "current": <button
             aria-expanded="false"
             aria-haspopup="listbox"
-            aria-labelledby="test-ID test-ID"
             class="md-select-dropdown-input"
             id="test-ID"
             type="button"
@@ -829,7 +825,6 @@ exports[`Select snapshot should match snapshot before and after opening select d
           aria-controls={null}
           aria-expanded={false}
           aria-haspopup="listbox"
-          aria-labelledby="test-ID test-ID"
           className="md-select-dropdown-input"
           id="test-ID"
           onBlur={[Function]}
@@ -1026,7 +1021,6 @@ exports[`Select snapshot should match snapshot before and after opening select d
               aria-controls={null}
               aria-expanded={false}
               aria-haspopup="listbox"
-              aria-labelledby="test-ID test-ID"
               className="md-select-dropdown-input"
               id="test-ID"
               onBlur={[Function]}
@@ -1270,7 +1264,6 @@ exports[`Select snapshot should match snapshot before and after opening select d
             aria-controls="test-ID"
             aria-expanded="true"
             aria-haspopup="listbox"
-            aria-labelledby="test-ID test-ID"
             class="md-select-dropdown-input md-select-open"
             id="test-ID"
             type="button"
@@ -1379,7 +1372,6 @@ exports[`Select snapshot should match snapshot before and after opening select d
           aria-controls="test-ID"
           aria-expanded={true}
           aria-haspopup="listbox"
-          aria-labelledby="test-ID test-ID"
           className="md-select-dropdown-input md-select-open"
           id="test-ID"
           onBlur={[Function]}
@@ -1576,7 +1568,6 @@ exports[`Select snapshot should match snapshot before and after opening select d
               aria-controls="test-ID"
               aria-expanded={true}
               aria-haspopup="listbox"
-              aria-labelledby="test-ID test-ID"
               className="md-select-dropdown-input md-select-open"
               id="test-ID"
               onBlur={[Function]}
@@ -2159,6 +2150,554 @@ exports[`Select snapshot should match snapshot before and after opening select d
 </Select>
 `;
 
+exports[`Select snapshot should match snapshot with aria-label 1`] = `
+<Select
+  ariaLabel="test-aria-label"
+  label="test"
+>
+  <div
+    className="md-select-wrapper"
+    style={
+      Object {
+        "--local-width": "100%",
+      }
+    }
+  >
+    <label
+      id="test-ID"
+      onClick={[Function]}
+    >
+      <Text>
+        <p
+          className="md-text-wrapper"
+          data-type="body-primary"
+        >
+          test
+        </p>
+      </Text>
+    </label>
+    <HiddenSelect
+      label="test"
+      state={
+        Object {
+          "close": [Function],
+          "collection": ListCollection {
+            "firstKey": "$.0",
+            "iterable": Object {
+              Symbol(Symbol.iterator): [Function],
+            },
+            "keyMap": Map {
+              "$.0" => Object {
+                "aria-label": undefined,
+                "childNodes": Object {
+                  Symbol(Symbol.iterator): [Function],
+                },
+                "hasChildNodes": false,
+                "index": 0,
+                "key": "$.0",
+                "level": 0,
+                "nextKey": "$.1",
+                "parentKey": null,
+                "prevKey": undefined,
+                "props": Object {
+                  "children": "Item 1",
+                },
+                "rendered": "Item 1",
+                "shouldInvalidate": undefined,
+                "textValue": "Item 1",
+                "type": "item",
+                "value": undefined,
+                "wrapper": undefined,
+              },
+              "$.1" => Object {
+                "aria-label": undefined,
+                "childNodes": Object {
+                  Symbol(Symbol.iterator): [Function],
+                },
+                "hasChildNodes": false,
+                "index": 1,
+                "key": "$.1",
+                "level": 0,
+                "nextKey": undefined,
+                "parentKey": null,
+                "prevKey": "$.0",
+                "props": Object {
+                  "children": "Item 2",
+                },
+                "rendered": "Item 2",
+                "shouldInvalidate": undefined,
+                "textValue": "Item 2",
+                "type": "item",
+                "value": undefined,
+                "wrapper": undefined,
+              },
+            },
+            "lastKey": "$.1",
+          },
+          "disabledKeys": Set {},
+          "focusStrategy": null,
+          "isFocused": false,
+          "isOpen": false,
+          "open": [Function],
+          "selectedItem": null,
+          "selectedKey": null,
+          "selectionManager": SelectionManager {
+            "_isSelectAll": null,
+            "allowsCellSelection": false,
+            "collection": ListCollection {
+              "firstKey": "$.0",
+              "iterable": Object {
+                Symbol(Symbol.iterator): [Function],
+              },
+              "keyMap": Map {
+                "$.0" => Object {
+                  "aria-label": undefined,
+                  "childNodes": Object {
+                    Symbol(Symbol.iterator): [Function],
+                  },
+                  "hasChildNodes": false,
+                  "index": 0,
+                  "key": "$.0",
+                  "level": 0,
+                  "nextKey": "$.1",
+                  "parentKey": null,
+                  "prevKey": undefined,
+                  "props": Object {
+                    "children": "Item 1",
+                  },
+                  "rendered": "Item 1",
+                  "shouldInvalidate": undefined,
+                  "textValue": "Item 1",
+                  "type": "item",
+                  "value": undefined,
+                  "wrapper": undefined,
+                },
+                "$.1" => Object {
+                  "aria-label": undefined,
+                  "childNodes": Object {
+                    Symbol(Symbol.iterator): [Function],
+                  },
+                  "hasChildNodes": false,
+                  "index": 1,
+                  "key": "$.1",
+                  "level": 0,
+                  "nextKey": undefined,
+                  "parentKey": null,
+                  "prevKey": "$.0",
+                  "props": Object {
+                    "children": "Item 2",
+                  },
+                  "rendered": "Item 2",
+                  "shouldInvalidate": undefined,
+                  "textValue": "Item 2",
+                  "type": "item",
+                  "value": undefined,
+                  "wrapper": undefined,
+                },
+              },
+              "lastKey": "$.1",
+            },
+            "state": Object {
+              "childFocusStrategy": null,
+              "disabledKeys": Set {},
+              "disallowEmptySelection": true,
+              "focusedKey": null,
+              "isFocused": false,
+              "selectedKeys": Set {},
+              "selectionMode": "single",
+              "setFocused": [Function],
+              "setFocusedKey": [Function],
+              "setSelectedKeys": [Function],
+            },
+          },
+          "setFocused": [Function],
+          "setSelectedKey": [Function],
+          "toggle": [Function],
+        }
+      }
+      triggerRef={
+        Object {
+          "current": <button
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            aria-label="test-aria-label"
+            class="md-select-dropdown-input"
+            id="test-ID"
+            type="button"
+          >
+            <span
+              class="md-select-selected-item-wrapper"
+              id="test-ID"
+            />
+            <span
+              aria-hidden="true"
+              class="md-select-icon-wrapper"
+            >
+              <div
+                aria-hidden="true"
+                class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  class=""
+                  data-autoscale="false"
+                  data-scale="16"
+                  data-test="arrow-down"
+                  fill="currentColor"
+                  height="100%"
+                  viewBox="0, 0, 32, 32"
+                  width="100%"
+                />
+              </div>
+            </span>
+          </button>,
+        }
+      }
+    >
+      <div
+        aria-hidden={true}
+        style={
+          Object {
+            "border": 0,
+            "clip": "rect(0 0 0 0)",
+            "clipPath": "inset(50%)",
+            "height": 1,
+            "margin": "0 -1px -1px 0",
+            "overflow": "hidden",
+            "padding": 0,
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": 1,
+          }
+        }
+      >
+        <input
+          onFocus={[Function]}
+          style={
+            Object {
+              "fontSize": 16,
+            }
+          }
+          tabIndex={-1}
+          type="text"
+        />
+        <label>
+          test
+          <select
+            onChange={[Function]}
+            size={2}
+            tabIndex={-1}
+            value=""
+          >
+            <option />
+            <option
+              key="$.0"
+              value="$.0"
+            >
+              Item 1
+            </option>
+            <option
+              key="$.1"
+              value="$.1"
+            >
+              Item 2
+            </option>
+          </select>
+        </label>
+      </div>
+    </HiddenSelect>
+    <Popover
+      className="md-select-popover"
+      hideOnEsc={false}
+      interactive={true}
+      onClickOutside={[Function]}
+      onHide={[Function]}
+      onKeyDown={[Function]}
+      placement="bottom"
+      setInstance={[Function]}
+      showArrow={false}
+      strategy="absolute"
+      style={
+        Object {
+          "maxHeight": "none",
+        }
+      }
+      trigger="manual"
+      triggerComponent={
+        <button
+          aria-controls={null}
+          aria-expanded={false}
+          aria-haspopup="listbox"
+          aria-label="test-aria-label"
+          className="md-select-dropdown-input"
+          id="test-ID"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onDragStart={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchCancel={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          type="button"
+        >
+          <span
+            className="md-select-selected-item-wrapper"
+            id="test-ID"
+          />
+          <span
+            aria-hidden="true"
+            className="md-select-icon-wrapper"
+          >
+            <Icon
+              name="arrow-down"
+              scale={16}
+              weight="bold"
+            />
+          </span>
+        </button>
+      }
+    >
+      <LazyTippy
+        animation={false}
+        appendTo="parent"
+        hideOnClick={false}
+        interactive={true}
+        offset={
+          Array [
+            0,
+            5,
+          ]
+        }
+        onClickOutside={[Function]}
+        onHide={[Function]}
+        placement="bottom"
+        plugins={
+          Array [
+            Object {
+              "fn": [Function],
+              "name": "addBackdropPlugin",
+            },
+          ]
+        }
+        popperOptions={
+          Object {
+            "modifiers": Array [
+              Object {
+                "enabled": false,
+                "name": "arrow",
+                "options": Object {
+                  "element": "#arrow1",
+                  "padding": 5,
+                },
+              },
+              Object {
+                "name": "preventOverflow",
+                "options": Object {
+                  "altAxis": true,
+                  "boundariesElement": "scrollParent",
+                  "padding": 8,
+                },
+              },
+            ],
+            "strategy": "absolute",
+          }
+        }
+        render={[Function]}
+        setInstance={[Function]}
+        trigger="manual"
+      >
+        <ForwardRef(TippyWrapper)
+          animation={false}
+          appendTo="parent"
+          hideOnClick={false}
+          interactive={true}
+          offset={
+            Array [
+              0,
+              5,
+            ]
+          }
+          onClickOutside={[Function]}
+          onHide={[Function]}
+          placement="bottom"
+          plugins={
+            Array [
+              Object {
+                "fn": [Function],
+              },
+              Object {
+                "fn": [Function],
+              },
+              Object {
+                "fn": [Function],
+                "name": "addBackdropPlugin",
+              },
+            ]
+          }
+          popperOptions={
+            Object {
+              "modifiers": Array [
+                Object {
+                  "enabled": false,
+                  "name": "arrow",
+                  "options": Object {
+                    "element": "#arrow1",
+                    "padding": 5,
+                  },
+                },
+                Object {
+                  "name": "preventOverflow",
+                  "options": Object {
+                    "altAxis": true,
+                    "boundariesElement": "scrollParent",
+                    "padding": 8,
+                  },
+                },
+              ],
+              "strategy": "absolute",
+            }
+          }
+          render={[Function]}
+          trigger="manual"
+        >
+          <Tippy
+            animation={false}
+            appendTo="parent"
+            hideOnClick={false}
+            interactive={true}
+            offset={
+              Array [
+                0,
+                5,
+              ]
+            }
+            onClickOutside={[Function]}
+            onHide={[Function]}
+            placement="bottom"
+            plugins={
+              Array [
+                Object {
+                  "fn": [Function],
+                },
+                Object {
+                  "fn": [Function],
+                },
+                Object {
+                  "fn": [Function],
+                  "name": "addBackdropPlugin",
+                },
+              ]
+            }
+            popperOptions={
+              Object {
+                "modifiers": Array [
+                  Object {
+                    "enabled": false,
+                    "name": "arrow",
+                    "options": Object {
+                      "element": "#arrow1",
+                      "padding": 5,
+                    },
+                  },
+                  Object {
+                    "name": "preventOverflow",
+                    "options": Object {
+                      "altAxis": true,
+                      "boundariesElement": "scrollParent",
+                      "padding": 8,
+                    },
+                  },
+                ],
+                "strategy": "absolute",
+              }
+            }
+            render={[Function]}
+            trigger="manual"
+          >
+            <button
+              aria-controls={null}
+              aria-expanded={false}
+              aria-haspopup="listbox"
+              aria-label="test-aria-label"
+              className="md-select-dropdown-input"
+              id="test-ID"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onDragStart={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+              onTouchCancel={[Function]}
+              onTouchEnd={[Function]}
+              onTouchMove={[Function]}
+              onTouchStart={[Function]}
+              type="button"
+            >
+              <span
+                className="md-select-selected-item-wrapper"
+                id="test-ID"
+              />
+              <span
+                aria-hidden="true"
+                className="md-select-icon-wrapper"
+              >
+                <Icon
+                  name="arrow-down"
+                  scale={16}
+                  weight="bold"
+                >
+                  <div
+                    aria-hidden="true"
+                    className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      className=""
+                      data-autoscale={false}
+                      data-scale={16}
+                      data-test="arrow-down"
+                      fill="currentColor"
+                      height="100%"
+                      style={Object {}}
+                      viewBox="0, 0, 32, 32"
+                      width="100%"
+                    />
+                  </div>
+                </Icon>
+              </span>
+            </button>
+            <Portal
+              containerInfo={
+                <div
+                  data-tippy-root=""
+                  id="tippy-13"
+                  style="z-index: 9999;"
+                >
+                  
+                </div>
+              }
+            />
+          </Tippy>
+        </ForwardRef(TippyWrapper)>
+      </LazyTippy>
+    </Popover>
+  </div>
+</Select>
+`;
+
 exports[`Select snapshot should match snapshot with border 1`] = `
 <Select
   id="test-id"
@@ -2331,7 +2870,6 @@ exports[`Select snapshot should match snapshot with border 1`] = `
           "current": <button
             aria-expanded="false"
             aria-haspopup="listbox"
-            aria-labelledby="test-ID test-ID"
             class="md-select-dropdown-input borderLess"
             id="test-ID"
             type="button"
@@ -2440,7 +2978,6 @@ exports[`Select snapshot should match snapshot with border 1`] = `
           aria-controls={null}
           aria-expanded={false}
           aria-haspopup="listbox"
-          aria-labelledby="test-ID test-ID"
           className="md-select-dropdown-input borderLess"
           id="test-ID"
           onBlur={[Function]}
@@ -2637,7 +3174,6 @@ exports[`Select snapshot should match snapshot with border 1`] = `
               aria-controls={null}
               aria-expanded={false}
               aria-haspopup="listbox"
-              aria-labelledby="test-ID test-ID"
               className="md-select-dropdown-input borderLess"
               id="test-ID"
               onBlur={[Function]}
@@ -2881,7 +3417,6 @@ exports[`Select snapshot should match snapshot with className 1`] = `
           "current": <button
             aria-expanded="false"
             aria-haspopup="listbox"
-            aria-labelledby="test-ID test-ID"
             class="md-select-dropdown-input"
             id="test-ID"
             type="button"
@@ -2990,7 +3525,6 @@ exports[`Select snapshot should match snapshot with className 1`] = `
           aria-controls={null}
           aria-expanded={false}
           aria-haspopup="listbox"
-          aria-labelledby="test-ID test-ID"
           className="md-select-dropdown-input"
           id="test-ID"
           onBlur={[Function]}
@@ -3187,7 +3721,6 @@ exports[`Select snapshot should match snapshot with className 1`] = `
               aria-controls={null}
               aria-expanded={false}
               aria-haspopup="listbox"
-              aria-labelledby="test-ID test-ID"
               className="md-select-dropdown-input"
               id="test-ID"
               onBlur={[Function]}
@@ -3431,7 +3964,6 @@ exports[`Select snapshot should match snapshot with direction 1`] = `
           "current": <button
             aria-expanded="false"
             aria-haspopup="listbox"
-            aria-labelledby="test-ID test-ID"
             class="md-select-dropdown-input"
             id="test-ID"
             type="button"
@@ -3540,7 +4072,6 @@ exports[`Select snapshot should match snapshot with direction 1`] = `
           aria-controls={null}
           aria-expanded={false}
           aria-haspopup="listbox"
-          aria-labelledby="test-ID test-ID"
           className="md-select-dropdown-input"
           id="test-ID"
           onBlur={[Function]}
@@ -3737,7 +4268,6 @@ exports[`Select snapshot should match snapshot with direction 1`] = `
               aria-controls={null}
               aria-expanded={false}
               aria-haspopup="listbox"
-              aria-labelledby="test-ID test-ID"
               className="md-select-dropdown-input"
               id="test-ID"
               onBlur={[Function]}
@@ -3991,7 +4521,6 @@ exports[`Select snapshot should match snapshot with disabled option 1`] = `
             aria-controls="test-ID"
             aria-expanded="true"
             aria-haspopup="listbox"
-            aria-labelledby="test-ID test-ID"
             class="md-select-dropdown-input md-select-open"
             id="test-ID"
             type="button"
@@ -4100,7 +4629,6 @@ exports[`Select snapshot should match snapshot with disabled option 1`] = `
           aria-controls="test-ID"
           aria-expanded={true}
           aria-haspopup="listbox"
-          aria-labelledby="test-ID test-ID"
           className="md-select-dropdown-input md-select-open"
           id="test-ID"
           onBlur={[Function]}
@@ -4297,7 +4825,6 @@ exports[`Select snapshot should match snapshot with disabled option 1`] = `
               aria-controls="test-ID"
               aria-expanded={true}
               aria-haspopup="listbox"
-              aria-labelledby="test-ID test-ID"
               className="md-select-dropdown-input md-select-open"
               id="test-ID"
               onBlur={[Function]}
@@ -5055,7 +5582,6 @@ exports[`Select snapshot should match snapshot with id 1`] = `
           "current": <button
             aria-expanded="false"
             aria-haspopup="listbox"
-            aria-labelledby="test-ID test-ID"
             class="md-select-dropdown-input"
             id="example-id"
             type="button"
@@ -5164,7 +5690,6 @@ exports[`Select snapshot should match snapshot with id 1`] = `
           aria-controls={null}
           aria-expanded={false}
           aria-haspopup="listbox"
-          aria-labelledby="test-ID test-ID"
           className="md-select-dropdown-input"
           id="example-id"
           onBlur={[Function]}
@@ -5361,7 +5886,6 @@ exports[`Select snapshot should match snapshot with id 1`] = `
               aria-controls={null}
               aria-expanded={false}
               aria-haspopup="listbox"
-              aria-labelledby="test-ID test-ID"
               className="md-select-dropdown-input"
               id="example-id"
               onBlur={[Function]}
@@ -5481,7 +6005,6 @@ exports[`Select snapshot should match snapshot with isInForm = false 1`] = `
           aria-controls={null}
           aria-expanded={false}
           aria-haspopup="listbox"
-          aria-labelledby="test-ID test-ID"
           className="md-select-dropdown-input"
           id="test-ID"
           onBlur={[Function]}
@@ -5678,7 +6201,6 @@ exports[`Select snapshot should match snapshot with isInForm = false 1`] = `
               aria-controls={null}
               aria-expanded={false}
               aria-haspopup="listbox"
-              aria-labelledby="test-ID test-ID"
               className="md-select-dropdown-input"
               id="test-ID"
               onBlur={[Function]}
@@ -5735,7 +6257,7 @@ exports[`Select snapshot should match snapshot with isInForm = false 1`] = `
               containerInfo={
                 <div
                   data-tippy-root=""
-                  id="tippy-15"
+                  id="tippy-16"
                   style="z-index: 9999;"
                 >
                   
@@ -5923,7 +6445,6 @@ exports[`Select snapshot should match snapshot with listbox opened 1`] = `
             aria-controls="test-ID"
             aria-expanded="true"
             aria-haspopup="listbox"
-            aria-labelledby="test-ID test-ID"
             class="md-select-dropdown-input md-select-open"
             id="test-ID"
             type="button"
@@ -6032,7 +6553,6 @@ exports[`Select snapshot should match snapshot with listbox opened 1`] = `
           aria-controls="test-ID"
           aria-expanded={true}
           aria-haspopup="listbox"
-          aria-labelledby="test-ID test-ID"
           className="md-select-dropdown-input md-select-open"
           id="test-ID"
           onBlur={[Function]}
@@ -6229,7 +6749,6 @@ exports[`Select snapshot should match snapshot with listbox opened 1`] = `
               aria-controls="test-ID"
               aria-expanded={true}
               aria-haspopup="listbox"
-              aria-labelledby="test-ID test-ID"
               className="md-select-dropdown-input md-select-open"
               id="test-ID"
               onBlur={[Function]}
@@ -6984,7 +7503,6 @@ exports[`Select snapshot should match snapshot with listboxMaxHeight 1`] = `
             aria-controls="test-ID"
             aria-expanded="true"
             aria-haspopup="listbox"
-            aria-labelledby="test-ID test-ID"
             class="md-select-dropdown-input md-select-open"
             id="test-ID"
             type="button"
@@ -7093,7 +7611,6 @@ exports[`Select snapshot should match snapshot with listboxMaxHeight 1`] = `
           aria-controls="test-ID"
           aria-expanded={true}
           aria-haspopup="listbox"
-          aria-labelledby="test-ID test-ID"
           className="md-select-dropdown-input md-select-open"
           id="test-ID"
           onBlur={[Function]}
@@ -7290,7 +7807,6 @@ exports[`Select snapshot should match snapshot with listboxMaxHeight 1`] = `
               aria-controls="test-ID"
               aria-expanded={true}
               aria-haspopup="listbox"
-              aria-labelledby="test-ID test-ID"
               className="md-select-dropdown-input md-select-open"
               id="test-ID"
               onBlur={[Function]}
@@ -7347,7 +7863,7 @@ exports[`Select snapshot should match snapshot with listboxMaxHeight 1`] = `
               containerInfo={
                 <div
                   data-tippy-root=""
-                  id="tippy-14"
+                  id="tippy-15"
                   style="z-index: 9999; position: absolute; left: 0px; top: 0px; margin: 0px; transform: translate(0px, 0px);"
                 >
                   <div
@@ -8045,7 +8561,6 @@ exports[`Select snapshot should match snapshot with listboxWidth 1`] = `
             aria-controls="test-ID"
             aria-expanded="true"
             aria-haspopup="listbox"
-            aria-labelledby="test-ID test-ID"
             class="md-select-dropdown-input md-select-open"
             id="test-ID"
             type="button"
@@ -8154,7 +8669,6 @@ exports[`Select snapshot should match snapshot with listboxWidth 1`] = `
           aria-controls="test-ID"
           aria-expanded={true}
           aria-haspopup="listbox"
-          aria-labelledby="test-ID test-ID"
           className="md-select-dropdown-input md-select-open"
           id="test-ID"
           onBlur={[Function]}
@@ -8351,7 +8865,6 @@ exports[`Select snapshot should match snapshot with listboxWidth 1`] = `
               aria-controls="test-ID"
               aria-expanded={true}
               aria-haspopup="listbox"
-              aria-labelledby="test-ID test-ID"
               className="md-select-dropdown-input md-select-open"
               id="test-ID"
               onBlur={[Function]}
@@ -8408,7 +8921,7 @@ exports[`Select snapshot should match snapshot with listboxWidth 1`] = `
               containerInfo={
                 <div
                   data-tippy-root=""
-                  id="tippy-16"
+                  id="tippy-17"
                   style="z-index: 9999; position: fixed; left: 0px; top: 0px; margin: 0px; transform: translate(0px, 0px);"
                 >
                   <div
@@ -9106,7 +9619,6 @@ exports[`Select snapshot should match snapshot with placeholder 1`] = `
           "current": <button
             aria-expanded="false"
             aria-haspopup="listbox"
-            aria-labelledby="test-ID test-ID"
             class="md-select-dropdown-input"
             id="test-ID"
             type="button"
@@ -9217,7 +9729,6 @@ exports[`Select snapshot should match snapshot with placeholder 1`] = `
           aria-controls={null}
           aria-expanded={false}
           aria-haspopup="listbox"
-          aria-labelledby="test-ID test-ID"
           className="md-select-dropdown-input"
           id="test-ID"
           onBlur={[Function]}
@@ -9416,7 +9927,6 @@ exports[`Select snapshot should match snapshot with placeholder 1`] = `
               aria-controls={null}
               aria-expanded={false}
               aria-haspopup="listbox"
-              aria-labelledby="test-ID test-ID"
               className="md-select-dropdown-input"
               id="test-ID"
               onBlur={[Function]}
@@ -9685,7 +10195,6 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
           "current": <button
             aria-expanded="false"
             aria-haspopup="listbox"
-            aria-labelledby="test-ID test-ID"
             class="md-select-dropdown-input md-select-selected"
             id="test-ID"
             type="button"
@@ -9797,7 +10306,6 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
           aria-controls={null}
           aria-expanded={false}
           aria-haspopup="listbox"
-          aria-labelledby="test-ID test-ID"
           className="md-select-dropdown-input md-select-selected"
           id="test-ID"
           onBlur={[Function]}
@@ -9997,7 +10505,6 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
               aria-controls={null}
               aria-expanded={false}
               aria-haspopup="listbox"
-              aria-labelledby="test-ID test-ID"
               className="md-select-dropdown-input md-select-selected"
               id="test-ID"
               onBlur={[Function]}
@@ -10269,7 +10776,6 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
             aria-controls="test-ID"
             aria-expanded="true"
             aria-haspopup="listbox"
-            aria-labelledby="test-ID test-ID"
             class="md-select-dropdown-input md-select-selected md-select-open"
             id="test-ID"
             type="button"
@@ -10381,7 +10887,6 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
           aria-controls="test-ID"
           aria-expanded={true}
           aria-haspopup="listbox"
-          aria-labelledby="test-ID test-ID"
           className="md-select-dropdown-input md-select-selected md-select-open"
           id="test-ID"
           onBlur={[Function]}
@@ -10581,7 +11086,6 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
               aria-controls="test-ID"
               aria-expanded={true}
               aria-haspopup="listbox"
-              aria-labelledby="test-ID test-ID"
               className="md-select-dropdown-input md-select-selected md-select-open"
               id="test-ID"
               onBlur={[Function]}
@@ -11427,7 +11931,6 @@ exports[`Select snapshot should match snapshot with style 1`] = `
           "current": <button
             aria-expanded="false"
             aria-haspopup="listbox"
-            aria-labelledby="test-ID test-ID"
             class="md-select-dropdown-input"
             id="test-ID"
             type="button"
@@ -11536,7 +12039,6 @@ exports[`Select snapshot should match snapshot with style 1`] = `
           aria-controls={null}
           aria-expanded={false}
           aria-haspopup="listbox"
-          aria-labelledby="test-ID test-ID"
           className="md-select-dropdown-input"
           id="test-ID"
           onBlur={[Function]}
@@ -11733,7 +12235,6 @@ exports[`Select snapshot should match snapshot with style 1`] = `
               aria-controls={null}
               aria-expanded={false}
               aria-haspopup="listbox"
-              aria-labelledby="test-ID test-ID"
               className="md-select-dropdown-input"
               id="test-ID"
               onBlur={[Function]}
@@ -11975,7 +12476,6 @@ exports[`Select snapshot should match snapshot with title 1`] = `
           "current": <button
             aria-expanded="false"
             aria-haspopup="listbox"
-            aria-labelledby="test-ID test-ID"
             class="md-select-dropdown-input"
             id="test-ID"
             title="Example text"
@@ -12085,7 +12585,6 @@ exports[`Select snapshot should match snapshot with title 1`] = `
           aria-controls={null}
           aria-expanded={false}
           aria-haspopup="listbox"
-          aria-labelledby="test-ID test-ID"
           className="md-select-dropdown-input"
           id="test-ID"
           onBlur={[Function]}
@@ -12283,7 +12782,6 @@ exports[`Select snapshot should match snapshot with title 1`] = `
               aria-controls={null}
               aria-expanded={false}
               aria-haspopup="listbox"
-              aria-labelledby="test-ID test-ID"
               className="md-select-dropdown-input"
               id="test-ID"
               onBlur={[Function]}
@@ -12341,7 +12839,7 @@ exports[`Select snapshot should match snapshot with title 1`] = `
               containerInfo={
                 <div
                   data-tippy-root=""
-                  id="tippy-13"
+                  id="tippy-14"
                   style="z-index: 9999;"
                 >
                   

--- a/src/components/Select/Select.unit.test.tsx.snap
+++ b/src/components/Select/Select.unit.test.tsx.snap
@@ -172,6 +172,7 @@ exports[`Select snapshot should match snapshot 1`] = `
             aria-controls="test-id"
             aria-expanded="false"
             aria-haspopup="listbox"
+            aria-labelledby="test-ID test-ID"
             class="md-select-dropdown-input"
             id="test-id"
             role="combobox"
@@ -281,6 +282,7 @@ exports[`Select snapshot should match snapshot 1`] = `
           aria-controls="test-id"
           aria-expanded={false}
           aria-haspopup="listbox"
+          aria-labelledby="test-ID test-ID"
           className="md-select-dropdown-input"
           id="test-id"
           onBlur={[Function]}
@@ -478,6 +480,7 @@ exports[`Select snapshot should match snapshot 1`] = `
               aria-controls="test-id"
               aria-expanded={false}
               aria-haspopup="listbox"
+              aria-labelledby="test-ID test-ID"
               className="md-select-dropdown-input"
               id="test-id"
               onBlur={[Function]}
@@ -722,6 +725,7 @@ exports[`Select snapshot should match snapshot before and after opening select d
             aria-controls="test-id"
             aria-expanded="false"
             aria-haspopup="listbox"
+            aria-labelledby="test-ID test-ID"
             class="md-select-dropdown-input"
             id="test-ID"
             role="combobox"
@@ -831,6 +835,7 @@ exports[`Select snapshot should match snapshot before and after opening select d
           aria-controls="test-id"
           aria-expanded={false}
           aria-haspopup="listbox"
+          aria-labelledby="test-ID test-ID"
           className="md-select-dropdown-input"
           id="test-ID"
           onBlur={[Function]}
@@ -1028,6 +1033,7 @@ exports[`Select snapshot should match snapshot before and after opening select d
               aria-controls="test-id"
               aria-expanded={false}
               aria-haspopup="listbox"
+              aria-labelledby="test-ID test-ID"
               className="md-select-dropdown-input"
               id="test-ID"
               onBlur={[Function]}
@@ -1272,6 +1278,7 @@ exports[`Select snapshot should match snapshot before and after opening select d
             aria-controls="test-id"
             aria-expanded="true"
             aria-haspopup="listbox"
+            aria-labelledby="test-ID test-ID"
             class="md-select-dropdown-input md-select-open"
             id="test-ID"
             role="combobox"
@@ -1381,6 +1388,7 @@ exports[`Select snapshot should match snapshot before and after opening select d
           aria-controls="test-id"
           aria-expanded={true}
           aria-haspopup="listbox"
+          aria-labelledby="test-ID test-ID"
           className="md-select-dropdown-input md-select-open"
           id="test-ID"
           onBlur={[Function]}
@@ -1578,6 +1586,7 @@ exports[`Select snapshot should match snapshot before and after opening select d
               aria-controls="test-id"
               aria-expanded={true}
               aria-haspopup="listbox"
+              aria-labelledby="test-ID test-ID"
               className="md-select-dropdown-input md-select-open"
               id="test-ID"
               onBlur={[Function]}
@@ -2161,555 +2170,6 @@ exports[`Select snapshot should match snapshot before and after opening select d
 </Select>
 `;
 
-exports[`Select snapshot should match snapshot with aria-label 1`] = `
-<Select
-  ariaLabel="test-aria-label"
-  label="test"
->
-  <div
-    className="md-select-wrapper"
-    style={
-      Object {
-        "--local-width": "100%",
-      }
-    }
-  >
-    <label
-      id="test-ID"
-      onClick={[Function]}
-    >
-      <Text>
-        <p
-          className="md-text-wrapper"
-          data-type="body-primary"
-        >
-          test
-        </p>
-      </Text>
-    </label>
-    <HiddenSelect
-      label="test"
-      state={
-        Object {
-          "close": [Function],
-          "collection": ListCollection {
-            "firstKey": "$.0",
-            "iterable": Object {
-              Symbol(Symbol.iterator): [Function],
-            },
-            "keyMap": Map {
-              "$.0" => Object {
-                "aria-label": undefined,
-                "childNodes": Object {
-                  Symbol(Symbol.iterator): [Function],
-                },
-                "hasChildNodes": false,
-                "index": 0,
-                "key": "$.0",
-                "level": 0,
-                "nextKey": "$.1",
-                "parentKey": null,
-                "prevKey": undefined,
-                "props": Object {
-                  "children": "Item 1",
-                },
-                "rendered": "Item 1",
-                "shouldInvalidate": undefined,
-                "textValue": "Item 1",
-                "type": "item",
-                "value": undefined,
-                "wrapper": undefined,
-              },
-              "$.1" => Object {
-                "aria-label": undefined,
-                "childNodes": Object {
-                  Symbol(Symbol.iterator): [Function],
-                },
-                "hasChildNodes": false,
-                "index": 1,
-                "key": "$.1",
-                "level": 0,
-                "nextKey": undefined,
-                "parentKey": null,
-                "prevKey": "$.0",
-                "props": Object {
-                  "children": "Item 2",
-                },
-                "rendered": "Item 2",
-                "shouldInvalidate": undefined,
-                "textValue": "Item 2",
-                "type": "item",
-                "value": undefined,
-                "wrapper": undefined,
-              },
-            },
-            "lastKey": "$.1",
-          },
-          "disabledKeys": Set {},
-          "focusStrategy": null,
-          "isFocused": false,
-          "isOpen": false,
-          "open": [Function],
-          "selectedItem": null,
-          "selectedKey": null,
-          "selectionManager": SelectionManager {
-            "_isSelectAll": null,
-            "allowsCellSelection": false,
-            "collection": ListCollection {
-              "firstKey": "$.0",
-              "iterable": Object {
-                Symbol(Symbol.iterator): [Function],
-              },
-              "keyMap": Map {
-                "$.0" => Object {
-                  "aria-label": undefined,
-                  "childNodes": Object {
-                    Symbol(Symbol.iterator): [Function],
-                  },
-                  "hasChildNodes": false,
-                  "index": 0,
-                  "key": "$.0",
-                  "level": 0,
-                  "nextKey": "$.1",
-                  "parentKey": null,
-                  "prevKey": undefined,
-                  "props": Object {
-                    "children": "Item 1",
-                  },
-                  "rendered": "Item 1",
-                  "shouldInvalidate": undefined,
-                  "textValue": "Item 1",
-                  "type": "item",
-                  "value": undefined,
-                  "wrapper": undefined,
-                },
-                "$.1" => Object {
-                  "aria-label": undefined,
-                  "childNodes": Object {
-                    Symbol(Symbol.iterator): [Function],
-                  },
-                  "hasChildNodes": false,
-                  "index": 1,
-                  "key": "$.1",
-                  "level": 0,
-                  "nextKey": undefined,
-                  "parentKey": null,
-                  "prevKey": "$.0",
-                  "props": Object {
-                    "children": "Item 2",
-                  },
-                  "rendered": "Item 2",
-                  "shouldInvalidate": undefined,
-                  "textValue": "Item 2",
-                  "type": "item",
-                  "value": undefined,
-                  "wrapper": undefined,
-                },
-              },
-              "lastKey": "$.1",
-            },
-            "state": Object {
-              "childFocusStrategy": null,
-              "disabledKeys": Set {},
-              "disallowEmptySelection": true,
-              "focusedKey": null,
-              "isFocused": false,
-              "selectedKeys": Set {},
-              "selectionMode": "single",
-              "setFocused": [Function],
-              "setFocusedKey": [Function],
-              "setSelectedKeys": [Function],
-            },
-          },
-          "setFocused": [Function],
-          "setSelectedKey": [Function],
-          "toggle": [Function],
-        }
-      }
-      triggerRef={
-        Object {
-          "current": <button
-            aria-expanded="false"
-            aria-haspopup="listbox"
-            aria-label="test-aria-label"
-            class="md-select-dropdown-input"
-            id="test-ID"
-            role="combobox"
-            type="button"
-          >
-            <span
-              class="md-select-selected-item-wrapper"
-              id="test-ID"
-            />
-            <span
-              aria-hidden="true"
-              class="md-select-icon-wrapper"
-            >
-              <div
-                aria-hidden="true"
-                class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
-                role="img"
-              >
-                <svg
-                  aria-hidden="true"
-                  class=""
-                  data-autoscale="false"
-                  data-scale="16"
-                  data-test="arrow-down"
-                  fill="currentColor"
-                  height="100%"
-                  viewBox="0, 0, 32, 32"
-                  width="100%"
-                />
-              </div>
-            </span>
-          </button>,
-        }
-      }
-    >
-      <div
-        aria-hidden={true}
-        style={
-          Object {
-            "border": 0,
-            "clip": "rect(0 0 0 0)",
-            "clipPath": "inset(50%)",
-            "height": 1,
-            "margin": "0 -1px -1px 0",
-            "overflow": "hidden",
-            "padding": 0,
-            "position": "absolute",
-            "whiteSpace": "nowrap",
-            "width": 1,
-          }
-        }
-      >
-        <input
-          onFocus={[Function]}
-          style={
-            Object {
-              "fontSize": 16,
-            }
-          }
-          tabIndex={-1}
-          type="text"
-        />
-        <label>
-          test
-          <select
-            onChange={[Function]}
-            size={2}
-            tabIndex={-1}
-            value=""
-          >
-            <option />
-            <option
-              key="$.0"
-              value="$.0"
-            >
-              Item 1
-            </option>
-            <option
-              key="$.1"
-              value="$.1"
-            >
-              Item 2
-            </option>
-          </select>
-        </label>
-      </div>
-    </HiddenSelect>
-    <Popover
-      className="md-select-popover"
-      hideOnEsc={false}
-      interactive={true}
-      onClickOutside={[Function]}
-      onHide={[Function]}
-      onKeyDown={[Function]}
-      placement="bottom"
-      setInstance={[Function]}
-      showArrow={false}
-      strategy="absolute"
-      style={
-        Object {
-          "maxHeight": "none",
-        }
-      }
-      trigger="manual"
-      triggerComponent={
-        <button
-          aria-expanded={false}
-          aria-haspopup="listbox"
-          aria-label="test-aria-label"
-          className="md-select-dropdown-input"
-          id="test-ID"
-          onBlur={[Function]}
-          onClick={[Function]}
-          onDragStart={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
-          onTouchCancel={[Function]}
-          onTouchEnd={[Function]}
-          onTouchMove={[Function]}
-          onTouchStart={[Function]}
-          role="combobox"
-          type="button"
-        >
-          <span
-            className="md-select-selected-item-wrapper"
-            id="test-ID"
-          />
-          <span
-            aria-hidden="true"
-            className="md-select-icon-wrapper"
-          >
-            <Icon
-              name="arrow-down"
-              scale={16}
-              weight="bold"
-            />
-          </span>
-        </button>
-      }
-    >
-      <LazyTippy
-        animation={false}
-        appendTo="parent"
-        hideOnClick={false}
-        interactive={true}
-        offset={
-          Array [
-            0,
-            5,
-          ]
-        }
-        onClickOutside={[Function]}
-        onHide={[Function]}
-        placement="bottom"
-        plugins={
-          Array [
-            Object {
-              "fn": [Function],
-              "name": "addBackdropPlugin",
-            },
-          ]
-        }
-        popperOptions={
-          Object {
-            "modifiers": Array [
-              Object {
-                "enabled": false,
-                "name": "arrow",
-                "options": Object {
-                  "element": "#arrow1",
-                  "padding": 5,
-                },
-              },
-              Object {
-                "name": "preventOverflow",
-                "options": Object {
-                  "altAxis": true,
-                  "boundariesElement": "scrollParent",
-                  "padding": 8,
-                },
-              },
-            ],
-            "strategy": "absolute",
-          }
-        }
-        render={[Function]}
-        setInstance={[Function]}
-        trigger="manual"
-      >
-        <ForwardRef(TippyWrapper)
-          animation={false}
-          appendTo="parent"
-          hideOnClick={false}
-          interactive={true}
-          offset={
-            Array [
-              0,
-              5,
-            ]
-          }
-          onClickOutside={[Function]}
-          onHide={[Function]}
-          placement="bottom"
-          plugins={
-            Array [
-              Object {
-                "fn": [Function],
-              },
-              Object {
-                "fn": [Function],
-              },
-              Object {
-                "fn": [Function],
-                "name": "addBackdropPlugin",
-              },
-            ]
-          }
-          popperOptions={
-            Object {
-              "modifiers": Array [
-                Object {
-                  "enabled": false,
-                  "name": "arrow",
-                  "options": Object {
-                    "element": "#arrow1",
-                    "padding": 5,
-                  },
-                },
-                Object {
-                  "name": "preventOverflow",
-                  "options": Object {
-                    "altAxis": true,
-                    "boundariesElement": "scrollParent",
-                    "padding": 8,
-                  },
-                },
-              ],
-              "strategy": "absolute",
-            }
-          }
-          render={[Function]}
-          trigger="manual"
-        >
-          <Tippy
-            animation={false}
-            appendTo="parent"
-            hideOnClick={false}
-            interactive={true}
-            offset={
-              Array [
-                0,
-                5,
-              ]
-            }
-            onClickOutside={[Function]}
-            onHide={[Function]}
-            placement="bottom"
-            plugins={
-              Array [
-                Object {
-                  "fn": [Function],
-                },
-                Object {
-                  "fn": [Function],
-                },
-                Object {
-                  "fn": [Function],
-                  "name": "addBackdropPlugin",
-                },
-              ]
-            }
-            popperOptions={
-              Object {
-                "modifiers": Array [
-                  Object {
-                    "enabled": false,
-                    "name": "arrow",
-                    "options": Object {
-                      "element": "#arrow1",
-                      "padding": 5,
-                    },
-                  },
-                  Object {
-                    "name": "preventOverflow",
-                    "options": Object {
-                      "altAxis": true,
-                      "boundariesElement": "scrollParent",
-                      "padding": 8,
-                    },
-                  },
-                ],
-                "strategy": "absolute",
-              }
-            }
-            render={[Function]}
-            trigger="manual"
-          >
-            <button
-              aria-expanded={false}
-              aria-haspopup="listbox"
-              aria-label="test-aria-label"
-              className="md-select-dropdown-input"
-              id="test-ID"
-              onBlur={[Function]}
-              onClick={[Function]}
-              onDragStart={[Function]}
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseEnter={[Function]}
-              onMouseLeave={[Function]}
-              onMouseUp={[Function]}
-              onTouchCancel={[Function]}
-              onTouchEnd={[Function]}
-              onTouchMove={[Function]}
-              onTouchStart={[Function]}
-              role="combobox"
-              type="button"
-            >
-              <span
-                className="md-select-selected-item-wrapper"
-                id="test-ID"
-              />
-              <span
-                aria-hidden="true"
-                className="md-select-icon-wrapper"
-              >
-                <Icon
-                  name="arrow-down"
-                  scale={16}
-                  weight="bold"
-                >
-                  <div
-                    aria-hidden="true"
-                    className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
-                    role="img"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      className=""
-                      data-autoscale={false}
-                      data-scale={16}
-                      data-test="arrow-down"
-                      fill="currentColor"
-                      height="100%"
-                      style={Object {}}
-                      viewBox="0, 0, 32, 32"
-                      width="100%"
-                    />
-                  </div>
-                </Icon>
-              </span>
-            </button>
-            <Portal
-              containerInfo={
-                <div
-                  data-tippy-root=""
-                  id="tippy-13"
-                  style="z-index: 9999;"
-                >
-                  
-                </div>
-              }
-            />
-          </Tippy>
-        </ForwardRef(TippyWrapper)>
-      </LazyTippy>
-    </Popover>
-  </div>
-</Select>
-`;
-
 exports[`Select snapshot should match snapshot with border 1`] = `
 <Select
   id="test-id"
@@ -2883,6 +2343,7 @@ exports[`Select snapshot should match snapshot with border 1`] = `
             aria-controls="test-id"
             aria-expanded="false"
             aria-haspopup="listbox"
+            aria-labelledby="test-ID test-ID"
             class="md-select-dropdown-input borderLess"
             id="test-ID"
             role="combobox"
@@ -2992,6 +2453,7 @@ exports[`Select snapshot should match snapshot with border 1`] = `
           aria-controls="test-id"
           aria-expanded={false}
           aria-haspopup="listbox"
+          aria-labelledby="test-ID test-ID"
           className="md-select-dropdown-input borderLess"
           id="test-ID"
           onBlur={[Function]}
@@ -3189,6 +2651,7 @@ exports[`Select snapshot should match snapshot with border 1`] = `
               aria-controls="test-id"
               aria-expanded={false}
               aria-haspopup="listbox"
+              aria-labelledby="test-ID test-ID"
               className="md-select-dropdown-input borderLess"
               id="test-ID"
               onBlur={[Function]}
@@ -3434,6 +2897,7 @@ exports[`Select snapshot should match snapshot with className 1`] = `
             aria-controls="test-id"
             aria-expanded="false"
             aria-haspopup="listbox"
+            aria-labelledby="test-ID test-ID"
             class="md-select-dropdown-input"
             id="test-ID"
             role="combobox"
@@ -3543,6 +3007,7 @@ exports[`Select snapshot should match snapshot with className 1`] = `
           aria-controls="test-id"
           aria-expanded={false}
           aria-haspopup="listbox"
+          aria-labelledby="test-ID test-ID"
           className="md-select-dropdown-input"
           id="test-ID"
           onBlur={[Function]}
@@ -3740,6 +3205,7 @@ exports[`Select snapshot should match snapshot with className 1`] = `
               aria-controls="test-id"
               aria-expanded={false}
               aria-haspopup="listbox"
+              aria-labelledby="test-ID test-ID"
               className="md-select-dropdown-input"
               id="test-ID"
               onBlur={[Function]}
@@ -3985,6 +3451,7 @@ exports[`Select snapshot should match snapshot with direction 1`] = `
             aria-controls="test-id"
             aria-expanded="false"
             aria-haspopup="listbox"
+            aria-labelledby="test-ID test-ID"
             class="md-select-dropdown-input"
             id="test-ID"
             role="combobox"
@@ -4094,6 +3561,7 @@ exports[`Select snapshot should match snapshot with direction 1`] = `
           aria-controls="test-id"
           aria-expanded={false}
           aria-haspopup="listbox"
+          aria-labelledby="test-ID test-ID"
           className="md-select-dropdown-input"
           id="test-ID"
           onBlur={[Function]}
@@ -4291,6 +3759,7 @@ exports[`Select snapshot should match snapshot with direction 1`] = `
               aria-controls="test-id"
               aria-expanded={false}
               aria-haspopup="listbox"
+              aria-labelledby="test-ID test-ID"
               className="md-select-dropdown-input"
               id="test-ID"
               onBlur={[Function]}
@@ -4545,6 +4014,7 @@ exports[`Select snapshot should match snapshot with disabled option 1`] = `
             aria-controls="test-id"
             aria-expanded="true"
             aria-haspopup="listbox"
+            aria-labelledby="test-ID test-ID"
             class="md-select-dropdown-input md-select-open"
             id="test-ID"
             role="combobox"
@@ -4654,6 +4124,7 @@ exports[`Select snapshot should match snapshot with disabled option 1`] = `
           aria-controls="test-id"
           aria-expanded={true}
           aria-haspopup="listbox"
+          aria-labelledby="test-ID test-ID"
           className="md-select-dropdown-input md-select-open"
           id="test-ID"
           onBlur={[Function]}
@@ -4851,6 +4322,7 @@ exports[`Select snapshot should match snapshot with disabled option 1`] = `
               aria-controls="test-id"
               aria-expanded={true}
               aria-haspopup="listbox"
+              aria-labelledby="test-ID test-ID"
               className="md-select-dropdown-input md-select-open"
               id="test-ID"
               onBlur={[Function]}
@@ -5610,6 +5082,7 @@ exports[`Select snapshot should match snapshot with id 1`] = `
             aria-controls="example-id"
             aria-expanded="false"
             aria-haspopup="listbox"
+            aria-labelledby="test-ID test-ID"
             class="md-select-dropdown-input"
             id="example-id"
             role="combobox"
@@ -5719,6 +5192,7 @@ exports[`Select snapshot should match snapshot with id 1`] = `
           aria-controls="example-id"
           aria-expanded={false}
           aria-haspopup="listbox"
+          aria-labelledby="test-ID test-ID"
           className="md-select-dropdown-input"
           id="example-id"
           onBlur={[Function]}
@@ -5916,6 +5390,7 @@ exports[`Select snapshot should match snapshot with id 1`] = `
               aria-controls="example-id"
               aria-expanded={false}
               aria-haspopup="listbox"
+              aria-labelledby="test-ID test-ID"
               className="md-select-dropdown-input"
               id="example-id"
               onBlur={[Function]}
@@ -6035,6 +5510,7 @@ exports[`Select snapshot should match snapshot with isInForm = false 1`] = `
         <button
           aria-expanded={false}
           aria-haspopup="listbox"
+          aria-labelledby="test-ID test-ID"
           className="md-select-dropdown-input"
           id="test-ID"
           onBlur={[Function]}
@@ -6231,6 +5707,7 @@ exports[`Select snapshot should match snapshot with isInForm = false 1`] = `
             <button
               aria-expanded={false}
               aria-haspopup="listbox"
+              aria-labelledby="test-ID test-ID"
               className="md-select-dropdown-input"
               id="test-ID"
               onBlur={[Function]}
@@ -6288,7 +5765,7 @@ exports[`Select snapshot should match snapshot with isInForm = false 1`] = `
               containerInfo={
                 <div
                   data-tippy-root=""
-                  id="tippy-16"
+                  id="tippy-15"
                   style="z-index: 9999;"
                 >
                   
@@ -6476,6 +5953,7 @@ exports[`Select snapshot should match snapshot with listbox opened 1`] = `
             aria-controls="test-id"
             aria-expanded="true"
             aria-haspopup="listbox"
+            aria-labelledby="test-ID test-ID"
             class="md-select-dropdown-input md-select-open"
             id="test-ID"
             role="combobox"
@@ -6585,6 +6063,7 @@ exports[`Select snapshot should match snapshot with listbox opened 1`] = `
           aria-controls="test-id"
           aria-expanded={true}
           aria-haspopup="listbox"
+          aria-labelledby="test-ID test-ID"
           className="md-select-dropdown-input md-select-open"
           id="test-ID"
           onBlur={[Function]}
@@ -6782,6 +6261,7 @@ exports[`Select snapshot should match snapshot with listbox opened 1`] = `
               aria-controls="test-id"
               aria-expanded={true}
               aria-haspopup="listbox"
+              aria-labelledby="test-ID test-ID"
               className="md-select-dropdown-input md-select-open"
               id="test-ID"
               onBlur={[Function]}
@@ -7536,6 +7016,7 @@ exports[`Select snapshot should match snapshot with listboxMaxHeight 1`] = `
           "current": <button
             aria-expanded="true"
             aria-haspopup="listbox"
+            aria-labelledby="test-ID test-ID"
             class="md-select-dropdown-input md-select-open"
             id="test-ID"
             role="combobox"
@@ -7644,6 +7125,7 @@ exports[`Select snapshot should match snapshot with listboxMaxHeight 1`] = `
         <button
           aria-expanded={true}
           aria-haspopup="listbox"
+          aria-labelledby="test-ID test-ID"
           className="md-select-dropdown-input md-select-open"
           id="test-ID"
           onBlur={[Function]}
@@ -7840,6 +7322,7 @@ exports[`Select snapshot should match snapshot with listboxMaxHeight 1`] = `
             <button
               aria-expanded={true}
               aria-haspopup="listbox"
+              aria-labelledby="test-ID test-ID"
               className="md-select-dropdown-input md-select-open"
               id="test-ID"
               onBlur={[Function]}
@@ -7897,7 +7380,7 @@ exports[`Select snapshot should match snapshot with listboxMaxHeight 1`] = `
               containerInfo={
                 <div
                   data-tippy-root=""
-                  id="tippy-15"
+                  id="tippy-14"
                   style="z-index: 9999; position: absolute; left: 0px; top: 0px; margin: 0px; transform: translate(0px, 0px);"
                 >
                   <div
@@ -8594,6 +8077,7 @@ exports[`Select snapshot should match snapshot with listboxWidth 1`] = `
           "current": <button
             aria-expanded="true"
             aria-haspopup="listbox"
+            aria-labelledby="test-ID test-ID"
             class="md-select-dropdown-input md-select-open"
             id="test-ID"
             role="combobox"
@@ -8702,6 +8186,7 @@ exports[`Select snapshot should match snapshot with listboxWidth 1`] = `
         <button
           aria-expanded={true}
           aria-haspopup="listbox"
+          aria-labelledby="test-ID test-ID"
           className="md-select-dropdown-input md-select-open"
           id="test-ID"
           onBlur={[Function]}
@@ -8898,6 +8383,7 @@ exports[`Select snapshot should match snapshot with listboxWidth 1`] = `
             <button
               aria-expanded={true}
               aria-haspopup="listbox"
+              aria-labelledby="test-ID test-ID"
               className="md-select-dropdown-input md-select-open"
               id="test-ID"
               onBlur={[Function]}
@@ -8955,7 +8441,7 @@ exports[`Select snapshot should match snapshot with listboxWidth 1`] = `
               containerInfo={
                 <div
                   data-tippy-root=""
-                  id="tippy-17"
+                  id="tippy-16"
                   style="z-index: 9999; position: fixed; left: 0px; top: 0px; margin: 0px; transform: translate(0px, 0px);"
                 >
                   <div
@@ -9654,6 +9140,7 @@ exports[`Select snapshot should match snapshot with placeholder 1`] = `
             aria-controls="test-id"
             aria-expanded="false"
             aria-haspopup="listbox"
+            aria-labelledby="test-ID test-ID"
             class="md-select-dropdown-input"
             id="test-ID"
             role="combobox"
@@ -9765,6 +9252,7 @@ exports[`Select snapshot should match snapshot with placeholder 1`] = `
           aria-controls="test-id"
           aria-expanded={false}
           aria-haspopup="listbox"
+          aria-labelledby="test-ID test-ID"
           className="md-select-dropdown-input"
           id="test-ID"
           onBlur={[Function]}
@@ -9964,6 +9452,7 @@ exports[`Select snapshot should match snapshot with placeholder 1`] = `
               aria-controls="test-id"
               aria-expanded={false}
               aria-haspopup="listbox"
+              aria-labelledby="test-ID test-ID"
               className="md-select-dropdown-input"
               id="test-ID"
               onBlur={[Function]}
@@ -10234,6 +9723,7 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
             aria-controls="test-id"
             aria-expanded="false"
             aria-haspopup="listbox"
+            aria-labelledby="test-ID test-ID"
             class="md-select-dropdown-input md-select-selected"
             id="test-ID"
             role="combobox"
@@ -10346,6 +9836,7 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
           aria-controls="test-id"
           aria-expanded={false}
           aria-haspopup="listbox"
+          aria-labelledby="test-ID test-ID"
           className="md-select-dropdown-input md-select-selected"
           id="test-ID"
           onBlur={[Function]}
@@ -10546,6 +10037,7 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
               aria-controls="test-id"
               aria-expanded={false}
               aria-haspopup="listbox"
+              aria-labelledby="test-ID test-ID"
               className="md-select-dropdown-input md-select-selected"
               id="test-ID"
               onBlur={[Function]}
@@ -10818,6 +10310,7 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
             aria-controls="test-id"
             aria-expanded="true"
             aria-haspopup="listbox"
+            aria-labelledby="test-ID test-ID"
             class="md-select-dropdown-input md-select-selected md-select-open"
             id="test-ID"
             role="combobox"
@@ -10930,6 +10423,7 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
           aria-controls="test-id"
           aria-expanded={true}
           aria-haspopup="listbox"
+          aria-labelledby="test-ID test-ID"
           className="md-select-dropdown-input md-select-selected md-select-open"
           id="test-ID"
           onBlur={[Function]}
@@ -11130,6 +10624,7 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
               aria-controls="test-id"
               aria-expanded={true}
               aria-haspopup="listbox"
+              aria-labelledby="test-ID test-ID"
               className="md-select-dropdown-input md-select-selected md-select-open"
               id="test-ID"
               onBlur={[Function]}
@@ -11977,6 +11472,7 @@ exports[`Select snapshot should match snapshot with style 1`] = `
             aria-controls="test-id"
             aria-expanded="false"
             aria-haspopup="listbox"
+            aria-labelledby="test-ID test-ID"
             class="md-select-dropdown-input"
             id="test-ID"
             role="combobox"
@@ -12086,6 +11582,7 @@ exports[`Select snapshot should match snapshot with style 1`] = `
           aria-controls="test-id"
           aria-expanded={false}
           aria-haspopup="listbox"
+          aria-labelledby="test-ID test-ID"
           className="md-select-dropdown-input"
           id="test-ID"
           onBlur={[Function]}
@@ -12283,6 +11780,7 @@ exports[`Select snapshot should match snapshot with style 1`] = `
               aria-controls="test-id"
               aria-expanded={false}
               aria-haspopup="listbox"
+              aria-labelledby="test-ID test-ID"
               className="md-select-dropdown-input"
               id="test-ID"
               onBlur={[Function]}
@@ -12525,6 +12023,7 @@ exports[`Select snapshot should match snapshot with title 1`] = `
           "current": <button
             aria-expanded="false"
             aria-haspopup="listbox"
+            aria-labelledby="test-ID test-ID"
             class="md-select-dropdown-input"
             id="test-ID"
             role="combobox"
@@ -12634,6 +12133,7 @@ exports[`Select snapshot should match snapshot with title 1`] = `
         <button
           aria-expanded={false}
           aria-haspopup="listbox"
+          aria-labelledby="test-ID test-ID"
           className="md-select-dropdown-input"
           id="test-ID"
           onBlur={[Function]}
@@ -12831,6 +12331,7 @@ exports[`Select snapshot should match snapshot with title 1`] = `
             <button
               aria-expanded={false}
               aria-haspopup="listbox"
+              aria-labelledby="test-ID test-ID"
               className="md-select-dropdown-input"
               id="test-ID"
               onBlur={[Function]}
@@ -12889,7 +12390,7 @@ exports[`Select snapshot should match snapshot with title 1`] = `
               containerInfo={
                 <div
                   data-tippy-root=""
-                  id="tippy-14"
+                  id="tippy-13"
                   style="z-index: 9999;"
                 >
                   

--- a/src/components/Select/Select.unit.test.tsx.snap
+++ b/src/components/Select/Select.unit.test.tsx.snap
@@ -169,10 +169,12 @@ exports[`Select snapshot should match snapshot 1`] = `
       triggerRef={
         Object {
           "current": <button
+            aria-controls="test-id"
             aria-expanded="false"
             aria-haspopup="listbox"
             class="md-select-dropdown-input"
             id="test-id"
+            role="combobox"
             type="button"
           >
             <span
@@ -276,7 +278,7 @@ exports[`Select snapshot should match snapshot 1`] = `
       trigger="manual"
       triggerComponent={
         <button
-          aria-controls={null}
+          aria-controls="test-id"
           aria-expanded={false}
           aria-haspopup="listbox"
           className="md-select-dropdown-input"
@@ -295,6 +297,7 @@ exports[`Select snapshot should match snapshot 1`] = `
           onTouchEnd={[Function]}
           onTouchMove={[Function]}
           onTouchStart={[Function]}
+          role="combobox"
           type="button"
         >
           <span
@@ -472,7 +475,7 @@ exports[`Select snapshot should match snapshot 1`] = `
             trigger="manual"
           >
             <button
-              aria-controls={null}
+              aria-controls="test-id"
               aria-expanded={false}
               aria-haspopup="listbox"
               className="md-select-dropdown-input"
@@ -491,6 +494,7 @@ exports[`Select snapshot should match snapshot 1`] = `
               onTouchEnd={[Function]}
               onTouchMove={[Function]}
               onTouchStart={[Function]}
+              role="combobox"
               type="button"
             >
               <span
@@ -715,10 +719,12 @@ exports[`Select snapshot should match snapshot before and after opening select d
       triggerRef={
         Object {
           "current": <button
+            aria-controls="test-id"
             aria-expanded="false"
             aria-haspopup="listbox"
             class="md-select-dropdown-input"
             id="test-ID"
+            role="combobox"
             type="button"
           >
             <span
@@ -822,7 +828,7 @@ exports[`Select snapshot should match snapshot before and after opening select d
       trigger="manual"
       triggerComponent={
         <button
-          aria-controls={null}
+          aria-controls="test-id"
           aria-expanded={false}
           aria-haspopup="listbox"
           className="md-select-dropdown-input"
@@ -841,6 +847,7 @@ exports[`Select snapshot should match snapshot before and after opening select d
           onTouchEnd={[Function]}
           onTouchMove={[Function]}
           onTouchStart={[Function]}
+          role="combobox"
           type="button"
         >
           <span
@@ -1018,7 +1025,7 @@ exports[`Select snapshot should match snapshot before and after opening select d
             trigger="manual"
           >
             <button
-              aria-controls={null}
+              aria-controls="test-id"
               aria-expanded={false}
               aria-haspopup="listbox"
               className="md-select-dropdown-input"
@@ -1037,6 +1044,7 @@ exports[`Select snapshot should match snapshot before and after opening select d
               onTouchEnd={[Function]}
               onTouchMove={[Function]}
               onTouchStart={[Function]}
+              role="combobox"
               type="button"
             >
               <span
@@ -1261,11 +1269,12 @@ exports[`Select snapshot should match snapshot before and after opening select d
       triggerRef={
         Object {
           "current": <button
-            aria-controls="test-ID"
+            aria-controls="test-id"
             aria-expanded="true"
             aria-haspopup="listbox"
             class="md-select-dropdown-input md-select-open"
             id="test-ID"
+            role="combobox"
             type="button"
           >
             <span
@@ -1369,7 +1378,7 @@ exports[`Select snapshot should match snapshot before and after opening select d
       trigger="manual"
       triggerComponent={
         <button
-          aria-controls="test-ID"
+          aria-controls="test-id"
           aria-expanded={true}
           aria-haspopup="listbox"
           className="md-select-dropdown-input md-select-open"
@@ -1388,6 +1397,7 @@ exports[`Select snapshot should match snapshot before and after opening select d
           onTouchEnd={[Function]}
           onTouchMove={[Function]}
           onTouchStart={[Function]}
+          role="combobox"
           type="button"
         >
           <span
@@ -1565,7 +1575,7 @@ exports[`Select snapshot should match snapshot before and after opening select d
             trigger="manual"
           >
             <button
-              aria-controls="test-ID"
+              aria-controls="test-id"
               aria-expanded={true}
               aria-haspopup="listbox"
               className="md-select-dropdown-input md-select-open"
@@ -1584,6 +1594,7 @@ exports[`Select snapshot should match snapshot before and after opening select d
               onTouchEnd={[Function]}
               onTouchMove={[Function]}
               onTouchStart={[Function]}
+              role="combobox"
               type="button"
             >
               <span
@@ -2323,6 +2334,7 @@ exports[`Select snapshot should match snapshot with aria-label 1`] = `
             aria-label="test-aria-label"
             class="md-select-dropdown-input"
             id="test-ID"
+            role="combobox"
             type="button"
           >
             <span
@@ -2426,7 +2438,6 @@ exports[`Select snapshot should match snapshot with aria-label 1`] = `
       trigger="manual"
       triggerComponent={
         <button
-          aria-controls={null}
           aria-expanded={false}
           aria-haspopup="listbox"
           aria-label="test-aria-label"
@@ -2446,6 +2457,7 @@ exports[`Select snapshot should match snapshot with aria-label 1`] = `
           onTouchEnd={[Function]}
           onTouchMove={[Function]}
           onTouchStart={[Function]}
+          role="combobox"
           type="button"
         >
           <span
@@ -2623,7 +2635,6 @@ exports[`Select snapshot should match snapshot with aria-label 1`] = `
             trigger="manual"
           >
             <button
-              aria-controls={null}
               aria-expanded={false}
               aria-haspopup="listbox"
               aria-label="test-aria-label"
@@ -2643,6 +2654,7 @@ exports[`Select snapshot should match snapshot with aria-label 1`] = `
               onTouchEnd={[Function]}
               onTouchMove={[Function]}
               onTouchStart={[Function]}
+              role="combobox"
               type="button"
             >
               <span
@@ -2868,10 +2880,12 @@ exports[`Select snapshot should match snapshot with border 1`] = `
       triggerRef={
         Object {
           "current": <button
+            aria-controls="test-id"
             aria-expanded="false"
             aria-haspopup="listbox"
             class="md-select-dropdown-input borderLess"
             id="test-ID"
+            role="combobox"
             type="button"
           >
             <span
@@ -2975,7 +2989,7 @@ exports[`Select snapshot should match snapshot with border 1`] = `
       trigger="manual"
       triggerComponent={
         <button
-          aria-controls={null}
+          aria-controls="test-id"
           aria-expanded={false}
           aria-haspopup="listbox"
           className="md-select-dropdown-input borderLess"
@@ -2994,6 +3008,7 @@ exports[`Select snapshot should match snapshot with border 1`] = `
           onTouchEnd={[Function]}
           onTouchMove={[Function]}
           onTouchStart={[Function]}
+          role="combobox"
           type="button"
         >
           <span
@@ -3171,7 +3186,7 @@ exports[`Select snapshot should match snapshot with border 1`] = `
             trigger="manual"
           >
             <button
-              aria-controls={null}
+              aria-controls="test-id"
               aria-expanded={false}
               aria-haspopup="listbox"
               className="md-select-dropdown-input borderLess"
@@ -3190,6 +3205,7 @@ exports[`Select snapshot should match snapshot with border 1`] = `
               onTouchEnd={[Function]}
               onTouchMove={[Function]}
               onTouchStart={[Function]}
+              role="combobox"
               type="button"
             >
               <span
@@ -3415,10 +3431,12 @@ exports[`Select snapshot should match snapshot with className 1`] = `
       triggerRef={
         Object {
           "current": <button
+            aria-controls="test-id"
             aria-expanded="false"
             aria-haspopup="listbox"
             class="md-select-dropdown-input"
             id="test-ID"
+            role="combobox"
             type="button"
           >
             <span
@@ -3522,7 +3540,7 @@ exports[`Select snapshot should match snapshot with className 1`] = `
       trigger="manual"
       triggerComponent={
         <button
-          aria-controls={null}
+          aria-controls="test-id"
           aria-expanded={false}
           aria-haspopup="listbox"
           className="md-select-dropdown-input"
@@ -3541,6 +3559,7 @@ exports[`Select snapshot should match snapshot with className 1`] = `
           onTouchEnd={[Function]}
           onTouchMove={[Function]}
           onTouchStart={[Function]}
+          role="combobox"
           type="button"
         >
           <span
@@ -3718,7 +3737,7 @@ exports[`Select snapshot should match snapshot with className 1`] = `
             trigger="manual"
           >
             <button
-              aria-controls={null}
+              aria-controls="test-id"
               aria-expanded={false}
               aria-haspopup="listbox"
               className="md-select-dropdown-input"
@@ -3737,6 +3756,7 @@ exports[`Select snapshot should match snapshot with className 1`] = `
               onTouchEnd={[Function]}
               onTouchMove={[Function]}
               onTouchStart={[Function]}
+              role="combobox"
               type="button"
             >
               <span
@@ -3962,10 +3982,12 @@ exports[`Select snapshot should match snapshot with direction 1`] = `
       triggerRef={
         Object {
           "current": <button
+            aria-controls="test-id"
             aria-expanded="false"
             aria-haspopup="listbox"
             class="md-select-dropdown-input"
             id="test-ID"
+            role="combobox"
             type="button"
           >
             <span
@@ -4069,7 +4091,7 @@ exports[`Select snapshot should match snapshot with direction 1`] = `
       trigger="manual"
       triggerComponent={
         <button
-          aria-controls={null}
+          aria-controls="test-id"
           aria-expanded={false}
           aria-haspopup="listbox"
           className="md-select-dropdown-input"
@@ -4088,6 +4110,7 @@ exports[`Select snapshot should match snapshot with direction 1`] = `
           onTouchEnd={[Function]}
           onTouchMove={[Function]}
           onTouchStart={[Function]}
+          role="combobox"
           type="button"
         >
           <span
@@ -4265,7 +4288,7 @@ exports[`Select snapshot should match snapshot with direction 1`] = `
             trigger="manual"
           >
             <button
-              aria-controls={null}
+              aria-controls="test-id"
               aria-expanded={false}
               aria-haspopup="listbox"
               className="md-select-dropdown-input"
@@ -4284,6 +4307,7 @@ exports[`Select snapshot should match snapshot with direction 1`] = `
               onTouchEnd={[Function]}
               onTouchMove={[Function]}
               onTouchStart={[Function]}
+              role="combobox"
               type="button"
             >
               <span
@@ -4518,11 +4542,12 @@ exports[`Select snapshot should match snapshot with disabled option 1`] = `
       triggerRef={
         Object {
           "current": <button
-            aria-controls="test-ID"
+            aria-controls="test-id"
             aria-expanded="true"
             aria-haspopup="listbox"
             class="md-select-dropdown-input md-select-open"
             id="test-ID"
+            role="combobox"
             type="button"
           >
             <span
@@ -4626,7 +4651,7 @@ exports[`Select snapshot should match snapshot with disabled option 1`] = `
       trigger="manual"
       triggerComponent={
         <button
-          aria-controls="test-ID"
+          aria-controls="test-id"
           aria-expanded={true}
           aria-haspopup="listbox"
           className="md-select-dropdown-input md-select-open"
@@ -4645,6 +4670,7 @@ exports[`Select snapshot should match snapshot with disabled option 1`] = `
           onTouchEnd={[Function]}
           onTouchMove={[Function]}
           onTouchStart={[Function]}
+          role="combobox"
           type="button"
         >
           <span
@@ -4822,7 +4848,7 @@ exports[`Select snapshot should match snapshot with disabled option 1`] = `
             trigger="manual"
           >
             <button
-              aria-controls="test-ID"
+              aria-controls="test-id"
               aria-expanded={true}
               aria-haspopup="listbox"
               className="md-select-dropdown-input md-select-open"
@@ -4841,6 +4867,7 @@ exports[`Select snapshot should match snapshot with disabled option 1`] = `
               onTouchEnd={[Function]}
               onTouchMove={[Function]}
               onTouchStart={[Function]}
+              role="combobox"
               type="button"
             >
               <span
@@ -5580,10 +5607,12 @@ exports[`Select snapshot should match snapshot with id 1`] = `
       triggerRef={
         Object {
           "current": <button
+            aria-controls="example-id"
             aria-expanded="false"
             aria-haspopup="listbox"
             class="md-select-dropdown-input"
             id="example-id"
+            role="combobox"
             type="button"
           >
             <span
@@ -5687,7 +5716,7 @@ exports[`Select snapshot should match snapshot with id 1`] = `
       trigger="manual"
       triggerComponent={
         <button
-          aria-controls={null}
+          aria-controls="example-id"
           aria-expanded={false}
           aria-haspopup="listbox"
           className="md-select-dropdown-input"
@@ -5706,6 +5735,7 @@ exports[`Select snapshot should match snapshot with id 1`] = `
           onTouchEnd={[Function]}
           onTouchMove={[Function]}
           onTouchStart={[Function]}
+          role="combobox"
           type="button"
         >
           <span
@@ -5883,7 +5913,7 @@ exports[`Select snapshot should match snapshot with id 1`] = `
             trigger="manual"
           >
             <button
-              aria-controls={null}
+              aria-controls="example-id"
               aria-expanded={false}
               aria-haspopup="listbox"
               className="md-select-dropdown-input"
@@ -5902,6 +5932,7 @@ exports[`Select snapshot should match snapshot with id 1`] = `
               onTouchEnd={[Function]}
               onTouchMove={[Function]}
               onTouchStart={[Function]}
+              role="combobox"
               type="button"
             >
               <span
@@ -6002,7 +6033,6 @@ exports[`Select snapshot should match snapshot with isInForm = false 1`] = `
       trigger="manual"
       triggerComponent={
         <button
-          aria-controls={null}
           aria-expanded={false}
           aria-haspopup="listbox"
           className="md-select-dropdown-input"
@@ -6021,6 +6051,7 @@ exports[`Select snapshot should match snapshot with isInForm = false 1`] = `
           onTouchEnd={[Function]}
           onTouchMove={[Function]}
           onTouchStart={[Function]}
+          role="combobox"
           type="button"
         >
           <span
@@ -6198,7 +6229,6 @@ exports[`Select snapshot should match snapshot with isInForm = false 1`] = `
             trigger="manual"
           >
             <button
-              aria-controls={null}
               aria-expanded={false}
               aria-haspopup="listbox"
               className="md-select-dropdown-input"
@@ -6217,6 +6247,7 @@ exports[`Select snapshot should match snapshot with isInForm = false 1`] = `
               onTouchEnd={[Function]}
               onTouchMove={[Function]}
               onTouchStart={[Function]}
+              role="combobox"
               type="button"
             >
               <span
@@ -6442,11 +6473,12 @@ exports[`Select snapshot should match snapshot with listbox opened 1`] = `
       triggerRef={
         Object {
           "current": <button
-            aria-controls="test-ID"
+            aria-controls="test-id"
             aria-expanded="true"
             aria-haspopup="listbox"
             class="md-select-dropdown-input md-select-open"
             id="test-ID"
+            role="combobox"
             type="button"
           >
             <span
@@ -6550,7 +6582,7 @@ exports[`Select snapshot should match snapshot with listbox opened 1`] = `
       trigger="manual"
       triggerComponent={
         <button
-          aria-controls="test-ID"
+          aria-controls="test-id"
           aria-expanded={true}
           aria-haspopup="listbox"
           className="md-select-dropdown-input md-select-open"
@@ -6569,6 +6601,7 @@ exports[`Select snapshot should match snapshot with listbox opened 1`] = `
           onTouchEnd={[Function]}
           onTouchMove={[Function]}
           onTouchStart={[Function]}
+          role="combobox"
           type="button"
         >
           <span
@@ -6746,7 +6779,7 @@ exports[`Select snapshot should match snapshot with listbox opened 1`] = `
             trigger="manual"
           >
             <button
-              aria-controls="test-ID"
+              aria-controls="test-id"
               aria-expanded={true}
               aria-haspopup="listbox"
               className="md-select-dropdown-input md-select-open"
@@ -6765,6 +6798,7 @@ exports[`Select snapshot should match snapshot with listbox opened 1`] = `
               onTouchEnd={[Function]}
               onTouchMove={[Function]}
               onTouchStart={[Function]}
+              role="combobox"
               type="button"
             >
               <span
@@ -7500,11 +7534,11 @@ exports[`Select snapshot should match snapshot with listboxMaxHeight 1`] = `
       triggerRef={
         Object {
           "current": <button
-            aria-controls="test-ID"
             aria-expanded="true"
             aria-haspopup="listbox"
             class="md-select-dropdown-input md-select-open"
             id="test-ID"
+            role="combobox"
             type="button"
           >
             <span
@@ -7608,7 +7642,6 @@ exports[`Select snapshot should match snapshot with listboxMaxHeight 1`] = `
       trigger="manual"
       triggerComponent={
         <button
-          aria-controls="test-ID"
           aria-expanded={true}
           aria-haspopup="listbox"
           className="md-select-dropdown-input md-select-open"
@@ -7627,6 +7660,7 @@ exports[`Select snapshot should match snapshot with listboxMaxHeight 1`] = `
           onTouchEnd={[Function]}
           onTouchMove={[Function]}
           onTouchStart={[Function]}
+          role="combobox"
           type="button"
         >
           <span
@@ -7804,7 +7838,6 @@ exports[`Select snapshot should match snapshot with listboxMaxHeight 1`] = `
             trigger="manual"
           >
             <button
-              aria-controls="test-ID"
               aria-expanded={true}
               aria-haspopup="listbox"
               className="md-select-dropdown-input md-select-open"
@@ -7823,6 +7856,7 @@ exports[`Select snapshot should match snapshot with listboxMaxHeight 1`] = `
               onTouchEnd={[Function]}
               onTouchMove={[Function]}
               onTouchStart={[Function]}
+              role="combobox"
               type="button"
             >
               <span
@@ -8558,11 +8592,11 @@ exports[`Select snapshot should match snapshot with listboxWidth 1`] = `
       triggerRef={
         Object {
           "current": <button
-            aria-controls="test-ID"
             aria-expanded="true"
             aria-haspopup="listbox"
             class="md-select-dropdown-input md-select-open"
             id="test-ID"
+            role="combobox"
             type="button"
           >
             <span
@@ -8666,7 +8700,6 @@ exports[`Select snapshot should match snapshot with listboxWidth 1`] = `
       trigger="manual"
       triggerComponent={
         <button
-          aria-controls="test-ID"
           aria-expanded={true}
           aria-haspopup="listbox"
           className="md-select-dropdown-input md-select-open"
@@ -8685,6 +8718,7 @@ exports[`Select snapshot should match snapshot with listboxWidth 1`] = `
           onTouchEnd={[Function]}
           onTouchMove={[Function]}
           onTouchStart={[Function]}
+          role="combobox"
           type="button"
         >
           <span
@@ -8862,7 +8896,6 @@ exports[`Select snapshot should match snapshot with listboxWidth 1`] = `
             trigger="manual"
           >
             <button
-              aria-controls="test-ID"
               aria-expanded={true}
               aria-haspopup="listbox"
               className="md-select-dropdown-input md-select-open"
@@ -8881,6 +8914,7 @@ exports[`Select snapshot should match snapshot with listboxWidth 1`] = `
               onTouchEnd={[Function]}
               onTouchMove={[Function]}
               onTouchStart={[Function]}
+              role="combobox"
               type="button"
             >
               <span
@@ -9617,10 +9651,12 @@ exports[`Select snapshot should match snapshot with placeholder 1`] = `
       triggerRef={
         Object {
           "current": <button
+            aria-controls="test-id"
             aria-expanded="false"
             aria-haspopup="listbox"
             class="md-select-dropdown-input"
             id="test-ID"
+            role="combobox"
             type="button"
           >
             <span
@@ -9726,7 +9762,7 @@ exports[`Select snapshot should match snapshot with placeholder 1`] = `
       trigger="manual"
       triggerComponent={
         <button
-          aria-controls={null}
+          aria-controls="test-id"
           aria-expanded={false}
           aria-haspopup="listbox"
           className="md-select-dropdown-input"
@@ -9745,6 +9781,7 @@ exports[`Select snapshot should match snapshot with placeholder 1`] = `
           onTouchEnd={[Function]}
           onTouchMove={[Function]}
           onTouchStart={[Function]}
+          role="combobox"
           type="button"
         >
           <span
@@ -9924,7 +9961,7 @@ exports[`Select snapshot should match snapshot with placeholder 1`] = `
             trigger="manual"
           >
             <button
-              aria-controls={null}
+              aria-controls="test-id"
               aria-expanded={false}
               aria-haspopup="listbox"
               className="md-select-dropdown-input"
@@ -9943,6 +9980,7 @@ exports[`Select snapshot should match snapshot with placeholder 1`] = `
               onTouchEnd={[Function]}
               onTouchMove={[Function]}
               onTouchStart={[Function]}
+              role="combobox"
               type="button"
             >
               <span
@@ -10193,10 +10231,12 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
       triggerRef={
         Object {
           "current": <button
+            aria-controls="test-id"
             aria-expanded="false"
             aria-haspopup="listbox"
             class="md-select-dropdown-input md-select-selected"
             id="test-ID"
+            role="combobox"
             type="button"
           >
             <span
@@ -10303,7 +10343,7 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
       trigger="manual"
       triggerComponent={
         <button
-          aria-controls={null}
+          aria-controls="test-id"
           aria-expanded={false}
           aria-haspopup="listbox"
           className="md-select-dropdown-input md-select-selected"
@@ -10322,6 +10362,7 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
           onTouchEnd={[Function]}
           onTouchMove={[Function]}
           onTouchStart={[Function]}
+          role="combobox"
           type="button"
         >
           <span
@@ -10502,7 +10543,7 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
             trigger="manual"
           >
             <button
-              aria-controls={null}
+              aria-controls="test-id"
               aria-expanded={false}
               aria-haspopup="listbox"
               className="md-select-dropdown-input md-select-selected"
@@ -10521,6 +10562,7 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
               onTouchEnd={[Function]}
               onTouchMove={[Function]}
               onTouchStart={[Function]}
+              role="combobox"
               type="button"
             >
               <span
@@ -10773,11 +10815,12 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
       triggerRef={
         Object {
           "current": <button
-            aria-controls="test-ID"
+            aria-controls="test-id"
             aria-expanded="true"
             aria-haspopup="listbox"
             class="md-select-dropdown-input md-select-selected md-select-open"
             id="test-ID"
+            role="combobox"
             type="button"
           >
             <span
@@ -10884,7 +10927,7 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
       trigger="manual"
       triggerComponent={
         <button
-          aria-controls="test-ID"
+          aria-controls="test-id"
           aria-expanded={true}
           aria-haspopup="listbox"
           className="md-select-dropdown-input md-select-selected md-select-open"
@@ -10903,6 +10946,7 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
           onTouchEnd={[Function]}
           onTouchMove={[Function]}
           onTouchStart={[Function]}
+          role="combobox"
           type="button"
         >
           <span
@@ -11083,7 +11127,7 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
             trigger="manual"
           >
             <button
-              aria-controls="test-ID"
+              aria-controls="test-id"
               aria-expanded={true}
               aria-haspopup="listbox"
               className="md-select-dropdown-input md-select-selected md-select-open"
@@ -11102,6 +11146,7 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
               onTouchEnd={[Function]}
               onTouchMove={[Function]}
               onTouchStart={[Function]}
+              role="combobox"
               type="button"
             >
               <span
@@ -11929,10 +11974,12 @@ exports[`Select snapshot should match snapshot with style 1`] = `
       triggerRef={
         Object {
           "current": <button
+            aria-controls="test-id"
             aria-expanded="false"
             aria-haspopup="listbox"
             class="md-select-dropdown-input"
             id="test-ID"
+            role="combobox"
             type="button"
           >
             <span
@@ -12036,7 +12083,7 @@ exports[`Select snapshot should match snapshot with style 1`] = `
       trigger="manual"
       triggerComponent={
         <button
-          aria-controls={null}
+          aria-controls="test-id"
           aria-expanded={false}
           aria-haspopup="listbox"
           className="md-select-dropdown-input"
@@ -12055,6 +12102,7 @@ exports[`Select snapshot should match snapshot with style 1`] = `
           onTouchEnd={[Function]}
           onTouchMove={[Function]}
           onTouchStart={[Function]}
+          role="combobox"
           type="button"
         >
           <span
@@ -12232,7 +12280,7 @@ exports[`Select snapshot should match snapshot with style 1`] = `
             trigger="manual"
           >
             <button
-              aria-controls={null}
+              aria-controls="test-id"
               aria-expanded={false}
               aria-haspopup="listbox"
               className="md-select-dropdown-input"
@@ -12251,6 +12299,7 @@ exports[`Select snapshot should match snapshot with style 1`] = `
               onTouchEnd={[Function]}
               onTouchMove={[Function]}
               onTouchStart={[Function]}
+              role="combobox"
               type="button"
             >
               <span
@@ -12478,6 +12527,7 @@ exports[`Select snapshot should match snapshot with title 1`] = `
             aria-haspopup="listbox"
             class="md-select-dropdown-input"
             id="test-ID"
+            role="combobox"
             title="Example text"
             type="button"
           >
@@ -12582,7 +12632,6 @@ exports[`Select snapshot should match snapshot with title 1`] = `
       trigger="manual"
       triggerComponent={
         <button
-          aria-controls={null}
           aria-expanded={false}
           aria-haspopup="listbox"
           className="md-select-dropdown-input"
@@ -12601,6 +12650,7 @@ exports[`Select snapshot should match snapshot with title 1`] = `
           onTouchEnd={[Function]}
           onTouchMove={[Function]}
           onTouchStart={[Function]}
+          role="combobox"
           title="Example text"
           type="button"
         >
@@ -12779,7 +12829,6 @@ exports[`Select snapshot should match snapshot with title 1`] = `
             trigger="manual"
           >
             <button
-              aria-controls={null}
               aria-expanded={false}
               aria-haspopup="listbox"
               className="md-select-dropdown-input"
@@ -12798,6 +12847,7 @@ exports[`Select snapshot should match snapshot with title 1`] = `
               onTouchEnd={[Function]}
               onTouchMove={[Function]}
               onTouchStart={[Function]}
+              role="combobox"
               title="Example text"
               type="button"
             >


### PR DESCRIPTION
# IMPORTANT

**Currently, this project is closed to any external contributions. Any pull request made against this project from external sources will likely be closed. If you would like to make changes to this project, please fork this project.**

# Guide

**This "Help" section can be deleted before submitting this pull request.**

*Update the name of this pull request to reflect the following shape:*

```
{type}/{scope?}/{message}
```

* **type** - A [conventional commit type](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional#type-enum) **REQUIRED**
* **scope** - The kabab-case scope of the changes in this request
* **message** - A short, kebab-case statement describing the changes **REQUIRED**

*Provide a general summary of the scope of the changes in this pull request.*

* [Readme](https://github.com/momentum-design/momentum-react-v2/blob/master/README.md)
* [Getting Started Guide](https://github.com/momentum-design/momentum-react-v2/blob/master/GETTING_STARTED.md)
* [Contributing Guide](https://github.com/momentum-design/momentum-react-v2/blob/master/CONTRIBUTING.md)

# Description

added aria-label to selectNext component as an optional prop so SR can announce meaningful label for drop down list when focused.  

To give precedence to aria-label in useButton props - deleted aria-labelledby since otherwise SR announces first selection in the dropdown as label since the id for aria-labelledby is linked like that. 

https://react-spectrum.adobe.com/react-aria/useButton.html

added role=combobox so SR can announce dropdowns as comboboxes (expected behavior) and not menu buttons (current behavior). 

https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-select-only/

# Links

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-505183
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-502434
