### PR TITLE
feat(clear-button-index): overwrite react aria excludeFromTabOrder

### DIFF
--- a/src/components/GlobalSearchInput/GlobalSearchInput.tsx
+++ b/src/components/GlobalSearchInput/GlobalSearchInput.tsx
@@ -56,6 +56,11 @@ const GlobalSearchInput: FC<Props> = (props: Props) => {
     ref
   );
 
+  // react aria useSearchField is setting excludeFromTabOrder to true
+  // check https://github.com/adobe/react-spectrum/blob/02f242f41f0347b3f11e50b019c197127b7d0a08/packages/%40react-aria/searchfield/src/useSearchField.ts#L118
+  // but clear button should be focusable, so we overwrite clearButtonProps.excludeFromTabOrder = false to false
+  clearButtonProps.excludeFromTabOrder = false;
+
   const handleClick = () => {
     if (ref.current) {
       ref.current.focus();

--- a/src/components/GlobalSearchInput/GlobalSearchInput.unit.test.tsx
+++ b/src/components/GlobalSearchInput/GlobalSearchInput.unit.test.tsx
@@ -5,6 +5,7 @@ import { mountAndWait } from '../../../test/utils';
 import Icon from '../Icon';
 import GlobalSearchInput, { GLOBAL_SEARCH_INPUT_CONSTANTS as CONSTANTS } from './';
 import { act } from 'react-dom/test-utils';
+import ButtonSimple from '../ButtonSimple';
 
 const testTranslations = {
   empty: 'empty',
@@ -174,7 +175,7 @@ describe('<GlobalSearchInput />', () => {
           <GlobalSearchInput
             aria-label="global search"
             style={style}
-            clearButtonAriaLabel="search"
+            clearButtonAriaLabel="clear"
           />
         )
       )
@@ -192,7 +193,7 @@ describe('<GlobalSearchInput />', () => {
           <GlobalSearchInput
             aria-label="global search"
             searching={true}
-            clearButtonAriaLabel="search"
+            clearButtonAriaLabel="clear"
           />
         )
       )
@@ -210,7 +211,7 @@ describe('<GlobalSearchInput />', () => {
           <GlobalSearchInput
             aria-label="global search"
             searching={true}
-            clearButtonAriaLabel="search"
+            clearButtonAriaLabel="clear"
           />
         )
       )
@@ -218,6 +219,31 @@ describe('<GlobalSearchInput />', () => {
         .getDOMNode();
 
       expect(element.getAttribute('aria-label')).toBe('global search');
+    });
+
+    it('should pass the correct properties to the clear button', async () => {
+      expect.assertions(1);
+
+      const element = (
+        await mountAndWait(
+          <GlobalSearchInput
+            aria-label="global search"
+            searching={true}
+            clearButtonAriaLabel="clear"
+            value="hello"
+          />
+        )
+      ).find(ButtonSimple);
+
+      expect(element.props()).toStrictEqual({
+        className: 'md-global-search-input-clear',
+        excludeFromTabOrder: false,
+        'aria-label': 'clear',
+        children: expect.any(Object),
+        onPress: expect.any(Function),
+        onPressStart: expect.any(Function),
+        preventFocusOnPress: true,
+      });
     });
   });
 
@@ -241,7 +267,7 @@ describe('<GlobalSearchInput />', () => {
             aria-label="global search"
             value="ab"
             filters={filters}
-            clearButtonAriaLabel="search"
+            clearButtonAriaLabel="clear"
           />
         );
       };
@@ -278,7 +304,7 @@ describe('<GlobalSearchInput />', () => {
           aria-label="global search"
           value="ab"
           filters={[{ term: 'from', value: '', translations: testTranslations }]}
-          clearButtonAriaLabel="search"
+          clearButtonAriaLabel="clear"
         />
       );
       const inputElement = wrapper.find('input');
@@ -313,7 +339,7 @@ describe('<GlobalSearchInput />', () => {
           aria-label="global search"
           value=""
           filters={[]}
-          clearButtonAriaLabel="search"
+          clearButtonAriaLabel="clear"
         />
       );
       const inputElement = wrapper.find('input');
@@ -346,7 +372,7 @@ describe('<GlobalSearchInput />', () => {
             aria-label="global search"
             value="ab"
             filters={[{ term: 'from', value: '', translations: testTranslations }]}
-            clearButtonAriaLabel="search"
+            clearButtonAriaLabel="clear"
           />
         )
       ).find('input');
@@ -382,7 +408,7 @@ describe('<GlobalSearchInput />', () => {
             aria-label="global search"
             value="ab cd"
             filters={filters}
-            clearButtonAriaLabel="search"
+            clearButtonAriaLabel="clear"
           />
         )
       ).find('input');
@@ -414,7 +440,7 @@ describe('<GlobalSearchInput />', () => {
             aria-label="global search"
             value="abc"
             filters={[{ term: 'from', value: '', translations: testTranslations }]}
-            clearButtonAriaLabel="search"
+            clearButtonAriaLabel="clear"
           />
         )
       ).find('input');
@@ -435,7 +461,7 @@ describe('<GlobalSearchInput />', () => {
       expect.assertions(1);
 
       const wrapper = await mountAndWait(
-        <GlobalSearchInput aria-label="global search" clearButtonAriaLabel="search" />
+        <GlobalSearchInput aria-label="global search" clearButtonAriaLabel="clear" />
       );
 
       const inputElement = wrapper.find('input');

--- a/src/components/GlobalSearchInput/GlobalSearchInput.unit.test.tsx.snap
+++ b/src/components/GlobalSearchInput/GlobalSearchInput.unit.test.tsx.snap
@@ -178,7 +178,7 @@ exports[`<GlobalSearchInput /> snapshot should match snapshot when filters are s
       <ButtonSimple
         aria-label="search"
         className="md-global-search-input-clear"
-        excludeFromTabOrder={true}
+        excludeFromTabOrder={false}
         onPress={[Function]}
         onPressStart={[Function]}
         preventFocusOnPress={true}
@@ -205,7 +205,6 @@ exports[`<GlobalSearchInput /> snapshot should match snapshot when filters are s
               onTouchEnd={[Function]}
               onTouchMove={[Function]}
               onTouchStart={[Function]}
-              tabIndex={-1}
               type="button"
             >
               <Icon


### PR DESCRIPTION
# Description

We are using react-aria's useSearchField for the GlobalSearchInput component. However, this hook is returning a static true on the clear button excludeFromTabOrder, which makes this button not focusable and violating accessibilty rules.

I am overwriting this prop from react aria to false before passing it to the clear button. 

# Links

[*Links to relevent resources.*](https://github.com/adobe/react-spectrum/blob/02f242f41f0347b3f11e50b019c197127b7d0a08/packages/%40react-aria/searchfield/src/useSearchField.ts#L118)
