### PR TITLE
fix(TooltipPopoverCombo): fix the aria-labelledby of the popover when the button has a tooltip

### DIFF
--- a/src/components/Popover/Popover.stories.args.ts
+++ b/src/components/Popover/Popover.stories.args.ts
@@ -153,6 +153,19 @@ const popoverArgTypes = {
       },
     },
   },
+  'aria-labelledby': {
+    description:
+      'aria-labelledby for an interactive popover only, defaults to the trigger component id',
+    control: { type: 'text' },
+    table: {
+      type: {
+        summary: 'string',
+      },
+      defaultValue: {
+        summary: 'undefined',
+      },
+    },
+  },
 };
 
 export { popoverArgTypes };

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -1,4 +1,4 @@
-import React, { ForwardedRef, forwardRef, useCallback, useEffect } from 'react';
+import React, { ForwardedRef, forwardRef, useCallback, useEffect, useRef } from 'react';
 import './Popover.style.scss';
 import ModalContainer from '../ModalContainer';
 import ButtonCircle from '../ButtonCircle';
@@ -65,6 +65,7 @@ const Popover = forwardRef((props: Props, ref: ForwardedRef<HTMLElement>) => {
     autoFocus = DEFAULTS.AUTO_FOCUS,
     appendTo = DEFAULTS.APPEND_TO,
     continuePropagationOnTrigger,
+    'aria-labelledby': providedAriaLabelledby,
     ...rest
   } = props;
 
@@ -76,11 +77,14 @@ const Popover = forwardRef((props: Props, ref: ForwardedRef<HTMLElement>) => {
 
   const popoverInstance = React.useRef<PopoverInstance>(undefined);
 
-  const triggerComponentId = triggerComponent.props?.id || uuidV4();
+  const generatedTriggerIdRef = useRef(uuidV4());
+  const generatedTriggerId = generatedTriggerIdRef.current;
+
+  const ariaLabelledby = providedAriaLabelledby || triggerComponent.props?.id || generatedTriggerId;
 
   const modalConditionalProps = {
     ...(interactive && {
-      'aria-labelledby': triggerComponentId,
+      'aria-labelledby': ariaLabelledby,
       focusLockProps: { restoreFocus: focusBackOnTrigger, autoFocus },
     }),
   };
@@ -114,13 +118,14 @@ const Popover = forwardRef((props: Props, ref: ForwardedRef<HTMLElement>) => {
     firstFocusElement?.focus();
   }, [firstFocusElement]);
 
-  const triggerComponentCommonProps = {
-    id: interactive ? triggerComponentId : triggerComponent.props?.id || id,
-  };
+  const triggerComponentCommonProps = {};
 
   if (interactive) {
     triggerComponentCommonProps['aria-haspopup'] =
       triggerComponent?.props?.['aria-haspopup'] || 'dialog';
+    if (!providedAriaLabelledby) {
+      triggerComponentCommonProps['id'] = ariaLabelledby;
+    }
   }
 
   const mrv2Props = isMRv2Button(triggerComponent) ? { useNativeKeyDown: true } : {};

--- a/src/components/Popover/Popover.types.ts
+++ b/src/components/Popover/Popover.types.ts
@@ -202,4 +202,9 @@ export interface Props extends PopoverCommonStyleProps, Partial<LifecycleHooks> 
    * Whether to allow the trigger event to continue to propagate after the Popover is triggered.
    */
   continuePropagationOnTrigger?: boolean;
+
+  /**
+   * aria-labelledby for an interactive popover only, defaults to the trigger component id
+   */
+  'aria-labelledby'?: string;
 }

--- a/src/components/Popover/Popover.unit.test.tsx
+++ b/src/components/Popover/Popover.unit.test.tsx
@@ -265,6 +265,27 @@ describe('<Popover />', () => {
         expect(container).toMatchSnapshot();
       }
     );
+
+    it('should match snapshot with aria-labelledby', async () => {
+      expect.assertions(3);
+      const user = userEvent.setup();
+
+      const { container } = render(
+        <Popover
+          aria-labelledby="test-aria-labelledby"
+          interactive={true}
+          triggerComponent={<button>Click Me!</button>}
+        >
+          <p>Content</p>
+        </Popover>
+      );
+
+      expect(container).toMatchSnapshot();
+
+      await openPopoverByClickingOnTriggerAndCheckContent(user);
+
+      expect(container).toMatchSnapshot();
+    });
   });
 
   describe('attributes', () => {
@@ -310,6 +331,24 @@ describe('<Popover />', () => {
       const content = await openPopoverByClickingOnTriggerAndCheckContent(user);
       expect(content.parentElement.getAttribute('aria-labelledby')).toBe(id);
       expect(content.parentElement.getAttribute('aria-modal')).toBe('true');
+    });
+
+    it('uses aria-labelledby from props instead of id if present, (used for trigger with aria-labelledby)', async () => {
+      const user = userEvent.setup();
+      const id = 'example-id';
+      const labelId = 'label-id';
+
+      render(
+        <Popover
+          aria-labelledby={labelId}
+          triggerComponent={<button id={id}>Click Me!</button>}
+          interactive
+        >
+          <p>Content</p>
+        </Popover>
+      );
+      const content = await openPopoverByClickingOnTriggerAndCheckContent(user);
+      expect(content.parentElement.getAttribute('aria-labelledby')).toBe(labelId);
     });
 
     it('has aria-modal false when non interactive', async () => {
@@ -369,7 +408,7 @@ describe('<Popover />', () => {
         </Popover>
       );
       const button1 = screen.getByRole('button', { name: /Popover 1/i });
-      expect(button1.getAttribute('id')).toBe(id);
+      expect(button1.getAttribute('id')).toBe(null);
       expect(button1.getAttribute('aria-haspopup')).toBe(null);
     });
 
@@ -406,6 +445,37 @@ describe('<Popover />', () => {
       const button1 = screen.getByRole('button', { name: /Popover 1/i });
       expect(button1.getAttribute('id')).toBe(id);
       expect(button1.getAttribute('aria-haspopup')).toBe(null);
+    });
+
+    it('triggerComponent id is not set when aria-labelledby is passed in (interactive and triggerComponent id undefined)', async () => {
+      render(
+        <Popover
+          aria-labelledby="dummy-id"
+          triggerComponent={<button>Popover 1</button>}
+          interactive
+        >
+          <p>Content</p>
+        </Popover>
+      );
+      const button1 = screen.getByRole('button', { name: /Popover 1/i });
+      expect(button1.getAttribute('id')).toBe(null);
+      expect(button1.getAttribute('aria-haspopup')).toBe('dialog');
+    });
+
+    it('triggerComponent id is not set when aria-labelledby is passed in (interactive and triggerComponent id defined)', async () => {
+      const id = 'example-id';
+      render(
+        <Popover
+          aria-labelledby="dummy-id"
+          triggerComponent={<button id={id}>Popover 1</button>}
+          interactive
+        >
+          <p>Content</p>
+        </Popover>
+      );
+      const button1 = screen.getByRole('button', { name: /Popover 1/i });
+      expect(button1.getAttribute('id')).toBe(id);
+      expect(button1.getAttribute('aria-haspopup')).toBe('dialog');
     });
 
     it('should not add useNativeKeyDown on the DOM button', async () => {

--- a/src/components/Popover/Popover.unit.test.tsx
+++ b/src/components/Popover/Popover.unit.test.tsx
@@ -1255,7 +1255,7 @@ describe('<Popover />', () => {
             trigger="mouseenter"
             showArrow
             triggerComponent={
-              <ButtonSimple style={{ margin: '10rem auto', display: 'flex' }} role='button'>
+              <ButtonSimple style={{ margin: '10rem auto', display: 'flex' }} role="button">
                 Hover or click me!
               </ButtonSimple>
             }
@@ -1703,7 +1703,7 @@ describe('<Popover />', () => {
                         data-testid="avatar"
                         // eslint-disable-next-line
                         onPress={() => {}}
-                        initials="AB"
+                        aria-label="AB"
                       >
                         Hover or click me!
                       </Avatar>

--- a/src/components/Popover/Popover.unit.test.tsx.snap
+++ b/src/components/Popover/Popover.unit.test.tsx.snap
@@ -534,6 +534,93 @@ exports[`<Popover /> snapshot should match snapshot 2`] = `
 </div>
 `;
 
+exports[`<Popover /> snapshot should match snapshot with aria-labelledby 1`] = `
+<div>
+  <button
+    aria-expanded="false"
+    aria-haspopup="dialog"
+  >
+    Click Me!
+  </button>
+</div>
+`;
+
+exports[`<Popover /> snapshot should match snapshot with aria-labelledby 2`] = `
+<div>
+  <button
+    aria-expanded="true"
+    aria-haspopup="dialog"
+  >
+    Click Me!
+  </button>
+  <div
+    data-tippy-root=""
+    id="tippy-15"
+    style="z-index: 9999; position: absolute; left: 0px; top: 0px; margin: 0px; bottom: 0px; transform: translate(0px, 0px);"
+  >
+    <span
+      data-focus-scope-start="true"
+      hidden=""
+    />
+    <div
+      aria-labelledby="test-aria-labelledby"
+      aria-modal="true"
+      class="md-modal-container-wrapper"
+      data-arrow-orientation="vertical"
+      data-color="primary"
+      data-elevation="3"
+      data-padded="true"
+      data-placement="top"
+      data-round="50"
+      role="dialog"
+    >
+      <p>
+        Content
+      </p>
+      <div
+        class="md-modal-container-arrow-wrapper"
+        data-popper-arrow="true"
+        id="arrow1"
+        style="position: absolute; left: 0px; transform: translate(5px, 0px);"
+      >
+        <svg
+          aria-hidden="true"
+          class="md-modal-arrow-svg"
+          data-placement="top"
+          height="12"
+          viewBox="0 0 24 12"
+          width="24"
+          xmlns="http://www.w3.org/svg/2000"
+        >
+          <defs>
+            <clippath
+              id="modal-arrow-cut-stroke-top"
+            >
+              <path
+                d="m 24 0 l -10 10 q -2 2 -4 0 l -10 -10"
+              />
+            </clippath>
+          </defs>
+          <path
+            clip-path="url(#modal-arrow-cut-stroke-top)"
+            d="m 24 0 l -10 10 q -2 2 -4 0 l -10 -10"
+            data-color="primary"
+          />
+        </svg>
+      </div>
+    </div>
+    <span
+      data-focus-scope-end="true"
+      hidden=""
+    />
+  </div>
+  <div
+    aria-hidden="true"
+    class="md-popover-backdrop"
+  />
+</div>
+`;
+
 exports[`<Popover /> snapshot should match snapshot with className 1`] = `
 <div>
   <button>
@@ -789,9 +876,7 @@ exports[`<Popover /> snapshot should match snapshot with color 2`] = `
 
 exports[`<Popover /> snapshot should match snapshot with id 1`] = `
 <div>
-  <button
-    id="example-id"
-  >
+  <button>
     Click Me!
   </button>
 </div>
@@ -801,7 +886,6 @@ exports[`<Popover /> snapshot should match snapshot with id 2`] = `
 <div>
   <button
     aria-describedby="tippy-3"
-    id="example-id"
   >
     Click Me!
   </button>

--- a/src/components/Toggletip/Toggletip.unit.test.tsx.snap
+++ b/src/components/Toggletip/Toggletip.unit.test.tsx.snap
@@ -719,9 +719,7 @@ exports[`<Toggletip /> snapshot should match snapshot with color 2`] = `
 
 exports[`<Toggletip /> snapshot should match snapshot with id 1`] = `
 <div>
-  <button
-    id="example-id"
-  >
+  <button>
     Click Me!
   </button>
   <div
@@ -732,9 +730,7 @@ exports[`<Toggletip /> snapshot should match snapshot with id 1`] = `
 
 exports[`<Toggletip /> snapshot should match snapshot with id 2`] = `
 <div>
-  <button
-    id="example-id"
-  >
+  <button>
     Click Me!
   </button>
   <div

--- a/src/components/Tooltip/Tooltip.stories.args.ts
+++ b/src/components/Tooltip/Tooltip.stories.args.ts
@@ -1,8 +1,6 @@
 import { commonStyles } from '../../storybook/helper.stories.argtypes';
 import { popoverArgTypes } from '../Popover/Popover.stories.args';
 
-import { DEFAULTS } from './Tooltip.constants';
-
 const tooltipArgTypes = {
   type: {
     description: `Determines, whether the tooltip is the description or the label of the trigger component, or none`,
@@ -14,6 +12,33 @@ const tooltipArgTypes = {
       },
       defaultValue: {
         summary: 'description',
+      },
+    },
+  },
+  labelOrDescriptionId: {
+    description:
+      'the id to use for the invisible div providing the label or description for the trigger, defaults to generated uuid',
+    control: { type: 'text' },
+    table: {
+      type: {
+        summary: 'string',
+      },
+      defaultValue: {
+        summary: 'undefined',
+      },
+    },
+  },
+  'aria-haspopup': {
+    defaultValue: undefined,
+    description: 'aria-haspopup will be passed through to the trigger component if provided',
+    options: [undefined, 'dialog', 'menu', 'grid'],
+    control: { type: 'select' },
+    table: {
+      type: {
+        summary: 'string',
+      },
+      defaultValue: {
+        summary: 'undefined',
       },
     },
   },

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -27,11 +27,14 @@ const Tooltip = forwardRef(
       variant = DEFAULTS.VARIANT,
       triggerComponent,
       children,
+      labelOrDescriptionId: providedLabelId,
+      'aria-haspopup': ariaHaspopup,
       ...otherProps
     }: Props,
     ref: ForwardedRef<HTMLElement>
   ) => {
-    const id = useId();
+    const generatedLabelId = useId();
+    const labelId = providedLabelId || generatedLabelId;
     const isLabelTooltip = type === 'label';
     const isDescription = type === 'description';
 
@@ -51,11 +54,11 @@ const Tooltip = forwardRef(
       [isLabelTooltip, otherProps?.setInstance]
     );
 
-    const newTriggerComponent = isLabelTooltip
-      ? React.cloneElement(triggerComponent, { 'aria-labelledby': id })
-      : isDescription
-      ? React.cloneElement(triggerComponent, { 'aria-describedby': id })
-      : triggerComponent;
+    const newTriggerComponent = React.cloneElement(triggerComponent, {
+      ...(isLabelTooltip && { 'aria-labelledby': labelId }),
+      ...(isDescription && { 'aria-describedby': labelId }),
+      ...(ariaHaspopup && { 'aria-haspopup': ariaHaspopup }),
+    });
 
     // In label and description mode we must render tooltip content twice
     // First inside the popover, second in a hidden div for Screen Readers (SR)
@@ -66,7 +69,7 @@ const Tooltip = forwardRef(
     // We use aria-labelledby and aria-describedby because the `children` might contains HTML elements
     const triggerLabel =
       isLabelTooltip || isDescription ? (
-        <div className={STYLE.label} id={id}>
+        <div className={STYLE.label} id={labelId}>
           {children}
         </div>
       ) : null;

--- a/src/components/Tooltip/Tooltip.types.ts
+++ b/src/components/Tooltip/Tooltip.types.ts
@@ -1,3 +1,4 @@
+import { AriaBaseButtonProps } from '@react-types/button';
 import { Props as PopoverProps } from '../Popover/Popover.types';
 
 /**
@@ -38,5 +39,20 @@ export interface Props
     | 'variant'
     | 'setInstance'
   > {
+  /**
+   * Whether the tooltip content should provide the aria label, description or neither to the trigger component.
+   * Possible values: 'label', 'description', 'none'.
+   * Usually 'label' is used for buttons with no text, 'description' is used for buttons with text. 'none' is rarely used.
+   */
   type: TooltipTypes;
+  /**
+   * When type is 'label' or 'desription', you can optionally use labelOrDescriptionId specify the id to use for labelling/describing.
+   * This enables you to use the same id to label or describe e.g. a dialog, as is used by TooltipPopoverCombo.
+   */
+  labelOrDescriptionId?: string;
+  /**
+   * aria-haspopup will be passed through to the trigger component if provided.
+   * This is only really useful for a nested component structure as in TooltipPopoverCombo.
+   */
+  'aria-haspopup'?: AriaBaseButtonProps['aria-haspopup'];
 }

--- a/src/components/Tooltip/Tooltip.unit.test.tsx
+++ b/src/components/Tooltip/Tooltip.unit.test.tsx
@@ -291,6 +291,69 @@ describe('<Tooltip type"description />', () => {
         expect(container).toMatchSnapshot();
       }
     );
+
+    it('should match snapshot with labelOrDescriptionId and type label', async () => {
+      expect.assertions(3);
+      const user = userEvent.setup();
+
+      const { container } = render(
+        <Tooltip
+          type="label"
+          labelOrDescriptionId="test-label-id"
+          triggerComponent={<button>Hover Me!</button>}
+        >
+          <p>Content</p>
+        </Tooltip>
+      );
+
+      expect(container).toMatchSnapshot();
+
+      await openTooltipByHoveringOnTriggerAndCheckContent(user, /content/i);
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match snapshot with labelOrDescriptionId and type description', async () => {
+      expect.assertions(3);
+      const user = userEvent.setup();
+
+      const { container } = render(
+        <Tooltip
+          type="description"
+          labelOrDescriptionId="test-description-id"
+          triggerComponent={<button>Hover Me!</button>}
+        >
+          <p>Content</p>
+        </Tooltip>
+      );
+
+      expect(container).toMatchSnapshot();
+
+      await openTooltipByHoveringOnTriggerAndCheckContent(user);
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match snapshot with aria-haspopup', async () => {
+      expect.assertions(3);
+      const user = userEvent.setup();
+
+      const { container } = render(
+        <Tooltip
+          type="description"
+          aria-haspopup="grid"
+          triggerComponent={<button>Hover Me!</button>}
+        >
+          <p>Content</p>
+        </Tooltip>
+      );
+
+      expect(container).toMatchSnapshot();
+
+      await openTooltipByHoveringOnTriggerAndCheckContent(user);
+
+      expect(container).toMatchSnapshot();
+    });
   });
 
   describe('attributes', () => {
@@ -325,7 +388,7 @@ describe('<Tooltip type"description />', () => {
       expect(content.parentElement.getAttribute('aria-labelledby')).toBeNull();
     });
 
-    it('add aria-labelledby to trigger component when type is label and overwriteAccessibleLabel true', async () => {
+    it('add aria-labelledby to trigger component when type is label', async () => {
       const user = userEvent.setup();
 
       render(
@@ -341,10 +404,34 @@ describe('<Tooltip type"description />', () => {
       await openTooltipByHoveringOnTriggerAndCheckContent(user, /Content/i);
       const trigger = await screen.findByText(/hover me!/i);
       expect(trigger.getAttribute('aria-labelledby')).toEqual('test-ID');
+      expect(trigger.getAttribute('aria-describedby')).toBe(null);
       expect(trigger.getAttribute('aria-haspopup')).toBe(null);
     });
 
-    it('add aria-labelledby to trigger component when type is none', async () => {
+    it('add correct aria-labelledby to trigger component when type is label and labelOrDescriptionId is provided', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <Tooltip
+          labelOrDescriptionId="test-label-id"
+          type="label"
+          triggerComponent={<button>Hover Me!</button>}
+        >
+          <p>Content</p>
+        </Tooltip>
+      );
+
+      // Button has the correct label before tooltip opened
+      expect(screen.getByRole('button', { name: /Content/i })).toBeVisible();
+
+      // Testing library use the accessible name for query not the actual label
+      await openTooltipByHoveringOnTriggerAndCheckContent(user, /Content/i);
+      const trigger = await screen.findByText(/hover me!/i);
+      expect(trigger.getAttribute('aria-labelledby')).toEqual('test-label-id');
+      expect(trigger.getAttribute('aria-describedby')).toBe(null);
+      expect(trigger.getAttribute('aria-haspopup')).toBe(null);
+    });
+    it('add nothing to trigger component when type is none', async () => {
       const user = userEvent.setup();
 
       render(
@@ -353,13 +440,13 @@ describe('<Tooltip type"description />', () => {
         </Tooltip>
       );
 
-      // Button has the correct label before tooltip opened
+      // Button has the inbuilt label before tooltip opened
       expect(screen.getByRole('button', { name: /Hover Me!/i })).toBeVisible();
 
-      // Testing library use the accessible name for query not the actual label
       await openTooltipByHoveringOnTriggerAndCheckContent(user);
       const trigger = await screen.findByText(/hover me!/i);
-      expect(trigger.getAttribute('aria-labelledby')).toEqual(null);
+      expect(trigger.getAttribute('aria-labelledby')).toBe(null);
+      expect(trigger.getAttribute('aria-describedby')).toBe(null);
       expect(trigger.getAttribute('aria-haspopup')).toBe(null);
     });
 
@@ -372,18 +459,44 @@ describe('<Tooltip type"description />', () => {
         </Tooltip>
       );
 
-      // Button has the correct description before tooltip opened
+      // Button has the inbuilt label and the correct description before tooltip opened
       const button = screen.getByRole('button', { name: /Hover Me!/i });
-      expect(button.getAttribute('aria-describedby')).toEqual('test-ID');
       expect(button).toBeVisible();
+      expect(button.getAttribute('aria-describedby')).toEqual('test-ID');
 
       await openTooltipByHoveringOnTriggerAndCheckContent(user);
       const trigger = await screen.findByText(/hover me!/i);
+      expect(trigger.getAttribute('aria-labelledby')).toBe(null);
       expect(trigger.getAttribute('aria-describedby')).toMatch('test-ID');
       expect(trigger.getAttribute('aria-haspopup')).toBe(null);
     });
 
-    it('checks triggerComponent props when aria-haspopup is defined', async () => {
+    it('add correct aria-labelledby to trigger component when type is description and labelOrDescriptionId is provided', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <Tooltip
+          labelOrDescriptionId="test-description-id"
+          type="description"
+          triggerComponent={<button>Hover Me!</button>}
+        >
+          <p>Content</p>
+        </Tooltip>
+      );
+
+      // Button has the inbuilt label and the correct description before tooltip opened
+      const button = screen.getByRole('button', { name: /Hover Me!/i });
+      expect(button).toBeVisible();
+      expect(button.getAttribute('aria-describedby')).toEqual('test-description-id');
+
+      await openTooltipByHoveringOnTriggerAndCheckContent(user);
+      const trigger = await screen.findByText(/hover me!/i);
+      expect(trigger.getAttribute('aria-labelledby')).toBe(null);
+      expect(trigger.getAttribute('aria-describedby')).toMatch('test-description-id');
+      expect(trigger.getAttribute('aria-haspopup')).toBe(null);
+    });
+
+    it("doesn't affect aria-haspopup and id on triggerComponent when aria-haspopup is defined on triggerComponent", async () => {
       render(
         <Tooltip
           type="description"
@@ -397,7 +510,7 @@ describe('<Tooltip type"description />', () => {
       expect(button1.getAttribute('aria-haspopup')).toBe('grid');
     });
 
-    it('checks triggerComponent props when id is not defined', async () => {
+    it("doesn't affect aria-haspopup and id on triggerComponent when aria-haspopup and id are not defined on triggerComponent", async () => {
       render(
         <Tooltip type="description" triggerComponent={<button>Tooltip 1</button>}>
           <p>Content</p>
@@ -408,7 +521,7 @@ describe('<Tooltip type"description />', () => {
       expect(button1.getAttribute('aria-haspopup')).toBe(null);
     });
 
-    it('checks triggerComponent props when id is defined', async () => {
+    it("doesn't affect aria-haspopup and id on triggerComponent when id is defined on triggerComponent", async () => {
       const id = 'example-id';
       render(
         <Tooltip type="description" triggerComponent={<button id={id}>Tooltip 1</button>}>
@@ -418,6 +531,29 @@ describe('<Tooltip type"description />', () => {
       const button1 = screen.getByRole('button', { name: /Tooltip 1/i });
       expect(button1.getAttribute('id')).toBe(id);
       expect(button1.getAttribute('aria-haspopup')).toBe(null);
+    });
+
+    it('passes through aria-haspopup to triggerComponent when defined', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <Tooltip
+          type="description"
+          aria-haspopup="grid"
+          triggerComponent={<button>Tooltip 1</button>}
+        >
+          <p>Content</p>
+        </Tooltip>
+      );
+      const button1 = screen.getByRole('button', { name: /Tooltip 1/i });
+      expect(button1.getAttribute('aria-haspopup')).toBe('grid');
+
+      const content = await openTooltipByHoveringOnTriggerAndCheckContent(
+        user,
+        /Tooltip 1/i,
+        /Content/i
+      );
+      expect(content.parentElement.getAttribute('aria-labelledby')).toBeNull();
     });
 
     it('should not add useNativeKeyDown on the DOM button', async () => {

--- a/src/components/Tooltip/Tooltip.unit.test.tsx.snap
+++ b/src/components/Tooltip/Tooltip.unit.test.tsx.snap
@@ -588,6 +588,97 @@ exports[`<Tooltip type"description /> snapshot should display only one tooltip a
 </div>
 `;
 
+exports[`<Tooltip type"description /> snapshot should match snapshot with aria-haspopup 1`] = `
+<div>
+  <button
+    aria-describedby="test-ID"
+    aria-haspopup="grid"
+  >
+    Hover Me!
+  </button>
+  <div
+    class="md-tooltip-label"
+    id="test-ID"
+  >
+    <p>
+      Content
+    </p>
+  </div>
+</div>
+`;
+
+exports[`<Tooltip type"description /> snapshot should match snapshot with aria-haspopup 2`] = `
+<div>
+  <button
+    aria-describedby="test-ID"
+    aria-haspopup="grid"
+  >
+    Hover Me!
+  </button>
+  <div
+    class="md-tooltip-label"
+    id="test-ID"
+  >
+    <p>
+      Content
+    </p>
+  </div>
+  <div
+    data-tippy-root=""
+    id="tippy-18"
+    style="pointer-events: none; z-index: 9999; position: absolute; left: 0px; top: 0px; margin: 0px; bottom: 0px; transform: translate(0px, 0px);"
+  >
+    <div
+      aria-hidden="true"
+      aria-modal="false"
+      class="md-modal-container-wrapper"
+      data-arrow-orientation="vertical"
+      data-color="primary"
+      data-elevation="3"
+      data-padded="true"
+      data-placement="top"
+      data-round="50"
+      role="tooltip"
+    >
+      <p>
+        Content
+      </p>
+      <div
+        class="md-modal-container-arrow-wrapper"
+        data-popper-arrow="true"
+        id="arrow1"
+        style="position: absolute; left: 0px; transform: translate(5px, 0px);"
+      >
+        <svg
+          aria-hidden="true"
+          class="md-modal-arrow-svg"
+          data-placement="top"
+          height="12"
+          viewBox="0 0 24 12"
+          width="24"
+          xmlns="http://www.w3.org/svg/2000"
+        >
+          <defs>
+            <clippath
+              id="modal-arrow-cut-stroke-top"
+            >
+              <path
+                d="m 24 0 l -10 10 q -2 2 -4 0 l -10 -10"
+              />
+            </clippath>
+          </defs>
+          <path
+            clip-path="url(#modal-arrow-cut-stroke-top)"
+            d="m 24 0 l -10 10 q -2 2 -4 0 l -10 -10"
+            data-color="primary"
+          />
+        </svg>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`<Tooltip type"description /> snapshot should match snapshot with className 1`] = `
 <div>
   <button
@@ -770,7 +861,6 @@ exports[`<Tooltip type"description /> snapshot should match snapshot with id 1`]
 <div>
   <button
     aria-describedby="test-ID"
-    id="example-id"
   >
     Hover Me!
   </button>
@@ -789,7 +879,6 @@ exports[`<Tooltip type"description /> snapshot should match snapshot with id 2`]
 <div>
   <button
     aria-describedby="test-ID"
-    id="example-id"
   >
     Hover Me!
   </button>
@@ -817,6 +906,184 @@ exports[`<Tooltip type"description /> snapshot should match snapshot with id 2`]
       data-placement="top"
       data-round="50"
       id="example-id"
+      role="tooltip"
+    >
+      <p>
+        Content
+      </p>
+      <div
+        class="md-modal-container-arrow-wrapper"
+        data-popper-arrow="true"
+        id="arrow1"
+        style="position: absolute; left: 0px; transform: translate(5px, 0px);"
+      >
+        <svg
+          aria-hidden="true"
+          class="md-modal-arrow-svg"
+          data-placement="top"
+          height="12"
+          viewBox="0 0 24 12"
+          width="24"
+          xmlns="http://www.w3.org/svg/2000"
+        >
+          <defs>
+            <clippath
+              id="modal-arrow-cut-stroke-top"
+            >
+              <path
+                d="m 24 0 l -10 10 q -2 2 -4 0 l -10 -10"
+              />
+            </clippath>
+          </defs>
+          <path
+            clip-path="url(#modal-arrow-cut-stroke-top)"
+            d="m 24 0 l -10 10 q -2 2 -4 0 l -10 -10"
+            data-color="primary"
+          />
+        </svg>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<Tooltip type"description /> snapshot should match snapshot with labelOrDescriptionId and type description 1`] = `
+<div>
+  <button
+    aria-describedby="test-description-id"
+  >
+    Hover Me!
+  </button>
+  <div
+    class="md-tooltip-label"
+    id="test-description-id"
+  >
+    <p>
+      Content
+    </p>
+  </div>
+</div>
+`;
+
+exports[`<Tooltip type"description /> snapshot should match snapshot with labelOrDescriptionId and type description 2`] = `
+<div>
+  <button
+    aria-describedby="test-description-id"
+  >
+    Hover Me!
+  </button>
+  <div
+    class="md-tooltip-label"
+    id="test-description-id"
+  >
+    <p>
+      Content
+    </p>
+  </div>
+  <div
+    data-tippy-root=""
+    id="tippy-17"
+    style="pointer-events: none; z-index: 9999; position: absolute; left: 0px; top: 0px; margin: 0px; bottom: 0px; transform: translate(0px, 0px);"
+  >
+    <div
+      aria-hidden="true"
+      aria-modal="false"
+      class="md-modal-container-wrapper"
+      data-arrow-orientation="vertical"
+      data-color="primary"
+      data-elevation="3"
+      data-padded="true"
+      data-placement="top"
+      data-round="50"
+      role="tooltip"
+    >
+      <p>
+        Content
+      </p>
+      <div
+        class="md-modal-container-arrow-wrapper"
+        data-popper-arrow="true"
+        id="arrow1"
+        style="position: absolute; left: 0px; transform: translate(5px, 0px);"
+      >
+        <svg
+          aria-hidden="true"
+          class="md-modal-arrow-svg"
+          data-placement="top"
+          height="12"
+          viewBox="0 0 24 12"
+          width="24"
+          xmlns="http://www.w3.org/svg/2000"
+        >
+          <defs>
+            <clippath
+              id="modal-arrow-cut-stroke-top"
+            >
+              <path
+                d="m 24 0 l -10 10 q -2 2 -4 0 l -10 -10"
+              />
+            </clippath>
+          </defs>
+          <path
+            clip-path="url(#modal-arrow-cut-stroke-top)"
+            d="m 24 0 l -10 10 q -2 2 -4 0 l -10 -10"
+            data-color="primary"
+          />
+        </svg>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<Tooltip type"description /> snapshot should match snapshot with labelOrDescriptionId and type label 1`] = `
+<div>
+  <button
+    aria-labelledby="test-label-id"
+  >
+    Hover Me!
+  </button>
+  <div
+    class="md-tooltip-label"
+    id="test-label-id"
+  >
+    <p>
+      Content
+    </p>
+  </div>
+</div>
+`;
+
+exports[`<Tooltip type"description /> snapshot should match snapshot with labelOrDescriptionId and type label 2`] = `
+<div>
+  <button
+    aria-labelledby="test-label-id"
+  >
+    Hover Me!
+  </button>
+  <div
+    class="md-tooltip-label"
+    id="test-label-id"
+  >
+    <p>
+      Content
+    </p>
+  </div>
+  <div
+    data-tippy-root=""
+    id="tippy-16"
+    style="pointer-events: none; z-index: 9999; position: absolute; left: 0px; top: 0px; margin: 0px; bottom: 0px; transform: translate(0px, 0px);"
+  >
+    <div
+      aria-hidden="false"
+      aria-modal="false"
+      class="md-modal-container-wrapper"
+      data-arrow-orientation="vertical"
+      data-color="primary"
+      data-elevation="3"
+      data-padded="true"
+      data-placement="top"
+      data-round="50"
       role="tooltip"
     >
       <p>

--- a/src/components/TooltipPopoverCombo/TooltipPopoverCombo.tsx
+++ b/src/components/TooltipPopoverCombo/TooltipPopoverCombo.tsx
@@ -17,11 +17,8 @@ const TooltipPopoverCombo: FC<Props> = (props: TooltipPopoverComboProps) => {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const [isTooltipOpen, setIsTooltipOpen] = useState(false);
 
-  const triggerComponentId = useRef(triggerComponent.props?.id || uuidV4());
-
-  const clonedTriggerComponent = React.cloneElement(triggerComponent, {
-    id: triggerComponentId.current, 'aria-haspopup': triggerComponent?.props?.['aria-haspopup'] || 'dialog'
-  });
+  const labelIdRef = useRef(uuidV4());
+  const labelId = labelIdRef.current;
 
   // Modified tooltipSetInstance to call both setInstance and updateInstance
   const setMergedTooltipInstances = useCallback(
@@ -75,15 +72,16 @@ const TooltipPopoverCombo: FC<Props> = (props: TooltipPopoverComboProps) => {
     <Popover
       trigger="click"
       interactive
+      aria-labelledby={labelId}
       triggerComponent={
         <Tooltip
           type="label"
-          triggerComponent={clonedTriggerComponent}
+          triggerComponent={triggerComponent}
           {...otherTooltipProps}
           onHide={handleOnHideTooltip}
           onShow={handleOnShowTooltip}
           setInstance={setMergedTooltipInstances}
-          id={triggerComponentId.current}
+          labelOrDescriptionId={labelId}
         >
           {tooltipContent}
         </Tooltip>

--- a/src/components/TooltipPopoverCombo/TooltipPopoverCombo.unit.test.tsx
+++ b/src/components/TooltipPopoverCombo/TooltipPopoverCombo.unit.test.tsx
@@ -17,7 +17,7 @@ jest.mock('uuid', () => {
 });
 
 describe('<TooltipPopoverCombo />', () => {
-  const triggerComponent = <button id="test-id" aria-haspopup="dialog">Example button</button>;
+  const triggerComponent = <button>Example button</button>;
   const tooltipContent = <Text>Example tooltip content</Text>;
   const popoverContent = <button>Example popover content button</button>;
 
@@ -82,6 +82,7 @@ describe('<TooltipPopoverCombo />', () => {
       const popover = comboElement.find(Popover).first();
 
       expect(popover.props()).toStrictEqual({
+        'aria-labelledby': '1',
         children: popoverContent,
         interactive: true,
         onHide: expect.any(Function),
@@ -100,7 +101,7 @@ describe('<TooltipPopoverCombo />', () => {
         triggerComponent: triggerComponent,
         type: 'label',
         'aria-haspopup': 'dialog',
-        id: 'test-id',
+        labelOrDescriptionId: '1',
       });
     });
 
@@ -119,6 +120,7 @@ describe('<TooltipPopoverCombo />', () => {
       const popover = comboElement.find(Popover).first();
 
       expect(popover.props()).toStrictEqual({
+        'aria-labelledby': '1',
         children: popoverContent,
         interactive: true,
         onHide: expect.any(Function),
@@ -151,7 +153,7 @@ describe('<TooltipPopoverCombo />', () => {
         triggerComponent: triggerComponent,
         type: 'label',
         'aria-haspopup': 'dialog',
-        id: 'test-id',
+        labelOrDescriptionId: '1',
         placement: 'top',
       });
     });

--- a/src/components/TooltipPopoverCombo/TooltipPopoverCombo.unit.test.tsx.snap
+++ b/src/components/TooltipPopoverCombo/TooltipPopoverCombo.unit.test.tsx.snap
@@ -13,30 +13,25 @@ exports[`<TooltipPopoverCombo /> snapshot should match snapshot 1`] = `
     </Text>
   }
   triggerComponent={
-    <button
-      aria-haspopup="dialog"
-      id="test-id"
-    >
+    <button>
       Example button
     </button>
   }
 >
   <Popover
+    aria-labelledby="1"
     interactive={true}
     onHide={[Function]}
     onShow={[Function]}
     trigger="click"
     triggerComponent={
       <Tooltip
-        id="test-id"
+        labelOrDescriptionId="1"
         onHide={[Function]}
         onShow={[Function]}
         setInstance={[Function]}
         triggerComponent={
-          <button
-            aria-haspopup="dialog"
-            id="test-id"
-          >
+          <button>
             Example button
           </button>
         }
@@ -231,15 +226,12 @@ exports[`<TooltipPopoverCombo /> snapshot should match snapshot 1`] = `
         >
           <Tooltip
             aria-haspopup="dialog"
-            id="test-id"
+            labelOrDescriptionId="1"
             onHide={[Function]}
             onShow={[Function]}
             setInstance={[Function]}
             triggerComponent={
-              <button
-                aria-haspopup="dialog"
-                id="test-id"
-              >
+              <button>
                 Example button
               </button>
             }
@@ -247,11 +239,9 @@ exports[`<TooltipPopoverCombo /> snapshot should match snapshot 1`] = `
           >
             <Popover
               addBackdrop={false}
-              aria-haspopup="dialog"
               aria-hidden={false}
               boundary="scrollParent"
               color="primary"
-              id="test-id"
               interactive={false}
               offsetDistance={5}
               offsetSkidding={0}
@@ -266,8 +256,7 @@ exports[`<TooltipPopoverCombo /> snapshot should match snapshot 1`] = `
               triggerComponent={
                 <button
                   aria-haspopup="dialog"
-                  aria-labelledby="test-ID"
-                  id="test-id"
+                  aria-labelledby="1"
                 >
                   Example button
                 </button>
@@ -445,8 +434,7 @@ exports[`<TooltipPopoverCombo /> snapshot should match snapshot 1`] = `
                   >
                     <button
                       aria-haspopup="dialog"
-                      aria-labelledby="test-ID"
-                      id="test-id"
+                      aria-labelledby="1"
                     >
                       Example button
                     </button>
@@ -467,7 +455,7 @@ exports[`<TooltipPopoverCombo /> snapshot should match snapshot 1`] = `
             </Popover>
             <div
               className="md-tooltip-label"
-              id="test-ID"
+              id="1"
             >
               <Text>
                 <p
@@ -515,31 +503,26 @@ exports[`<TooltipPopoverCombo /> snapshot should match snapshot with otherPopove
     </Text>
   }
   triggerComponent={
-    <button
-      aria-haspopup="dialog"
-      id="test-id"
-    >
+    <button>
       Example button
     </button>
   }
 >
   <Popover
+    aria-labelledby="1"
     interactive={true}
     onHide={[Function]}
     onShow={[Function]}
     trigger="click"
     triggerComponent={
       <Tooltip
-        id="test-id"
+        labelOrDescriptionId="1"
         onHide={[Function]}
         onShow={[Function]}
         placement="bottom"
         setInstance={[Function]}
         triggerComponent={
-          <button
-            aria-haspopup="dialog"
-            id="test-id"
-          >
+          <button>
             Example button
           </button>
         }
@@ -734,16 +717,13 @@ exports[`<TooltipPopoverCombo /> snapshot should match snapshot with otherPopove
         >
           <Tooltip
             aria-haspopup="dialog"
-            id="test-id"
+            labelOrDescriptionId="1"
             onHide={[Function]}
             onShow={[Function]}
             placement="bottom"
             setInstance={[Function]}
             triggerComponent={
-              <button
-                aria-haspopup="dialog"
-                id="test-id"
-              >
+              <button>
                 Example button
               </button>
             }
@@ -751,11 +731,9 @@ exports[`<TooltipPopoverCombo /> snapshot should match snapshot with otherPopove
           >
             <Popover
               addBackdrop={false}
-              aria-haspopup="dialog"
               aria-hidden={false}
               boundary="scrollParent"
               color="primary"
-              id="test-id"
               interactive={false}
               offsetDistance={5}
               offsetSkidding={0}
@@ -770,8 +748,7 @@ exports[`<TooltipPopoverCombo /> snapshot should match snapshot with otherPopove
               triggerComponent={
                 <button
                   aria-haspopup="dialog"
-                  aria-labelledby="test-ID"
-                  id="test-id"
+                  aria-labelledby="1"
                 >
                   Example button
                 </button>
@@ -949,8 +926,7 @@ exports[`<TooltipPopoverCombo /> snapshot should match snapshot with otherPopove
                   >
                     <button
                       aria-haspopup="dialog"
-                      aria-labelledby="test-ID"
-                      id="test-id"
+                      aria-labelledby="1"
                     >
                       Example button
                     </button>
@@ -971,7 +947,7 @@ exports[`<TooltipPopoverCombo /> snapshot should match snapshot with otherPopove
             </Popover>
             <div
               className="md-tooltip-label"
-              id="test-ID"
+              id="1"
             >
               <Text>
                 <p
@@ -1019,31 +995,26 @@ exports[`<TooltipPopoverCombo /> snapshot should match snapshot with otherToolti
     </Text>
   }
   triggerComponent={
-    <button
-      aria-haspopup="dialog"
-      id="test-id"
-    >
+    <button>
       Example button
     </button>
   }
 >
   <Popover
+    aria-labelledby="1"
     interactive={true}
     onHide={[Function]}
     onShow={[Function]}
     trigger="click"
     triggerComponent={
       <Tooltip
-        id="test-id"
+        labelOrDescriptionId="1"
         onHide={[Function]}
         onShow={[Function]}
         placement="top"
         setInstance={[Function]}
         triggerComponent={
-          <button
-            aria-haspopup="dialog"
-            id="test-id"
-          >
+          <button>
             Example button
           </button>
         }
@@ -1238,16 +1209,13 @@ exports[`<TooltipPopoverCombo /> snapshot should match snapshot with otherToolti
         >
           <Tooltip
             aria-haspopup="dialog"
-            id="test-id"
+            labelOrDescriptionId="1"
             onHide={[Function]}
             onShow={[Function]}
             placement="top"
             setInstance={[Function]}
             triggerComponent={
-              <button
-                aria-haspopup="dialog"
-                id="test-id"
-              >
+              <button>
                 Example button
               </button>
             }
@@ -1255,11 +1223,9 @@ exports[`<TooltipPopoverCombo /> snapshot should match snapshot with otherToolti
           >
             <Popover
               addBackdrop={false}
-              aria-haspopup="dialog"
               aria-hidden={false}
               boundary="scrollParent"
               color="primary"
-              id="test-id"
               interactive={false}
               offsetDistance={5}
               offsetSkidding={0}
@@ -1274,8 +1240,7 @@ exports[`<TooltipPopoverCombo /> snapshot should match snapshot with otherToolti
               triggerComponent={
                 <button
                   aria-haspopup="dialog"
-                  aria-labelledby="test-ID"
-                  id="test-id"
+                  aria-labelledby="1"
                 >
                   Example button
                 </button>
@@ -1453,8 +1418,7 @@ exports[`<TooltipPopoverCombo /> snapshot should match snapshot with otherToolti
                   >
                     <button
                       aria-haspopup="dialog"
-                      aria-labelledby="test-ID"
-                      id="test-id"
+                      aria-labelledby="1"
                     >
                       Example button
                     </button>
@@ -1475,7 +1439,7 @@ exports[`<TooltipPopoverCombo /> snapshot should match snapshot with otherToolti
             </Popover>
             <div
               className="md-tooltip-label"
-              id="test-ID"
+              id="1"
             >
               <Text>
                 <p


### PR DESCRIPTION
# Description

This fixes the aria-labelledby chaining issue to provide the correct label for the popover in TooltipPopoverCombo, by allowing Popover to have aria-labelledby overridden and allowing Tooltip to have labelId overridden. This fix removes some duplicate and now-unnecessary ids.

This also removes the extra aria-haspopup which was incorrectly being added to the tooltip itself in TooltipPopoverCombo.

This also fixes Tooltip treating type none the same as type description.
