### PR TITLE
fix(OverlayAlert): don't close overlay alert if popover is open inside

### DIFF
--- a/src/components/OverlayAlert/OverlayAlert.stories.tsx
+++ b/src/components/OverlayAlert/OverlayAlert.stories.tsx
@@ -12,6 +12,8 @@ import Icon from '../Icon';
 import OverlayAlert, { OverlayAlertProps } from './';
 import argTypes from './OverlayAlert.stories.args';
 import Documentation from './OverlayAlert.stories.docs.mdx';
+import Tooltip from '../Tooltip';
+import TooltipPopoverCombo from '../TooltipPopoverCombo';
 
 export default {
   title: 'Momentum UI/OverlayAlert',
@@ -186,4 +188,68 @@ const FigmaExample: Story<OverlayAlertProps> = (args: OverlayAlertProps) => {
 
 FigmaExample.argTypes = { ...argTypes };
 
-export { Example, WithoutActions, WithoutControls, WithoutTitle, FigmaExample };
+const ContainsPopovers: Story<OverlayAlertProps> = (args: OverlayAlertProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const open = () => {
+    setIsOpen(true);
+  };
+
+  const close = () => {
+    setIsOpen(false);
+  };
+
+  const actions = [
+    <ButtonPill key={0} outline inverted onPress={close} size={32}>
+      Secondary
+    </ButtonPill>,
+    <ButtonPill key={1} onPress={close} size={32}>
+      Primary
+    </ButtonPill>,
+  ];
+
+  const controls = [<ButtonControl key={2} onPress={close} control="close" />];
+
+  return (
+    <div
+      style={{
+        alignItems: 'center',
+        backgroundColor: 'var(--mds-color-theme-background-solid-primary-normal)',
+        border:
+          '1px var(--md-globals-border-style-solid) var(--mds-color-theme-outline-secondary-normal)',
+        display: 'flex',
+        height: '80%',
+        paddingLeft: '4rem',
+        position: 'relative',
+        width: '80%',
+      }}
+    >
+      <ButtonPill onPress={open}>Open</ButtonPill>
+      {isOpen && (
+        <OverlayAlert
+          details="In ultrices dapibus tortor in posuere. Sed rhoncus mi sem."
+          title="Title"
+          actions={<>{actions}</>}
+          controls={<>{controls}</>}
+          onClose={close}
+          {...args}
+        >
+          <div           
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center'
+            }}
+          > 
+            Focus on this button. Closing the tooltip using Esc will not close the OverlayAlert.
+            <Tooltip placement="top" triggerComponent={<ButtonCircle><Icon name="accessibility"/></ButtonCircle>} type="label">Tooltip content</Tooltip>
+          </div>
+        </OverlayAlert>
+      )}
+    </div>
+  );
+};
+
+ContainsPopovers.argTypes = { ...argTypes };
+
+export { Example, WithoutActions, WithoutControls, WithoutTitle, FigmaExample, ContainsPopovers };

--- a/src/components/OverlayAlert/OverlayAlert.tsx
+++ b/src/components/OverlayAlert/OverlayAlert.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useRef } from 'react';
+import React, { FC, useCallback, useRef } from 'react';
 import classnames from 'classnames';
 
 import ModalContainer from '../ModalContainer';
@@ -9,6 +9,7 @@ import { DEFAULTS, STYLE } from './OverlayAlert.constants';
 import { Props } from './OverlayAlert.types';
 import './OverlayAlert.style.scss';
 import { v4 as uuidV4 } from 'uuid';
+import { useShouldCloseOnEsc } from '../../hooks/useShouldCloseOnEsc';
 
 /**
  * The OverlayAlert component.
@@ -30,15 +31,15 @@ const OverlayAlert: FC<Props> = (props: Props) => {
     ariaLabel,
     ...other
   } = props;
-
   const id = useRef(uuidV4());
   const detailsId = useRef(uuidV4());
+  const {shouldCloseOnEsc} = useShouldCloseOnEsc();
 
-  const onKeyDown = (event: React.KeyboardEvent) => {
-    if (event.key === 'Escape') {
+  const onKeyDown = useCallback((event: React.KeyboardEvent) => {
+    if (event.key === 'Escape' && shouldCloseOnEsc) {
       onClose?.();
     }
-  };
+  }, [shouldCloseOnEsc]);
 
   return (
     <Overlay

--- a/src/components/OverlayAlert/OverlayAlert.unit.test.tsx
+++ b/src/components/OverlayAlert/OverlayAlert.unit.test.tsx
@@ -13,6 +13,7 @@ import OverlayAlert, { OVERLAY_ALERT_CONSTANTS as CONSTANTS, OVERLAY_ALERT_CONST
 import { STYLE as OVERLAY_STYLE } from '../Overlay/Overlay.constants';
 import Text from '../Text';
 import Tooltip from '../Tooltip';
+import Popover from '../Popover';
 
 jest.mock('uuid', () => {
   return {
@@ -415,97 +416,266 @@ describe('<OverlayAlert />', () => {
 
       expect(onCloseFn).toHaveBeenCalledTimes(1);
     });
-  });
 
-  it('should lock focus by default', async () => {
-    const Component = () => {
-      return (
-        <>
-          <button>button3</button>
-          <OverlayAlert>
-            <button>button1</button>
-            <button>button2</button>
-          </OverlayAlert>
-        </>
-      );
-    };
+    it('should lock focus by default', async () => {
+      const Component = () => {
+        return (
+          <>
+            <button>button3</button>
+            <OverlayAlert>
+              <button>button1</button>
+              <button>button2</button>
+            </OverlayAlert>
+          </>
+        );
+      };
 
-    const user = userEvent.setup();
+      const user = userEvent.setup();
 
-    render(<Component />);
+      render(<Component />);
 
-    const button1 = screen.getByRole('button', {name: 'button1'});
-    const button2 = screen.getByRole('button', {name: 'button2'});
-    const button3 = screen.getByRole('button', {name: 'button3'});
+      const button1 = screen.getByRole('button', {name: 'button1'});
+      const button2 = screen.getByRole('button', {name: 'button2'});
+      const button3 = screen.getByRole('button', {name: 'button3'});
 
-    expect(button1).toHaveFocus();
-    expect(button3).not.toHaveFocus();
+      expect(button1).toHaveFocus();
+      expect(button3).not.toHaveFocus();
 
-    await user.tab();
+      await user.tab();
 
-    expect(button2).toHaveFocus();
-    expect(button3).not.toHaveFocus();
+      expect(button2).toHaveFocus();
+      expect(button3).not.toHaveFocus();
 
-    await user.tab();
+      await user.tab();
 
-    expect(button1).toHaveFocus();
-    expect(button3).not.toHaveFocus();
-  });
+      expect(button1).toHaveFocus();
+      expect(button3).not.toHaveFocus();
+    });
 
-  it('should not close on Esc press while a tooltip is open inside the overlay alert', async () => {
-    const onCloseMock = jest.fn();
+    it('should not close on Esc press while a tooltip is open inside the overlay alert', async () => {
+      const onCloseMock = jest.fn();
 
-    const Component = () => {
-      return (
-        <>
-          <OverlayAlert
-            onClose={onCloseMock}
-          >
-            <Tooltip 
-              triggerComponent={
-                <button>button1</button>
-              } 
-              type="none"
+      const Component = () => {
+        return (
+          <>
+            <OverlayAlert
+              onClose={onCloseMock}
             >
-              Tooltip text
-            </Tooltip>
-          </OverlayAlert>
-        </>
-      );
-    };
+              <Tooltip 
+                triggerComponent={
+                  <button>button1</button>
+                } 
+                type="none"
+              >
+                Tooltip text
+              </Tooltip>
+            </OverlayAlert>
+          </>
+        );
+      };
 
-    const user = userEvent.setup();
+      const user = userEvent.setup();
 
-    render(<Component />);
+      render(<Component />);
 
-    // press tab
-    await user.tab();
+      // press tab
+      await user.tab();
 
-    const button1 = screen.getByRole('button', {name: 'button1'});
+      const button1 = screen.getByRole('button', {name: 'button1'});
 
-    // trigger button should be focused, tooltip should be shown
-    expect(button1).toHaveFocus();
+      // trigger button should be focused, tooltip should be shown
+      expect(button1).toHaveFocus();
 
-    const tooltip = screen.getByRole('tooltip', { hidden: true });
+      const tooltip = screen.getByRole('tooltip', { hidden: true });
 
-    await waitFor(() => {
-      expect(getByText(tooltip, 'Tooltip text')).toBeInTheDocument();
+      await waitFor(() => {
+        expect(getByText(tooltip, 'Tooltip text')).toBeInTheDocument();
+      });
+
+      // press Escape
+      await user.keyboard('{Escape}');
+
+      // trigger button should be focused, tooltip should be hidden and onClose should not have been called
+      expect(button1).toHaveFocus();
+      await waitFor(() => {
+        expect(queryByText(tooltip, 'Tooltip text')).not.toBeInTheDocument();
+        expect(onCloseMock).not.toBeCalled();
+      });
+
+      // press Escape
+      await user.keyboard('{Escape}');
+
+      // onClose is called on the next Escape press
+      expect(onCloseMock).toBeCalledTimes(1);
     });
 
-    // press Escape
-    await user.keyboard('{Escape}');
+    it('should close on Esc press while a tooltip with hideOnEsc = false is open inside the overlay alert', async () => {
+      const onCloseMock = jest.fn();
 
-    // trigger button should be focused, tooltip should be hidden and onClose should not have been called
-    expect(button1).toHaveFocus();
-    await waitFor(() => {
-      expect(queryByText(tooltip, 'Tooltip text')).not.toBeInTheDocument();
-      expect(onCloseMock).not.toBeCalled();
+      const Component = () => {
+        return (
+          <>
+            <OverlayAlert
+              onClose={onCloseMock}
+            >
+              <Popover 
+                triggerComponent={
+                  <button>button1</button>
+                } 
+                hideOnEsc={false}
+                role="tooltip"
+                trigger="mouseenter focusin"
+              >
+                Tooltip text
+              </Popover>
+            </OverlayAlert>
+          </>
+        );
+      };
+
+      const user = userEvent.setup();
+
+      render(<Component />);
+
+      // press tab
+      await user.tab();
+
+      const button1 = screen.getByRole('button', {name: 'button1'});
+
+      // trigger button should be focused, tooltip should be shown
+      expect(button1).toHaveFocus();
+
+      const tooltip = screen.getByRole('tooltip', { hidden: true });
+
+      await waitFor(() => {
+        expect(getByText(tooltip, 'Tooltip text')).toBeInTheDocument();
+      });
+
+      // press Escape
+      await user.keyboard('{Escape}');
+
+      // onClose is called on the next Escape press, tooltip did not close
+      await waitFor(() => {
+        expect(getByText(tooltip, 'Tooltip text')).toBeInTheDocument();
+        expect(onCloseMock).toBeCalledTimes(1);
+      });
     });
 
-    // press Escape
-    await user.keyboard('{Escape}');
+    it('should close on Esc press while a popover is open inside the overlay alert', async () => {
+      const onCloseMock = jest.fn();
 
-    // onClose is called on the next Escape press
-    expect(onCloseMock).toBeCalledTimes(1);
+      const Component = () => {
+        return (
+          <>
+            <OverlayAlert
+              onClose={onCloseMock}
+            >
+              <Popover 
+                triggerComponent={
+                  <button>button1</button>
+                } 
+                interactive
+              >
+                <button>button2</button>
+              </Popover>
+            </OverlayAlert>
+          </>
+        );
+      };
+
+      const user = userEvent.setup();
+
+      render(<Component />);
+
+      // press tab
+      await user.tab();
+
+      const button1 = screen.getByRole('button', {name: 'button1'});
+
+      // trigger button should be focused
+      expect(button1).toHaveFocus();
+
+      // press Enter
+      await user.keyboard('{Enter}');
+
+      const button2 = screen.getByRole('button', {name: 'button2'});
+
+      // popover should be shown with button2 focused
+      await waitFor(() => {
+        expect(button2).toHaveFocus();
+      });
+
+      // press Escape
+      await user.keyboard('{Escape}');
+
+      // trigger button should be focused, popover should be hidden (button2 is not in doc) and onClose should not have been called
+      expect(button1).toHaveFocus();
+      await waitFor(() => {
+        expect(button1).toHaveFocus();
+        expect(button2).not.toBeInTheDocument();
+        expect(onCloseMock).not.toBeCalled();
+      });
+
+      // press Escape
+      await user.keyboard('{Escape}');
+
+      // onClose is called on the next Escape press
+      expect(onCloseMock).toBeCalledTimes(1);
+    });
+
+    it('should not close on Esc press while a popover with hideOnEsc = false is open inside the overlay alert', async () => {
+      const onCloseMock = jest.fn();
+
+      const Component = () => {
+        return (
+          <>
+            <OverlayAlert
+              onClose={onCloseMock}
+            >
+              <Popover 
+                triggerComponent={
+                  <button>button1</button>
+                } 
+                interactive
+                hideOnEsc={false}
+              >
+                <button>button2</button>
+              </Popover>
+            </OverlayAlert>
+          </>
+        );
+      };
+
+      const user = userEvent.setup();
+
+      render(<Component />);
+
+      // press tab
+      await user.tab();
+
+      const button1 = screen.getByRole('button', {name: 'button1'});
+
+      // trigger button should be focused
+      expect(button1).toHaveFocus();
+
+      // press Enter
+      await user.keyboard('{Enter}');
+
+      const button2 = screen.getByRole('button', {name: 'button2'});
+
+      // popover should be shown with button2 focused
+      await waitFor(() => {
+        expect(button2).toHaveFocus();
+      });
+
+      // press Escape
+      await user.keyboard('{Escape}');
+
+      // onClose is called on the next Escape press, popover is still open with button2 focused
+      expect(onCloseMock).toBeCalledTimes(1);
+      await waitFor(() => {
+        expect(button2).toHaveFocus();
+      });
+    });
   });
 });

--- a/src/components/Popover/Popover.events.ts
+++ b/src/components/Popover/Popover.events.ts
@@ -1,0 +1,79 @@
+import { v4 as uuidV4 } from 'uuid';
+
+/**
+ * An event target to handle communication between instances of OverlayAlert and Popover.
+ * This will enable us to keep track of Popover instances (specifically those with hideOnEsc = true)
+ * which are opened while an OverlayAlert is rendered. While such Popover instances remain open, the OverlayAlert
+ * will not close on Esc.
+ * 
+ * This operates on the assumption that any Popover instance that is opened after an OverlayAlert is
+ * rendered on the screen is part of the content of said OverlayAlert and should be closed before the OverlayAlert
+ * itself.
+ */
+
+export enum EventType {
+  TIPPY_INSTANCE_ADDED = 'tippyInstanceAdded',
+  TIPPY_INSTANCE_REMOVED = 'tippyInstanceRemoved'
+}
+
+type CustomEventHandler = (event: CustomEvent) => void;
+type EventHandler = (data?: unknown) => void;
+
+const eventHandlers: Record<EventType, Record<string, CustomEventHandler>> = {
+  [EventType.TIPPY_INSTANCE_ADDED]: {},
+  [EventType.TIPPY_INSTANCE_REMOVED]: {},
+};
+
+/**
+ * Event target used for Popover instances with hideOnEsc = true
+ */
+const eventTarget = new EventTarget();
+
+/**
+ * Dispatch a custom event to the event target.
+ * @param eventType The category, allowing for listeners to listen to specific events
+ * @param data The data associated with the event (provided in the custom event detail)
+ */
+const dispatchEvent = (eventType: EventType, data?: unknown): void => {
+  eventTarget.dispatchEvent(new CustomEvent(eventType, {detail: {data}}));
+};
+
+/**
+ * Add a listener for a specific type (category) of event.
+ * This wraps the provided event handler to obfuscate the use of the custom event.
+ * Due to this the event listener is stored against an ID which can be used to remove it later.
+ * @param eventType The category of event
+ * @param handler The handler function to call, expecting a type and data arguments
+ * @returns The ID of the listener added
+ */
+const addListener = (eventType: EventType, handler: EventHandler): string => {
+  const id = uuidV4();
+  const eventHandler = ({detail: {data}}: CustomEvent) => {
+    handler(data);
+  };
+
+  eventTarget.addEventListener(eventType, eventHandler);
+  eventHandlers[eventType][id] = eventHandler;
+
+  return id;
+};
+
+/**
+ * Remove a listener for a specific type (category) of event.
+ * Removes the stored listener based on the event type and handler ID provided.
+ * @param eventType The category of event
+ * @param id The ID of the listener to be removed
+ */
+const removeListener = (eventType: EventType, id: string): void => {
+  const eventHandler = eventHandlers[eventType][id];
+
+  if (!eventHandler) {
+    console.warn(`PopoverEvents:removeListener - No event handler found for ID: ${id}`);
+    return;
+  }
+
+  eventTarget.removeEventListener(eventType, eventHandler);
+  delete eventHandlers[eventType][id];
+};
+
+export {dispatchEvent, addListener, removeListener};

--- a/src/components/Popover/tippy-plugins/hideOnEscPlugin.test.ts
+++ b/src/components/Popover/tippy-plugins/hideOnEscPlugin.test.ts
@@ -1,12 +1,20 @@
+import { waitFor } from '@testing-library/react';
 import { sypOnEventListener } from '../../../../test/utils';
+import * as PopoverEvents from '../Popover.events';
 
 const createTippyInstance = () => {
   return { hide: jest.fn(), show: jest.fn() };
 };
 
 describe('hideOnEscPlugin', () => {
+  let popoverEventsDispatchEventSpy;
+
+  beforeEach(() => {
+    popoverEventsDispatchEventSpy = jest.spyOn(PopoverEvents, 'dispatchEvent');
+  });
+
   afterEach(() => {
-    jest.resetModules();
+    popoverEventsDispatchEventSpy.mockRestore();
   });
 
   it('should return plugin correctly', async () => {
@@ -32,16 +40,40 @@ describe('hideOnEscPlugin', () => {
 
     plugin1.onShow(tippy1);
     expect(addEventListenerSpy).toHaveBeenNthCalledWith(1, 'keydown', expect.any(Function));
+    await waitFor(() => {
+        expect(popoverEventsDispatchEventSpy).toHaveBeenNthCalledWith(1, 'tippyInstanceAdded', tippy1);
+      }
+    );
+
     addEventListenerSpy.mockReset();
+    popoverEventsDispatchEventSpy.mockReset();
+
     plugin2.onShow(tippy2);
     expect(addEventListenerSpy).toBeCalledTimes(0);
     expect(eventHandlers.keydown.length).toBe(1);
+    await waitFor(() => {
+      expect(popoverEventsDispatchEventSpy).toHaveBeenNthCalledWith(1, 'tippyInstanceAdded', tippy2);
+      }
+    );
+
+    popoverEventsDispatchEventSpy.mockReset();
 
     plugin1.onHide(tippy1);
     expect(removeEventListenerSpy).toBeCalledTimes(0);
+    await waitFor(() => {
+      expect(popoverEventsDispatchEventSpy).toHaveBeenNthCalledWith(1, 'tippyInstanceRemoved', tippy1);
+      }
+    );
+
+    popoverEventsDispatchEventSpy.mockReset();
+
     plugin2.onHide(tippy2);
     expect(removeEventListenerSpy).toHaveBeenNthCalledWith(1, 'keydown', expect.any(Function));
     expect(eventHandlers.keydown.length).toBe(0);
+    await waitFor(() => {
+      expect(popoverEventsDispatchEventSpy).toHaveBeenNthCalledWith(1, 'tippyInstanceRemoved', tippy2);
+      }
+    );
   });
 
   it('should trigger hide when user press esc', async () => {
@@ -58,6 +90,8 @@ describe('hideOnEscPlugin', () => {
   });
 
   it('should hide tippy instances in reverse order of opening', async () => {
+    jest.resetModules();
+
     const { hideOnEscPlugin } = await import('./hideOnEscPlugin');
     const { eventHandlers } = sypOnEventListener(window, ['keydown']);
 

--- a/src/components/Popover/tippy-plugins/hideOnEscPlugin.ts
+++ b/src/components/Popover/tippy-plugins/hideOnEscPlugin.ts
@@ -1,5 +1,7 @@
 import type { Instance as TippyInstance, Plugin } from 'tippy.js';
 
+import {dispatchEvent, EventType} from '../Popover.events';
+
 const openedTippyInstances: TippyInstance[] = [];
 
 // hide the last opened popover when Escape key is pressed
@@ -26,6 +28,13 @@ const addInstance = (instance: TippyInstance) => {
   }
 
   openedTippyInstances.push(instance);
+
+  // Send custom event that tippy instance is shown on screen. This event is listened for in instances of OverlayAlert to prevent it from closing unintentionally.
+  //
+  // We do this in the next event cycle because, if we don't, and the first element focused in an OverlayAlert is the trigger of a tooltip, then the event is
+  // dispatched before the OverlayAlert is mounted. (Use setTimeout without delay to execute code in the
+  // next event cycle, see https://developer.mozilla.org/en-US/docs/Web/API/setTimeout#delay)
+  setTimeout(() => dispatchEvent(EventType.TIPPY_INSTANCE_ADDED, instance));
 };
 
 /**
@@ -38,6 +47,9 @@ const removeInstance = (instance: TippyInstance) => {
   if (openedTippyInstances.length === 0) {
     window.removeEventListener('keydown', onKeyDown);
   }
+  // Send custom event that tippy instance is no longer shown on screen. This event is listened for in instances of OverlayAlert to allow it to close once there are no tippy instances
+  // still shown on screen that were opened after the render of the OverlayAlert.
+  dispatchEvent(EventType.TIPPY_INSTANCE_REMOVED, instance);
 };
 
 /**

--- a/src/hooks/useShouldCloseOnEsc.test.ts
+++ b/src/hooks/useShouldCloseOnEsc.test.ts
@@ -1,0 +1,53 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import * as PopoverEvents from '../components/Popover/Popover.events';
+import { useShouldCloseOnEsc } from './useShouldCloseOnEsc';
+
+describe('useShouldCloseOnEsc', () => {
+
+  const addPopoverInstance = (id: string) => {
+    // Simulate adding a Popover instance
+    act(() => {
+      PopoverEvents.dispatchEvent(PopoverEvents.EventType.TIPPY_INSTANCE_ADDED, id);
+    });
+  };
+
+  const removePopoverInstance = (id: string) => {
+    // Simulate removing a Popover instance
+    act(() => {
+      PopoverEvents.dispatchEvent(PopoverEvents.EventType.TIPPY_INSTANCE_REMOVED, id);
+    });
+  };
+
+  it('should be true by default', () => {
+    const { result } = renderHook(() => useShouldCloseOnEsc());
+    expect(result.current.shouldCloseOnEsc).toBe(true);
+  });
+
+  it('should be false when a Popover instance is added', () => {
+    const { result } = renderHook(() => useShouldCloseOnEsc());
+
+    addPopoverInstance('popover-1');
+
+    expect(result.current.shouldCloseOnEsc).toBe(false);
+  });
+
+  it('should be true when all Popover instances are removed', () => {
+    const { result } = renderHook(() => useShouldCloseOnEsc());
+
+    addPopoverInstance('popover-1');
+
+    removePopoverInstance('popover-1');
+
+    expect(result.current.shouldCloseOnEsc).toBe(true);
+  });
+
+  it('should work as expected if an instance that was never added is attempted to be removed', () => {
+    const { result } = renderHook(() => useShouldCloseOnEsc());
+
+    addPopoverInstance('popover-1');
+
+    removePopoverInstance('popover-2');
+
+    expect(result.current.shouldCloseOnEsc).toBe(false);
+  });
+});

--- a/src/hooks/useShouldCloseOnEsc.ts
+++ b/src/hooks/useShouldCloseOnEsc.ts
@@ -1,0 +1,67 @@
+import { useEffect, useState } from 'react';
+
+import * as PopoverEvents from '../components/Popover/Popover.events';
+
+/**
+ * A custom React hook that manages the ability to close a component which can contain Popovers when the escape key is pressed.
+ * 
+ * The hook listens for custom events indicating the addition or removal of tippy instances
+ * that should close when Esc is pressed (e.g., instances with `hideOnEsc = true`).
+ * It maintains a set of such instances and provides a `shouldCloseOnEsc` boolean that determines
+ * whether the parent component should close on Esc press.
+ * 
+ * The hook leverages two custom events defined in `Popover.events`:
+ * - `EventType.TIPPY_INSTANCE_ADDED`: Indicates a new Popover instance has been added.
+ * - `EventType.TIPPY_INSTANCE_REMOVED`: Indicates a Popover instance has been removed.
+ * 
+ * Each Popover instance is expected to dispatch these events with the instance itself when it is shown and hidden.
+ * 
+ * @returns An object containing a single property `shouldCloseOnEsc`, which is `true` if no Popover instances
+ *          are currently active (i.e., all have been hidden), and `false` otherwise.
+ *
+ */
+export const useShouldCloseOnEsc = (): {shouldCloseOnEsc: boolean} => {
+    const [popoverInstances, setPopoverInstances] = useState(new Set);
+    const [shouldCloseOnEsc, setShouldCloseOnEsc] = useState(true);
+
+    const add = (e: CustomEvent) => {
+        setPopoverInstances((prev) => {
+            const newSet = new Set(prev);
+            newSet.add(e); 
+            return newSet;
+        });
+      };
+    
+    const remove = (e: CustomEvent) => {
+        setPopoverInstances((prev) => {
+            const newSet = new Set(prev);
+
+            newSet.delete(e); 
+            return newSet;
+            } 
+        );
+    };
+
+    useEffect(() => {
+        const addId = PopoverEvents.addListener(PopoverEvents.EventType.TIPPY_INSTANCE_ADDED, add);
+        const removeId = PopoverEvents.addListener(PopoverEvents.EventType.TIPPY_INSTANCE_REMOVED, remove);
+
+        return () => {
+            PopoverEvents.removeListener(PopoverEvents.EventType.TIPPY_INSTANCE_ADDED, addId);
+            PopoverEvents.removeListener(PopoverEvents.EventType.TIPPY_INSTANCE_REMOVED, removeId);
+        };
+    }, []);
+
+    useEffect(() => {
+        const newShouldCloseOnEsc = popoverInstances.size === 0;
+
+        if (newShouldCloseOnEsc !== shouldCloseOnEsc) {
+          setShouldCloseOnEsc(newShouldCloseOnEsc);
+        }
+        
+      }, [popoverInstances]);
+
+    return {
+        shouldCloseOnEsc
+    };
+};


### PR DESCRIPTION
# Description

This is to fix https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-503237

Issue: If there is a tooltip in an overlay alert then Esc will close the overlayalert first instead of the tooltip. To fix this the overlay alert has to be made aware of whether any popover instances are opened while it is rendered. We use events for this and we keep track of the number of instances open to know if onClose on the overlayalert should be fired or not.

This will also work for interactive popovers as long as hideonEsc is true.

