### PR TITLE
fix(images): add ariaHidden to ModalArrow to not be read by SR

### DIFF
--- a/src/components/Coachmark/Coachmark.unit.test.tsx.snap
+++ b/src/components/Coachmark/Coachmark.unit.test.tsx.snap
@@ -154,6 +154,7 @@ exports[`<Coachmark /> snapshot should match snapshot with header 1`] = `
         style="position: absolute; left: 0px; transform: translate(5px, 0px);"
       >
         <svg
+          aria-hidden="true"
           class="md-modal-arrow-svg"
           data-placement="top"
           height="12"
@@ -310,6 +311,7 @@ exports[`<Coachmark /> snapshot should match snapshot without header 1`] = `
         style="position: absolute; left: 0px; transform: translate(5px, 0px);"
       >
         <svg
+          aria-hidden="true"
           class="md-modal-arrow-svg"
           data-placement="top"
           height="12"

--- a/src/components/MenuTrigger/MenuTrigger.unit.test.tsx.snap
+++ b/src/components/MenuTrigger/MenuTrigger.unit.test.tsx.snap
@@ -11359,6 +11359,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with showArrow 
                     style="position: absolute; left: 0px; transform: translate(5px, 0px);"
                   >
                     <svg
+                      aria-hidden="true"
                       class="md-modal-arrow-svg"
                       data-placement="bottom-start"
                       height="12"
@@ -13138,6 +13139,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with showArrow 
                       placement="bottom-start"
                     >
                       <svg
+                        aria-hidden="true"
                         className="md-modal-arrow-svg"
                         data-placement="bottom-start"
                         height={12}

--- a/src/components/ModalArrow/ModalArrow.tsx
+++ b/src/components/ModalArrow/ModalArrow.tsx
@@ -76,6 +76,7 @@ const ModalArrow: FC<Props> = (props: Props) => {
       id={id}
       className={classnames(STYLE.svg, className)}
       style={style}
+      aria-hidden='true'
       xmlns="http://www.w3.org/svg/2000"
       width={viewBoxWidth}
       height={viewBoxHeight}

--- a/src/components/ModalArrow/ModalArrow.tsx
+++ b/src/components/ModalArrow/ModalArrow.tsx
@@ -76,7 +76,7 @@ const ModalArrow: FC<Props> = (props: Props) => {
       id={id}
       className={classnames(STYLE.svg, className)}
       style={style}
-      aria-hidden='true'
+      aria-hidden="true"
       xmlns="http://www.w3.org/svg/2000"
       width={viewBoxWidth}
       height={viewBoxHeight}

--- a/src/components/ModalArrow/ModalArrow.unit.test.tsx
+++ b/src/components/ModalArrow/ModalArrow.unit.test.tsx
@@ -25,7 +25,7 @@ describe('<ModalArrow />', () => {
       expect(container).toMatchSnapshot();
     });
 
-    it('should match snapshot with aira-hidden', () => {
+    it('should match snapshot with aria-hidden', () => {
       expect.assertions(1);
 
       const ariaHidden = 'true';

--- a/src/components/ModalArrow/ModalArrow.unit.test.tsx
+++ b/src/components/ModalArrow/ModalArrow.unit.test.tsx
@@ -25,6 +25,16 @@ describe('<ModalArrow />', () => {
       expect(container).toMatchSnapshot();
     });
 
+    it('should match snapshot with aira-hidden', () => {
+      expect.assertions(1);
+
+      const ariaHidden = 'true';
+
+      const container = mount(<ModalArrow placement={placement} aria-hidden={ariaHidden} />);
+
+      expect(container).toMatchSnapshot();
+    });
+
     it('should match snapshot with id', () => {
       expect.assertions(1);
 
@@ -65,6 +75,18 @@ describe('<ModalArrow />', () => {
         .getDOMNode();
 
       expect(element.classList.contains(CONSTANTS.STYLE.svg)).toBe(true);
+    });
+
+    it('should have ariaHidden prop in svg', () => {
+      expect.assertions(1);
+
+      const ariaHidden = 'true';
+
+      const element = mount(<ModalArrow placement={placement} />)
+        .find(ModalArrow)
+        .getDOMNode();
+
+      expect(element.getAttribute('aria-hidden')).toBe(ariaHidden);
     });
 
     it('should have provided class when className is provided', () => {

--- a/src/components/ModalArrow/ModalArrow.unit.test.tsx.snap
+++ b/src/components/ModalArrow/ModalArrow.unit.test.tsx.snap
@@ -5,6 +5,39 @@ exports[`<ModalArrow /> snapshot should match snapshot 1`] = `
   placement="bottom"
 >
   <svg
+    aria-hidden="true"
+    className="md-modal-arrow-svg"
+    data-placement="bottom"
+    height={12}
+    viewBox="0 0 24 12"
+    width={24}
+    xmlns="http://www.w3.org/svg/2000"
+  >
+    <defs>
+      <clipPath
+        id="modal-arrow-cut-stroke-bottom"
+      >
+        <path
+          d="m 0 12 l 10 -10 q 2 -2 4 0 l 10 10"
+        />
+      </clipPath>
+    </defs>
+    <path
+      clipPath="url(#modal-arrow-cut-stroke-bottom)"
+      d="m 0 12 l 10 -10 q 2 -2 4 0 l 10 10"
+      data-color="primary"
+    />
+  </svg>
+</ModalArrow>
+`;
+
+exports[`<ModalArrow /> snapshot should match snapshot with aira-hidden 1`] = `
+<ModalArrow
+  aria-hidden="true"
+  placement="bottom"
+>
+  <svg
+    aria-hidden="true"
     className="md-modal-arrow-svg"
     data-placement="bottom"
     height={12}
@@ -36,6 +69,7 @@ exports[`<ModalArrow /> snapshot should match snapshot with className 1`] = `
   placement="bottom"
 >
   <svg
+    aria-hidden="true"
     className="md-modal-arrow-svg example-class"
     data-placement="bottom"
     height={12}
@@ -67,6 +101,7 @@ exports[`<ModalArrow /> snapshot should match snapshot with color 1`] = `
   placement="bottom"
 >
   <svg
+    aria-hidden="true"
     className="md-modal-arrow-svg"
     data-placement="bottom"
     height={12}
@@ -98,6 +133,7 @@ exports[`<ModalArrow /> snapshot should match snapshot with id 1`] = `
   placement="bottom"
 >
   <svg
+    aria-hidden="true"
     className="md-modal-arrow-svg"
     data-placement="bottom"
     height={12}
@@ -134,6 +170,7 @@ exports[`<ModalArrow /> snapshot should match snapshot with style 1`] = `
   }
 >
   <svg
+    aria-hidden="true"
     className="md-modal-arrow-svg"
     data-placement="bottom"
     height={12}

--- a/src/components/ModalArrow/ModalArrow.unit.test.tsx.snap
+++ b/src/components/ModalArrow/ModalArrow.unit.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`<ModalArrow /> snapshot should match snapshot 1`] = `
 </ModalArrow>
 `;
 
-exports[`<ModalArrow /> snapshot should match snapshot with aira-hidden 1`] = `
+exports[`<ModalArrow /> snapshot should match snapshot with aria-hidden 1`] = `
 <ModalArrow
   aria-hidden="true"
   placement="bottom"

--- a/src/components/ModalContainer/ModalContainer.unit.test.tsx.snap
+++ b/src/components/ModalContainer/ModalContainer.unit.test.tsx.snap
@@ -52,6 +52,7 @@ exports[`<ModalContainer /> snapshot should match snapshot with arrow 1`] = `
         color="primary"
       >
         <svg
+          aria-hidden="true"
           className="md-modal-arrow-svg"
           data-placement="auto"
           height={24}

--- a/src/components/Popover/Popover.unit.test.tsx.snap
+++ b/src/components/Popover/Popover.unit.test.tsx.snap
@@ -86,6 +86,7 @@ exports[`<Popover /> snapshot should display only one popover at all time 2`] = 
         style="position: absolute; left: 0px; transform: translate(5px, 0px);"
       >
         <svg
+          aria-hidden="true"
           class="md-modal-arrow-svg"
           data-placement="top"
           height="12"
@@ -173,6 +174,7 @@ exports[`<Popover /> snapshot should display only one popover at all time 3`] = 
         style="position: absolute; left: 0px; transform: translate(5px, 0px);"
       >
         <svg
+          aria-hidden="true"
           class="md-modal-arrow-svg"
           data-placement="top"
           height="12"
@@ -322,6 +324,7 @@ exports[`<Popover /> snapshot should display only one popover at all time 6`] = 
         style="position: absolute; left: 0px; transform: translate(5px, 0px);"
       >
         <svg
+          aria-hidden="true"
           class="md-modal-arrow-svg"
           data-placement="top"
           height="12"
@@ -409,6 +412,7 @@ exports[`<Popover /> snapshot should display only one popover at all time 7`] = 
         style="position: absolute; left: 0px; transform: translate(5px, 0px);"
       >
         <svg
+          aria-hidden="true"
           class="md-modal-arrow-svg"
           data-placement="top"
           height="12"
@@ -516,6 +520,7 @@ exports[`<Popover /> snapshot should match snapshot 2`] = `
         style="position: absolute; left: 0px; transform: translate(5px, 0px);"
       >
         <svg
+          aria-hidden="true"
           class="md-modal-arrow-svg"
           data-placement="top"
           height="12"
@@ -592,6 +597,7 @@ exports[`<Popover /> snapshot should match snapshot with className 2`] = `
         style="position: absolute; left: 0px; transform: translate(5px, 0px);"
       >
         <svg
+          aria-hidden="true"
           class="md-modal-arrow-svg"
           data-placement="top"
           height="12"
@@ -699,6 +705,7 @@ exports[`<Popover /> snapshot should match snapshot with closeButtonPlacement 2`
         style="position: absolute; left: 0px; transform: translate(5px, 0px);"
       >
         <svg
+          aria-hidden="true"
           class="md-modal-arrow-svg"
           data-placement="top"
           height="12"
@@ -775,6 +782,7 @@ exports[`<Popover /> snapshot should match snapshot with color 2`] = `
         style="position: absolute; left: 0px; transform: translate(5px, 0px);"
       >
         <svg
+          aria-hidden="true"
           class="md-modal-arrow-svg"
           data-placement="top"
           height="12"
@@ -852,6 +860,7 @@ exports[`<Popover /> snapshot should match snapshot with id 2`] = `
         style="position: absolute; left: 0px; transform: translate(5px, 0px);"
       >
         <svg
+          aria-hidden="true"
           class="md-modal-arrow-svg"
           data-placement="top"
           height="12"
@@ -928,6 +937,7 @@ exports[`<Popover /> snapshot should match snapshot with offsetDistance 2`] = `
         style="position: absolute; left: 0px; transform: translate(5px, 0px);"
       >
         <svg
+          aria-hidden="true"
           class="md-modal-arrow-svg"
           data-placement="top"
           height="12"
@@ -1004,6 +1014,7 @@ exports[`<Popover /> snapshot should match snapshot with offsetSkidding 2`] = `
         style="position: absolute; left: 0px; transform: translate(5px, 0px);"
       >
         <svg
+          aria-hidden="true"
           class="md-modal-arrow-svg"
           data-placement="top"
           height="12"
@@ -1080,6 +1091,7 @@ exports[`<Popover /> snapshot should match snapshot with offsetSkidding and offs
         style="position: absolute; left: 0px; transform: translate(5px, 0px);"
       >
         <svg
+          aria-hidden="true"
           class="md-modal-arrow-svg"
           data-placement="top"
           height="12"
@@ -1156,6 +1168,7 @@ exports[`<Popover /> snapshot should match snapshot with strategy = fixed 2`] = 
         style="position: absolute; left: 0px; transform: translate(5px, 0px);"
       >
         <svg
+          aria-hidden="true"
           class="md-modal-arrow-svg"
           data-placement="top"
           height="12"
@@ -1233,6 +1246,7 @@ exports[`<Popover /> snapshot should match snapshot with style 2`] = `
         style="position: absolute; left: 0px; transform: translate(5px, 0px);"
       >
         <svg
+          aria-hidden="true"
           class="md-modal-arrow-svg"
           data-placement="top"
           height="12"


### PR DESCRIPTION
# IMPORTANT

**Currently, this project is closed to any external contributions. Any pull request made against this project from external sources will likely be closed. If you would like to make changes to this project, please fork this project.**

# Guide

**This "Help" section can be deleted before submitting this pull request.**

*Update the name of this pull request to reflect the following shape:*

```
{type}/{scope?}/{message}
```

* **type** - A [conventional commit type](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional#type-enum) **REQUIRED**
* **scope** - The kabab-case scope of the changes in this request
* **message** - A short, kebab-case statement describing the changes **REQUIRED**

*Provide a general summary of the scope of the changes in this pull request.*

* [Readme](https://github.com/momentum-design/momentum-react-v2/blob/master/README.md)
* [Getting Started Guide](https://github.com/momentum-design/momentum-react-v2/blob/master/GETTING_STARTED.md)
* [Contributing Guide](https://github.com/momentum-design/momentum-react-v2/blob/master/CONTRIBUTING.md)

# Description
add aria-hidden to ModalArrow componnet as an prop, so SR will not read it "image".
aria-hidden="true" to any element, this will hide the element and all its childrens from SR.
*The full description of the changes made in this request.*

# Links
It can be seen in this link:
 https://confluence-eng-gpk2.cisco.com/conf/display/WTWC/ACCESSIBILITY+GENERAL+GUIDELINES
Here is the link of A11y bug:
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-503236
8.SR reads the decorated graphic [SPARK-522091](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-522091)*Links to relevent resources.*
