### PR TITLE
feat(SelectNext): Escape key handling for trigger button

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -38,6 +38,7 @@ function Select<T extends object>(props: Props<T>, ref: RefObject<HTMLDivElement
     listboxMaxHeight,
     isInForm = DEFAULTS.IS_IN_FORM,
     listboxWidth,
+    escapeOnTriggerCallback,
   } = props;
   const [popoverInstance, setPopoverInstance] = useState<PopoverInstance>();
   const hasBeenOpened = useRef<boolean>(false);
@@ -88,6 +89,11 @@ function Select<T extends object>(props: Props<T>, ref: RefObject<HTMLDivElement
    */
   const onKeyDown = useCallback((e) => {
     switch (e.key) {
+      case 'Escape':
+        if (escapeOnTriggerCallback) {
+          escapeOnTriggerCallback(e);
+        }
+        break;
       // useButton already provides Keyboard event support for Enter and Space
       case 'ArrowUp':
       case 'ArrowDown':

--- a/src/components/Select/Select.types.ts
+++ b/src/components/Select/Select.types.ts
@@ -58,4 +58,6 @@ export interface Props<T> extends AriaSelectProps<T> {
    * NOTE: if set, the popover strategy will be set to 'fixed'
    */
   listboxWidth?: string;
+
+  escapeOnTriggerCallback?: (e: KeyboardEvent) => void;
 }

--- a/src/components/Select/Select.types.ts
+++ b/src/components/Select/Select.types.ts
@@ -59,5 +59,8 @@ export interface Props<T> extends AriaSelectProps<T> {
    */
   listboxWidth?: string;
 
+  /**
+   * Callback for handling escape keyboard action while dropdown is collapsed
+   */
   escapeOnTriggerCallback?: (e: KeyboardEvent) => void;
 }

--- a/src/components/Select/Select.unit.test.tsx
+++ b/src/components/Select/Select.unit.test.tsx
@@ -708,4 +708,30 @@ describe('Select', () => {
 
     expect(button).toHaveAttribute('aria-labelledby', 'test-ID');
   });
+
+  it('should call escape callback if prop is passed', async () => {
+    const user = userEvent.setup();
+    const escapeOnTriggerCallbackMock = jest.fn();
+
+    render(
+      <Select id="test-id" label="test" escapeOnTriggerCallback={escapeOnTriggerCallbackMock}>
+        <Item>Item 1</Item>
+        <Item>Item 2</Item>
+      </Select>
+    );
+
+    const button = screen.getByRole('combobox', { name: 'test' });
+    button.focus();
+    expect(button).toHaveFocus();
+
+    await user.keyboard('{Escape}');
+
+    expect(escapeOnTriggerCallbackMock).toBeCalledTimes(1);
+
+    await user.keyboard('{ArrowDown}');
+    await user.keyboard('{Escape}');
+
+    // ensure that callback is only triggered when dropdown is collapsed and focus is on the trigger button
+    expect(escapeOnTriggerCallbackMock).toBeCalledTimes(1);
+  });
 });


### PR DESCRIPTION
# IMPORTANT

**Currently, this project is closed to any external contributions. Any pull request made against this project from external sources will likely be closed. If you would like to make changes to this project, please fork this project.**

# Guide

**This "Help" section can be deleted before submitting this pull request.**

*Update the name of this pull request to reflect the following shape:*

```
{type}/{scope?}/{message}
```

* **type** - A [conventional commit type](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional#type-enum) **REQUIRED**
* **scope** - The kabab-case scope of the changes in this request
* **message** - A short, kebab-case statement describing the changes **REQUIRED**

*Provide a general summary of the scope of the changes in this pull request.*

* [Readme](https://github.com/momentum-design/momentum-react-v2/blob/master/README.md)
* [Getting Started Guide](https://github.com/momentum-design/momentum-react-v2/blob/master/GETTING_STARTED.md)
* [Contributing Guide](https://github.com/momentum-design/momentum-react-v2/blob/master/CONTRIBUTING.md)

# Description
There is an issue in web client where escape won't close the menu that a select box is in because the select trigger button has focus and the onkeydown of the selectbox triggers instead of the menu's onkeydown
*The full description of the changes made in this request.*
- Allowed the ability to pass escape functionality to the onkeydown of the trigger button
# Links

*Links to relevent resources.*
[https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-506187](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-506187)