### PR TITLE
fix(RadioGroup): add aria-describedby

### DIFF
--- a/src/components/RadioGroup/RadioGroup.tsx
+++ b/src/components/RadioGroup/RadioGroup.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react';
 import classnames from 'classnames';
+import { v4 as uuidV4 } from 'uuid';
 import { useRadioGroup } from '@react-aria/radio';
 import { useRadioGroupState } from '@react-stately/radio';
 
@@ -27,11 +28,23 @@ const RadioGroup: FC<RadioGroupProps> = (props: RadioGroupProps) => {
 
   const state = useRadioGroupState(props);
   const { radioGroupProps, labelProps } = useRadioGroup(props, state);
+  const radioGroupId = id || uuidV4();
+  const descriptionId = description ? `radio-group-description-${radioGroupId}` : undefined;
 
   return (
-    <div {...radioGroupProps} className={classnames(className, STYLE.group)} id={id} style={style}>
+    <div
+      {...radioGroupProps}
+      className={classnames(className, STYLE.group)}
+      id={radioGroupId}
+      style={style}
+      aria-describedby={description ? descriptionId : undefined}
+    >
       <span {...labelProps}>{label}</span>
-      {description && <Text type={TEXT_CONSTANTS.TYPES.BODY_SECONDARY}>{description}</Text>}
+      {description &&
+        <Text id={descriptionId} type={TEXT_CONSTANTS.TYPES.BODY_SECONDARY}>
+          {description}
+        </Text>
+      }
       <RadioContext.Provider value={state}>
         {options &&
           options.map((option: string | RadioProps) => {

--- a/src/components/RadioGroup/RadioGroup.unit.test.tsx
+++ b/src/components/RadioGroup/RadioGroup.unit.test.tsx
@@ -6,6 +6,12 @@ import userEvent from '@testing-library/user-event';
 import RadioGroup from './';
 import { STYLE } from './RadioGroup.constants';
 
+jest.mock('uuid', () => {
+  return {
+    v4: () => '1',
+  };
+});
+
 describe('<RadioGroup />', () => {
   describe('snapshot', () => {
     it('should match snapshot', () => {
@@ -85,6 +91,7 @@ describe('<RadioGroup />', () => {
           label="Test Radio Group"
           description="The radio group description"
           style={style}
+          id='example-id'
         />
       );
 
@@ -347,6 +354,16 @@ describe('<RadioGroup />', () => {
       const radioGroup = screen.getByRole('radiogroup');
 
       expect(radioGroup).toHaveClass(STYLE.group);
+    });
+
+    it('should have provided aria-describedby when description is provided', () => {
+      expect.assertions(1);
+
+      render(<RadioGroup label="Test Radio Group" description="The radio group description" id='example-id' />);
+
+      const radioGroup = screen.getByRole('radiogroup');
+
+      expect(radioGroup).toHaveAttribute('aria-describedby', 'radio-group-description-example-id');
     });
 
     it('should have provided class when className is provided', () => {

--- a/src/components/RadioGroup/RadioGroup.unit.test.tsx.snap
+++ b/src/components/RadioGroup/RadioGroup.unit.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`<RadioGroup /> snapshot should match snapshot 1`] = `
     aria-labelledby="test-ID"
     aria-orientation="vertical"
     class="md-radio-group"
+    id="1"
     role="radiogroup"
   >
     <span
@@ -23,6 +24,7 @@ exports[`<RadioGroup /> snapshot should match snapshot when rendered with a mix 
     aria-labelledby="test-ID"
     aria-orientation="vertical"
     class="md-radio-group"
+    id="1"
     role="radiogroup"
   >
     <span
@@ -68,6 +70,7 @@ exports[`<RadioGroup /> snapshot should match snapshot when rendered with list o
     aria-labelledby="test-ID"
     aria-orientation="vertical"
     class="md-radio-group"
+    id="1"
     role="radiogroup"
   >
     <span
@@ -113,6 +116,7 @@ exports[`<RadioGroup /> snapshot should match snapshot with child 1`] = `
     aria-labelledby="test-ID"
     aria-orientation="vertical"
     class="md-radio-group"
+    id="1"
     role="radiogroup"
   >
     <span
@@ -144,6 +148,7 @@ exports[`<RadioGroup /> snapshot should match snapshot with child className 1`] 
     aria-labelledby="test-ID"
     aria-orientation="vertical"
     class="md-radio-group"
+    id="1"
     role="radiogroup"
   >
     <span
@@ -175,6 +180,7 @@ exports[`<RadioGroup /> snapshot should match snapshot with child id 1`] = `
     aria-labelledby="test-ID"
     aria-orientation="vertical"
     class="md-radio-group"
+    id="1"
     role="radiogroup"
   >
     <span
@@ -208,6 +214,7 @@ exports[`<RadioGroup /> snapshot should match snapshot with child style 1`] = `
     aria-labelledby="test-ID"
     aria-orientation="vertical"
     class="md-radio-group"
+    id="1"
     role="radiogroup"
   >
     <span
@@ -240,6 +247,7 @@ exports[`<RadioGroup /> snapshot should match snapshot with child thats disabled
     aria-labelledby="test-ID"
     aria-orientation="vertical"
     class="md-radio-group"
+    id="1"
     role="radiogroup"
   >
     <span
@@ -271,6 +279,7 @@ exports[`<RadioGroup /> snapshot should match snapshot with child thats disabled
     aria-labelledby="test-ID"
     aria-orientation="vertical"
     class="md-radio-group"
+    id="1"
     role="radiogroup"
   >
     <span
@@ -303,6 +312,7 @@ exports[`<RadioGroup /> snapshot should match snapshot with child thats selected
     aria-labelledby="test-ID"
     aria-orientation="vertical"
     class="md-radio-group"
+    id="1"
     role="radiogroup"
   >
     <span
@@ -335,6 +345,7 @@ exports[`<RadioGroup /> snapshot should match snapshot with className 1`] = `
     aria-labelledby="test-ID"
     aria-orientation="vertical"
     class="example-class md-radio-group"
+    id="1"
     role="radiogroup"
   >
     <span
@@ -349,9 +360,11 @@ exports[`<RadioGroup /> snapshot should match snapshot with className 1`] = `
 exports[`<RadioGroup /> snapshot should match snapshot with description 1`] = `
 <DocumentFragment>
   <div
+    aria-describedby="radio-group-description-example-id"
     aria-labelledby="test-ID"
     aria-orientation="vertical"
     class="md-radio-group"
+    id="example-id"
     role="radiogroup"
     style="color: pink;"
   >
@@ -363,6 +376,7 @@ exports[`<RadioGroup /> snapshot should match snapshot with description 1`] = `
     <small
       class="md-text-wrapper"
       data-type="body-secondary"
+      id="radio-group-description-example-id"
     >
       The radio group description
     </small>
@@ -394,6 +408,7 @@ exports[`<RadioGroup /> snapshot should match snapshot with multiple children 1`
     aria-labelledby="test-ID"
     aria-orientation="vertical"
     class="md-radio-group"
+    id="1"
     role="radiogroup"
   >
     <span
@@ -454,6 +469,7 @@ exports[`<RadioGroup /> snapshot should match snapshot with multiple children wi
     aria-labelledby="test-ID"
     aria-orientation="vertical"
     class="md-radio-group"
+    id="1"
     role="radiogroup"
   >
     <span
@@ -513,6 +529,7 @@ exports[`<RadioGroup /> snapshot should match snapshot with multiple children wi
     aria-labelledby="test-ID"
     aria-orientation="vertical"
     class="md-radio-group"
+    id="1"
     role="radiogroup"
   >
     <span
@@ -572,6 +589,7 @@ exports[`<RadioGroup /> snapshot should match snapshot with multiple children wi
     aria-labelledby="test-ID"
     aria-orientation="vertical"
     class="md-radio-group"
+    id="1"
     role="radiogroup"
   >
     <span
@@ -632,6 +650,7 @@ exports[`<RadioGroup /> snapshot should match snapshot with style 1`] = `
     aria-labelledby="test-ID"
     aria-orientation="vertical"
     class="md-radio-group"
+    id="1"
     role="radiogroup"
     style="color: pink;"
   >

--- a/src/components/RadioSimpleGroup/RadioSimpleGroup.stories.tsx
+++ b/src/components/RadioSimpleGroup/RadioSimpleGroup.stories.tsx
@@ -81,6 +81,7 @@ Example.args = {
   ),
   label: <div style={{padding: '16px 0'}}>Select your favorite color</div>,
   description: <div style={{padding: '16px 0'}}>Only choose one color</div>,
+  id: 'select-color-radio-simple-group',
 };
 
 const Layout = MultiTemplate<RadioSimpleGroupProps>(RadioSimpleGroup).bind({});
@@ -149,6 +150,7 @@ Layout.parameters = {
       ),
       label: <div style={{padding: '16px 0'}}>Layout</div>,
       description: <div style={{padding: '16px 0'}}>Please choose your favorite layout</div>,
+      id: 'select-layout-radio-simple-group',
     },
   ],
 };

--- a/src/components/RadioSimpleGroup/RadioSimpleGroup.tsx
+++ b/src/components/RadioSimpleGroup/RadioSimpleGroup.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react';
 import classnames from 'classnames';
+import { v4 as uuidV4 } from 'uuid';
 import { useRadioGroup } from '@react-aria/radio';
 import { useRadioGroupState } from '@react-stately/radio';
 
@@ -17,17 +18,20 @@ const RadioSimpleGroup: FC<RadioSimpleGroupProps> = (props: RadioSimpleGroupProp
 
   const state = useRadioGroupState(props);
   const { radioGroupProps, labelProps } = useRadioGroup(props, state);
+  const radioSimpleGroupId = id || uuidV4();
+  const descriptionId = description ? `radio-simple-group-description-${radioSimpleGroupId}` : undefined;
 
   return (
     <div
       {...radioGroupProps}
       className={classnames(className, STYLE.wrapper)}
       data-disabled={state.isDisabled}
-      id={id}
+      id={radioSimpleGroupId}
       style={style}
+      aria-describedby={descriptionId}
     >
       {label && <span {...labelProps}>{label}</span>}
-      {description}
+      {description && <span id={descriptionId}>{description}</span>}
       <RadioSimpleGroupContext.Provider value={state}>{children}</RadioSimpleGroupContext.Provider>
     </div>
   );

--- a/src/components/RadioSimpleGroup/RadioSimpleGroup.unit.test.tsx
+++ b/src/components/RadioSimpleGroup/RadioSimpleGroup.unit.test.tsx
@@ -9,6 +9,12 @@ import RadioSimple from '../RadioSimple';
 import Text from '../Text';
 import Icon from '../Icon';
 
+jest.mock('uuid', () => {
+  return {
+    v4: () => '1',
+  };
+});
+
 describe('<RadioSimpleGroup />', () => {
   const children = [
     <RadioSimple value="red" key="0">
@@ -83,6 +89,7 @@ describe('<RadioSimpleGroup />', () => {
         <RadioSimpleGroup
           children={children}
           description={description}
+          id='example-id'
         />
       );
 
@@ -138,6 +145,16 @@ describe('<RadioSimpleGroup />', () => {
       const radioGroup = screen.getByRole('radiogroup');
 
       expect(radioGroup).toHaveClass(STYLE.wrapper);
+    });
+
+    it('should have provided aria-describedby when description is provided', () => {
+      expect.assertions(1);
+
+      render(<RadioSimpleGroup children={children} description={description} id='example-id' />);
+
+      const radioGroup = screen.getByRole('radiogroup');
+
+      expect(radioGroup).toHaveAttribute('aria-describedby', 'radio-simple-group-description-example-id');
     });
 
     it('should have provided class when className is provided', () => {

--- a/src/components/RadioSimpleGroup/RadioSimpleGroup.unit.test.tsx.snap
+++ b/src/components/RadioSimpleGroup/RadioSimpleGroup.unit.test.tsx.snap
@@ -3,10 +3,12 @@
 exports[`<RadioSimpleGroup /> snapshot should match snapshot 1`] = `
 <DocumentFragment>
   <div
+    aria-describedby="radio-simple-group-description-1"
     aria-labelledby="test-ID"
     aria-orientation="vertical"
     class="md-radio-simple-group-wrapper"
     data-disabled="false"
+    id="1"
     role="radiogroup"
   >
     <span
@@ -16,9 +18,13 @@ exports[`<RadioSimpleGroup /> snapshot should match snapshot 1`] = `
         Select your favorite color
       </div>
     </span>
-    <div>
-      Only choose one
-    </div>
+    <span
+      id="radio-simple-group-description-1"
+    >
+      <div>
+        Only choose one
+      </div>
+    </span>
     <label
       class="md-radio-simple-wrapper"
       data-disabled="false"
@@ -98,6 +104,7 @@ exports[`<RadioSimpleGroup /> snapshot should match snapshot with child thats se
     aria-orientation="vertical"
     class="md-radio-simple-group-wrapper"
     data-disabled="false"
+    id="1"
     role="radiogroup"
   >
     <label
@@ -180,6 +187,7 @@ exports[`<RadioSimpleGroup /> snapshot should match snapshot with children 1`] =
     aria-orientation="vertical"
     class="md-radio-simple-group-wrapper"
     data-disabled="false"
+    id="1"
     role="radiogroup"
   >
     <label
@@ -262,6 +270,7 @@ exports[`<RadioSimpleGroup /> snapshot should match snapshot with children with 
     aria-orientation="vertical"
     class="md-radio-simple-group-wrapper"
     data-disabled="true"
+    id="1"
     role="radiogroup"
   >
     <label
@@ -344,6 +353,7 @@ exports[`<RadioSimpleGroup /> snapshot should match snapshot with children with 
     aria-readonly="true"
     class="md-radio-simple-group-wrapper"
     data-disabled="false"
+    id="1"
     role="radiogroup"
   >
     <label
@@ -428,6 +438,7 @@ exports[`<RadioSimpleGroup /> snapshot should match snapshot with className 1`] 
     aria-orientation="vertical"
     class="example-className md-radio-simple-group-wrapper"
     data-disabled="false"
+    id="1"
     role="radiogroup"
   >
     <label
@@ -506,14 +517,20 @@ exports[`<RadioSimpleGroup /> snapshot should match snapshot with className 1`] 
 exports[`<RadioSimpleGroup /> snapshot should match snapshot with description 1`] = `
 <DocumentFragment>
   <div
+    aria-describedby="radio-simple-group-description-example-id"
     aria-orientation="vertical"
     class="md-radio-simple-group-wrapper"
     data-disabled="false"
+    id="example-id"
     role="radiogroup"
   >
-    <div>
-      Only choose one
-    </div>
+    <span
+      id="radio-simple-group-description-example-id"
+    >
+      <div>
+        Only choose one
+      </div>
+    </span>
     <label
       class="md-radio-simple-wrapper"
       data-disabled="false"
@@ -675,6 +692,7 @@ exports[`<RadioSimpleGroup /> snapshot should match snapshot with style 1`] = `
     aria-orientation="vertical"
     class="md-radio-simple-group-wrapper"
     data-disabled="false"
+    id="1"
     role="radiogroup"
     style="color: pink;"
   >


### PR DESCRIPTION
# IMPORTANT

**Currently, this project is closed to any external contributions. Any pull request made against this project from external sources will likely be closed. If you would like to make changes to this project, please fork this project.**

# Guide

**This "Help" section can be deleted before submitting this pull request.**

*Update the name of this pull request to reflect the following shape:*

```
{type}/{scope?}/{message}
```

* **type** - A [conventional commit type](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional#type-enum) **REQUIRED**
* **scope** - The kabab-case scope of the changes in this request
* **message** - A short, kebab-case statement describing the changes **REQUIRED**

*Provide a general summary of the scope of the changes in this pull request.*
Add ```aria-describedby``` for ```RadioGroup``` and ```RadioSimpleGroup```

* [Readme](https://github.com/momentum-design/momentum-react-v2/blob/master/README.md)
* [Getting Started Guide](https://github.com/momentum-design/momentum-react-v2/blob/master/GETTING_STARTED.md)
* [Contributing Guide](https://github.com/momentum-design/momentum-react-v2/blob/master/CONTRIBUTING.md)

# Description

*The full description of the changes made in this request.*
Add ```aria-describedby``` for ```RadioGroup``` and ```RadioSimpleGroup```
```descriptionProps``` is not supported in the current ```react-aria``` version, we cannot use ```descriptionProps``` returned by the hook ```useRadioGroup```. So we have to manually add ```aria-describedby``` to the radio group.

Note: we need to remove this once we upgrade the ```react-aria``` version.

# Links

*Links to relevent resources.*
https://react-spectrum.adobe.com/react-aria/useRadioGroup.html