### PR TITLE
do-no-merge feat(search-input): make clearButtonAriaLabel required

### DIFF
--- a/src/components/List/List.stories.tsx
+++ b/src/components/List/List.stories.tsx
@@ -197,7 +197,7 @@ const ListSearchWrapper = () => {
 
   return (
     <>
-      <SearchInput value={query} onChange={setQuery} />
+      <SearchInput value={query} onChange={setQuery} clearButtonAriaLabel='Clear'/>
       <List shouldItemFocusBeInset listSize={filtered.length}>
         {filtered &&
           filtered.map((item, index) => (

--- a/src/components/SearchInput/SearchInput.stories.args.ts
+++ b/src/components/SearchInput/SearchInput.stories.args.ts
@@ -19,6 +19,7 @@ export default {
     description: 'The aria-label for clear button',
     table: {
       category: 'Props',
+      defaultValue: 'Clear',
     },
   },
   searching: {

--- a/src/components/SearchInput/SearchInput.stories.tsx
+++ b/src/components/SearchInput/SearchInput.stories.tsx
@@ -110,6 +110,7 @@ const BetterExample: FC<SearchInputExampleProps> = (props: SearchInputExamplePro
       onFiltersChange={handleFiltersChange}
       onChange={handleChange}
       label={initialLabel}
+      clearButtonAriaLabel='Clear'
       {...mutatedProps}
       searching={searching}
     />

--- a/src/components/SearchInput/SearchInput.types.ts
+++ b/src/components/SearchInput/SearchInput.types.ts
@@ -78,7 +78,7 @@ export interface Props extends AriaSearchFieldProps {
   /**
    * aria-label for clear button
    */
-  clearButtonAriaLabel?: string;
+  clearButtonAriaLabel: string;
 
   /**
    * Initial text for accessible label

--- a/src/components/SearchInput/SearchInput.unit.test.tsx
+++ b/src/components/SearchInput/SearchInput.unit.test.tsx
@@ -25,7 +25,7 @@ describe('<SearchInput />', () => {
     it('should match snapshot', async () => {
       expect.assertions(1);
 
-      const container = await mountComponent(<SearchInput aria-label="search" />);
+      const container = await mountComponent(<SearchInput aria-label="search" clearButtonAriaLabel='Clear' />);
 
       expect(container).toMatchSnapshot();
     });
@@ -36,7 +36,7 @@ describe('<SearchInput />', () => {
       const className = 'example-class';
 
       const container = await mountComponent(
-        <SearchInput aria-label="search" className={className} />
+        <SearchInput aria-label="search" className={className} clearButtonAriaLabel='Clear' />
       );
 
       expect(container).toMatchSnapshot();
@@ -47,7 +47,7 @@ describe('<SearchInput />', () => {
 
       const id = 'example-id';
 
-      const container = await mountComponent(<SearchInput aria-label="search" id={id} />);
+      const container = await mountComponent(<SearchInput aria-label="search" id={id} clearButtonAriaLabel='Clear'/>);
 
       expect(container).toMatchSnapshot();
     });
@@ -55,7 +55,7 @@ describe('<SearchInput />', () => {
     it('should match snapshot with a label', async () => {
       expect.assertions(1);
 
-      const container = await mountComponent(<SearchInput label="search" aria-label="search" />);
+      const container = await mountComponent(<SearchInput label="search" aria-label="search" clearButtonAriaLabel='Clear'/>);
 
       expect(container).toMatchSnapshot();
     });
@@ -65,7 +65,7 @@ describe('<SearchInput />', () => {
 
       const style = { color: 'pink' };
 
-      const container = await mountComponent(<SearchInput aria-label="search" style={style} />);
+      const container = await mountComponent(<SearchInput aria-label="search" style={style} clearButtonAriaLabel='Clear'/>);
 
       expect(container).toMatchSnapshot();
     });
@@ -73,7 +73,7 @@ describe('<SearchInput />', () => {
     it('should match snapshot when searching', async () => {
       expect.assertions(1);
 
-      const container = await mountComponent(<SearchInput aria-label="search" searching={true} />);
+      const container = await mountComponent(<SearchInput aria-label="search" searching={true} clearButtonAriaLabel='Clear'/>);
 
       expect(container).toMatchSnapshot();
     });
@@ -81,7 +81,7 @@ describe('<SearchInput />', () => {
     it('should match snapshot with height', async () => {
       expect.assertions(1);
 
-      const container = await mountComponent(<SearchInput aria-label="search" height={28} />);
+      const container = await mountComponent(<SearchInput aria-label="search" height={28} clearButtonAriaLabel='Clear'/>);
 
       expect(container).toMatchSnapshot();
     });
@@ -93,6 +93,7 @@ describe('<SearchInput />', () => {
         <SearchInput
           aria-label="search"
           value="From: someone"
+          clearButtonAriaLabel='Clear'
           filters={[
             {
               term: 'from',
@@ -116,7 +117,7 @@ describe('<SearchInput />', () => {
     it('should have its wrapper class', async () => {
       expect.assertions(1);
 
-      const element = (await mountAndWait(<SearchInput aria-label="search" />))
+      const element = (await mountAndWait(<SearchInput aria-label="search" clearButtonAriaLabel='Clear'/>))
         .find(SearchInput)
         .getDOMNode();
 
@@ -129,7 +130,7 @@ describe('<SearchInput />', () => {
       const className = 'example-class';
 
       const element = (
-        await mountAndWait(<SearchInput aria-label="search" className={className} />)
+        await mountAndWait(<SearchInput aria-label="search" className={className} clearButtonAriaLabel='Clear'/>)
       )
         .find(SearchInput)
         .getDOMNode();
@@ -142,7 +143,7 @@ describe('<SearchInput />', () => {
 
       const id = 'example-id-2';
 
-      const element = (await mountAndWait(<SearchInput aria-label="search" id={id} />))
+      const element = (await mountAndWait(<SearchInput aria-label="search" id={id} clearButtonAriaLabel='Clear'/>))
         .find(SearchInput)
         .getDOMNode();
 
@@ -155,7 +156,7 @@ describe('<SearchInput />', () => {
       const style = { color: 'pink' };
       const styleString = 'color: pink;';
 
-      const element = (await mountAndWait(<SearchInput aria-label="search" style={style} />))
+      const element = (await mountAndWait(<SearchInput aria-label="search" style={style} clearButtonAriaLabel='Clear'/>))
         .find(SearchInput)
         .getDOMNode();
 
@@ -165,7 +166,7 @@ describe('<SearchInput />', () => {
     it('should have provided height when height is provided', async () => {
       expect.assertions(1);
 
-      const element = (await mountAndWait(<SearchInput aria-label="search" height={28} />))
+      const element = (await mountAndWait(<SearchInput aria-label="search" height={28} clearButtonAriaLabel='Clear'/>))
         .find(SearchInput)
         .getDOMNode();
 
@@ -175,7 +176,7 @@ describe('<SearchInput />', () => {
     it('should have default height when height is not provided', async () => {
       expect.assertions(1);
 
-      const element = (await mountAndWait(<SearchInput aria-label="search" />))
+      const element = (await mountAndWait(<SearchInput aria-label="search" clearButtonAriaLabel='Clear' />))
         .find(SearchInput)
         .getDOMNode();
 
@@ -185,7 +186,7 @@ describe('<SearchInput />', () => {
     it('should pass the aria label to the input', async () => {
       expect.assertions(1);
 
-      const element = (await mountAndWait(<SearchInput aria-label="search" searching={true} />))
+      const element = (await mountAndWait(<SearchInput aria-label="search" searching={true} clearButtonAriaLabel='Clear'/>))
         .find('input')
         .getDOMNode();
 
@@ -195,7 +196,7 @@ describe('<SearchInput />', () => {
     it('should pass label to the label', async () => {
       expect.assertions(2);
 
-      const wrapper = await mountAndWait(<SearchInput aria-label="search" label="a label" />);
+      const wrapper = await mountAndWait(<SearchInput aria-label="search" label="a label" clearButtonAriaLabel='Clear'/>);
       const label = wrapper.find('label');
       const realInputId = wrapper.find('input').getDOMNode().getAttribute('id');
 
@@ -206,7 +207,7 @@ describe('<SearchInput />', () => {
     it('should forward a ref if provided', async () => {
       const ref = React.createRef<HTMLInputElement>();
 
-      await mountAndWait(<SearchInput ref={ref} aria-label="search" value="test" />);
+      await mountAndWait(<SearchInput ref={ref} aria-label="search" value="test" clearButtonAriaLabel='Clear'/>);
 
       expect(ref.current).toBeInstanceOf(HTMLInputElement);
       expect(ref.current.value).toEqual('test');
@@ -214,7 +215,7 @@ describe('<SearchInput />', () => {
 
     it('should work with autofocus', async () => {
       // eslint-disable-next-line jsx-a11y/no-autofocus
-      await mountAndWait(<SearchInput autoFocus aria-label="search" value="test" />);
+      await mountAndWait(<SearchInput autoFocus aria-label="search" value="test" clearButtonAriaLabel='Clear' />);
     });
 
     it('should not render ButtonSimple if there is no value', async () => {
@@ -242,7 +243,7 @@ describe('<SearchInput />', () => {
         onPress: expect.any(Function),
         onPressStart: expect.any(Function),
         useNativeKeyDown: true,
-      })
+      });
     });
   });
 
@@ -250,7 +251,7 @@ describe('<SearchInput />', () => {
     it('clicking on another part of the component gives focus to the input', async () => {
       expect.assertions(1);
 
-      const wrapper = await mountAndWait(<SearchInput aria-label="search" />);
+      const wrapper = await mountAndWait(<SearchInput aria-label="search" clearButtonAriaLabel='Clear'/>);
 
       const inputElement = wrapper.find('input');
       const icon = wrapper.find(Icon);

--- a/src/components/SearchInput/SearchInput.unit.test.tsx.snap
+++ b/src/components/SearchInput/SearchInput.unit.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`<SearchInput /> snapshot should match snapshot 1`] = `
 <SSRProvider>
   <SearchInput
     aria-label="search"
+    clearButtonAriaLabel="Clear"
   >
     <div
       className="md-search-input-wrapper"
@@ -84,6 +85,7 @@ exports[`<SearchInput /> snapshot should match snapshot when filters are set 1`]
 <SSRProvider>
   <SearchInput
     aria-label="search"
+    clearButtonAriaLabel="Clear"
     filters={
       Array [
         Object {
@@ -162,6 +164,7 @@ exports[`<SearchInput /> snapshot should match snapshot when filters are set 1`]
         />
       </div>
       <ButtonSimple
+        aria-label="Clear"
         className="md-search-input-clear"
         excludeFromTabOrder={false}
         onPress={[Function]}
@@ -175,6 +178,7 @@ exports[`<SearchInput /> snapshot should match snapshot when filters are set 1`]
             focusRingClass="md-focus-ring-wrapper children"
           >
             <button
+              aria-label="Clear"
               className="md-search-input-clear md-button-simple-wrapper"
               onBlur={[Function]}
               onClick={[Function]}
@@ -249,6 +253,7 @@ exports[`<SearchInput /> snapshot should match snapshot when searching 1`] = `
 <SSRProvider>
   <SearchInput
     aria-label="search"
+    clearButtonAriaLabel="Clear"
     searching={true}
   >
     <div
@@ -363,6 +368,7 @@ exports[`<SearchInput /> snapshot should match snapshot with a label 1`] = `
 <SSRProvider>
   <SearchInput
     aria-label="search"
+    clearButtonAriaLabel="Clear"
     label="search"
   >
     <div
@@ -452,6 +458,7 @@ exports[`<SearchInput /> snapshot should match snapshot with className 1`] = `
   <SearchInput
     aria-label="search"
     className="example-class"
+    clearButtonAriaLabel="Clear"
   >
     <div
       className="example-class md-search-input-wrapper"
@@ -532,6 +539,7 @@ exports[`<SearchInput /> snapshot should match snapshot with height 1`] = `
 <SSRProvider>
   <SearchInput
     aria-label="search"
+    clearButtonAriaLabel="Clear"
     height={28}
   >
     <div
@@ -613,6 +621,7 @@ exports[`<SearchInput /> snapshot should match snapshot with id 1`] = `
 <SSRProvider>
   <SearchInput
     aria-label="search"
+    clearButtonAriaLabel="Clear"
     id="example-id"
   >
     <div
@@ -695,6 +704,7 @@ exports[`<SearchInput /> snapshot should match snapshot with style 1`] = `
 <SSRProvider>
   <SearchInput
     aria-label="search"
+    clearButtonAriaLabel="Clear"
     style={
       Object {
         "color": "pink",


### PR DESCRIPTION
BREAKING CHANGE: DO NOT MERGE IF YOU ARE NOT THE AUTHOR

# Description

On the SearchInput component, we need to require the consumer to pass a clearButtonAriaLabel property for when the user has added value to the input. This is an accessibilty requirement, as the clear button will always be a ButtonCircle with an X, so aria-label is needed to describe to the impaired user what would happen if he clicks on that X.

Cantina PR to handle breaking-changes: 
