### PR TITLE
fix(PopoverNext): pass zIndex param to tippy, allow ariaLabel param to override default labelling

### DIFF
--- a/src/components/MenuTrigger/MenuTrigger.stories.args.ts
+++ b/src/components/MenuTrigger/MenuTrigger.stories.args.ts
@@ -59,4 +59,5 @@ export default {
   color: popoverArgTypes.color,
   variant: popoverArgTypes.variant,
   showArrow: popoverArgTypes.showArrow,
+  zIndex: popoverArgTypes.zIndex,
 };

--- a/src/components/MenuTrigger/MenuTrigger.tsx
+++ b/src/components/MenuTrigger/MenuTrigger.tsx
@@ -28,6 +28,7 @@ const MenuTrigger: FC<Props> = (props: Props) => {
     showArrow = DEFAULTS.SHOW_ARROW,
     placement = DEFAULTS.PLACEMENT,
     triggerComponent,
+    zIndex,
   } = props;
 
   const state = useMenuTriggerState(props);
@@ -39,7 +40,11 @@ const MenuTrigger: FC<Props> = (props: Props) => {
 
   const menuTriggerType = triggerComponent.props?.['aria-haspopup'] || 'menu';
 
-  const { menuTriggerProps, menuProps } = useMenuTrigger({ type: menuTriggerType }, state, buttonRef);
+  const { menuTriggerProps, menuProps } = useMenuTrigger(
+    { type: menuTriggerType },
+    state,
+    buttonRef
+  );
 
   menuTriggerProps['aria-haspopup'] = menuTriggerProps['aria-haspopup'] || menuTriggerType;
 
@@ -112,6 +117,7 @@ const MenuTrigger: FC<Props> = (props: Props) => {
       // MenuContext.Provider should take care of the auto focusing
       // eslint-disable-next-line jsx-a11y/no-autofocus
       autoFocus={false}
+      zIndex={zIndex}
       {...(keyboardProps as Omit<React.HTMLAttributes<HTMLElement>, 'color'>)}
     >
       {menus.map((menu: ReactElement, index) => {

--- a/src/components/MenuTrigger/MenuTrigger.unit.test.tsx
+++ b/src/components/MenuTrigger/MenuTrigger.unit.test.tsx
@@ -5,7 +5,7 @@ import MenuTrigger, { MENU_TRIGGER_CONSTANTS as CONSTANTS } from './';
 import ButtonPill from '../ButtonPill';
 import Menu from '../Menu';
 import { mountAndWait } from '../../../test/utils';
-import { ModalContainer } from '..';
+import { ModalContainer, Popover } from '..';
 import { ROUNDS } from '../ModalContainer/ModalContainer.constants';
 
 import { render, screen, waitFor } from '@testing-library/react';
@@ -109,6 +109,16 @@ describe('<MenuTrigger /> - Enzyme', () => {
       const placement = 'top';
 
       const container = await mountAndWait(<MenuTrigger {...defaultProps} placement={placement} />);
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match snapshot with zIndex', async () => {
+      expect.assertions(1);
+
+      const zIndex = 9998;
+
+      const container = await mountAndWait(<MenuTrigger {...defaultProps} zIndex={zIndex} />);
 
       expect(container).toMatchSnapshot();
     });
@@ -220,6 +230,18 @@ describe('<MenuTrigger /> - Enzyme', () => {
         .find(ModalContainer);
 
       expect(element.prop('placement')).toBe(placement);
+    });
+
+    it('should have provided zIndex to Popover when zIndex is provided', async () => {
+      expect.assertions(1);
+
+      const zIndex = 9998;
+
+      const element = (await mountAndWait(<MenuTrigger {...defaultProps} zIndex={zIndex} />))
+        .find(MenuTrigger)
+        .find(Popover);
+
+      expect(element.prop('zIndex')).toBe(zIndex);
     });
   });
 });

--- a/src/components/MenuTrigger/MenuTrigger.unit.test.tsx.snap
+++ b/src/components/MenuTrigger/MenuTrigger.unit.test.tsx.snap
@@ -17640,3 +17640,2201 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with variant 1`
   </Popover>
 </MenuTrigger>
 `;
+
+exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with zIndex 1`] = `
+<MenuTrigger
+  aria-label="Menu Trigger Component "
+  isOpen={true}
+  triggerComponent={
+    <ButtonPill>
+      Hello world
+    </ButtonPill>
+  }
+  zIndex={9998}
+>
+  <Popover
+    autoFocus={false}
+    className="md-menu-trigger-wrapper"
+    color="primary"
+    hideOnEsc={false}
+    interactive={true}
+    onClickOutside={[Function]}
+    onKeyDown={[Function]}
+    placement="bottom-start"
+    setInstance={[Function]}
+    showArrow={false}
+    trigger="click"
+    triggerComponent={
+      <ButtonPill
+        aria-controls="test-ID"
+        aria-expanded={true}
+        aria-haspopup={true}
+        id="test-ID"
+        onPress={[Function]}
+        onPressStart={[Function]}
+      >
+        Hello world
+      </ButtonPill>
+    }
+    variant="medium"
+    zIndex={9998}
+  >
+    <LazyTippy
+      animation={false}
+      appendTo="parent"
+      hideOnClick={true}
+      interactive={true}
+      offset={
+        Array [
+          0,
+          5,
+        ]
+      }
+      onClickOutside={[Function]}
+      onHidden={[Function]}
+      placement="bottom-start"
+      plugins={
+        Array [
+          Object {
+            "fn": [Function],
+            "name": "addBackdropPlugin",
+          },
+        ]
+      }
+      popperOptions={
+        Object {
+          "modifiers": Array [
+            Object {
+              "enabled": false,
+              "name": "arrow",
+              "options": Object {
+                "element": "#arrow1",
+                "padding": 5,
+              },
+            },
+            Object {
+              "name": "preventOverflow",
+              "options": Object {
+                "altAxis": true,
+                "boundariesElement": "scrollParent",
+                "padding": 8,
+              },
+            },
+          ],
+          "strategy": "absolute",
+        }
+      }
+      render={[Function]}
+      setInstance={[Function]}
+      trigger="click"
+      zIndex={9998}
+    >
+      <ForwardRef(TippyWrapper)
+        animation={false}
+        appendTo="parent"
+        hideOnClick={true}
+        interactive={true}
+        offset={
+          Array [
+            0,
+            5,
+          ]
+        }
+        onClickOutside={[Function]}
+        onHidden={[Function]}
+        placement="bottom-start"
+        plugins={
+          Array [
+            Object {
+              "fn": [Function],
+            },
+            Object {
+              "fn": [Function],
+            },
+            Object {
+              "fn": [Function],
+            },
+            Object {
+              "fn": [Function],
+              "name": "addBackdropPlugin",
+            },
+          ]
+        }
+        popperOptions={
+          Object {
+            "modifiers": Array [
+              Object {
+                "enabled": false,
+                "name": "arrow",
+                "options": Object {
+                  "element": "#arrow1",
+                  "padding": 5,
+                },
+              },
+              Object {
+                "name": "preventOverflow",
+                "options": Object {
+                  "altAxis": true,
+                  "boundariesElement": "scrollParent",
+                  "padding": 8,
+                },
+              },
+            ],
+            "strategy": "absolute",
+          }
+        }
+        render={[Function]}
+        trigger="click"
+        zIndex={9998}
+      >
+        <Tippy
+          animation={false}
+          appendTo="parent"
+          hideOnClick={true}
+          interactive={true}
+          offset={
+            Array [
+              0,
+              5,
+            ]
+          }
+          onClickOutside={[Function]}
+          onHidden={[Function]}
+          placement="bottom-start"
+          plugins={
+            Array [
+              Object {
+                "fn": [Function],
+              },
+              Object {
+                "fn": [Function],
+              },
+              Object {
+                "fn": [Function],
+              },
+              Object {
+                "fn": [Function],
+                "name": "addBackdropPlugin",
+              },
+            ]
+          }
+          popperOptions={
+            Object {
+              "modifiers": Array [
+                Object {
+                  "enabled": false,
+                  "name": "arrow",
+                  "options": Object {
+                    "element": "#arrow1",
+                    "padding": 5,
+                  },
+                },
+                Object {
+                  "name": "preventOverflow",
+                  "options": Object {
+                    "altAxis": true,
+                    "boundariesElement": "scrollParent",
+                    "padding": 8,
+                  },
+                },
+              ],
+              "strategy": "absolute",
+            }
+          }
+          render={[Function]}
+          trigger="click"
+          zIndex={9998}
+        >
+          <ButtonPill
+            aria-controls="test-ID"
+            aria-expanded={true}
+            aria-haspopup={true}
+            id="test-ID"
+            onPress={[Function]}
+            onPressStart={[Function]}
+            useNativeKeyDown={true}
+          >
+            <ButtonSimple
+              aria-controls="test-ID"
+              aria-disabled={false}
+              aria-expanded={true}
+              aria-haspopup={true}
+              className="md-button-pill-wrapper"
+              data-color="primary"
+              data-disabled={false}
+              data-ghost={false}
+              data-grown={false}
+              data-inverted={false}
+              data-outline={false}
+              data-shallow-disabled={false}
+              data-size={40}
+              id="test-ID"
+              onPress={[Function]}
+              onPressStart={[Function]}
+              useNativeKeyDown={true}
+            >
+              <FocusRing>
+                <FocusRing
+                  focusClass="md-focus-ring-wrapper children"
+                  focusRingClass="md-focus-ring-wrapper children"
+                >
+                  <button
+                    aria-controls="test-ID"
+                    aria-expanded={true}
+                    aria-haspopup={true}
+                    className="md-button-pill-wrapper md-button-simple-wrapper"
+                    data-color="primary"
+                    data-disabled={false}
+                    data-ghost={false}
+                    data-grown={false}
+                    data-inverted={false}
+                    data-outline={false}
+                    data-shallow-disabled={false}
+                    data-size={40}
+                    id="test-ID"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onDragStart={[Function]}
+                    onFocus={[Function]}
+                    onKeyUp={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchCancel={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchMove={[Function]}
+                    onTouchStart={[Function]}
+                    type="button"
+                  >
+                    <span>
+                      Hello world
+                    </span>
+                  </button>
+                </FocusRing>
+              </FocusRing>
+            </ButtonSimple>
+          </ButtonPill>
+          <Portal
+            containerInfo={
+              <div
+                data-tippy-root=""
+                id="tippy-9"
+                style="z-index: 9998; position: absolute; left: 0px; top: 0px; margin: 0px; transform: translate(0px, 0px);"
+              >
+                <span
+                  data-focus-scope-start="true"
+                  hidden=""
+                />
+                <div
+                  aria-labelledby="test-ID"
+                  aria-modal="true"
+                  class="md-menu-trigger-wrapper md-modal-container-wrapper"
+                  data-arrow-orientation="vertical"
+                  data-color="primary"
+                  data-elevation="3"
+                  data-padded="true"
+                  data-placement="bottom-start"
+                  data-round="75"
+                  role="dialog"
+                >
+                  <ul
+                    class="md-menu-wrapper"
+                    id="test-ID"
+                    role="menu"
+                    tabindex="-1"
+                  >
+                    <li
+                      aria-checked="false"
+                      aria-disabled="false"
+                      class="md-menu-item-wrapper md-list-item-base-wrapper"
+                      data-disabled="false"
+                      data-interactive="true"
+                      data-key="one"
+                      data-padded="true"
+                      data-shape="rectangle"
+                      data-size="40"
+                      role="menuitemradio"
+                      tabindex="0"
+                    >
+                      <div
+                        data-position="fill"
+                        title="One"
+                      >
+                        One
+                      </div>
+                    </li>
+                    <li
+                      aria-checked="false"
+                      aria-disabled="false"
+                      class="md-menu-item-wrapper md-list-item-base-wrapper"
+                      data-disabled="false"
+                      data-interactive="true"
+                      data-key="two"
+                      data-padded="true"
+                      data-shape="rectangle"
+                      data-size="40"
+                      role="menuitemradio"
+                      tabindex="-1"
+                    >
+                      <div
+                        data-position="fill"
+                        title="Two"
+                      >
+                        Two
+                      </div>
+                    </li>
+                    <li
+                      aria-checked="false"
+                      aria-disabled="false"
+                      class="md-menu-item-wrapper md-list-item-base-wrapper"
+                      data-disabled="false"
+                      data-interactive="true"
+                      data-key="three"
+                      data-padded="true"
+                      data-shape="rectangle"
+                      data-size="40"
+                      role="menuitemradio"
+                      tabindex="-1"
+                    >
+                      <div
+                        data-position="fill"
+                        title="Three"
+                      >
+                        Three
+                      </div>
+                    </li>
+                  </ul>
+                  <li
+                    class="md-content-separator-wrapper"
+                    role="separator"
+                  />
+                  <ul
+                    class="md-menu-wrapper"
+                    id="test-ID"
+                    role="menu"
+                    tabindex="0"
+                  >
+                    <li
+                      aria-checked="false"
+                      aria-disabled="false"
+                      class="md-menu-item-wrapper md-list-item-base-wrapper"
+                      data-disabled="false"
+                      data-interactive="true"
+                      data-key="asd"
+                      data-padded="true"
+                      data-shape="rectangle"
+                      data-size="40"
+                      role="menuitemcheckbox"
+                      tabindex="-1"
+                    >
+                      <div
+                        data-position="fill"
+                        title="Four"
+                      >
+                        Four
+                      </div>
+                    </li>
+                    <li
+                      aria-checked="false"
+                      aria-disabled="false"
+                      class="md-menu-item-wrapper md-list-item-base-wrapper"
+                      data-disabled="false"
+                      data-interactive="true"
+                      data-key="ff"
+                      data-padded="true"
+                      data-shape="rectangle"
+                      data-size="40"
+                      role="menuitemcheckbox"
+                      tabindex="-1"
+                    >
+                      <div
+                        data-position="fill"
+                        title="Five"
+                      >
+                        Five
+                      </div>
+                    </li>
+                    <li
+                      aria-checked="false"
+                      aria-disabled="false"
+                      class="md-menu-item-wrapper md-list-item-base-wrapper"
+                      data-disabled="false"
+                      data-interactive="true"
+                      data-key="d"
+                      data-padded="true"
+                      data-shape="rectangle"
+                      data-size="40"
+                      role="menuitemcheckbox"
+                      tabindex="-1"
+                    >
+                      <div
+                        data-position="fill"
+                        title="Six"
+                      >
+                        Six
+                      </div>
+                    </li>
+                  </ul>
+                </div>
+                <span
+                  data-focus-scope-end="true"
+                  hidden=""
+                />
+              </div>
+            }
+          >
+            <ModalContainer
+              aria-labelledby="test-ID"
+              ariaModal={true}
+              arrowId="arrow1"
+              className="md-menu-trigger-wrapper"
+              color="primary"
+              elevation={3}
+              focusLockProps={
+                Object {
+                  "autoFocus": false,
+                  "restoreFocus": true,
+                }
+              }
+              isPadded={true}
+              onKeyDown={[Function]}
+              placement="bottom-start"
+              role="dialog"
+              round={75}
+              showArrow={false}
+            >
+              <FocusScope
+                autoFocus={false}
+                contain={true}
+                restoreFocus={true}
+              >
+                <span
+                  data-focus-scope-start={true}
+                  hidden={true}
+                />
+                <div
+                  aria-labelledby="test-ID"
+                  aria-modal={true}
+                  className="md-menu-trigger-wrapper md-modal-container-wrapper"
+                  data-arrow-orientation="vertical"
+                  data-color="primary"
+                  data-elevation={3}
+                  data-padded={true}
+                  data-placement="bottom-start"
+                  data-round={75}
+                  onKeyDown={[Function]}
+                  role="dialog"
+                >
+                  <_Menu
+                    key=".$2"
+                    selectionMode="single"
+                  >
+                    <ul
+                      className="md-menu-wrapper"
+                      id="test-ID"
+                      onBlur={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onKeyDownCapture={[Function]}
+                      onMouseDown={[Function]}
+                      role="menu"
+                      tabIndex={-1}
+                    >
+                      <MenuItem
+                        item={
+                          Object {
+                            "aria-label": undefined,
+                            "childNodes": Object {
+                              Symbol(Symbol.iterator): [Function],
+                            },
+                            "hasChildNodes": false,
+                            "index": 0,
+                            "key": "one",
+                            "level": 0,
+                            "nextKey": "two",
+                            "parentKey": null,
+                            "prevKey": undefined,
+                            "props": Object {
+                              "children": "One",
+                            },
+                            "rendered": "One",
+                            "shouldInvalidate": undefined,
+                            "textValue": "One",
+                            "type": "item",
+                            "value": undefined,
+                            "wrapper": undefined,
+                          }
+                        }
+                        key="one"
+                        state={
+                          Object {
+                            "collection": $f4c7caecb598119f63e2918a55ec91a9$export$TreeCollection {
+                              "firstKey": "one",
+                              "iterable": Object {
+                                Symbol(Symbol.iterator): [Function],
+                              },
+                              "keyMap": Map {
+                                "one" => Object {
+                                  "aria-label": undefined,
+                                  "childNodes": Object {
+                                    Symbol(Symbol.iterator): [Function],
+                                  },
+                                  "hasChildNodes": false,
+                                  "index": 0,
+                                  "key": "one",
+                                  "level": 0,
+                                  "nextKey": "two",
+                                  "parentKey": null,
+                                  "prevKey": undefined,
+                                  "props": Object {
+                                    "children": "One",
+                                  },
+                                  "rendered": "One",
+                                  "shouldInvalidate": undefined,
+                                  "textValue": "One",
+                                  "type": "item",
+                                  "value": undefined,
+                                  "wrapper": undefined,
+                                },
+                                "two" => Object {
+                                  "aria-label": undefined,
+                                  "childNodes": Object {
+                                    Symbol(Symbol.iterator): [Function],
+                                  },
+                                  "hasChildNodes": false,
+                                  "index": 1,
+                                  "key": "two",
+                                  "level": 0,
+                                  "nextKey": "three",
+                                  "parentKey": null,
+                                  "prevKey": "one",
+                                  "props": Object {
+                                    "children": "Two",
+                                  },
+                                  "rendered": "Two",
+                                  "shouldInvalidate": undefined,
+                                  "textValue": "Two",
+                                  "type": "item",
+                                  "value": undefined,
+                                  "wrapper": undefined,
+                                },
+                                "three" => Object {
+                                  "aria-label": undefined,
+                                  "childNodes": Object {
+                                    Symbol(Symbol.iterator): [Function],
+                                  },
+                                  "hasChildNodes": false,
+                                  "index": 2,
+                                  "key": "three",
+                                  "level": 0,
+                                  "nextKey": undefined,
+                                  "parentKey": null,
+                                  "prevKey": "two",
+                                  "props": Object {
+                                    "children": "Three",
+                                  },
+                                  "rendered": "Three",
+                                  "shouldInvalidate": undefined,
+                                  "textValue": "Three",
+                                  "type": "item",
+                                  "value": undefined,
+                                  "wrapper": undefined,
+                                },
+                              },
+                              "lastKey": "three",
+                            },
+                            "disabledKeys": Set {},
+                            "expandedKeys": Set {},
+                            "selectionManager": SelectionManager {
+                              "_isSelectAll": null,
+                              "allowsCellSelection": false,
+                              "collection": $f4c7caecb598119f63e2918a55ec91a9$export$TreeCollection {
+                                "firstKey": "one",
+                                "iterable": Object {
+                                  Symbol(Symbol.iterator): [Function],
+                                },
+                                "keyMap": Map {
+                                  "one" => Object {
+                                    "aria-label": undefined,
+                                    "childNodes": Object {
+                                      Symbol(Symbol.iterator): [Function],
+                                    },
+                                    "hasChildNodes": false,
+                                    "index": 0,
+                                    "key": "one",
+                                    "level": 0,
+                                    "nextKey": "two",
+                                    "parentKey": null,
+                                    "prevKey": undefined,
+                                    "props": Object {
+                                      "children": "One",
+                                    },
+                                    "rendered": "One",
+                                    "shouldInvalidate": undefined,
+                                    "textValue": "One",
+                                    "type": "item",
+                                    "value": undefined,
+                                    "wrapper": undefined,
+                                  },
+                                  "two" => Object {
+                                    "aria-label": undefined,
+                                    "childNodes": Object {
+                                      Symbol(Symbol.iterator): [Function],
+                                    },
+                                    "hasChildNodes": false,
+                                    "index": 1,
+                                    "key": "two",
+                                    "level": 0,
+                                    "nextKey": "three",
+                                    "parentKey": null,
+                                    "prevKey": "one",
+                                    "props": Object {
+                                      "children": "Two",
+                                    },
+                                    "rendered": "Two",
+                                    "shouldInvalidate": undefined,
+                                    "textValue": "Two",
+                                    "type": "item",
+                                    "value": undefined,
+                                    "wrapper": undefined,
+                                  },
+                                  "three" => Object {
+                                    "aria-label": undefined,
+                                    "childNodes": Object {
+                                      Symbol(Symbol.iterator): [Function],
+                                    },
+                                    "hasChildNodes": false,
+                                    "index": 2,
+                                    "key": "three",
+                                    "level": 0,
+                                    "nextKey": undefined,
+                                    "parentKey": null,
+                                    "prevKey": "two",
+                                    "props": Object {
+                                      "children": "Three",
+                                    },
+                                    "rendered": "Three",
+                                    "shouldInvalidate": undefined,
+                                    "textValue": "Three",
+                                    "type": "item",
+                                    "value": undefined,
+                                    "wrapper": undefined,
+                                  },
+                                },
+                                "lastKey": "three",
+                              },
+                              "state": Object {
+                                "childFocusStrategy": "first",
+                                "disabledKeys": Set {},
+                                "disallowEmptySelection": undefined,
+                                "focusedKey": "one",
+                                "isFocused": true,
+                                "selectedKeys": Set {},
+                                "selectionMode": "single",
+                                "setFocused": [Function],
+                                "setFocusedKey": [Function],
+                                "setSelectedKeys": [Function],
+                              },
+                            },
+                            "toggleKey": [Function],
+                          }
+                        }
+                      >
+                        <ListItemBase
+                          aria-checked={false}
+                          aria-disabled={false}
+                          aria-labelledby={null}
+                          className="md-menu-item-wrapper"
+                          data-key="one"
+                          isDisabled={false}
+                          isPadded={true}
+                          onClick={[Function]}
+                          onDragStart={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onKeyUp={[Function]}
+                          onMouseDown={[Function]}
+                          onMouseUp={[Function]}
+                          onTouchCancel={[Function]}
+                          onTouchEnd={[Function]}
+                          onTouchMove={[Function]}
+                          onTouchStart={[Function]}
+                          role="menuitemradio"
+                          shape="rectangle"
+                          size={40}
+                          tabIndex={0}
+                        >
+                          <FocusRing
+                            isInset={false}
+                          >
+                            <FocusRing
+                              focusClass="md-focus-ring-wrapper children"
+                              focusRingClass="md-focus-ring-wrapper children"
+                              isInset={false}
+                            >
+                              <li
+                                aria-checked={false}
+                                aria-disabled={false}
+                                aria-labelledby={null}
+                                className="md-menu-item-wrapper md-list-item-base-wrapper"
+                                data-disabled={false}
+                                data-interactive={true}
+                                data-key="one"
+                                data-padded={true}
+                                data-shape="rectangle"
+                                data-size={40}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onDragStart={[Function]}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                onKeyUp={[Function]}
+                                onMouseDown={[Function]}
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                                onMouseUp={[Function]}
+                                onTouchCancel={[Function]}
+                                onTouchEnd={[Function]}
+                                onTouchMove={[Function]}
+                                onTouchStart={[Function]}
+                                role="menuitemradio"
+                                tabIndex={0}
+                              >
+                                <ListItemBaseSection
+                                  position="fill"
+                                  title="One"
+                                >
+                                  <div
+                                    data-position="fill"
+                                    title="One"
+                                  >
+                                    One
+                                  </div>
+                                </ListItemBaseSection>
+                              </li>
+                            </FocusRing>
+                          </FocusRing>
+                        </ListItemBase>
+                      </MenuItem>
+                      <MenuItem
+                        item={
+                          Object {
+                            "aria-label": undefined,
+                            "childNodes": Object {
+                              Symbol(Symbol.iterator): [Function],
+                            },
+                            "hasChildNodes": false,
+                            "index": 1,
+                            "key": "two",
+                            "level": 0,
+                            "nextKey": "three",
+                            "parentKey": null,
+                            "prevKey": "one",
+                            "props": Object {
+                              "children": "Two",
+                            },
+                            "rendered": "Two",
+                            "shouldInvalidate": undefined,
+                            "textValue": "Two",
+                            "type": "item",
+                            "value": undefined,
+                            "wrapper": undefined,
+                          }
+                        }
+                        key="two"
+                        state={
+                          Object {
+                            "collection": $f4c7caecb598119f63e2918a55ec91a9$export$TreeCollection {
+                              "firstKey": "one",
+                              "iterable": Object {
+                                Symbol(Symbol.iterator): [Function],
+                              },
+                              "keyMap": Map {
+                                "one" => Object {
+                                  "aria-label": undefined,
+                                  "childNodes": Object {
+                                    Symbol(Symbol.iterator): [Function],
+                                  },
+                                  "hasChildNodes": false,
+                                  "index": 0,
+                                  "key": "one",
+                                  "level": 0,
+                                  "nextKey": "two",
+                                  "parentKey": null,
+                                  "prevKey": undefined,
+                                  "props": Object {
+                                    "children": "One",
+                                  },
+                                  "rendered": "One",
+                                  "shouldInvalidate": undefined,
+                                  "textValue": "One",
+                                  "type": "item",
+                                  "value": undefined,
+                                  "wrapper": undefined,
+                                },
+                                "two" => Object {
+                                  "aria-label": undefined,
+                                  "childNodes": Object {
+                                    Symbol(Symbol.iterator): [Function],
+                                  },
+                                  "hasChildNodes": false,
+                                  "index": 1,
+                                  "key": "two",
+                                  "level": 0,
+                                  "nextKey": "three",
+                                  "parentKey": null,
+                                  "prevKey": "one",
+                                  "props": Object {
+                                    "children": "Two",
+                                  },
+                                  "rendered": "Two",
+                                  "shouldInvalidate": undefined,
+                                  "textValue": "Two",
+                                  "type": "item",
+                                  "value": undefined,
+                                  "wrapper": undefined,
+                                },
+                                "three" => Object {
+                                  "aria-label": undefined,
+                                  "childNodes": Object {
+                                    Symbol(Symbol.iterator): [Function],
+                                  },
+                                  "hasChildNodes": false,
+                                  "index": 2,
+                                  "key": "three",
+                                  "level": 0,
+                                  "nextKey": undefined,
+                                  "parentKey": null,
+                                  "prevKey": "two",
+                                  "props": Object {
+                                    "children": "Three",
+                                  },
+                                  "rendered": "Three",
+                                  "shouldInvalidate": undefined,
+                                  "textValue": "Three",
+                                  "type": "item",
+                                  "value": undefined,
+                                  "wrapper": undefined,
+                                },
+                              },
+                              "lastKey": "three",
+                            },
+                            "disabledKeys": Set {},
+                            "expandedKeys": Set {},
+                            "selectionManager": SelectionManager {
+                              "_isSelectAll": null,
+                              "allowsCellSelection": false,
+                              "collection": $f4c7caecb598119f63e2918a55ec91a9$export$TreeCollection {
+                                "firstKey": "one",
+                                "iterable": Object {
+                                  Symbol(Symbol.iterator): [Function],
+                                },
+                                "keyMap": Map {
+                                  "one" => Object {
+                                    "aria-label": undefined,
+                                    "childNodes": Object {
+                                      Symbol(Symbol.iterator): [Function],
+                                    },
+                                    "hasChildNodes": false,
+                                    "index": 0,
+                                    "key": "one",
+                                    "level": 0,
+                                    "nextKey": "two",
+                                    "parentKey": null,
+                                    "prevKey": undefined,
+                                    "props": Object {
+                                      "children": "One",
+                                    },
+                                    "rendered": "One",
+                                    "shouldInvalidate": undefined,
+                                    "textValue": "One",
+                                    "type": "item",
+                                    "value": undefined,
+                                    "wrapper": undefined,
+                                  },
+                                  "two" => Object {
+                                    "aria-label": undefined,
+                                    "childNodes": Object {
+                                      Symbol(Symbol.iterator): [Function],
+                                    },
+                                    "hasChildNodes": false,
+                                    "index": 1,
+                                    "key": "two",
+                                    "level": 0,
+                                    "nextKey": "three",
+                                    "parentKey": null,
+                                    "prevKey": "one",
+                                    "props": Object {
+                                      "children": "Two",
+                                    },
+                                    "rendered": "Two",
+                                    "shouldInvalidate": undefined,
+                                    "textValue": "Two",
+                                    "type": "item",
+                                    "value": undefined,
+                                    "wrapper": undefined,
+                                  },
+                                  "three" => Object {
+                                    "aria-label": undefined,
+                                    "childNodes": Object {
+                                      Symbol(Symbol.iterator): [Function],
+                                    },
+                                    "hasChildNodes": false,
+                                    "index": 2,
+                                    "key": "three",
+                                    "level": 0,
+                                    "nextKey": undefined,
+                                    "parentKey": null,
+                                    "prevKey": "two",
+                                    "props": Object {
+                                      "children": "Three",
+                                    },
+                                    "rendered": "Three",
+                                    "shouldInvalidate": undefined,
+                                    "textValue": "Three",
+                                    "type": "item",
+                                    "value": undefined,
+                                    "wrapper": undefined,
+                                  },
+                                },
+                                "lastKey": "three",
+                              },
+                              "state": Object {
+                                "childFocusStrategy": "first",
+                                "disabledKeys": Set {},
+                                "disallowEmptySelection": undefined,
+                                "focusedKey": "one",
+                                "isFocused": true,
+                                "selectedKeys": Set {},
+                                "selectionMode": "single",
+                                "setFocused": [Function],
+                                "setFocusedKey": [Function],
+                                "setSelectedKeys": [Function],
+                              },
+                            },
+                            "toggleKey": [Function],
+                          }
+                        }
+                      >
+                        <ListItemBase
+                          aria-checked={false}
+                          aria-disabled={false}
+                          aria-labelledby={null}
+                          className="md-menu-item-wrapper"
+                          data-key="two"
+                          isDisabled={false}
+                          isPadded={true}
+                          onClick={[Function]}
+                          onDragStart={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onKeyUp={[Function]}
+                          onMouseDown={[Function]}
+                          onMouseUp={[Function]}
+                          onTouchCancel={[Function]}
+                          onTouchEnd={[Function]}
+                          onTouchMove={[Function]}
+                          onTouchStart={[Function]}
+                          role="menuitemradio"
+                          shape="rectangle"
+                          size={40}
+                          tabIndex={-1}
+                        >
+                          <FocusRing
+                            isInset={false}
+                          >
+                            <FocusRing
+                              focusClass="md-focus-ring-wrapper children"
+                              focusRingClass="md-focus-ring-wrapper children"
+                              isInset={false}
+                            >
+                              <li
+                                aria-checked={false}
+                                aria-disabled={false}
+                                aria-labelledby={null}
+                                className="md-menu-item-wrapper md-list-item-base-wrapper"
+                                data-disabled={false}
+                                data-interactive={true}
+                                data-key="two"
+                                data-padded={true}
+                                data-shape="rectangle"
+                                data-size={40}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onDragStart={[Function]}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                onKeyUp={[Function]}
+                                onMouseDown={[Function]}
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                                onMouseUp={[Function]}
+                                onTouchCancel={[Function]}
+                                onTouchEnd={[Function]}
+                                onTouchMove={[Function]}
+                                onTouchStart={[Function]}
+                                role="menuitemradio"
+                                tabIndex={-1}
+                              >
+                                <ListItemBaseSection
+                                  position="fill"
+                                  title="Two"
+                                >
+                                  <div
+                                    data-position="fill"
+                                    title="Two"
+                                  >
+                                    Two
+                                  </div>
+                                </ListItemBaseSection>
+                              </li>
+                            </FocusRing>
+                          </FocusRing>
+                        </ListItemBase>
+                      </MenuItem>
+                      <MenuItem
+                        item={
+                          Object {
+                            "aria-label": undefined,
+                            "childNodes": Object {
+                              Symbol(Symbol.iterator): [Function],
+                            },
+                            "hasChildNodes": false,
+                            "index": 2,
+                            "key": "three",
+                            "level": 0,
+                            "nextKey": undefined,
+                            "parentKey": null,
+                            "prevKey": "two",
+                            "props": Object {
+                              "children": "Three",
+                            },
+                            "rendered": "Three",
+                            "shouldInvalidate": undefined,
+                            "textValue": "Three",
+                            "type": "item",
+                            "value": undefined,
+                            "wrapper": undefined,
+                          }
+                        }
+                        key="three"
+                        state={
+                          Object {
+                            "collection": $f4c7caecb598119f63e2918a55ec91a9$export$TreeCollection {
+                              "firstKey": "one",
+                              "iterable": Object {
+                                Symbol(Symbol.iterator): [Function],
+                              },
+                              "keyMap": Map {
+                                "one" => Object {
+                                  "aria-label": undefined,
+                                  "childNodes": Object {
+                                    Symbol(Symbol.iterator): [Function],
+                                  },
+                                  "hasChildNodes": false,
+                                  "index": 0,
+                                  "key": "one",
+                                  "level": 0,
+                                  "nextKey": "two",
+                                  "parentKey": null,
+                                  "prevKey": undefined,
+                                  "props": Object {
+                                    "children": "One",
+                                  },
+                                  "rendered": "One",
+                                  "shouldInvalidate": undefined,
+                                  "textValue": "One",
+                                  "type": "item",
+                                  "value": undefined,
+                                  "wrapper": undefined,
+                                },
+                                "two" => Object {
+                                  "aria-label": undefined,
+                                  "childNodes": Object {
+                                    Symbol(Symbol.iterator): [Function],
+                                  },
+                                  "hasChildNodes": false,
+                                  "index": 1,
+                                  "key": "two",
+                                  "level": 0,
+                                  "nextKey": "three",
+                                  "parentKey": null,
+                                  "prevKey": "one",
+                                  "props": Object {
+                                    "children": "Two",
+                                  },
+                                  "rendered": "Two",
+                                  "shouldInvalidate": undefined,
+                                  "textValue": "Two",
+                                  "type": "item",
+                                  "value": undefined,
+                                  "wrapper": undefined,
+                                },
+                                "three" => Object {
+                                  "aria-label": undefined,
+                                  "childNodes": Object {
+                                    Symbol(Symbol.iterator): [Function],
+                                  },
+                                  "hasChildNodes": false,
+                                  "index": 2,
+                                  "key": "three",
+                                  "level": 0,
+                                  "nextKey": undefined,
+                                  "parentKey": null,
+                                  "prevKey": "two",
+                                  "props": Object {
+                                    "children": "Three",
+                                  },
+                                  "rendered": "Three",
+                                  "shouldInvalidate": undefined,
+                                  "textValue": "Three",
+                                  "type": "item",
+                                  "value": undefined,
+                                  "wrapper": undefined,
+                                },
+                              },
+                              "lastKey": "three",
+                            },
+                            "disabledKeys": Set {},
+                            "expandedKeys": Set {},
+                            "selectionManager": SelectionManager {
+                              "_isSelectAll": null,
+                              "allowsCellSelection": false,
+                              "collection": $f4c7caecb598119f63e2918a55ec91a9$export$TreeCollection {
+                                "firstKey": "one",
+                                "iterable": Object {
+                                  Symbol(Symbol.iterator): [Function],
+                                },
+                                "keyMap": Map {
+                                  "one" => Object {
+                                    "aria-label": undefined,
+                                    "childNodes": Object {
+                                      Symbol(Symbol.iterator): [Function],
+                                    },
+                                    "hasChildNodes": false,
+                                    "index": 0,
+                                    "key": "one",
+                                    "level": 0,
+                                    "nextKey": "two",
+                                    "parentKey": null,
+                                    "prevKey": undefined,
+                                    "props": Object {
+                                      "children": "One",
+                                    },
+                                    "rendered": "One",
+                                    "shouldInvalidate": undefined,
+                                    "textValue": "One",
+                                    "type": "item",
+                                    "value": undefined,
+                                    "wrapper": undefined,
+                                  },
+                                  "two" => Object {
+                                    "aria-label": undefined,
+                                    "childNodes": Object {
+                                      Symbol(Symbol.iterator): [Function],
+                                    },
+                                    "hasChildNodes": false,
+                                    "index": 1,
+                                    "key": "two",
+                                    "level": 0,
+                                    "nextKey": "three",
+                                    "parentKey": null,
+                                    "prevKey": "one",
+                                    "props": Object {
+                                      "children": "Two",
+                                    },
+                                    "rendered": "Two",
+                                    "shouldInvalidate": undefined,
+                                    "textValue": "Two",
+                                    "type": "item",
+                                    "value": undefined,
+                                    "wrapper": undefined,
+                                  },
+                                  "three" => Object {
+                                    "aria-label": undefined,
+                                    "childNodes": Object {
+                                      Symbol(Symbol.iterator): [Function],
+                                    },
+                                    "hasChildNodes": false,
+                                    "index": 2,
+                                    "key": "three",
+                                    "level": 0,
+                                    "nextKey": undefined,
+                                    "parentKey": null,
+                                    "prevKey": "two",
+                                    "props": Object {
+                                      "children": "Three",
+                                    },
+                                    "rendered": "Three",
+                                    "shouldInvalidate": undefined,
+                                    "textValue": "Three",
+                                    "type": "item",
+                                    "value": undefined,
+                                    "wrapper": undefined,
+                                  },
+                                },
+                                "lastKey": "three",
+                              },
+                              "state": Object {
+                                "childFocusStrategy": "first",
+                                "disabledKeys": Set {},
+                                "disallowEmptySelection": undefined,
+                                "focusedKey": "one",
+                                "isFocused": true,
+                                "selectedKeys": Set {},
+                                "selectionMode": "single",
+                                "setFocused": [Function],
+                                "setFocusedKey": [Function],
+                                "setSelectedKeys": [Function],
+                              },
+                            },
+                            "toggleKey": [Function],
+                          }
+                        }
+                      >
+                        <ListItemBase
+                          aria-checked={false}
+                          aria-disabled={false}
+                          aria-labelledby={null}
+                          className="md-menu-item-wrapper"
+                          data-key="three"
+                          isDisabled={false}
+                          isPadded={true}
+                          onClick={[Function]}
+                          onDragStart={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onKeyUp={[Function]}
+                          onMouseDown={[Function]}
+                          onMouseUp={[Function]}
+                          onTouchCancel={[Function]}
+                          onTouchEnd={[Function]}
+                          onTouchMove={[Function]}
+                          onTouchStart={[Function]}
+                          role="menuitemradio"
+                          shape="rectangle"
+                          size={40}
+                          tabIndex={-1}
+                        >
+                          <FocusRing
+                            isInset={false}
+                          >
+                            <FocusRing
+                              focusClass="md-focus-ring-wrapper children"
+                              focusRingClass="md-focus-ring-wrapper children"
+                              isInset={false}
+                            >
+                              <li
+                                aria-checked={false}
+                                aria-disabled={false}
+                                aria-labelledby={null}
+                                className="md-menu-item-wrapper md-list-item-base-wrapper"
+                                data-disabled={false}
+                                data-interactive={true}
+                                data-key="three"
+                                data-padded={true}
+                                data-shape="rectangle"
+                                data-size={40}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onDragStart={[Function]}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                onKeyUp={[Function]}
+                                onMouseDown={[Function]}
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                                onMouseUp={[Function]}
+                                onTouchCancel={[Function]}
+                                onTouchEnd={[Function]}
+                                onTouchMove={[Function]}
+                                onTouchStart={[Function]}
+                                role="menuitemradio"
+                                tabIndex={-1}
+                              >
+                                <ListItemBaseSection
+                                  position="fill"
+                                  title="Three"
+                                >
+                                  <div
+                                    data-position="fill"
+                                    title="Three"
+                                  >
+                                    Three
+                                  </div>
+                                </ListItemBaseSection>
+                              </li>
+                            </FocusRing>
+                          </FocusRing>
+                        </ListItemBase>
+                      </MenuItem>
+                    </ul>
+                  </_Menu>
+                  <ContentSeparator
+                    key="separator-0"
+                  >
+                    <li
+                      className="md-content-separator-wrapper"
+                      role="separator"
+                    />
+                  </ContentSeparator>
+                  <_Menu
+                    key=".$4"
+                    selectionMode="multiple"
+                  >
+                    <ul
+                      className="md-menu-wrapper"
+                      id="test-ID"
+                      onBlur={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onKeyDownCapture={[Function]}
+                      onMouseDown={[Function]}
+                      role="menu"
+                      tabIndex={0}
+                    >
+                      <MenuItem
+                        item={
+                          Object {
+                            "aria-label": undefined,
+                            "childNodes": Object {
+                              Symbol(Symbol.iterator): [Function],
+                            },
+                            "hasChildNodes": false,
+                            "index": 0,
+                            "key": "asd",
+                            "level": 0,
+                            "nextKey": "ff",
+                            "parentKey": null,
+                            "prevKey": undefined,
+                            "props": Object {
+                              "children": "Four",
+                            },
+                            "rendered": "Four",
+                            "shouldInvalidate": undefined,
+                            "textValue": "Four",
+                            "type": "item",
+                            "value": undefined,
+                            "wrapper": undefined,
+                          }
+                        }
+                        key="asd"
+                        state={
+                          Object {
+                            "collection": $f4c7caecb598119f63e2918a55ec91a9$export$TreeCollection {
+                              "firstKey": "asd",
+                              "iterable": Object {
+                                Symbol(Symbol.iterator): [Function],
+                              },
+                              "keyMap": Map {
+                                "asd" => Object {
+                                  "aria-label": undefined,
+                                  "childNodes": Object {
+                                    Symbol(Symbol.iterator): [Function],
+                                  },
+                                  "hasChildNodes": false,
+                                  "index": 0,
+                                  "key": "asd",
+                                  "level": 0,
+                                  "nextKey": "ff",
+                                  "parentKey": null,
+                                  "prevKey": undefined,
+                                  "props": Object {
+                                    "children": "Four",
+                                  },
+                                  "rendered": "Four",
+                                  "shouldInvalidate": undefined,
+                                  "textValue": "Four",
+                                  "type": "item",
+                                  "value": undefined,
+                                  "wrapper": undefined,
+                                },
+                                "ff" => Object {
+                                  "aria-label": undefined,
+                                  "childNodes": Object {
+                                    Symbol(Symbol.iterator): [Function],
+                                  },
+                                  "hasChildNodes": false,
+                                  "index": 1,
+                                  "key": "ff",
+                                  "level": 0,
+                                  "nextKey": "d",
+                                  "parentKey": null,
+                                  "prevKey": "asd",
+                                  "props": Object {
+                                    "children": "Five",
+                                  },
+                                  "rendered": "Five",
+                                  "shouldInvalidate": undefined,
+                                  "textValue": "Five",
+                                  "type": "item",
+                                  "value": undefined,
+                                  "wrapper": undefined,
+                                },
+                                "d" => Object {
+                                  "aria-label": undefined,
+                                  "childNodes": Object {
+                                    Symbol(Symbol.iterator): [Function],
+                                  },
+                                  "hasChildNodes": false,
+                                  "index": 2,
+                                  "key": "d",
+                                  "level": 0,
+                                  "nextKey": undefined,
+                                  "parentKey": null,
+                                  "prevKey": "ff",
+                                  "props": Object {
+                                    "children": "Six",
+                                  },
+                                  "rendered": "Six",
+                                  "shouldInvalidate": undefined,
+                                  "textValue": "Six",
+                                  "type": "item",
+                                  "value": undefined,
+                                  "wrapper": undefined,
+                                },
+                              },
+                              "lastKey": "d",
+                            },
+                            "disabledKeys": Set {},
+                            "expandedKeys": Set {},
+                            "selectionManager": SelectionManager {
+                              "_isSelectAll": null,
+                              "allowsCellSelection": false,
+                              "collection": $f4c7caecb598119f63e2918a55ec91a9$export$TreeCollection {
+                                "firstKey": "asd",
+                                "iterable": Object {
+                                  Symbol(Symbol.iterator): [Function],
+                                },
+                                "keyMap": Map {
+                                  "asd" => Object {
+                                    "aria-label": undefined,
+                                    "childNodes": Object {
+                                      Symbol(Symbol.iterator): [Function],
+                                    },
+                                    "hasChildNodes": false,
+                                    "index": 0,
+                                    "key": "asd",
+                                    "level": 0,
+                                    "nextKey": "ff",
+                                    "parentKey": null,
+                                    "prevKey": undefined,
+                                    "props": Object {
+                                      "children": "Four",
+                                    },
+                                    "rendered": "Four",
+                                    "shouldInvalidate": undefined,
+                                    "textValue": "Four",
+                                    "type": "item",
+                                    "value": undefined,
+                                    "wrapper": undefined,
+                                  },
+                                  "ff" => Object {
+                                    "aria-label": undefined,
+                                    "childNodes": Object {
+                                      Symbol(Symbol.iterator): [Function],
+                                    },
+                                    "hasChildNodes": false,
+                                    "index": 1,
+                                    "key": "ff",
+                                    "level": 0,
+                                    "nextKey": "d",
+                                    "parentKey": null,
+                                    "prevKey": "asd",
+                                    "props": Object {
+                                      "children": "Five",
+                                    },
+                                    "rendered": "Five",
+                                    "shouldInvalidate": undefined,
+                                    "textValue": "Five",
+                                    "type": "item",
+                                    "value": undefined,
+                                    "wrapper": undefined,
+                                  },
+                                  "d" => Object {
+                                    "aria-label": undefined,
+                                    "childNodes": Object {
+                                      Symbol(Symbol.iterator): [Function],
+                                    },
+                                    "hasChildNodes": false,
+                                    "index": 2,
+                                    "key": "d",
+                                    "level": 0,
+                                    "nextKey": undefined,
+                                    "parentKey": null,
+                                    "prevKey": "ff",
+                                    "props": Object {
+                                      "children": "Six",
+                                    },
+                                    "rendered": "Six",
+                                    "shouldInvalidate": undefined,
+                                    "textValue": "Six",
+                                    "type": "item",
+                                    "value": undefined,
+                                    "wrapper": undefined,
+                                  },
+                                },
+                                "lastKey": "d",
+                              },
+                              "state": Object {
+                                "childFocusStrategy": null,
+                                "disabledKeys": Set {},
+                                "disallowEmptySelection": undefined,
+                                "focusedKey": null,
+                                "isFocused": false,
+                                "selectedKeys": Set {},
+                                "selectionMode": "multiple",
+                                "setFocused": [Function],
+                                "setFocusedKey": [Function],
+                                "setSelectedKeys": [Function],
+                              },
+                            },
+                            "toggleKey": [Function],
+                          }
+                        }
+                      >
+                        <ListItemBase
+                          aria-checked={false}
+                          aria-disabled={false}
+                          aria-labelledby={null}
+                          className="md-menu-item-wrapper"
+                          data-key="asd"
+                          isDisabled={false}
+                          isPadded={true}
+                          onClick={[Function]}
+                          onDragStart={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onKeyUp={[Function]}
+                          onMouseDown={[Function]}
+                          onMouseUp={[Function]}
+                          onTouchCancel={[Function]}
+                          onTouchEnd={[Function]}
+                          onTouchMove={[Function]}
+                          onTouchStart={[Function]}
+                          role="menuitemcheckbox"
+                          shape="rectangle"
+                          size={40}
+                          tabIndex={-1}
+                        >
+                          <FocusRing
+                            isInset={false}
+                          >
+                            <FocusRing
+                              focusClass="md-focus-ring-wrapper children"
+                              focusRingClass="md-focus-ring-wrapper children"
+                              isInset={false}
+                            >
+                              <li
+                                aria-checked={false}
+                                aria-disabled={false}
+                                aria-labelledby={null}
+                                className="md-menu-item-wrapper md-list-item-base-wrapper"
+                                data-disabled={false}
+                                data-interactive={true}
+                                data-key="asd"
+                                data-padded={true}
+                                data-shape="rectangle"
+                                data-size={40}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onDragStart={[Function]}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                onKeyUp={[Function]}
+                                onMouseDown={[Function]}
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                                onMouseUp={[Function]}
+                                onTouchCancel={[Function]}
+                                onTouchEnd={[Function]}
+                                onTouchMove={[Function]}
+                                onTouchStart={[Function]}
+                                role="menuitemcheckbox"
+                                tabIndex={-1}
+                              >
+                                <ListItemBaseSection
+                                  position="fill"
+                                  title="Four"
+                                >
+                                  <div
+                                    data-position="fill"
+                                    title="Four"
+                                  >
+                                    Four
+                                  </div>
+                                </ListItemBaseSection>
+                              </li>
+                            </FocusRing>
+                          </FocusRing>
+                        </ListItemBase>
+                      </MenuItem>
+                      <MenuItem
+                        item={
+                          Object {
+                            "aria-label": undefined,
+                            "childNodes": Object {
+                              Symbol(Symbol.iterator): [Function],
+                            },
+                            "hasChildNodes": false,
+                            "index": 1,
+                            "key": "ff",
+                            "level": 0,
+                            "nextKey": "d",
+                            "parentKey": null,
+                            "prevKey": "asd",
+                            "props": Object {
+                              "children": "Five",
+                            },
+                            "rendered": "Five",
+                            "shouldInvalidate": undefined,
+                            "textValue": "Five",
+                            "type": "item",
+                            "value": undefined,
+                            "wrapper": undefined,
+                          }
+                        }
+                        key="ff"
+                        state={
+                          Object {
+                            "collection": $f4c7caecb598119f63e2918a55ec91a9$export$TreeCollection {
+                              "firstKey": "asd",
+                              "iterable": Object {
+                                Symbol(Symbol.iterator): [Function],
+                              },
+                              "keyMap": Map {
+                                "asd" => Object {
+                                  "aria-label": undefined,
+                                  "childNodes": Object {
+                                    Symbol(Symbol.iterator): [Function],
+                                  },
+                                  "hasChildNodes": false,
+                                  "index": 0,
+                                  "key": "asd",
+                                  "level": 0,
+                                  "nextKey": "ff",
+                                  "parentKey": null,
+                                  "prevKey": undefined,
+                                  "props": Object {
+                                    "children": "Four",
+                                  },
+                                  "rendered": "Four",
+                                  "shouldInvalidate": undefined,
+                                  "textValue": "Four",
+                                  "type": "item",
+                                  "value": undefined,
+                                  "wrapper": undefined,
+                                },
+                                "ff" => Object {
+                                  "aria-label": undefined,
+                                  "childNodes": Object {
+                                    Symbol(Symbol.iterator): [Function],
+                                  },
+                                  "hasChildNodes": false,
+                                  "index": 1,
+                                  "key": "ff",
+                                  "level": 0,
+                                  "nextKey": "d",
+                                  "parentKey": null,
+                                  "prevKey": "asd",
+                                  "props": Object {
+                                    "children": "Five",
+                                  },
+                                  "rendered": "Five",
+                                  "shouldInvalidate": undefined,
+                                  "textValue": "Five",
+                                  "type": "item",
+                                  "value": undefined,
+                                  "wrapper": undefined,
+                                },
+                                "d" => Object {
+                                  "aria-label": undefined,
+                                  "childNodes": Object {
+                                    Symbol(Symbol.iterator): [Function],
+                                  },
+                                  "hasChildNodes": false,
+                                  "index": 2,
+                                  "key": "d",
+                                  "level": 0,
+                                  "nextKey": undefined,
+                                  "parentKey": null,
+                                  "prevKey": "ff",
+                                  "props": Object {
+                                    "children": "Six",
+                                  },
+                                  "rendered": "Six",
+                                  "shouldInvalidate": undefined,
+                                  "textValue": "Six",
+                                  "type": "item",
+                                  "value": undefined,
+                                  "wrapper": undefined,
+                                },
+                              },
+                              "lastKey": "d",
+                            },
+                            "disabledKeys": Set {},
+                            "expandedKeys": Set {},
+                            "selectionManager": SelectionManager {
+                              "_isSelectAll": null,
+                              "allowsCellSelection": false,
+                              "collection": $f4c7caecb598119f63e2918a55ec91a9$export$TreeCollection {
+                                "firstKey": "asd",
+                                "iterable": Object {
+                                  Symbol(Symbol.iterator): [Function],
+                                },
+                                "keyMap": Map {
+                                  "asd" => Object {
+                                    "aria-label": undefined,
+                                    "childNodes": Object {
+                                      Symbol(Symbol.iterator): [Function],
+                                    },
+                                    "hasChildNodes": false,
+                                    "index": 0,
+                                    "key": "asd",
+                                    "level": 0,
+                                    "nextKey": "ff",
+                                    "parentKey": null,
+                                    "prevKey": undefined,
+                                    "props": Object {
+                                      "children": "Four",
+                                    },
+                                    "rendered": "Four",
+                                    "shouldInvalidate": undefined,
+                                    "textValue": "Four",
+                                    "type": "item",
+                                    "value": undefined,
+                                    "wrapper": undefined,
+                                  },
+                                  "ff" => Object {
+                                    "aria-label": undefined,
+                                    "childNodes": Object {
+                                      Symbol(Symbol.iterator): [Function],
+                                    },
+                                    "hasChildNodes": false,
+                                    "index": 1,
+                                    "key": "ff",
+                                    "level": 0,
+                                    "nextKey": "d",
+                                    "parentKey": null,
+                                    "prevKey": "asd",
+                                    "props": Object {
+                                      "children": "Five",
+                                    },
+                                    "rendered": "Five",
+                                    "shouldInvalidate": undefined,
+                                    "textValue": "Five",
+                                    "type": "item",
+                                    "value": undefined,
+                                    "wrapper": undefined,
+                                  },
+                                  "d" => Object {
+                                    "aria-label": undefined,
+                                    "childNodes": Object {
+                                      Symbol(Symbol.iterator): [Function],
+                                    },
+                                    "hasChildNodes": false,
+                                    "index": 2,
+                                    "key": "d",
+                                    "level": 0,
+                                    "nextKey": undefined,
+                                    "parentKey": null,
+                                    "prevKey": "ff",
+                                    "props": Object {
+                                      "children": "Six",
+                                    },
+                                    "rendered": "Six",
+                                    "shouldInvalidate": undefined,
+                                    "textValue": "Six",
+                                    "type": "item",
+                                    "value": undefined,
+                                    "wrapper": undefined,
+                                  },
+                                },
+                                "lastKey": "d",
+                              },
+                              "state": Object {
+                                "childFocusStrategy": null,
+                                "disabledKeys": Set {},
+                                "disallowEmptySelection": undefined,
+                                "focusedKey": null,
+                                "isFocused": false,
+                                "selectedKeys": Set {},
+                                "selectionMode": "multiple",
+                                "setFocused": [Function],
+                                "setFocusedKey": [Function],
+                                "setSelectedKeys": [Function],
+                              },
+                            },
+                            "toggleKey": [Function],
+                          }
+                        }
+                      >
+                        <ListItemBase
+                          aria-checked={false}
+                          aria-disabled={false}
+                          aria-labelledby={null}
+                          className="md-menu-item-wrapper"
+                          data-key="ff"
+                          isDisabled={false}
+                          isPadded={true}
+                          onClick={[Function]}
+                          onDragStart={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onKeyUp={[Function]}
+                          onMouseDown={[Function]}
+                          onMouseUp={[Function]}
+                          onTouchCancel={[Function]}
+                          onTouchEnd={[Function]}
+                          onTouchMove={[Function]}
+                          onTouchStart={[Function]}
+                          role="menuitemcheckbox"
+                          shape="rectangle"
+                          size={40}
+                          tabIndex={-1}
+                        >
+                          <FocusRing
+                            isInset={false}
+                          >
+                            <FocusRing
+                              focusClass="md-focus-ring-wrapper children"
+                              focusRingClass="md-focus-ring-wrapper children"
+                              isInset={false}
+                            >
+                              <li
+                                aria-checked={false}
+                                aria-disabled={false}
+                                aria-labelledby={null}
+                                className="md-menu-item-wrapper md-list-item-base-wrapper"
+                                data-disabled={false}
+                                data-interactive={true}
+                                data-key="ff"
+                                data-padded={true}
+                                data-shape="rectangle"
+                                data-size={40}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onDragStart={[Function]}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                onKeyUp={[Function]}
+                                onMouseDown={[Function]}
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                                onMouseUp={[Function]}
+                                onTouchCancel={[Function]}
+                                onTouchEnd={[Function]}
+                                onTouchMove={[Function]}
+                                onTouchStart={[Function]}
+                                role="menuitemcheckbox"
+                                tabIndex={-1}
+                              >
+                                <ListItemBaseSection
+                                  position="fill"
+                                  title="Five"
+                                >
+                                  <div
+                                    data-position="fill"
+                                    title="Five"
+                                  >
+                                    Five
+                                  </div>
+                                </ListItemBaseSection>
+                              </li>
+                            </FocusRing>
+                          </FocusRing>
+                        </ListItemBase>
+                      </MenuItem>
+                      <MenuItem
+                        item={
+                          Object {
+                            "aria-label": undefined,
+                            "childNodes": Object {
+                              Symbol(Symbol.iterator): [Function],
+                            },
+                            "hasChildNodes": false,
+                            "index": 2,
+                            "key": "d",
+                            "level": 0,
+                            "nextKey": undefined,
+                            "parentKey": null,
+                            "prevKey": "ff",
+                            "props": Object {
+                              "children": "Six",
+                            },
+                            "rendered": "Six",
+                            "shouldInvalidate": undefined,
+                            "textValue": "Six",
+                            "type": "item",
+                            "value": undefined,
+                            "wrapper": undefined,
+                          }
+                        }
+                        key="d"
+                        state={
+                          Object {
+                            "collection": $f4c7caecb598119f63e2918a55ec91a9$export$TreeCollection {
+                              "firstKey": "asd",
+                              "iterable": Object {
+                                Symbol(Symbol.iterator): [Function],
+                              },
+                              "keyMap": Map {
+                                "asd" => Object {
+                                  "aria-label": undefined,
+                                  "childNodes": Object {
+                                    Symbol(Symbol.iterator): [Function],
+                                  },
+                                  "hasChildNodes": false,
+                                  "index": 0,
+                                  "key": "asd",
+                                  "level": 0,
+                                  "nextKey": "ff",
+                                  "parentKey": null,
+                                  "prevKey": undefined,
+                                  "props": Object {
+                                    "children": "Four",
+                                  },
+                                  "rendered": "Four",
+                                  "shouldInvalidate": undefined,
+                                  "textValue": "Four",
+                                  "type": "item",
+                                  "value": undefined,
+                                  "wrapper": undefined,
+                                },
+                                "ff" => Object {
+                                  "aria-label": undefined,
+                                  "childNodes": Object {
+                                    Symbol(Symbol.iterator): [Function],
+                                  },
+                                  "hasChildNodes": false,
+                                  "index": 1,
+                                  "key": "ff",
+                                  "level": 0,
+                                  "nextKey": "d",
+                                  "parentKey": null,
+                                  "prevKey": "asd",
+                                  "props": Object {
+                                    "children": "Five",
+                                  },
+                                  "rendered": "Five",
+                                  "shouldInvalidate": undefined,
+                                  "textValue": "Five",
+                                  "type": "item",
+                                  "value": undefined,
+                                  "wrapper": undefined,
+                                },
+                                "d" => Object {
+                                  "aria-label": undefined,
+                                  "childNodes": Object {
+                                    Symbol(Symbol.iterator): [Function],
+                                  },
+                                  "hasChildNodes": false,
+                                  "index": 2,
+                                  "key": "d",
+                                  "level": 0,
+                                  "nextKey": undefined,
+                                  "parentKey": null,
+                                  "prevKey": "ff",
+                                  "props": Object {
+                                    "children": "Six",
+                                  },
+                                  "rendered": "Six",
+                                  "shouldInvalidate": undefined,
+                                  "textValue": "Six",
+                                  "type": "item",
+                                  "value": undefined,
+                                  "wrapper": undefined,
+                                },
+                              },
+                              "lastKey": "d",
+                            },
+                            "disabledKeys": Set {},
+                            "expandedKeys": Set {},
+                            "selectionManager": SelectionManager {
+                              "_isSelectAll": null,
+                              "allowsCellSelection": false,
+                              "collection": $f4c7caecb598119f63e2918a55ec91a9$export$TreeCollection {
+                                "firstKey": "asd",
+                                "iterable": Object {
+                                  Symbol(Symbol.iterator): [Function],
+                                },
+                                "keyMap": Map {
+                                  "asd" => Object {
+                                    "aria-label": undefined,
+                                    "childNodes": Object {
+                                      Symbol(Symbol.iterator): [Function],
+                                    },
+                                    "hasChildNodes": false,
+                                    "index": 0,
+                                    "key": "asd",
+                                    "level": 0,
+                                    "nextKey": "ff",
+                                    "parentKey": null,
+                                    "prevKey": undefined,
+                                    "props": Object {
+                                      "children": "Four",
+                                    },
+                                    "rendered": "Four",
+                                    "shouldInvalidate": undefined,
+                                    "textValue": "Four",
+                                    "type": "item",
+                                    "value": undefined,
+                                    "wrapper": undefined,
+                                  },
+                                  "ff" => Object {
+                                    "aria-label": undefined,
+                                    "childNodes": Object {
+                                      Symbol(Symbol.iterator): [Function],
+                                    },
+                                    "hasChildNodes": false,
+                                    "index": 1,
+                                    "key": "ff",
+                                    "level": 0,
+                                    "nextKey": "d",
+                                    "parentKey": null,
+                                    "prevKey": "asd",
+                                    "props": Object {
+                                      "children": "Five",
+                                    },
+                                    "rendered": "Five",
+                                    "shouldInvalidate": undefined,
+                                    "textValue": "Five",
+                                    "type": "item",
+                                    "value": undefined,
+                                    "wrapper": undefined,
+                                  },
+                                  "d" => Object {
+                                    "aria-label": undefined,
+                                    "childNodes": Object {
+                                      Symbol(Symbol.iterator): [Function],
+                                    },
+                                    "hasChildNodes": false,
+                                    "index": 2,
+                                    "key": "d",
+                                    "level": 0,
+                                    "nextKey": undefined,
+                                    "parentKey": null,
+                                    "prevKey": "ff",
+                                    "props": Object {
+                                      "children": "Six",
+                                    },
+                                    "rendered": "Six",
+                                    "shouldInvalidate": undefined,
+                                    "textValue": "Six",
+                                    "type": "item",
+                                    "value": undefined,
+                                    "wrapper": undefined,
+                                  },
+                                },
+                                "lastKey": "d",
+                              },
+                              "state": Object {
+                                "childFocusStrategy": null,
+                                "disabledKeys": Set {},
+                                "disallowEmptySelection": undefined,
+                                "focusedKey": null,
+                                "isFocused": false,
+                                "selectedKeys": Set {},
+                                "selectionMode": "multiple",
+                                "setFocused": [Function],
+                                "setFocusedKey": [Function],
+                                "setSelectedKeys": [Function],
+                              },
+                            },
+                            "toggleKey": [Function],
+                          }
+                        }
+                      >
+                        <ListItemBase
+                          aria-checked={false}
+                          aria-disabled={false}
+                          aria-labelledby={null}
+                          className="md-menu-item-wrapper"
+                          data-key="d"
+                          isDisabled={false}
+                          isPadded={true}
+                          onClick={[Function]}
+                          onDragStart={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onKeyUp={[Function]}
+                          onMouseDown={[Function]}
+                          onMouseUp={[Function]}
+                          onTouchCancel={[Function]}
+                          onTouchEnd={[Function]}
+                          onTouchMove={[Function]}
+                          onTouchStart={[Function]}
+                          role="menuitemcheckbox"
+                          shape="rectangle"
+                          size={40}
+                          tabIndex={-1}
+                        >
+                          <FocusRing
+                            isInset={false}
+                          >
+                            <FocusRing
+                              focusClass="md-focus-ring-wrapper children"
+                              focusRingClass="md-focus-ring-wrapper children"
+                              isInset={false}
+                            >
+                              <li
+                                aria-checked={false}
+                                aria-disabled={false}
+                                aria-labelledby={null}
+                                className="md-menu-item-wrapper md-list-item-base-wrapper"
+                                data-disabled={false}
+                                data-interactive={true}
+                                data-key="d"
+                                data-padded={true}
+                                data-shape="rectangle"
+                                data-size={40}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onDragStart={[Function]}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                onKeyUp={[Function]}
+                                onMouseDown={[Function]}
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                                onMouseUp={[Function]}
+                                onTouchCancel={[Function]}
+                                onTouchEnd={[Function]}
+                                onTouchMove={[Function]}
+                                onTouchStart={[Function]}
+                                role="menuitemcheckbox"
+                                tabIndex={-1}
+                              >
+                                <ListItemBaseSection
+                                  position="fill"
+                                  title="Six"
+                                >
+                                  <div
+                                    data-position="fill"
+                                    title="Six"
+                                  >
+                                    Six
+                                  </div>
+                                </ListItemBaseSection>
+                              </li>
+                            </FocusRing>
+                          </FocusRing>
+                        </ListItemBase>
+                      </MenuItem>
+                    </ul>
+                  </_Menu>
+                </div>
+                <span
+                  data-focus-scope-end={true}
+                  hidden={true}
+                />
+              </FocusScope>
+            </ModalContainer>
+          </Portal>
+        </Tippy>
+      </ForwardRef(TippyWrapper)>
+    </LazyTippy>
+  </Popover>
+</MenuTrigger>
+`;

--- a/src/components/Popover/Popover.stories.args.ts
+++ b/src/components/Popover/Popover.stories.args.ts
@@ -153,9 +153,34 @@ const popoverArgTypes = {
       },
     },
   },
+  zIndex: {
+    description: `The z-index of the tippy popover. If not supplied, tippy will default to 9999`,
+    control: { type: 'number' },
+    table: {
+      type: {
+        summary: 'number',
+      },
+      defaultValue: {
+        summary: 'undefined',
+      },
+    },
+  },
   'aria-labelledby': {
     description:
       'aria-labelledby for an interactive popover only, defaults to the trigger component id',
+    control: { type: 'text' },
+    table: {
+      type: {
+        summary: 'string',
+      },
+      defaultValue: {
+        summary: 'undefined',
+      },
+    },
+  },
+  'aria-label': {
+    description:
+      'The aria-label for interactive popover. If not supplied, Popover will be labelled by the triggerComponent',
     control: { type: 'text' },
     table: {
       type: {

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -66,6 +66,8 @@ const Popover = forwardRef((props: Props, ref: ForwardedRef<HTMLElement>) => {
     appendTo = DEFAULTS.APPEND_TO,
     continuePropagationOnTrigger,
     'aria-labelledby': providedAriaLabelledby,
+    zIndex,
+    'aria-label': ariaLabel,
     ...rest
   } = props;
 
@@ -84,7 +86,8 @@ const Popover = forwardRef((props: Props, ref: ForwardedRef<HTMLElement>) => {
 
   const modalConditionalProps = {
     ...(interactive && {
-      'aria-labelledby': ariaLabelledby,
+      ...((providedAriaLabelledby || !ariaLabel) && { 'aria-labelledby': ariaLabelledby }),
+      ...(ariaLabel && { 'aria-label': ariaLabel }),
       focusLockProps: { restoreFocus: focusBackOnTrigger, autoFocus },
     }),
   };
@@ -123,7 +126,7 @@ const Popover = forwardRef((props: Props, ref: ForwardedRef<HTMLElement>) => {
   if (interactive) {
     triggerComponentCommonProps['aria-haspopup'] =
       triggerComponent?.props?.['aria-haspopup'] || 'dialog';
-    if (!providedAriaLabelledby) {
+    if (!providedAriaLabelledby && !ariaLabel) {
       triggerComponentCommonProps['id'] = ariaLabelledby;
     }
   }
@@ -235,6 +238,7 @@ const Popover = forwardRef((props: Props, ref: ForwardedRef<HTMLElement>) => {
         onHidden?.(instance);
       }}
       setInstance={popoverSetInstance}
+      zIndex={zIndex}
     >
       {clonedTriggerComponent}
     </LazyTippy>

--- a/src/components/Popover/Popover.types.ts
+++ b/src/components/Popover/Popover.types.ts
@@ -81,6 +81,11 @@ export type PopoverCommonStyleProps = {
    * @default true
    */
   addBackdrop?: boolean;
+
+  /**
+   * The z-index of the tippy popover. If not supplied, tippy will default to 9999
+   */
+  zIndex?: number;
 };
 
 export interface Props extends PopoverCommonStyleProps, Partial<LifecycleHooks> {
@@ -204,7 +209,14 @@ export interface Props extends PopoverCommonStyleProps, Partial<LifecycleHooks> 
   continuePropagationOnTrigger?: boolean;
 
   /**
-   * aria-labelledby for an interactive popover only, defaults to the trigger component id
+   * aria-labelledby for an interactive popover only, defaults to the trigger component id.
+   * Used in nested cases where the triggerComponent isn't the actual button.
    */
   'aria-labelledby'?: string;
+
+  /**
+   * aria-label for an interactive popover only. By default, it will be labelled by the triggerComponent.
+   * Only required in the unusual circumstance where the popover label cannot match the trigger.
+   */
+  'aria-label'?: string;
 }

--- a/src/components/Popover/Popover.unit.test.tsx
+++ b/src/components/Popover/Popover.unit.test.tsx
@@ -286,6 +286,44 @@ describe('<Popover />', () => {
 
       expect(container).toMatchSnapshot();
     });
+
+    it('should match snapshot with aria-label', async () => {
+      expect.assertions(3);
+      const user = userEvent.setup();
+
+      const { container } = render(
+        <Popover
+          aria-label="test-aria-label"
+          interactive={true}
+          triggerComponent={<button>Click Me!</button>}
+        >
+          <p>Content</p>
+        </Popover>
+      );
+
+      expect(container).toMatchSnapshot();
+
+      await openPopoverByClickingOnTriggerAndCheckContent(user);
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match snapshot with zIndex', async () => {
+      expect.assertions(3);
+      const user = userEvent.setup();
+
+      const { container } = render(
+        <Popover zIndex={9998} triggerComponent={<button>Click Me!</button>}>
+          <p>Content</p>
+        </Popover>
+      );
+
+      expect(container).toMatchSnapshot();
+
+      await openPopoverByClickingOnTriggerAndCheckContent(user);
+
+      expect(container).toMatchSnapshot();
+    });
   });
 
   describe('attributes', () => {
@@ -349,6 +387,47 @@ describe('<Popover />', () => {
       );
       const content = await openPopoverByClickingOnTriggerAndCheckContent(user);
       expect(content.parentElement.getAttribute('aria-labelledby')).toBe(labelId);
+      expect(content.parentElement.getAttribute('aria-label')).toEqual(null);
+    });
+
+    it('uses aria-label from props instead adding aria-labelledby if present', async () => {
+      const user = userEvent.setup();
+      const id = 'example-id';
+      const label = 'label string';
+
+      render(
+        <Popover
+          aria-label={label}
+          triggerComponent={<button id={id}>Click Me!</button>}
+          interactive
+        >
+          <p>Content</p>
+        </Popover>
+      );
+      const content = await openPopoverByClickingOnTriggerAndCheckContent(user);
+      expect(content.parentElement.getAttribute('aria-labelledby')).toBe(null);
+      expect(content.parentElement.getAttribute('aria-label')).toEqual(label);
+    });
+
+    it('uses aria-label and aria-labelledby from props if present (should not happen)', async () => {
+      const user = userEvent.setup();
+      const id = 'example-id';
+      const labelId = 'label-id';
+      const label = 'label string';
+
+      render(
+        <Popover
+          aria-labelledby={labelId}
+          aria-label={label}
+          triggerComponent={<button id={id}>Click Me!</button>}
+          interactive
+        >
+          <p>Content</p>
+        </Popover>
+      );
+      const content = await openPopoverByClickingOnTriggerAndCheckContent(user);
+      expect(content.parentElement.getAttribute('aria-labelledby')).toBe(labelId);
+      expect(content.parentElement.getAttribute('aria-label')).toEqual(label);
     });
 
     it('has aria-modal false when non interactive', async () => {
@@ -467,6 +546,33 @@ describe('<Popover />', () => {
       render(
         <Popover
           aria-labelledby="dummy-id"
+          triggerComponent={<button id={id}>Popover 1</button>}
+          interactive
+        >
+          <p>Content</p>
+        </Popover>
+      );
+      const button1 = screen.getByRole('button', { name: /Popover 1/i });
+      expect(button1.getAttribute('id')).toBe(id);
+      expect(button1.getAttribute('aria-haspopup')).toBe('dialog');
+    });
+
+    it('triggerComponent id is not set when aria-label is passed in (interactive and triggerComponent id undefined)', async () => {
+      render(
+        <Popover aria-label="some label" triggerComponent={<button>Popover 1</button>} interactive>
+          <p>Content</p>
+        </Popover>
+      );
+      const button1 = screen.getByRole('button', { name: /Popover 1/i });
+      expect(button1.getAttribute('id')).toBe(null);
+      expect(button1.getAttribute('aria-haspopup')).toBe('dialog');
+    });
+
+    it('triggerComponent id is not set when aria-label is passed in (interactive and triggerComponent id defined)', async () => {
+      const id = 'example-id';
+      render(
+        <Popover
+          aria-label="some label"
           triggerComponent={<button id={id}>Popover 1</button>}
           interactive
         >
@@ -676,6 +782,30 @@ describe('<Popover />', () => {
       // assert no backdrop has been rendered
       const backdrop = container.querySelector(`.${POPOVER_STYLE.backdrop}`);
       expect(backdrop).not.toBeInTheDocument();
+    });
+
+    it('tippy popover should have default z-index of 9999 if not provided', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <Popover triggerComponent={<button>Click Me!</button>}>
+          <p>Content</p>
+        </Popover>
+      );
+      const content = await openPopoverByClickingOnTriggerAndCheckContent(user);
+      expect(content.parentElement.parentElement.getAttribute('style')).toContain('z-index: 9999');
+    });
+
+    it('tippy popover should have z-index set if provided', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <Popover triggerComponent={<button>Click Me!</button>} zIndex={9998}>
+          <p>Content</p>
+        </Popover>
+      );
+      const content = await openPopoverByClickingOnTriggerAndCheckContent(user);
+      expect(content.parentElement.parentElement.getAttribute('style')).toContain('z-index: 9998');
     });
   });
 

--- a/src/components/Popover/Popover.unit.test.tsx.snap
+++ b/src/components/Popover/Popover.unit.test.tsx.snap
@@ -534,6 +534,93 @@ exports[`<Popover /> snapshot should match snapshot 2`] = `
 </div>
 `;
 
+exports[`<Popover /> snapshot should match snapshot with aria-label 1`] = `
+<div>
+  <button
+    aria-expanded="false"
+    aria-haspopup="dialog"
+  >
+    Click Me!
+  </button>
+</div>
+`;
+
+exports[`<Popover /> snapshot should match snapshot with aria-label 2`] = `
+<div>
+  <button
+    aria-expanded="true"
+    aria-haspopup="dialog"
+  >
+    Click Me!
+  </button>
+  <div
+    data-tippy-root=""
+    id="tippy-16"
+    style="z-index: 9999; position: absolute; left: 0px; top: 0px; margin: 0px; bottom: 0px; transform: translate(0px, 0px);"
+  >
+    <span
+      data-focus-scope-start="true"
+      hidden=""
+    />
+    <div
+      aria-label="test-aria-label"
+      aria-modal="true"
+      class="md-modal-container-wrapper"
+      data-arrow-orientation="vertical"
+      data-color="primary"
+      data-elevation="3"
+      data-padded="true"
+      data-placement="top"
+      data-round="50"
+      role="dialog"
+    >
+      <p>
+        Content
+      </p>
+      <div
+        class="md-modal-container-arrow-wrapper"
+        data-popper-arrow="true"
+        id="arrow1"
+        style="position: absolute; left: 0px; transform: translate(5px, 0px);"
+      >
+        <svg
+          aria-hidden="true"
+          class="md-modal-arrow-svg"
+          data-placement="top"
+          height="12"
+          viewBox="0 0 24 12"
+          width="24"
+          xmlns="http://www.w3.org/svg/2000"
+        >
+          <defs>
+            <clippath
+              id="modal-arrow-cut-stroke-top"
+            >
+              <path
+                d="m 24 0 l -10 10 q -2 2 -4 0 l -10 -10"
+              />
+            </clippath>
+          </defs>
+          <path
+            clip-path="url(#modal-arrow-cut-stroke-top)"
+            d="m 24 0 l -10 10 q -2 2 -4 0 l -10 -10"
+            data-color="primary"
+          />
+        </svg>
+      </div>
+    </div>
+    <span
+      data-focus-scope-end="true"
+      hidden=""
+    />
+  </div>
+  <div
+    aria-hidden="true"
+    class="md-popover-backdrop"
+  />
+</div>
+`;
+
 exports[`<Popover /> snapshot should match snapshot with aria-labelledby 1`] = `
 <div>
   <button
@@ -1276,6 +1363,80 @@ exports[`<Popover /> snapshot should match snapshot with style 2`] = `
       data-round="50"
       role="dialog"
       style="color: pink;"
+    >
+      <p>
+        Content
+      </p>
+      <div
+        class="md-modal-container-arrow-wrapper"
+        data-popper-arrow="true"
+        id="arrow1"
+        style="position: absolute; left: 0px; transform: translate(5px, 0px);"
+      >
+        <svg
+          aria-hidden="true"
+          class="md-modal-arrow-svg"
+          data-placement="top"
+          height="12"
+          viewBox="0 0 24 12"
+          width="24"
+          xmlns="http://www.w3.org/svg/2000"
+        >
+          <defs>
+            <clippath
+              id="modal-arrow-cut-stroke-top"
+            >
+              <path
+                d="m 24 0 l -10 10 q -2 2 -4 0 l -10 -10"
+              />
+            </clippath>
+          </defs>
+          <path
+            clip-path="url(#modal-arrow-cut-stroke-top)"
+            d="m 24 0 l -10 10 q -2 2 -4 0 l -10 -10"
+            data-color="primary"
+          />
+        </svg>
+      </div>
+    </div>
+  </div>
+  <div
+    aria-hidden="true"
+    class="md-popover-backdrop"
+  />
+</div>
+`;
+
+exports[`<Popover /> snapshot should match snapshot with zIndex 1`] = `
+<div>
+  <button>
+    Click Me!
+  </button>
+</div>
+`;
+
+exports[`<Popover /> snapshot should match snapshot with zIndex 2`] = `
+<div>
+  <button
+    aria-describedby="tippy-17"
+  >
+    Click Me!
+  </button>
+  <div
+    data-tippy-root=""
+    id="tippy-17"
+    style="pointer-events: none; z-index: 9998; position: absolute; left: 0px; top: 0px; margin: 0px; bottom: 0px; transform: translate(0px, 0px);"
+  >
+    <div
+      aria-modal="false"
+      class="md-modal-container-wrapper"
+      data-arrow-orientation="vertical"
+      data-color="primary"
+      data-elevation="3"
+      data-padded="true"
+      data-placement="top"
+      data-round="50"
+      role="dialog"
     >
       <p>
         Content


### PR DESCRIPTION
# IMPORTANT

**Currently, this project is closed to any external contributions. Any pull request made against this project from external sources will likely be closed. If you would like to make changes to this project, please fork this project.**

# Description

*The full description of the changes made in this request.*
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-505185
https://sqbu-github.cisco.com/WebExSquared/webex-web-client/pull/5917

This is used for the positioning-only trigger for webex assistant. zIndex puts the assistant response popover slightly behind the webex assistant control popover. Added to MenuTrigger, just because other style-related props are. ariaLabel provides a label directly, as the positioning-only trigger cannot be used as aria-labelledby.

# Links

*Links to relevent resources.*
