### PR TITLE
fix(a11y): popover interactive mouseenter

### DIFF
--- a/src/components/Popover/Popover.stories.tsx
+++ b/src/components/Popover/Popover.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useState } from 'react';
 import { MultiTemplate, Template } from '../../storybook/helper.stories.templates';
 import { DocumentationPage } from '../../storybook/helper.stories.docs';
 import StyleDocs from '../../storybook/docs.stories.style.mdx';
@@ -14,6 +14,7 @@ import argTypes from './Popover.stories.args';
 import { PLACEMENTS } from '../ModalArrow/ModalArrow.constants';
 import Flex from '../Flex';
 import AriaToolbar from '../AriaToolbar';
+import Avatar from '../Avatar';
 
 export default {
   title: 'Momentum UI/Popover',
@@ -58,6 +59,76 @@ InteractiveContent.args = {
   delay: [0, 0],
   triggerComponent: (
     <ButtonPill style={{ margin: '10rem auto', display: 'flex' }}>Click me!</ButtonPill>
+  ),
+  children: (
+    <Menu selectionMode="single" key="2" style={{ width: '200px' }}>
+      <Item key="one">One</Item>
+      <Item key="two">Two</Item>
+      <Item key="three">Three</Item>
+      <Item key="four">Four</Item>
+      <Item key="five">Five</Item>
+      <Item key="six">Six</Item>
+    </Menu>
+  ),
+};
+
+const InteractiveHover = Template<PopoverProps>(Popover).bind({});
+
+InteractiveHover.argTypes = { ...argTypes };
+
+InteractiveHover.args = {
+  trigger: 'mouseenter',
+  placement: PLACEMENTS.BOTTOM,
+  showArrow: true,
+  interactive: true,
+  variant: 'small',
+  color: COLORS.TERTIARY,
+  delay: [0, 0],
+  triggerComponent: (
+    <ButtonPill style={{ margin: '10rem auto', display: 'flex' }}>Hover me!</ButtonPill>
+  ),
+  children: (
+    <Menu selectionMode="single" key="2" style={{ width: '200px' }}>
+      <Item key="one">One</Item>
+      <Item key="two">Two</Item>
+      <Item key="three">Three</Item>
+      <Item key="four">Four</Item>
+      <Item key="five">Five</Item>
+      <Item key="six">Six</Item>
+    </Menu>
+  ),
+};
+
+const AvatarExample = Template<PopoverProps>(Popover).bind({});
+
+AvatarExample.argTypes = { ...argTypes };
+
+AvatarExample.args = {
+  trigger: 'mouseenter',
+  placement: PLACEMENTS.BOTTOM,
+  showArrow: true,
+  interactive: true,
+  variant: 'small',
+  color: COLORS.TERTIARY,
+  delay: [0, 0],
+  triggerComponent: (
+    <ButtonSimple useNativeKeyDown
+      style={{
+        height: '24px',
+        borderRadius: '12px',
+        width: '24px',
+        display: 'flex',
+        backgroundColor: 'unset',
+        padding: 0,
+        margin: 0,
+        border: 'unset',
+      }}
+    >
+      <Avatar
+        icon={'participant-unknown'}
+        type={'person'}
+      />
+    </ButtonSimple>
   ),
   children: (
     <Menu selectionMode="single" key="2" style={{ width: '200px' }}>
@@ -167,7 +238,7 @@ const MultiplePopovers = Template<PopoverProps>((args: PopoverProps) => {
   >
     Description tooltip on hover
   </Popover>);
-  return <Popover {...args} triggerComponent={triggerComponent}/>;
+  return <Popover {...args} triggerComponent={triggerComponent} />;
 }).bind({});
 
 MultiplePopovers.argTypes = { ...argTypes };
@@ -281,10 +352,12 @@ Common.parameters = {
 export {
   Example,
   InteractiveContent,
+  InteractiveHover,
   InteractiveFocus,
   WithCloseButton,
   Offset,
   MultiplePopovers,
   NestedPopover,
+  AvatarExample,
   Common,
 };

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -27,7 +27,7 @@ import { PopoverInstance } from '.';
 const Popover = forwardRef((props: Props, ref: ForwardedRef<HTMLElement>) => {
   const {
     children,
-    trigger = DEFAULTS.TRIGGER,
+    trigger: triggerFromProps = DEFAULTS.TRIGGER,
     triggerComponent,
     variant = DEFAULTS.VARIANT,
     placement = DEFAULTS.PLACEMENT,
@@ -129,6 +129,20 @@ const Popover = forwardRef((props: Props, ref: ForwardedRef<HTMLElement>) => {
     ...mrv2Props,
   });
 
+  let trigger = triggerFromProps;
+  if (triggerFromProps === 'mouseenter') {
+    if (interactive) {
+      // if the popover is interactive, there is interactive content inside the popover
+      // so we can't use the focusin trigger, since after closing with escape key, the
+      // popover keeps opening. So we need to use the click trigger instead.
+      trigger = 'mouseenter click';
+    } else {
+      // non-interactive popovers with trigger mouseenter (like a tooltip) should also open
+      // when focusing to the trigger element
+      trigger = 'mouseenter focusin';
+    }
+  }
+
   return (
     <LazyTippy
       ref={ref}
@@ -167,8 +181,7 @@ const Popover = forwardRef((props: Props, ref: ForwardedRef<HTMLElement>) => {
         </ModalContainer>
       )}
       placement={placement as PlacementType}
-      /* add focusin automatically if only mouseenter is passed in as a trigger - this is for accessibility reasons */
-      trigger={trigger === 'mouseenter' ? 'mouseenter focusin' : trigger}
+      trigger={trigger}
       interactive={interactive}
       appendTo={appendTo}
       popperOptions={{

--- a/src/components/Popover/Popover.unit.test.tsx
+++ b/src/components/Popover/Popover.unit.test.tsx
@@ -1244,6 +1244,91 @@ describe('<Popover />', () => {
           expect(screen.queryByText('Content')).not.toBeInTheDocument();
         });
       });
+
+      it('should behave as expected when interactive and trigger="mouseenter"', async () => {
+        /**
+         * Expected behavior for this test:
+         * 1. Hover to TriggerButton, Popover should open and focus inside
+         * 2. Press Esc, Popover should close and focus should go back to trigger
+         * 3. Press Enter, Popover should open again and focus should go inside
+         * 4. Press Esc, Popover should close and focus should go back to trigger
+         * 5. Press Tab, focus should go away from trigger
+         * 6. Press Shift+Tab, focus should go back to trigger (popover should not open)
+         * 7. Press Space, Popover should open again and focus should go inside
+         */
+        const user = userEvent.setup();
+
+        render(
+          <>
+            <Popover triggerComponent={<button>Hover Me!</button>} interactive={true} trigger="mouseenter">
+              <div>
+                <p>Content</p>
+                <button>Button within popover</button>
+              </div>
+            </Popover>
+            <button>Button which should not be focused</button>
+          </>
+        );
+
+        /**
+         * Hover to TriggerButton, Popover should open and focus inside
+         */
+        const hoverMeButton = await screen.findByRole('button', { name: 'Hover Me!' });
+        await user.hover(hoverMeButton);
+        
+        await waitFor(() => {
+          expect(screen.getByText('Content')).toBeInTheDocument();
+        });
+        expect(await screen.findByRole('button', { name: 'Button within popover' })).toHaveFocus();
+
+        /**
+         * Press Esc, Popover should close and focus should go back to trigger
+         */
+        await user.keyboard('{Escape}');
+        await waitFor(() => {
+          expect(screen.queryByText('Content')).not.toBeInTheDocument();
+        });
+        expect(hoverMeButton).toHaveFocus();
+
+        /**
+         * Press Enter, Popover should open again and focus should go inside
+         */
+        await user.keyboard('{Enter}');
+        await waitFor(() => {
+          expect(screen.getByText('Content')).toBeInTheDocument();
+        });
+        expect(await screen.findByRole('button', { name: 'Button within popover' })).toHaveFocus();
+
+        /**
+         * Press Esc, Popover should close and focus should go back to trigger
+         */
+        await user.keyboard('{Escape}');
+        await waitFor(() => {
+          expect(screen.queryByText('Content')).not.toBeInTheDocument();
+        });
+        expect(hoverMeButton).toHaveFocus();
+
+        /**
+         * Press Tab, focus should go away from trigger
+         */
+        await user.tab();
+        expect(await screen.findByRole('button', { name: 'Button which should not be focused' })).toHaveFocus();
+        
+        /**
+         * Press Shift+Tab, focus should go back to trigger (popover should not open)
+         */
+        await user.tab({ shift: true });
+        expect(hoverMeButton).toHaveFocus();
+
+        /**
+         * Press Space, Popover should open again and focus should go inside
+         */
+        await user.keyboard(' ');
+        await waitFor(() => {
+          expect(screen.getByText('Content')).toBeInTheDocument();
+        });
+        expect(await screen.findByRole('button', { name: 'Button within popover' })).toHaveFocus();
+      });
     });
   });
 });


### PR DESCRIPTION
# Description

- This fixes the current behavior of interactive Popovers with trigger="mouseenter", where the focus back to the trigger causes the Popover to show again. When a Popover has interactive=true and trigger="mouseenter", we only want it to open on hover and when pressing space/enter, therefore we are using "mouseenter click" as the trigger combination.
- Tested with a Avatar and created Storybook
- Tested with a Avatar within a ListItemBase, but doesn't work (not fixing in this ticket, since its too much changes and belongs to the ListItemBase changes)
- Created unit tests and stories

