### PR TITLE
feat(text-input): Link clear button with input

### DIFF
--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -42,6 +42,8 @@ const TextInput = (props: Props, ref: RefObject<HTMLInputElement>): ReactElement
   const state = useSearchFieldState(props);
 
   const messageId = useRef(uuidV4());
+  const labelId = useRef(uuidV4());
+  const clearButtonId = useRef(uuidV4());
 
   const onClearButtonPress = () => {
     state.setValue('');
@@ -66,7 +68,7 @@ const TextInput = (props: Props, ref: RefObject<HTMLInputElement>): ReactElement
       className={classnames(STYLE.wrapper, className)}
     >
       {label && (
-        <label {...labelProps} htmlFor={labelProps.htmlFor}>
+        <label {...labelProps} htmlFor={labelProps.htmlFor} id={labelId.current}>
           {label}
         </label>
       )}
@@ -84,6 +86,17 @@ const TextInput = (props: Props, ref: RefObject<HTMLInputElement>): ReactElement
             className="clear-icon"
             aria-label={clearAriaLabel}
             onPress={onClearButtonPress}
+            id={clearButtonId.current}
+            // If there is a visible label, then sr should read for this x button "clearAriaLabel (Ex. 'Clear input') + visible label (Ex. 'Password')"
+            // Else, if input was given an id and ideally has an aria-label, then sr should read for this x button "clearAriaLabel (Ex. 'Clear input') + input aria-label (Ex. 'Password')"
+            // Else, sr should read for this x button "clearAriaLabel (Ex. 'Clear input')"
+            aria-labelledby={
+              label
+                ? `${clearButtonId.current} ${labelId.current}`
+                : id
+                ? `${clearButtonId.current} ${id}`
+                : clearButtonId.current
+            }
           >
             <Icon scale={18} name="cancel" />
           </ButtonSimple>

--- a/src/components/TextInput/TextInput.unit.test.tsx
+++ b/src/components/TextInput/TextInput.unit.test.tsx
@@ -50,6 +50,28 @@ describe('<TextInput/>', () => {
       expect(container).toMatchSnapshot();
     });
 
+    it('should match snapshot with label', async () => {
+      expect.assertions(1);
+
+      const id = 'example-id';
+
+      const container = await mountComponent(<TextInput label="Password" id={id} />);
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match snapshot with clearAriaLabel', async () => {
+      expect.assertions(1);
+
+      const id = 'example-id';
+
+      const container = await mountComponent(
+        <TextInput label="Password" clearAriaLabel="Clear this input" id={id} />
+      );
+
+      expect(container).toMatchSnapshot();
+    });
+
     it('should match snapshot with style', async () => {
       expect.assertions(1);
 
@@ -121,9 +143,10 @@ describe('<TextInput/>', () => {
 
       const id = 'example-id-2';
 
-      const element = (await mountAndWait(<TextInput aria-label="text-input" id={id} />))
-        .find(TextInput);
-      
+      const element = (await mountAndWait(<TextInput aria-label="text-input" id={id} />)).find(
+        TextInput
+      );
+
       expect(element.props()).toMatchObject({ 'aria-label': 'text-input', id: 'example-id-2' });
     });
 
@@ -164,20 +187,27 @@ describe('<TextInput/>', () => {
     it('should have aria-describedby and id when message is provided', async () => {
       expect.assertions(2);
 
-      const textInputComponent = (await mountAndWait(<TextInput aria-label="text-input" aria-describedby={'desc-test-ID'} />))
-        .find(TextInput);
+      const textInputComponent = (
+        await mountAndWait(<TextInput aria-label="text-input" aria-describedby={'desc-test-ID'} />)
+      ).find(TextInput);
 
-      const inputMessageComponent = (await mountAndWait(<InputMessage className='error' level="error" id={'desc-test-ID'} />)).find(InputMessage);
+      const inputMessageComponent = (
+        await mountAndWait(<InputMessage className="error" level="error" id={'desc-test-ID'} />)
+      ).find(InputMessage);
 
       expect(inputMessageComponent.props().id).toStrictEqual('desc-test-ID');
-      expect(textInputComponent.props()).toMatchObject({ 'aria-label': 'text-input', 'aria-describedby': 'desc-test-ID' });
+      expect(textInputComponent.props()).toMatchObject({
+        'aria-label': 'text-input',
+        'aria-describedby': 'desc-test-ID',
+      });
     });
 
     it('should not have aria-labelledby when message is not provided', async () => {
       expect.assertions(1);
 
-      const textInputComponent = (await mountAndWait(<TextInput aria-label="text-input" />))
-        .find(TextInput);
+      const textInputComponent = (await mountAndWait(<TextInput aria-label="text-input" />)).find(
+        TextInput
+      );
 
       expect(textInputComponent.props()['aria-describedby']).toBe(undefined);
     });

--- a/src/components/TextInput/TextInput.unit.test.tsx.snap
+++ b/src/components/TextInput/TextInput.unit.test.tsx.snap
@@ -61,6 +61,44 @@ exports[`<TextInput/> snapshot should match snapshot with className 1`] = `
 </SSRProvider>
 `;
 
+exports[`<TextInput/> snapshot should match snapshot with clearAriaLabel 1`] = `
+<SSRProvider>
+  <TextInput
+    clearAriaLabel="Clear this input"
+    id="example-id"
+    label="Password"
+  >
+    <div
+      className="md-text-input-wrapper"
+      data-focus={false}
+      data-level="none"
+      onClick={[Function]}
+    >
+      <label
+        htmlFor="test-ID"
+        id="desc-test-ID"
+      >
+        Password
+      </label>
+      <div
+        className="md-text-input-container"
+      >
+        <input
+          aria-labelledby="test-ID"
+          disabled={false}
+          id="example-id"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          readOnly={false}
+          type="text"
+        />
+      </div>
+    </div>
+  </TextInput>
+</SSRProvider>
+`;
+
 exports[`<TextInput/> snapshot should match snapshot with description 1`] = `
 <SSRProvider>
   <TextInput
@@ -277,6 +315,43 @@ exports[`<TextInput/> snapshot should match snapshot with inputMaxLen 1`] = `
           disabled={false}
           id="test-ID"
           maxLength={4}
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          readOnly={false}
+          type="text"
+        />
+      </div>
+    </div>
+  </TextInput>
+</SSRProvider>
+`;
+
+exports[`<TextInput/> snapshot should match snapshot with label 1`] = `
+<SSRProvider>
+  <TextInput
+    id="example-id"
+    label="Password"
+  >
+    <div
+      className="md-text-input-wrapper"
+      data-focus={false}
+      data-level="none"
+      onClick={[Function]}
+    >
+      <label
+        htmlFor="test-ID"
+        id="desc-test-ID"
+      >
+        Password
+      </label>
+      <div
+        className="md-text-input-container"
+      >
+        <input
+          aria-labelledby="test-ID"
+          disabled={false}
+          id="example-id"
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}


### PR DESCRIPTION
# Description
As part of [SPARK-367394](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-367394) (issue 2 of Other issues), they are asking us that:

Expected Result:
The Clear text button for each text field should have a unique label announced so the user understand to which input it refers to,
as Clear text <input label>
Actual result:
The Clear text button for each text field announces the same label and the user would not understand to which input it refers to,
as Clear text <input label>

For this, I have linked the X button with the input or its visible label using aria-labelledby

# Links

[SPARK-367394](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-367394)
