### PR TITLE
feat(SelectNext): aria-activedescendant added

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -48,6 +48,8 @@ function Select<T extends object>(props: Props<T>, ref: RefObject<HTMLDivElement
   const state = useSelectState(props);
   const { labelProps, triggerProps, valueProps, menuProps } = useSelect(props, state, selectRef);
   const { buttonProps } = useButton({ ...triggerProps, isDisabled }, selectRef);
+  const ariaActivedesecendant = menuProps?.id && state?.selectionManager?.focusedKey && `${menuProps.id}-option-${state.selectionManager.focusedKey}`;
+
   delete buttonProps.color;
   delete buttonProps.onKeyDown;
 
@@ -102,6 +104,7 @@ function Select<T extends object>(props: Props<T>, ref: RefObject<HTMLDivElement
       role="combobox"
       aria-expanded={!!state.isOpen}
       aria-controls={id}
+      aria-activedescendant={ariaActivedesecendant}
       className={classnames(
         STYLE.dropdownInput,
         { [STYLE.selected]: state.selectedItem },

--- a/src/components/Select/Select.unit.test.tsx
+++ b/src/components/Select/Select.unit.test.tsx
@@ -124,6 +124,7 @@ describe('Select', () => {
       expect(container).toMatchSnapshot();
     });
 
+    // this one
     it('should match snapshot with listbox opened', async () => {
       expect.assertions(1);
 
@@ -658,5 +659,39 @@ describe('Select', () => {
       // second item should be selected
       expect(screen.getByRole('combobox', { name: 'test' }).textContent).toBe('Item 2');
     });
+  });
+
+  it('should properly handle aria activedescendant when dropdown is expanded', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Select id="test-id" label="test">
+        <Item>Item 1</Item>
+        <Item>Item 2</Item>
+      </Select>
+    );
+
+    // list box shouldn't be shown initially
+    let listbox = screen.queryByRole('listbox');
+    expect(listbox).not.toBeInTheDocument();
+
+    let button = screen.getByRole('combobox', { name: 'test' });
+    button.focus();
+    expect(button).toHaveFocus();
+    expect(button).not.toHaveAttribute('aria-activedescendant');
+
+    await user.keyboard('{ArrowUp}');
+    // list box should be shown after focus and pressing space
+
+    button = screen.getByRole('combobox', { name: 'test' });
+    expect(button).toHaveAttribute('aria-activedescendant', 'test-ID-option-$.0');
+
+    listbox = screen.getByRole('listbox');
+    expect(listbox).toBeVisible();
+
+    await user.keyboard('{ArrowDown}');
+
+    button = screen.getByRole('combobox', { name: 'test' });
+    expect(button).toHaveAttribute('aria-activedescendant', 'test-ID-option-$.1');
   });
 });

--- a/src/components/Select/Select.unit.test.tsx
+++ b/src/components/Select/Select.unit.test.tsx
@@ -124,7 +124,6 @@ describe('Select', () => {
       expect(container).toMatchSnapshot();
     });
 
-    // this one
     it('should match snapshot with listbox opened', async () => {
       expect.assertions(1);
 

--- a/src/components/Select/Select.unit.test.tsx.snap
+++ b/src/components/Select/Select.unit.test.tsx.snap
@@ -280,6 +280,7 @@ exports[`Select snapshot should match snapshot 1`] = `
       trigger="manual"
       triggerComponent={
         <button
+          aria-activedescendant={null}
           aria-controls="test-id"
           aria-expanded={false}
           aria-haspopup="listbox"
@@ -481,6 +482,7 @@ exports[`Select snapshot should match snapshot 1`] = `
             trigger="manual"
           >
             <button
+              aria-activedescendant={null}
               aria-controls="test-id"
               aria-expanded={false}
               aria-haspopup="listbox"
@@ -837,6 +839,7 @@ exports[`Select snapshot should match snapshot before and after opening select d
       trigger="manual"
       triggerComponent={
         <button
+          aria-activedescendant={null}
           aria-controls="test-id"
           aria-expanded={false}
           aria-haspopup="listbox"
@@ -1038,6 +1041,7 @@ exports[`Select snapshot should match snapshot before and after opening select d
             trigger="manual"
           >
             <button
+              aria-activedescendant={null}
               aria-controls="test-id"
               aria-expanded={false}
               aria-haspopup="listbox"
@@ -1283,6 +1287,7 @@ exports[`Select snapshot should match snapshot before and after opening select d
       triggerRef={
         Object {
           "current": <button
+            aria-activedescendant="test-ID-option-$.0"
             aria-controls="test-id"
             aria-expanded="true"
             aria-haspopup="listbox"
@@ -1394,6 +1399,7 @@ exports[`Select snapshot should match snapshot before and after opening select d
       trigger="manual"
       triggerComponent={
         <button
+          aria-activedescendant="test-ID-option-$.0"
           aria-controls="test-id"
           aria-expanded={true}
           aria-haspopup="listbox"
@@ -1595,6 +1601,7 @@ exports[`Select snapshot should match snapshot before and after opening select d
             trigger="manual"
           >
             <button
+              aria-activedescendant="test-ID-option-$.0"
               aria-controls="test-id"
               aria-expanded={true}
               aria-haspopup="listbox"
@@ -2479,6 +2486,7 @@ exports[`Select snapshot should match snapshot with border 1`] = `
       trigger="manual"
       triggerComponent={
         <button
+          aria-activedescendant={null}
           aria-controls="test-id"
           aria-expanded={false}
           aria-haspopup="listbox"
@@ -2680,6 +2688,7 @@ exports[`Select snapshot should match snapshot with border 1`] = `
             trigger="manual"
           >
             <button
+              aria-activedescendant={null}
               aria-controls="test-id"
               aria-expanded={false}
               aria-haspopup="listbox"
@@ -3037,6 +3046,7 @@ exports[`Select snapshot should match snapshot with className 1`] = `
       trigger="manual"
       triggerComponent={
         <button
+          aria-activedescendant={null}
           aria-controls="test-id"
           aria-expanded={false}
           aria-haspopup="listbox"
@@ -3238,6 +3248,7 @@ exports[`Select snapshot should match snapshot with className 1`] = `
             trigger="manual"
           >
             <button
+              aria-activedescendant={null}
               aria-controls="test-id"
               aria-expanded={false}
               aria-haspopup="listbox"
@@ -3595,6 +3606,7 @@ exports[`Select snapshot should match snapshot with direction 1`] = `
       trigger="manual"
       triggerComponent={
         <button
+          aria-activedescendant={null}
           aria-controls="test-id"
           aria-expanded={false}
           aria-haspopup="listbox"
@@ -3796,6 +3808,7 @@ exports[`Select snapshot should match snapshot with direction 1`] = `
             trigger="manual"
           >
             <button
+              aria-activedescendant={null}
               aria-controls="test-id"
               aria-expanded={false}
               aria-haspopup="listbox"
@@ -4051,6 +4064,7 @@ exports[`Select snapshot should match snapshot with disabled option 1`] = `
       triggerRef={
         Object {
           "current": <button
+            aria-activedescendant="test-ID-option-$.1"
             aria-controls="test-id"
             aria-expanded="true"
             aria-haspopup="listbox"
@@ -4162,6 +4176,7 @@ exports[`Select snapshot should match snapshot with disabled option 1`] = `
       trigger="manual"
       triggerComponent={
         <button
+          aria-activedescendant="test-ID-option-$.1"
           aria-controls="test-id"
           aria-expanded={true}
           aria-haspopup="listbox"
@@ -4363,6 +4378,7 @@ exports[`Select snapshot should match snapshot with disabled option 1`] = `
             trigger="manual"
           >
             <button
+              aria-activedescendant="test-ID-option-$.1"
               aria-controls="test-id"
               aria-expanded={true}
               aria-haspopup="listbox"
@@ -5250,6 +5266,7 @@ exports[`Select snapshot should match snapshot with id 1`] = `
       trigger="manual"
       triggerComponent={
         <button
+          aria-activedescendant={null}
           aria-controls="example-id"
           aria-expanded={false}
           aria-haspopup="listbox"
@@ -5451,6 +5468,7 @@ exports[`Select snapshot should match snapshot with id 1`] = `
             trigger="manual"
           >
             <button
+              aria-activedescendant={null}
               aria-controls="example-id"
               aria-expanded={false}
               aria-haspopup="listbox"
@@ -5573,6 +5591,7 @@ exports[`Select snapshot should match snapshot with isInForm = false 1`] = `
       trigger="manual"
       triggerComponent={
         <button
+          aria-activedescendant={null}
           aria-expanded={false}
           aria-haspopup="listbox"
           aria-labelledby="test-ID test-ID"
@@ -5773,6 +5792,7 @@ exports[`Select snapshot should match snapshot with isInForm = false 1`] = `
             trigger="manual"
           >
             <button
+              aria-activedescendant={null}
               aria-expanded={false}
               aria-haspopup="listbox"
               aria-labelledby="test-ID test-ID"
@@ -6018,6 +6038,7 @@ exports[`Select snapshot should match snapshot with listbox opened 1`] = `
       triggerRef={
         Object {
           "current": <button
+            aria-activedescendant="test-ID-option-$.0"
             aria-controls="test-id"
             aria-expanded="true"
             aria-haspopup="listbox"
@@ -6129,6 +6150,7 @@ exports[`Select snapshot should match snapshot with listbox opened 1`] = `
       trigger="manual"
       triggerComponent={
         <button
+          aria-activedescendant="test-ID-option-$.0"
           aria-controls="test-id"
           aria-expanded={true}
           aria-haspopup="listbox"
@@ -6330,6 +6352,7 @@ exports[`Select snapshot should match snapshot with listbox opened 1`] = `
             trigger="manual"
           >
             <button
+              aria-activedescendant="test-ID-option-$.0"
               aria-controls="test-id"
               aria-expanded={true}
               aria-haspopup="listbox"
@@ -7102,6 +7125,7 @@ exports[`Select snapshot should match snapshot with listboxMaxHeight 1`] = `
       triggerRef={
         Object {
           "current": <button
+            aria-activedescendant="test-ID-option-$.0"
             aria-expanded="true"
             aria-haspopup="listbox"
             aria-labelledby="test-ID test-ID"
@@ -7212,6 +7236,7 @@ exports[`Select snapshot should match snapshot with listboxMaxHeight 1`] = `
       trigger="manual"
       triggerComponent={
         <button
+          aria-activedescendant="test-ID-option-$.0"
           aria-expanded={true}
           aria-haspopup="listbox"
           aria-labelledby="test-ID test-ID"
@@ -7412,6 +7437,7 @@ exports[`Select snapshot should match snapshot with listboxMaxHeight 1`] = `
             trigger="manual"
           >
             <button
+              aria-activedescendant="test-ID-option-$.0"
               aria-expanded={true}
               aria-haspopup="listbox"
               aria-labelledby="test-ID test-ID"
@@ -8183,6 +8209,7 @@ exports[`Select snapshot should match snapshot with listboxWidth 1`] = `
       triggerRef={
         Object {
           "current": <button
+            aria-activedescendant="test-ID-option-$.0"
             aria-expanded="true"
             aria-haspopup="listbox"
             aria-labelledby="test-ID test-ID"
@@ -8293,6 +8320,7 @@ exports[`Select snapshot should match snapshot with listboxWidth 1`] = `
       trigger="manual"
       triggerComponent={
         <button
+          aria-activedescendant="test-ID-option-$.0"
           aria-expanded={true}
           aria-haspopup="listbox"
           aria-labelledby="test-ID test-ID"
@@ -8493,6 +8521,7 @@ exports[`Select snapshot should match snapshot with listboxWidth 1`] = `
             trigger="manual"
           >
             <button
+              aria-activedescendant="test-ID-option-$.0"
               aria-expanded={true}
               aria-haspopup="listbox"
               aria-labelledby="test-ID test-ID"
@@ -9378,6 +9407,7 @@ exports[`Select snapshot should match snapshot with placeholder 1`] = `
       trigger="manual"
       triggerComponent={
         <button
+          aria-activedescendant={null}
           aria-controls="test-id"
           aria-expanded={false}
           aria-haspopup="listbox"
@@ -9581,6 +9611,7 @@ exports[`Select snapshot should match snapshot with placeholder 1`] = `
             trigger="manual"
           >
             <button
+              aria-activedescendant={null}
               aria-controls="test-id"
               aria-expanded={false}
               aria-haspopup="listbox"
@@ -9966,6 +9997,7 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
       trigger="manual"
       triggerComponent={
         <button
+          aria-activedescendant={null}
           aria-controls="test-id"
           aria-expanded={false}
           aria-haspopup="listbox"
@@ -10170,6 +10202,7 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
             trigger="manual"
           >
             <button
+              aria-activedescendant={null}
               aria-controls="test-id"
               aria-expanded={false}
               aria-haspopup="listbox"
@@ -10443,6 +10476,7 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
       triggerRef={
         Object {
           "current": <button
+            aria-activedescendant="test-ID-option-$.0"
             aria-controls="test-id"
             aria-expanded="true"
             aria-haspopup="listbox"
@@ -10557,6 +10591,7 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
       trigger="manual"
       triggerComponent={
         <button
+          aria-activedescendant="test-ID-option-$.0"
           aria-controls="test-id"
           aria-expanded={true}
           aria-haspopup="listbox"
@@ -10761,6 +10796,7 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
             trigger="manual"
           >
             <button
+              aria-activedescendant="test-ID-option-$.0"
               aria-controls="test-id"
               aria-expanded={true}
               aria-haspopup="listbox"
@@ -11736,6 +11772,7 @@ exports[`Select snapshot should match snapshot with style 1`] = `
       trigger="manual"
       triggerComponent={
         <button
+          aria-activedescendant={null}
           aria-controls="test-id"
           aria-expanded={false}
           aria-haspopup="listbox"
@@ -11937,6 +11974,7 @@ exports[`Select snapshot should match snapshot with style 1`] = `
             trigger="manual"
           >
             <button
+              aria-activedescendant={null}
               aria-controls="test-id"
               aria-expanded={false}
               aria-haspopup="listbox"
@@ -12292,6 +12330,7 @@ exports[`Select snapshot should match snapshot with title 1`] = `
       trigger="manual"
       triggerComponent={
         <button
+          aria-activedescendant={null}
           aria-expanded={false}
           aria-haspopup="listbox"
           aria-labelledby="test-ID test-ID"
@@ -12493,6 +12532,7 @@ exports[`Select snapshot should match snapshot with title 1`] = `
             trigger="manual"
           >
             <button
+              aria-activedescendant={null}
               aria-expanded={false}
               aria-haspopup="listbox"
               aria-labelledby="test-ID test-ID"


### PR DESCRIPTION
# IMPORTANT

**Currently, this project is closed to any external contributions. Any pull request made against this project from external sources will likely be closed. If you would like to make changes to this project, please fork this project.**

# Guide

**This "Help" section can be deleted before submitting this pull request.**

*Update the name of this pull request to reflect the following shape:*

```
{type}/{scope?}/{message}
```

* **type** - A [conventional commit type](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional#type-enum) **REQUIRED**
* **scope** - The kabab-case scope of the changes in this request
* **message** - A short, kebab-case statement describing the changes **REQUIRED**

*Provide a general summary of the scope of the changes in this pull request.*

* [Readme](https://github.com/momentum-design/momentum-react-v2/blob/master/README.md)
* [Getting Started Guide](https://github.com/momentum-design/momentum-react-v2/blob/master/GETTING_STARTED.md)
* [Contributing Guide](https://github.com/momentum-design/momentum-react-v2/blob/master/CONTRIBUTING.md)

# Description

*The full description of the changes made in this request.*
- Added aria-activedescendant to Select dropdown. "Browsers do not manage visibility of elements referenced by aria-activedescendant like they do for elements with focus. When a keyboard event changes the active option in the listbox, the JavaScript scrolls the option referenced by aria-activedescendant into view. Managing aria-activedescendant visibility is essential to accessibility for people who use a browser's zoom feature to increase the size of content." 
- Tests added
# Links

*Links to relevent resources.*
[https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-502434](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-502434)
[Reference wiki](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-select-only/)