### PR TITLE
feat(card): dont render status if not color status provided

### DIFF
--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -21,7 +21,7 @@ export default {
 };
 
 const ChildWrapper = ({ children }: { children: string }) => (
-  <div style={{ marginRight: '0.5rem', display: 'flex', alignItems: 'center' }}>{children}</div>
+  <div style={{ margin: '0.5rem', display: 'flex', alignItems: 'center' }}>{children}</div>
 );
 
 const Example = Template<CardProps>(Card).bind({});
@@ -30,7 +30,7 @@ Example.argTypes = { ...argTypes };
 
 Example.args = {
   children: (
-    <div style={{ marginRight: '0.5rem', display: 'flex', alignItems: 'center' }}>Example Text</div>
+    <div style={{ margin: '0.5rem', display: 'flex', alignItems: 'center' }}>Example Text</div>
   ),
 };
 

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -43,21 +43,17 @@ const Card: FC<Props> = (props: Props) => {
 
   return (
     <>
-      {
-        isStatic ?
-          <div {...wrapperProps} {...otherProps}>
-            <CardStatus color={statusColor} striped={statusStriped} />
-            {children}
-          </div> :
-          <ButtonSimple
-            {...wrapperProps}
-            isDisabled={isDisabled}
-            {...otherProps}
-          >
-            <CardStatus color={statusColor} striped={statusStriped} />
-            {children}
-          </ButtonSimple>
-      }
+      {isStatic ? (
+        <div {...wrapperProps} {...otherProps}>
+          <CardStatus color={statusColor} striped={statusStriped} />
+          {children}
+        </div>
+      ) : (
+        <ButtonSimple {...wrapperProps} isDisabled={isDisabled} {...otherProps}>
+          {statusColor && <CardStatus color={statusColor} striped={statusStriped} />}
+          {children}
+        </ButtonSimple>
+      )}
     </>
   );
 };

--- a/src/components/Card/Card.unit.test.tsx
+++ b/src/components/Card/Card.unit.test.tsx
@@ -255,13 +255,26 @@ describe('<Card />', () => {
       expect(target.getAttribute(attribute)).toBe(statusColor);
     });
 
+    it('should not render CardStatus if no statusColor prop is provided', async () => {
+      expect.assertions(1);
+
+      const children = <div>Hello</div>;
+
+      render(<Card data-testid={testid} children={children} />);
+
+      const component = await screen.findByTestId(testid);
+      const target = component.firstElementChild;
+
+      expect(target.classList.contains('md-card-status-wrapper')).toBe(false);
+    });
+
     it('should have status with data-striped attribute when statusStriped prop is provided', async () => {
       expect.assertions(1);
 
       const attribute = 'data-striped';
       const statusStriped = true;
 
-      render(<Card statusStriped={statusStriped} data-testid={testid} />);
+      render(<Card statusStriped={statusStriped} statusColor="inactive" data-testid={testid} />);
 
       const component = await screen.findByTestId(testid);
       const target = component.firstElementChild;

--- a/src/components/Card/Card.unit.test.tsx.snap
+++ b/src/components/Card/Card.unit.test.tsx.snap
@@ -8,11 +8,7 @@ exports[`<Card /> snapshot should match snapshot 1`] = `
     data-height="small"
     data-rounding="2"
     type="button"
-  >
-    <div
-      class="md-card-status-wrapper"
-    />
-  </button>
+  />
 </div>
 `;
 
@@ -25,9 +21,6 @@ exports[`<Card /> snapshot should match snapshot with children 1`] = `
     data-rounding="2"
     type="button"
   >
-    <div
-      class="md-card-status-wrapper"
-    />
     <div>
       example child
     </div>
@@ -43,11 +36,7 @@ exports[`<Card /> snapshot should match snapshot with class name 1`] = `
     data-height="small"
     data-rounding="2"
     type="button"
-  >
-    <div
-      class="md-card-status-wrapper"
-    />
-  </button>
+  />
 </div>
 `;
 
@@ -59,11 +48,7 @@ exports[`<Card /> snapshot should match snapshot with color 1`] = `
     data-height="small"
     data-rounding="2"
     type="button"
-  >
-    <div
-      class="md-card-status-wrapper"
-    />
-  </button>
+  />
 </div>
 `;
 
@@ -75,11 +60,7 @@ exports[`<Card /> snapshot should match snapshot with height 1`] = `
     data-height="tiny"
     data-rounding="2"
     type="button"
-  >
-    <div
-      class="md-card-status-wrapper"
-    />
-  </button>
+  />
 </div>
 `;
 
@@ -92,11 +73,7 @@ exports[`<Card /> snapshot should match snapshot with id 1`] = `
     data-rounding="2"
     id="example-id"
     type="button"
-  >
-    <div
-      class="md-card-status-wrapper"
-    />
-  </button>
+  />
 </div>
 `;
 
@@ -110,11 +87,7 @@ exports[`<Card /> snapshot should match snapshot with isDisabled 1`] = `
     data-rounding="2"
     disabled=""
     type="button"
-  >
-    <div
-      class="md-card-status-wrapper"
-    />
-  </button>
+  />
 </div>
 `;
 
@@ -143,11 +116,7 @@ exports[`<Card /> snapshot should match snapshot with outline 1`] = `
     data-outline="true"
     data-rounding="2"
     type="button"
-  >
-    <div
-      class="md-card-status-wrapper"
-    />
-  </button>
+  />
 </div>
 `;
 
@@ -159,11 +128,7 @@ exports[`<Card /> snapshot should match snapshot with rounding 1`] = `
     data-height="small"
     data-rounding="2"
     type="button"
-  >
-    <div
-      class="md-card-status-wrapper"
-    />
-  </button>
+  />
 </div>
 `;
 
@@ -192,12 +157,7 @@ exports[`<Card /> snapshot should match snapshot with statusStriped 1`] = `
     data-height="small"
     data-rounding="2"
     type="button"
-  >
-    <div
-      class="md-card-status-wrapper"
-      data-striped="true"
-    />
-  </button>
+  />
 </div>
 `;
 
@@ -210,10 +170,6 @@ exports[`<Card /> snapshot should match snapshot with style 1`] = `
     data-rounding="2"
     style="color: pink;"
     type="button"
-  >
-    <div
-      class="md-card-status-wrapper"
-    />
-  </button>
+  />
 </div>
 `;

--- a/src/components/MeetingContainer/MeetingContainer.unit.test.tsx.snap
+++ b/src/components/MeetingContainer/MeetingContainer.unit.test.tsx.snap
@@ -38,11 +38,6 @@ exports[`<MeetingContainer /> snapshot should match snapshot 1`] = `
             onTouchStart={[Function]}
             type="button"
           >
-            <CardStatus>
-              <div
-                className="md-card-status-wrapper"
-              />
-            </CardStatus>
             <div
               className="md-meeting-container-container"
             >
@@ -151,11 +146,6 @@ exports[`<MeetingContainer /> snapshot should match snapshot with avatar supplie
             onTouchStart={[Function]}
             type="button"
           >
-            <CardStatus>
-              <div
-                className="md-card-status-wrapper"
-              />
-            </CardStatus>
             <div
               className="md-meeting-container-container"
             >
@@ -271,11 +261,6 @@ exports[`<MeetingContainer /> snapshot should match snapshot with children suppl
             onTouchStart={[Function]}
             type="button"
           >
-            <CardStatus>
-              <div
-                className="md-card-status-wrapper"
-              />
-            </CardStatus>
             <div
               className="md-meeting-container-container"
             >
@@ -412,11 +397,6 @@ exports[`<MeetingContainer /> snapshot should match snapshot with circle action 
             onTouchStart={[Function]}
             type="button"
           >
-            <CardStatus>
-              <div
-                className="md-card-status-wrapper"
-              />
-            </CardStatus>
             <div
               className="md-meeting-container-container"
             >
@@ -704,11 +684,6 @@ exports[`<MeetingContainer /> snapshot should match snapshot with className 1`] 
             onTouchStart={[Function]}
             type="button"
           >
-            <CardStatus>
-              <div
-                className="md-card-status-wrapper"
-              />
-            </CardStatus>
             <div
               className="md-meeting-container-container"
             >
@@ -853,11 +828,6 @@ exports[`<MeetingContainer /> snapshot should match snapshot with disable suppli
             onTouchStart={[Function]}
             type="button"
           >
-            <CardStatus>
-              <div
-                className="md-card-status-wrapper"
-              />
-            </CardStatus>
             <div
               className="md-meeting-container-container"
             >
@@ -1240,11 +1210,6 @@ exports[`<MeetingContainer /> snapshot should match snapshot with id 1`] = `
             onTouchStart={[Function]}
             type="button"
           >
-            <CardStatus>
-              <div
-                className="md-card-status-wrapper"
-              />
-            </CardStatus>
             <div
               className="md-meeting-container-container"
             >
@@ -1373,11 +1338,6 @@ exports[`<MeetingContainer /> snapshot should match snapshot with pill action bu
             onTouchStart={[Function]}
             type="button"
           >
-            <CardStatus>
-              <div
-                className="md-card-status-wrapper"
-              />
-            </CardStatus>
             <div
               className="md-meeting-container-container"
             >
@@ -1616,11 +1576,6 @@ exports[`<MeetingContainer /> snapshot should match snapshot with scheduleInfoFi
             onTouchStart={[Function]}
             type="button"
           >
-            <CardStatus>
-              <div
-                className="md-card-status-wrapper"
-              />
-            </CardStatus>
             <div
               className="md-meeting-container-container"
             >
@@ -1728,11 +1683,6 @@ exports[`<MeetingContainer /> snapshot should match snapshot with scheduleInfoFi
             onTouchStart={[Function]}
             type="button"
           >
-            <CardStatus>
-              <div
-                className="md-card-status-wrapper"
-              />
-            </CardStatus>
             <div
               className="md-meeting-container-container"
             >
@@ -1839,11 +1789,6 @@ exports[`<MeetingContainer /> snapshot should match snapshot with scheduleInfoSe
             onTouchStart={[Function]}
             type="button"
           >
-            <CardStatus>
-              <div
-                className="md-card-status-wrapper"
-              />
-            </CardStatus>
             <div
               className="md-meeting-container-container"
             >
@@ -1956,11 +1901,6 @@ exports[`<MeetingContainer /> snapshot should match snapshot with scheduleInfoSe
             onTouchStart={[Function]}
             type="button"
           >
-            <CardStatus>
-              <div
-                className="md-card-status-wrapper"
-              />
-            </CardStatus>
             <div
               className="md-meeting-container-container"
             >
@@ -2079,11 +2019,6 @@ exports[`<MeetingContainer /> snapshot should match snapshot with spacelink supp
             onTouchStart={[Function]}
             type="button"
           >
-            <CardStatus>
-              <div
-                className="md-card-status-wrapper"
-              />
-            </CardStatus>
             <div
               className="md-meeting-container-container"
             >
@@ -2257,11 +2192,6 @@ exports[`<MeetingContainer /> snapshot should match snapshot with style 1`] = `
             }
             type="button"
           >
-            <CardStatus>
-              <div
-                className="md-card-status-wrapper"
-              />
-            </CardStatus>
             <div
               className="md-meeting-container-container"
             >
@@ -2375,11 +2305,6 @@ exports[`<MeetingContainer /> snapshot should match snapshot with tags supplied 
             onTouchStart={[Function]}
             type="button"
           >
-            <CardStatus>
-              <div
-                className="md-card-status-wrapper"
-              />
-            </CardStatus>
             <div
               className="md-meeting-container-container"
             >


### PR DESCRIPTION
# Description

The non-legacy Card component, which is currently not used in Cantina or in MRV2, renders an invisible cardStatus component even if there is no status to render. I am conditioning the render of this child component to only if colorStatus prop is passed to the parent.

# Links

*Links to relevent resources.*
