### PR TITLE
fix: ariatoolbar propagate keydown

### DIFF
--- a/src/components/AriaToolbar/AriaToolbar.stories.tsx
+++ b/src/components/AriaToolbar/AriaToolbar.stories.tsx
@@ -6,6 +6,8 @@ import AriaToolbar from './';
 import Documentation from './AriaToolbar.stories.docs.mdx';
 import ButtonCircle from '../ButtonCircle';
 import ButtonPill from '../ButtonPill';
+import ButtonSimple from '../ButtonSimple';
+import Popover from '../Popover';
 
 import argTypes from './AriaToolbar.stories.args';
 
@@ -79,4 +81,38 @@ const Vertical = () => {
   );
 };
 
-export { Horizontal, Vertical };
+const WithinPopover = () => {
+  return (
+    <Popover trigger="click" interactive triggerComponent={<ButtonSimple style={{ margin: '10rem auto', display: 'flex' }}>Click me!</ButtonSimple>}>
+        <AriaToolbar
+          orientation="vertical"
+          ariaControls="textInput"
+          ariaLabel="toolbar 1"
+          style={{ display: 'flex', rowGap: '0.5rem', flexDirection: 'column' }}
+        >
+          <ButtonCircle onPress={onPressHandler}>1</ButtonCircle>
+          <ButtonCircle onPress={onPressHandler}>2</ButtonCircle>
+          <ButtonCircle onPress={onPressHandler}>3</ButtonCircle>
+        </AriaToolbar>
+        <AriaToolbar
+          orientation="vertical"
+          ariaControls="textInput"
+          ariaLabel="toolbar 2"
+          style={{
+            display: 'flex',
+            rowGap: '0.5rem',
+            flexDirection: 'column',
+            marginTop: '1rem',
+            marginBottom: '1rem',
+          }}
+        >
+          <ButtonCircle onPress={onPressHandler}>1</ButtonCircle>
+          <ButtonCircle onPress={onPressHandler}>2</ButtonCircle>
+          <ButtonCircle onPress={onPressHandler}>3</ButtonCircle>
+        </AriaToolbar>
+    </Popover>
+
+  );
+};
+
+export { Horizontal, Vertical, WithinPopover };

--- a/src/components/AriaToolbar/AriaToolbar.tsx
+++ b/src/components/AriaToolbar/AriaToolbar.tsx
@@ -31,6 +31,10 @@ const AriaToolbar: FC<Props> = (props: Props) => {
 
   const { keyboardProps } = useKeyboard({
     onKeyDown: (e) => {
+      // for the escape key (and other key presses), continue propagation to let Popovers / Modals know that
+      // they should close
+      e.continuePropagation();
+      
       switch (e.key) {
         case orientation === 'horizontal' ? 'ArrowLeft' : 'ArrowUp':
           e.preventDefault();
@@ -89,6 +93,7 @@ const AriaToolbar: FC<Props> = (props: Props) => {
               child.props.onPress();
             }
           },
+          useNativeKeyDown: true,
           ...keyboardProps,
         });
       })}

--- a/src/components/AriaToolbar/AriaToolbar.unit.test.tsx
+++ b/src/components/AriaToolbar/AriaToolbar.unit.test.tsx
@@ -234,21 +234,41 @@ describe('<AriaToolbar />', () => {
 
       expect(onTabPress).toBeCalled();
     });
-  });
 
-  it('child onPress is still called', () => {
-    expect.assertions(1);
+    it('child onPress is still called', () => {
+      expect.assertions(1);
 
-    const onPress = jest.fn();
+      const onPress = jest.fn();
 
-    const element = mount(
-      <AriaToolbar ariaLabel="test">
-        <ButtonSimple onPress={onPress}>test button</ButtonSimple>
-      </AriaToolbar>
-    );
+      const element = mount(
+        <AriaToolbar ariaLabel="test">
+          <ButtonSimple onPress={onPress}>test button</ButtonSimple>
+        </AriaToolbar>
+      );
 
-    triggerPress(element.find(ButtonSimple));
+      triggerPress(element.find(ButtonSimple));
 
-    expect(onPress).toBeCalled();
+      expect(onPress).toBeCalled();
+    });
+
+    it('keydown events propagate up', () => {
+      const onKeyDown = jest.fn();
+
+      const element = mount(
+        // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+        <div onKeyDown={onKeyDown}>
+          <AriaToolbar ariaLabel="test" >
+            <ButtonSimple>test button</ButtonSimple>
+          </AriaToolbar>
+        </div>
+
+      );
+
+      element.find(ButtonSimple).simulate('keyDown', { key: 'Escape' });
+      element.find(ButtonSimple).simulate('keyDown', { key: 'Tab' });
+
+      expect(onKeyDown.mock.calls[0][0].key).toBe('Escape');
+      expect(onKeyDown.mock.calls[1][0].key).toBe('Tab');
+    });
   });
 });

--- a/src/components/AriaToolbar/AriaToolbar.unit.test.tsx.snap
+++ b/src/components/AriaToolbar/AriaToolbar.unit.test.tsx.snap
@@ -77,6 +77,7 @@ exports[`<AriaToolbar /> snapshot should not render invalid elements 1`] = `
       onKeyDown={[Function]}
       onPress={[Function]}
       tabIndex={0}
+      useNativeKeyDown={true}
     >
       <FocusRing>
         <FocusRing
@@ -123,6 +124,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - horizonta
       onKeyDown={[Function]}
       onPress={[Function]}
       tabIndex={0}
+      useNativeKeyDown={true}
     >
       <FocusRing>
         <FocusRing
@@ -156,6 +158,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - horizonta
       onKeyDown={[Function]}
       onPress={[Function]}
       tabIndex={-1}
+      useNativeKeyDown={true}
     >
       <FocusRing>
         <FocusRing
@@ -190,6 +193,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - horizonta
       onKeyDown={[Function]}
       onPress={[Function]}
       tabIndex={-1}
+      useNativeKeyDown={true}
     >
       <FocusRing>
         <FocusRing
@@ -237,6 +241,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - horizonta
       onKeyDown={[Function]}
       onPress={[Function]}
       tabIndex={-1}
+      useNativeKeyDown={true}
     >
       <FocusRing>
         <FocusRing
@@ -271,6 +276,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - horizonta
       onKeyDown={[Function]}
       onPress={[Function]}
       tabIndex={-1}
+      useNativeKeyDown={true}
     >
       <FocusRing>
         <FocusRing
@@ -305,6 +311,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - horizonta
       onKeyDown={[Function]}
       onPress={[Function]}
       tabIndex={0}
+      useNativeKeyDown={true}
     >
       <FocusRing>
         <FocusRing
@@ -351,6 +358,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - horizonta
       onKeyDown={[Function]}
       onPress={[Function]}
       tabIndex={-1}
+      useNativeKeyDown={true}
     >
       <FocusRing>
         <FocusRing
@@ -385,6 +393,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - horizonta
       onKeyDown={[Function]}
       onPress={[Function]}
       tabIndex={0}
+      useNativeKeyDown={true}
     >
       <FocusRing>
         <FocusRing
@@ -418,6 +427,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - horizonta
       onKeyDown={[Function]}
       onPress={[Function]}
       tabIndex={-1}
+      useNativeKeyDown={true}
     >
       <FocusRing>
         <FocusRing
@@ -465,6 +475,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - horizonta
       onKeyDown={[Function]}
       onPress={[Function]}
       tabIndex={-1}
+      useNativeKeyDown={true}
     >
       <FocusRing>
         <FocusRing
@@ -499,6 +510,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - horizonta
       onKeyDown={[Function]}
       onPress={[Function]}
       tabIndex={-1}
+      useNativeKeyDown={true}
     >
       <FocusRing>
         <FocusRing
@@ -533,6 +545,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - horizonta
       onKeyDown={[Function]}
       onPress={[Function]}
       tabIndex={0}
+      useNativeKeyDown={true}
     >
       <FocusRing>
         <FocusRing
@@ -580,6 +593,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - vertical 
       onKeyDown={[Function]}
       onPress={[Function]}
       tabIndex={0}
+      useNativeKeyDown={true}
     >
       <FocusRing>
         <FocusRing
@@ -613,6 +627,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - vertical 
       onKeyDown={[Function]}
       onPress={[Function]}
       tabIndex={-1}
+      useNativeKeyDown={true}
     >
       <FocusRing>
         <FocusRing
@@ -647,6 +662,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - vertical 
       onKeyDown={[Function]}
       onPress={[Function]}
       tabIndex={-1}
+      useNativeKeyDown={true}
     >
       <FocusRing>
         <FocusRing
@@ -695,6 +711,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - vertical 
       onKeyDown={[Function]}
       onPress={[Function]}
       tabIndex={-1}
+      useNativeKeyDown={true}
     >
       <FocusRing>
         <FocusRing
@@ -729,6 +746,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - vertical 
       onKeyDown={[Function]}
       onPress={[Function]}
       tabIndex={-1}
+      useNativeKeyDown={true}
     >
       <FocusRing>
         <FocusRing
@@ -763,6 +781,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - vertical 
       onKeyDown={[Function]}
       onPress={[Function]}
       tabIndex={0}
+      useNativeKeyDown={true}
     >
       <FocusRing>
         <FocusRing
@@ -810,6 +829,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - vertical 
       onKeyDown={[Function]}
       onPress={[Function]}
       tabIndex={-1}
+      useNativeKeyDown={true}
     >
       <FocusRing>
         <FocusRing
@@ -844,6 +864,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - vertical 
       onKeyDown={[Function]}
       onPress={[Function]}
       tabIndex={0}
+      useNativeKeyDown={true}
     >
       <FocusRing>
         <FocusRing
@@ -877,6 +898,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - vertical 
       onKeyDown={[Function]}
       onPress={[Function]}
       tabIndex={-1}
+      useNativeKeyDown={true}
     >
       <FocusRing>
         <FocusRing
@@ -925,6 +947,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - vertical 
       onKeyDown={[Function]}
       onPress={[Function]}
       tabIndex={-1}
+      useNativeKeyDown={true}
     >
       <FocusRing>
         <FocusRing
@@ -959,6 +982,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - vertical 
       onKeyDown={[Function]}
       onPress={[Function]}
       tabIndex={-1}
+      useNativeKeyDown={true}
     >
       <FocusRing>
         <FocusRing
@@ -993,6 +1017,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - vertical 
       onKeyDown={[Function]}
       onPress={[Function]}
       tabIndex={0}
+      useNativeKeyDown={true}
     >
       <FocusRing>
         <FocusRing


### PR DESCRIPTION
# Description

- Fixed the aria toolbar, by allowing the keyDown event to propagate up (this is for fixing accessibility issues, when using a aria toolbar within a Popover)
