### PR TITLE
feat(textInput): Removed id from the whole wrapper of the component

### DIFF
--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -58,7 +58,6 @@ const TextInput = (props: Props, ref: RefObject<HTMLInputElement>): ReactElement
       data-level={messageType}
       data-focus={isFocused}
       data-disabled={isDisabled}
-      id={id}
       style={style}
       onClick={handleClick}
       className={classnames(STYLE.wrapper, className)}

--- a/src/components/TextInput/TextInput.unit.test.tsx
+++ b/src/components/TextInput/TextInput.unit.test.tsx
@@ -109,6 +109,17 @@ describe('<TextInput/>', () => {
       expect(element.classList.contains(className)).toBe(true);
     });
 
+    it('should have provided id when id is provided', async () => {
+      expect.assertions(1);
+
+      const id = 'example-id-2';
+
+      const element = (await mountAndWait(<TextInput aria-label="text-input" id={id} />))
+        .find(TextInput);
+      
+      expect(element.props()).toMatchObject({ 'aria-label': 'text-input', id: 'example-id-2' });
+    });
+
     it('should have provided style when style is provided', async () => {
       expect.assertions(1);
 

--- a/src/components/TextInput/TextInput.unit.test.tsx
+++ b/src/components/TextInput/TextInput.unit.test.tsx
@@ -109,18 +109,6 @@ describe('<TextInput/>', () => {
       expect(element.classList.contains(className)).toBe(true);
     });
 
-    it('should have provided id when id is provided', async () => {
-      expect.assertions(1);
-
-      const id = 'example-id-2';
-
-      const element = (await mountAndWait(<TextInput aria-label="text-input" id={id} />))
-        .find(TextInput)
-        .getDOMNode();
-
-      expect(element.id).toBe(id);
-    });
-
     it('should have provided style when style is provided', async () => {
       expect.assertions(1);
 

--- a/src/components/TextInput/TextInput.unit.test.tsx.snap
+++ b/src/components/TextInput/TextInput.unit.test.tsx.snap
@@ -233,7 +233,6 @@ exports[`<TextInput/> snapshot should match snapshot with id 1`] = `
       className="md-text-input-wrapper"
       data-focus={false}
       data-level="none"
-      id="example-id"
       onClick={[Function]}
     >
       <div


### PR DESCRIPTION
# IMPORTANT

**Currently, this project is closed to any external contributions. Any pull request made against this project from external sources will likely be closed. If you would like to make changes to this project, please fork this project.**

# Guide

**This "Help" section can be deleted before submitting this pull request.**

*Update the name of this pull request to reflect the following shape:*

```
{type}/{scope?}/{message}
```

* **type** - A [conventional commit type](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional#type-enum) **REQUIRED**
* **scope** - The kabab-case scope of the changes in this request
* **message** - A short, kebab-case statement describing the changes **REQUIRED**

*Provide a general summary of the scope of the changes in this pull request.*

* [Readme](https://github.com/momentum-design/momentum-react-v2/blob/master/README.md)
* [Getting Started Guide](https://github.com/momentum-design/momentum-react-v2/blob/master/GETTING_STARTED.md)
* [Contributing Guide](https://github.com/momentum-design/momentum-react-v2/blob/master/CONTRIBUTING.md)

# Description
The scope of this ticket involves removing the id attribute from the wrapper as it was causing SR to announce the whole component props when it is not intended to do so.

# Links
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-367398