### PR TITLE
fix(list): fix escape event propagation for list

### DIFF
--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -37,6 +37,9 @@ const List: FC<Props> = (props: Props) => {
   const { keyboardProps } = useKeyboard({
     onKeyDown: (e) => {
       switch (e.key) {
+        case 'Escape':
+          e.continuePropagation();
+          break;
         case 'ArrowUp':
         case 'ArrowLeft':
           e.preventDefault();

--- a/src/components/List/List.unit.test.tsx
+++ b/src/components/List/List.unit.test.tsx
@@ -161,6 +161,29 @@ describe('<List />', () => {
   });
 
   describe('list focus', () => {
+    it('should handle escape being pressed', async () => {
+      const keyDownHandler = jest.fn();
+
+      const { getByRole } = render(
+        // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+        <div onKeyDown={keyDownHandler}>
+          <List listSize={1}>
+            <ListItemBase key="0" itemIndex={0}>
+              ListItemBase 1
+            </ListItemBase>
+          </List>
+        </div>
+      );
+
+      const listItem = getByRole('listitem');
+
+      await userEvent.tab();
+      expect(listItem).toHaveFocus();
+
+      await userEvent.keyboard('{Escape}');
+      expect(keyDownHandler).toHaveBeenCalled();
+    });
+
     it('should handle up/down arrow keys correctly', async () => {
       expect.assertions(8);
       const user = userEvent.setup();

--- a/src/components/Popover/Popover.stories.tsx
+++ b/src/components/Popover/Popover.stories.tsx
@@ -17,6 +17,7 @@ import AriaToolbar from '../AriaToolbar';
 import Avatar from '../Avatar';
 import MeetingListItem from '../MeetingListItem';
 import SearchInput from '../SearchInput';
+import List from '../List';
 
 export default {
   title: 'Momentum UI/Popover',
@@ -352,6 +353,52 @@ WithMeetingListItemWithButtonsWithPopover.args = {
   ),
 };
 
+const PopoverInList = (props: PopoverProps) => {
+  return (
+    <List listSize={3}>
+      <Popover {...props} />
+    </List>
+  );
+};
+
+const WithMeetingListItemWithButtonsWithPopoverInList = Template<PopoverProps>(PopoverInList).bind(
+  {}
+);
+
+WithMeetingListItemWithButtonsWithPopoverInList.argTypes = { ...argTypes };
+
+WithMeetingListItemWithButtonsWithPopoverInList.args = {
+  trigger: 'click',
+  placement: PLACEMENTS.TOP,
+  showArrow: true,
+  interactive: true,
+  children: (
+    <div>
+      <Popover
+        interactive
+        trigger="click"
+        triggerComponent={
+          <Avatar
+            onPress={() => {
+              alert('avatar on press');
+            }}
+            initials="AB"
+          >
+            Hover or click me!
+          </Avatar>
+        }
+      >
+        <ButtonSimple>hi</ButtonSimple>
+      </Popover>
+    </div>
+  ),
+  triggerComponent: (
+    <MeetingListItem style={{ margin: '10rem auto', display: 'flex' }}>
+      Hover or click me!
+    </MeetingListItem>
+  ),
+};
+
 const WithSearchInput = Template<PopoverProps>(Popover).bind({});
 
 const SearchInputComponent = () => {
@@ -446,4 +493,5 @@ export {
   WithMeetingListItem,
   WithMeetingListItemWithButtonsWithPopover,
   WithSearchInput,
+  WithMeetingListItemWithButtonsWithPopoverInList,
 };

--- a/src/components/Popover/Popover.unit.test.tsx
+++ b/src/components/Popover/Popover.unit.test.tsx
@@ -12,6 +12,7 @@ import { PopoverInstance, PositioningStrategy } from './Popover.types';
 import SearchInput from '../SearchInput';
 import Avatar from '../Avatar';
 import MeetingListItem from '../MeetingListItem';
+import List from '../List';
 
 jest.mock('uuid', () => {
   return {
@@ -1552,6 +1553,57 @@ describe('<Popover />', () => {
           expect(meetingListItem).toHaveFocus();
         }
       );
+
+      it('should behave as expected when it is rendered inside a List', async () => {
+        /**
+         * Expected behavior for this test:
+         * 1. When the MeetingListItem is pressed, the popover opens
+         * 2. When the popover is open, the focus should be on the first focusable element within the popover
+         * 3. When Escape is pressed, the popover closes
+         * 4. The focus returns to the MeetingListItem
+         */
+
+        const user = userEvent.setup();
+
+        render(
+          <List listSize={1}>
+            <Popover
+              triggerComponent={<MeetingListItem>list item content</MeetingListItem>}
+              interactive
+            >
+              <div>
+                <p>Content</p>
+                <button>Button within popover</button>
+              </div>
+            </Popover>
+          </List>
+        );
+
+        // 1.
+        const meetingListItem = await screen.findByRole('listitem');
+        await user.click(meetingListItem);
+
+        await waitFor(() => {
+          expect(screen.getByText('Content')).toBeInTheDocument();
+        });
+
+        // 2.
+        const buttonWithinPopover = await screen.findByRole('button', {
+          name: 'Button within popover',
+        });
+        await waitFor(() => {
+          expect(buttonWithinPopover).toHaveFocus();
+        });
+
+        // 3.
+        await user.keyboard('{Escape}');
+        await waitFor(() => {
+          expect(screen.queryByText('Content')).not.toBeInTheDocument();
+        });
+
+        // 4.
+        expect(meetingListItem).toHaveFocus();
+      });
     });
   });
 });


### PR DESCRIPTION
# Description

Lists have keyboard event handling. This keyboard handling prevented the Escape keyboard event from reaching the window, where the popover closing plugin has the event handler.

This stopped Popovers closing when they were rendered inside of Lists


