### PR TITLE
fix(popover): disable propagation on trigger

### DIFF
--- a/src/components/MenuTrigger/MenuTrigger.unit.test.tsx.snap
+++ b/src/components/MenuTrigger/MenuTrigger.unit.test.tsx.snap
@@ -109,6 +109,9 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot 1`] = `
             },
             Object {
               "fn": [Function],
+            },
+            Object {
+              "fn": [Function],
               "name": "addBackdropPlugin",
             },
           ]
@@ -155,6 +158,9 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot 1`] = `
           placement="bottom-start"
           plugins={
             Array [
+              Object {
+                "fn": [Function],
+              },
               Object {
                 "fn": [Function],
               },
@@ -2297,6 +2303,9 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with className 
             },
             Object {
               "fn": [Function],
+            },
+            Object {
+              "fn": [Function],
               "name": "addBackdropPlugin",
             },
           ]
@@ -2343,6 +2352,9 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with className 
           placement="bottom-start"
           plugins={
             Array [
+              Object {
+                "fn": [Function],
+              },
               Object {
                 "fn": [Function],
               },
@@ -4485,6 +4497,9 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with color 1`] 
             },
             Object {
               "fn": [Function],
+            },
+            Object {
+              "fn": [Function],
               "name": "addBackdropPlugin",
             },
           ]
@@ -4531,6 +4546,9 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with color 1`] 
           placement="bottom-start"
           plugins={
             Array [
+              Object {
+                "fn": [Function],
+              },
               Object {
                 "fn": [Function],
               },
@@ -6674,6 +6692,9 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with id 1`] = `
             },
             Object {
               "fn": [Function],
+            },
+            Object {
+              "fn": [Function],
               "name": "addBackdropPlugin",
             },
           ]
@@ -6720,6 +6741,9 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with id 1`] = `
           placement="bottom-start"
           plugins={
             Array [
+              Object {
+                "fn": [Function],
+              },
               Object {
                 "fn": [Function],
               },
@@ -8865,6 +8889,9 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with placement 
             },
             Object {
               "fn": [Function],
+            },
+            Object {
+              "fn": [Function],
               "name": "addBackdropPlugin",
             },
           ]
@@ -8911,6 +8938,9 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with placement 
           placement="top"
           plugins={
             Array [
+              Object {
+                "fn": [Function],
+              },
               Object {
                 "fn": [Function],
               },
@@ -11053,6 +11083,9 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with showArrow 
             },
             Object {
               "fn": [Function],
+            },
+            Object {
+              "fn": [Function],
               "name": "addBackdropPlugin",
             },
           ]
@@ -11099,6 +11132,9 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with showArrow 
           placement="bottom-start"
           plugins={
             Array [
+              Object {
+                "fn": [Function],
+              },
               Object {
                 "fn": [Function],
               },
@@ -13316,6 +13352,9 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with style 1`] 
             },
             Object {
               "fn": [Function],
+            },
+            Object {
+              "fn": [Function],
               "name": "addBackdropPlugin",
             },
           ]
@@ -13362,6 +13401,9 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with style 1`] 
           placement="bottom-start"
           plugins={
             Array [
+              Object {
+                "fn": [Function],
+              },
               Object {
                 "fn": [Function],
               },
@@ -15515,6 +15557,9 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with variant 1`
             },
             Object {
               "fn": [Function],
+            },
+            Object {
+              "fn": [Function],
               "name": "addBackdropPlugin",
             },
           ]
@@ -15561,6 +15606,9 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with variant 1`
           placement="bottom-start"
           plugins={
             Array [
+              Object {
+                "fn": [Function],
+              },
               Object {
                 "fn": [Function],
               },

--- a/src/components/Popover/Popover.stories.tsx
+++ b/src/components/Popover/Popover.stories.tsx
@@ -479,6 +479,55 @@ Common.parameters = {
   ],
 };
 
+const WithMeetingListItemWithAvatarWithPopover = Template<PopoverProps>((args) => {
+  return (
+    <Popover
+      {...args}
+      triggerComponent={
+        <MeetingListItem style={{ margin: '10rem auto', display: 'flex' }}>
+          <Popover
+            {...args}
+            triggerComponent={
+              <Avatar
+                // eslint-disable-next-line
+                onPress={() => {}}
+                initials="AB"
+              >
+                Hover or click me!
+              </Avatar>
+            }
+          >
+            <div>
+              <ButtonPill>test 1</ButtonPill>
+              <ButtonPill>test 2</ButtonPill>
+              <ButtonPill>test 3</ButtonPill>
+            </div>
+          </Popover>
+          test
+        </MeetingListItem>
+      }
+      trigger="click"
+      interactive
+    >
+      <div>
+        <ButtonPill>test 4</ButtonPill>
+        <ButtonPill>test 5</ButtonPill>
+        <ButtonPill>test 6</ButtonPill>
+      </div>
+    </Popover>
+  );
+}).bind({});
+
+WithMeetingListItemWithAvatarWithPopover.argTypes = { ...argTypes };
+
+WithMeetingListItemWithAvatarWithPopover.args = {
+  trigger: 'mouseenter',
+  placement: PLACEMENTS.TOP,
+  showArrow: true,
+  interactive: true,
+  appendTo: () => document.querySelector('#theme-provider'),
+};
+
 export {
   Example,
   InteractiveContent,
@@ -494,4 +543,5 @@ export {
   WithMeetingListItemWithButtonsWithPopover,
   WithSearchInput,
   WithMeetingListItemWithButtonsWithPopoverInList,
+  WithMeetingListItemWithAvatarWithPopover,
 };

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -64,6 +64,7 @@ const Popover = forwardRef((props: Props, ref: ForwardedRef<HTMLElement>) => {
     firstFocusElement,
     autoFocus = DEFAULTS.AUTO_FOCUS,
     appendTo = DEFAULTS.APPEND_TO,
+    continuePropagationOnTrigger,
     ...rest
   } = props;
 
@@ -148,6 +149,7 @@ const Popover = forwardRef((props: Props, ref: ForwardedRef<HTMLElement>) => {
       ref={ref}
       /* needed to prevent the popover from closing when the focus is changed via click events */
       hideOnClick={!trigger.includes('manual')}
+      continuePropagationOnTrigger={continuePropagationOnTrigger}
       render={(attrs) => (
         <ModalContainer
           id={id}

--- a/src/components/Popover/Popover.types.ts
+++ b/src/components/Popover/Popover.types.ts
@@ -197,4 +197,9 @@ export interface Props extends PopoverCommonStyleProps, Partial<LifecycleHooks> 
    * The element to append the popover to.
    */
   appendTo?: AppendToType;
+
+  /**
+   * Whether to allow the trigger event to continue to propagate after the Popover is triggered.
+   */
+  continuePropagationOnTrigger?: boolean;
 }

--- a/src/components/Popover/Popover.unit.test.tsx
+++ b/src/components/Popover/Popover.unit.test.tsx
@@ -13,6 +13,7 @@ import SearchInput from '../SearchInput';
 import Avatar from '../Avatar';
 import MeetingListItem from '../MeetingListItem';
 import List from '../List';
+import ButtonPill from '../ButtonPill';
 
 jest.mock('uuid', () => {
   return {
@@ -1604,6 +1605,77 @@ describe('<Popover />', () => {
         // 4.
         expect(meetingListItem).toHaveFocus();
       });
+
+      it.each([
+        { continuePropagationOnTrigger: true },
+        { continuePropagationOnTrigger: false },
+        { continuePropagationOnTrigger: undefined },
+      ])(
+        'should behave as expected when the trigger is nested',
+        async ({ continuePropagationOnTrigger }) => {
+          const user = userEvent.setup();
+          const args = {
+            trigger: 'mouseenter',
+            interactive: true,
+          };
+
+          render(
+            <Popover
+              {...args}
+              triggerComponent={
+                <MeetingListItem style={{ margin: '10rem auto', display: 'flex' }}>
+                  <Popover
+                    continuePropagationOnTrigger={continuePropagationOnTrigger}
+                    {...args}
+                    triggerComponent={
+                      <Avatar
+                        data-testid="avatar"
+                        // eslint-disable-next-line
+                        onPress={() => {}}
+                        initials="AB"
+                      >
+                        Hover or click me!
+                      </Avatar>
+                    }
+                  >
+                    <div>
+                      <ButtonPill>test 1</ButtonPill>
+                      <ButtonPill>test 2</ButtonPill>
+                      <ButtonPill>test 3</ButtonPill>
+                    </div>
+                  </Popover>
+                  test
+                </MeetingListItem>
+              }
+              trigger="click"
+              interactive
+            >
+              <div>
+                <ButtonPill>test 4</ButtonPill>
+                <ButtonPill>test 5</ButtonPill>
+                <ButtonPill>test 6</ButtonPill>
+              </div>
+            </Popover>
+          );
+
+          // When space is pressed while focused on the avatar, only one popover opens
+          const avatarButton = await screen.findByRole('button', { name: 'AB' });
+
+          await avatarButton.focus();
+
+          await user.keyboard('{Enter}');
+
+          await waitFor(() => {
+            expect(screen.getByText('test 1')).toBeInTheDocument();
+          });
+
+          if (continuePropagationOnTrigger) {
+            expect(screen.getByText('test 4')).toBeInTheDocument();
+          } else {
+            expect(screen.queryByText('test 4')).not.toBeInTheDocument();
+          }
+        }
+      );
     });
   });
 });

--- a/src/components/Select/Select.unit.test.tsx.snap
+++ b/src/components/Select/Select.unit.test.tsx.snap
@@ -396,6 +396,9 @@ exports[`Select snapshot should match snapshot 1`] = `
               },
               Object {
                 "fn": [Function],
+              },
+              Object {
+                "fn": [Function],
                 "name": "addBackdropPlugin",
               },
             ]
@@ -443,6 +446,9 @@ exports[`Select snapshot should match snapshot 1`] = `
             placement="bottom"
             plugins={
               Array [
+                Object {
+                  "fn": [Function],
+                },
                 Object {
                   "fn": [Function],
                 },
@@ -955,6 +961,9 @@ exports[`Select snapshot should match snapshot before and after opening select d
               },
               Object {
                 "fn": [Function],
+              },
+              Object {
+                "fn": [Function],
                 "name": "addBackdropPlugin",
               },
             ]
@@ -1002,6 +1011,9 @@ exports[`Select snapshot should match snapshot before and after opening select d
             placement="bottom"
             plugins={
               Array [
+                Object {
+                  "fn": [Function],
+                },
                 Object {
                   "fn": [Function],
                 },
@@ -1515,6 +1527,9 @@ exports[`Select snapshot should match snapshot before and after opening select d
               },
               Object {
                 "fn": [Function],
+              },
+              Object {
+                "fn": [Function],
                 "name": "addBackdropPlugin",
               },
             ]
@@ -1562,6 +1577,9 @@ exports[`Select snapshot should match snapshot before and after opening select d
             placement="bottom"
             plugins={
               Array [
+                Object {
+                  "fn": [Function],
+                },
                 Object {
                   "fn": [Function],
                 },
@@ -2602,6 +2620,9 @@ exports[`Select snapshot should match snapshot with border 1`] = `
               },
               Object {
                 "fn": [Function],
+              },
+              Object {
+                "fn": [Function],
                 "name": "addBackdropPlugin",
               },
             ]
@@ -2649,6 +2670,9 @@ exports[`Select snapshot should match snapshot with border 1`] = `
             placement="bottom"
             plugins={
               Array [
+                Object {
+                  "fn": [Function],
+                },
                 Object {
                   "fn": [Function],
                 },
@@ -3162,6 +3186,9 @@ exports[`Select snapshot should match snapshot with className 1`] = `
               },
               Object {
                 "fn": [Function],
+              },
+              Object {
+                "fn": [Function],
                 "name": "addBackdropPlugin",
               },
             ]
@@ -3209,6 +3236,9 @@ exports[`Select snapshot should match snapshot with className 1`] = `
             placement="bottom"
             plugins={
               Array [
+                Object {
+                  "fn": [Function],
+                },
                 Object {
                   "fn": [Function],
                 },
@@ -3722,6 +3752,9 @@ exports[`Select snapshot should match snapshot with direction 1`] = `
               },
               Object {
                 "fn": [Function],
+              },
+              Object {
+                "fn": [Function],
                 "name": "addBackdropPlugin",
               },
             ]
@@ -3769,6 +3802,9 @@ exports[`Select snapshot should match snapshot with direction 1`] = `
             placement="top"
             plugins={
               Array [
+                Object {
+                  "fn": [Function],
+                },
                 Object {
                   "fn": [Function],
                 },
@@ -4292,6 +4328,9 @@ exports[`Select snapshot should match snapshot with disabled option 1`] = `
               },
               Object {
                 "fn": [Function],
+              },
+              Object {
+                "fn": [Function],
                 "name": "addBackdropPlugin",
               },
             ]
@@ -4339,6 +4378,9 @@ exports[`Select snapshot should match snapshot with disabled option 1`] = `
             placement="bottom"
             plugins={
               Array [
+                Object {
+                  "fn": [Function],
+                },
                 Object {
                   "fn": [Function],
                 },
@@ -5382,6 +5424,9 @@ exports[`Select snapshot should match snapshot with id 1`] = `
               },
               Object {
                 "fn": [Function],
+              },
+              Object {
+                "fn": [Function],
                 "name": "addBackdropPlugin",
               },
             ]
@@ -5429,6 +5474,9 @@ exports[`Select snapshot should match snapshot with id 1`] = `
             placement="bottom"
             plugins={
               Array [
+                Object {
+                  "fn": [Function],
+                },
                 Object {
                   "fn": [Function],
                 },
@@ -5706,6 +5754,9 @@ exports[`Select snapshot should match snapshot with isInForm = false 1`] = `
               },
               Object {
                 "fn": [Function],
+              },
+              Object {
+                "fn": [Function],
                 "name": "addBackdropPlugin",
               },
             ]
@@ -5753,6 +5804,9 @@ exports[`Select snapshot should match snapshot with isInForm = false 1`] = `
             placement="bottom"
             plugins={
               Array [
+                Object {
+                  "fn": [Function],
+                },
                 Object {
                   "fn": [Function],
                 },
@@ -6266,6 +6320,9 @@ exports[`Select snapshot should match snapshot with listbox opened 1`] = `
               },
               Object {
                 "fn": [Function],
+              },
+              Object {
+                "fn": [Function],
                 "name": "addBackdropPlugin",
               },
             ]
@@ -6313,6 +6370,9 @@ exports[`Select snapshot should match snapshot with listbox opened 1`] = `
             placement="bottom"
             plugins={
               Array [
+                Object {
+                  "fn": [Function],
+                },
                 Object {
                   "fn": [Function],
                 },
@@ -7351,6 +7411,9 @@ exports[`Select snapshot should match snapshot with listboxMaxHeight 1`] = `
               },
               Object {
                 "fn": [Function],
+              },
+              Object {
+                "fn": [Function],
                 "name": "addBackdropPlugin",
               },
             ]
@@ -7398,6 +7461,9 @@ exports[`Select snapshot should match snapshot with listboxMaxHeight 1`] = `
             placement="bottom"
             plugins={
               Array [
+                Object {
+                  "fn": [Function],
+                },
                 Object {
                   "fn": [Function],
                 },
@@ -8435,6 +8501,9 @@ exports[`Select snapshot should match snapshot with listboxWidth 1`] = `
               },
               Object {
                 "fn": [Function],
+              },
+              Object {
+                "fn": [Function],
                 "name": "addBackdropPlugin",
               },
             ]
@@ -8482,6 +8551,9 @@ exports[`Select snapshot should match snapshot with listboxWidth 1`] = `
             placement="bottom"
             plugins={
               Array [
+                Object {
+                  "fn": [Function],
+                },
                 Object {
                   "fn": [Function],
                 },
@@ -9525,6 +9597,9 @@ exports[`Select snapshot should match snapshot with placeholder 1`] = `
               },
               Object {
                 "fn": [Function],
+              },
+              Object {
+                "fn": [Function],
                 "name": "addBackdropPlugin",
               },
             ]
@@ -9572,6 +9647,9 @@ exports[`Select snapshot should match snapshot with placeholder 1`] = `
             placement="bottom"
             plugins={
               Array [
+                Object {
+                  "fn": [Function],
+                },
                 Object {
                   "fn": [Function],
                 },
@@ -10116,6 +10194,9 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
               },
               Object {
                 "fn": [Function],
+              },
+              Object {
+                "fn": [Function],
                 "name": "addBackdropPlugin",
               },
             ]
@@ -10163,6 +10244,9 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
             placement="bottom"
             plugins={
               Array [
+                Object {
+                  "fn": [Function],
+                },
                 Object {
                   "fn": [Function],
                 },
@@ -10710,6 +10794,9 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
               },
               Object {
                 "fn": [Function],
+              },
+              Object {
+                "fn": [Function],
                 "name": "addBackdropPlugin",
               },
             ]
@@ -10757,6 +10844,9 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
             placement="bottom"
             plugins={
               Array [
+                Object {
+                  "fn": [Function],
+                },
                 Object {
                   "fn": [Function],
                 },
@@ -11888,6 +11978,9 @@ exports[`Select snapshot should match snapshot with style 1`] = `
               },
               Object {
                 "fn": [Function],
+              },
+              Object {
+                "fn": [Function],
                 "name": "addBackdropPlugin",
               },
             ]
@@ -11935,6 +12028,9 @@ exports[`Select snapshot should match snapshot with style 1`] = `
             placement="bottom"
             plugins={
               Array [
+                Object {
+                  "fn": [Function],
+                },
                 Object {
                   "fn": [Function],
                 },
@@ -12446,6 +12542,9 @@ exports[`Select snapshot should match snapshot with title 1`] = `
               },
               Object {
                 "fn": [Function],
+              },
+              Object {
+                "fn": [Function],
                 "name": "addBackdropPlugin",
               },
             ]
@@ -12493,6 +12592,9 @@ exports[`Select snapshot should match snapshot with title 1`] = `
             placement="bottom"
             plugins={
               Array [
+                Object {
+                  "fn": [Function],
+                },
                 Object {
                   "fn": [Function],
                 },

--- a/src/components/TooltipPopoverCombo/TooltipPopoverCombo.unit.test.tsx.snap
+++ b/src/components/TooltipPopoverCombo/TooltipPopoverCombo.unit.test.tsx.snap
@@ -127,6 +127,9 @@ exports[`<TooltipPopoverCombo /> snapshot should match snapshot 1`] = `
               "fn": [Function],
             },
             Object {
+              "fn": [Function],
+            },
+            Object {
               "defaultValue": true,
               "fn": [Function],
               "name": "hideOnEsc",
@@ -180,6 +183,9 @@ exports[`<TooltipPopoverCombo /> snapshot should match snapshot 1`] = `
           placement="auto"
           plugins={
             Array [
+              Object {
+                "fn": [Function],
+              },
               Object {
                 "fn": [Function],
               },
@@ -343,6 +349,9 @@ exports[`<TooltipPopoverCombo /> snapshot should match snapshot 1`] = `
                         "fn": [Function],
                       },
                       Object {
+                        "fn": [Function],
+                      },
+                      Object {
                         "defaultValue": true,
                         "fn": [Function],
                         "name": "hideOnEsc",
@@ -392,6 +401,9 @@ exports[`<TooltipPopoverCombo /> snapshot should match snapshot 1`] = `
                     placement="auto"
                     plugins={
                       Array [
+                        Object {
+                          "fn": [Function],
+                        },
                         Object {
                           "fn": [Function],
                         },
@@ -618,6 +630,9 @@ exports[`<TooltipPopoverCombo /> snapshot should match snapshot with otherPopove
               "fn": [Function],
             },
             Object {
+              "fn": [Function],
+            },
+            Object {
               "defaultValue": true,
               "fn": [Function],
               "name": "hideOnEsc",
@@ -671,6 +686,9 @@ exports[`<TooltipPopoverCombo /> snapshot should match snapshot with otherPopove
           placement="auto"
           plugins={
             Array [
+              Object {
+                "fn": [Function],
+              },
               Object {
                 "fn": [Function],
               },
@@ -835,6 +853,9 @@ exports[`<TooltipPopoverCombo /> snapshot should match snapshot with otherPopove
                         "fn": [Function],
                       },
                       Object {
+                        "fn": [Function],
+                      },
+                      Object {
                         "defaultValue": true,
                         "fn": [Function],
                         "name": "hideOnEsc",
@@ -884,6 +905,9 @@ exports[`<TooltipPopoverCombo /> snapshot should match snapshot with otherPopove
                     placement="bottom"
                     plugins={
                       Array [
+                        Object {
+                          "fn": [Function],
+                        },
                         Object {
                           "fn": [Function],
                         },
@@ -1110,6 +1134,9 @@ exports[`<TooltipPopoverCombo /> snapshot should match snapshot with otherToolti
               "fn": [Function],
             },
             Object {
+              "fn": [Function],
+            },
+            Object {
               "defaultValue": true,
               "fn": [Function],
               "name": "hideOnEsc",
@@ -1163,6 +1190,9 @@ exports[`<TooltipPopoverCombo /> snapshot should match snapshot with otherToolti
           placement="auto"
           plugins={
             Array [
+              Object {
+                "fn": [Function],
+              },
               Object {
                 "fn": [Function],
               },
@@ -1327,6 +1357,9 @@ exports[`<TooltipPopoverCombo /> snapshot should match snapshot with otherToolti
                         "fn": [Function],
                       },
                       Object {
+                        "fn": [Function],
+                      },
+                      Object {
                         "defaultValue": true,
                         "fn": [Function],
                         "name": "hideOnEsc",
@@ -1376,6 +1409,9 @@ exports[`<TooltipPopoverCombo /> snapshot should match snapshot with otherToolti
                     placement="top"
                     plugins={
                       Array [
+                        Object {
+                          "fn": [Function],
+                        },
                         Object {
                           "fn": [Function],
                         },


### PR DESCRIPTION
# Description

Prior to this change, keyboard enter press popovers with nested triggers would open them both. We don't want this ordinarily. Added a new prop **continuePropagationOnTrigger** to re-enable this behavior if we decide we do have a case for it

# Links

*Links to relevent resources.*
