### PR TITLE
fix(): adding aria-label and aria-describedby to input props

### DIFF
--- a/src/components/CodeInput/CodeInput.tsx
+++ b/src/components/CodeInput/CodeInput.tsx
@@ -17,6 +17,7 @@ const CodeInput: React.FC<Props> = (props: Props): ReactElement => {
       /* Optional */
     },
     ariaLabel,
+    ariaDescribedby,
     messageArr = [],
     disabled = false,
     className,
@@ -49,7 +50,13 @@ const CodeInput: React.FC<Props> = (props: Props): ReactElement => {
   return (
     <div className={classnames(STYLE.wrapper, className)} data-level={messageType}>
       <VerificationInput
-        inputProps={{ 'aria-label': ariaLabel, id: inputId, name: inputId, disabled }}
+        inputProps={{
+          'aria-label': `${ariaLabel ? ariaLabel : ''}, field ${value.length + 1} of ${numDigits}`,
+          'aria-describedby': `${ariaDescribedby}`,
+          id: inputId,
+          name: inputId,
+          disabled,
+        }}
         length={numDigits}
         onChange={setValue}
         onFocus={() => {

--- a/src/components/CodeInput/CodeInput.tsx
+++ b/src/components/CodeInput/CodeInput.tsx
@@ -51,8 +51,8 @@ const CodeInput: React.FC<Props> = (props: Props): ReactElement => {
     <div className={classnames(STYLE.wrapper, className)} data-level={messageType}>
       <VerificationInput
         inputProps={{
-          'aria-label': `${ariaLabel ? ariaLabel : ''}, field ${value.length + 1} of ${numDigits}`,
-          'aria-describedby': `${ariaDescribedby}`,
+          'aria-label': ariaLabel,
+          'aria-describedby': ariaDescribedby,
           id: inputId,
           name: inputId,
           disabled,

--- a/src/components/CodeInput/CodeInput.types.ts
+++ b/src/components/CodeInput/CodeInput.types.ts
@@ -34,4 +34,8 @@ export interface Props {
    * referencing to htmlFor attribute of <label> tag in cantina.
    */
   inputId?: string;
+  /**
+   * ariaDescribedby: the aria-describedby attribute to be passed to the input
+   */
+  ariaDescribedby?: string;
 }

--- a/src/components/CodeInput/CodeInput.unit.test.tsx
+++ b/src/components/CodeInput/CodeInput.unit.test.tsx
@@ -39,7 +39,7 @@ describe('CodeInput', () => {
         0
       );
       expect(component.find('input').prop('aria-label')).toBeDefined();
-      expect(component.find('input').prop('aria-label')).toBe('enter 6 digit code, field 1 of 6');
+      expect(component.find('input').prop('aria-label')).toBe('enter 6 digit code');
     });
 
     it('input accepts prop ariaDescribedby', () => {

--- a/src/components/CodeInput/CodeInput.unit.test.tsx
+++ b/src/components/CodeInput/CodeInput.unit.test.tsx
@@ -34,12 +34,20 @@ describe('CodeInput', () => {
       expect(component.find('input').props().disabled).toBeTruthy();
     });
 
-    it('input accepts prop aria-label', () => {
+    it('input accepts prop ariaLabel', () => {
       const component = mount(<CodeInput numDigits={6} ariaLabel="enter 6 digit code" />).childAt(
         0
       );
       expect(component.find('input').prop('aria-label')).toBeDefined();
-      expect(component.find('input').prop('aria-label')).toBe('enter 6 digit code');
+      expect(component.find('input').prop('aria-label')).toBe('enter 6 digit code, field 1 of 6');
+    });
+
+    it('input accepts prop ariaDescribedby', () => {
+      const component = mount(
+        <CodeInput numDigits={6} ariaDescribedby="invalid input code" />
+      ).childAt(0);
+      expect(component.find('input').prop('aria-describedby')).toBeDefined();
+      expect(component.find('input').prop('aria-describedby')).toBe('invalid input code');
     });
 
     it('input accepts prop name and id', () => {

--- a/src/components/CodeInput/CodeInput.unit.test.tsx.snap
+++ b/src/components/CodeInput/CodeInput.unit.test.tsx.snap
@@ -21,7 +21,8 @@ exports[`CodeInput snapshot should match snapshot 1`] = `
       debug={false}
       inputProps={
         Object {
-          "aria-label": undefined,
+          "aria-describedby": "undefined",
+          "aria-label": ", field 1 of 6",
           "disabled": false,
           "id": undefined,
           "name": undefined,
@@ -39,6 +40,8 @@ exports[`CodeInput snapshot should match snapshot 1`] = `
         className="vi__wrapper"
       >
         <input
+          aria-describedby="undefined"
+          aria-label=", field 1 of 6"
           className="vi"
           disabled={false}
           onBlur={[Function]}

--- a/src/components/CodeInput/CodeInput.unit.test.tsx.snap
+++ b/src/components/CodeInput/CodeInput.unit.test.tsx.snap
@@ -21,8 +21,8 @@ exports[`CodeInput snapshot should match snapshot 1`] = `
       debug={false}
       inputProps={
         Object {
-          "aria-describedby": "undefined",
-          "aria-label": ", field 1 of 6",
+          "aria-describedby": undefined,
+          "aria-label": undefined,
           "disabled": false,
           "id": undefined,
           "name": undefined,
@@ -40,8 +40,6 @@ exports[`CodeInput snapshot should match snapshot 1`] = `
         className="vi__wrapper"
       >
         <input
-          aria-describedby="undefined"
-          aria-label=", field 1 of 6"
           className="vi"
           disabled={false}
           onBlur={[Function]}


### PR DESCRIPTION
# IMPORTANT

**Currently, this project is closed to any external contributions. Any pull request made against this project from external sources will likely be closed. If you would like to make changes to this project, please fork this project.**

# Guide

**This "Help" section can be deleted before submitting this pull request.**

*Update the name of this pull request to reflect the following shape:*

```
{type}/{scope?}/{message}
```

* **type** - A [conventional commit type](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional#type-enum) **REQUIRED**
* **scope** - The kabab-case scope of the changes in this request
* **message** - A short, kebab-case statement describing the changes **REQUIRED**

*Provide a general summary of the scope of the changes in this pull request.*

* [Readme](https://github.com/momentum-design/momentum-react-v2/blob/master/README.md)
* [Getting Started Guide](https://github.com/momentum-design/momentum-react-v2/blob/master/GETTING_STARTED.md)
* [Contributing Guide](https://github.com/momentum-design/momentum-react-v2/blob/master/CONTRIBUTING.md)

# Description

added aria-label to input props in `codeInput` so confirmation code digits can be announces as {ariaLabel}, field {value.length} of {length} - eg: field 1 of 6, 2 of 6...

added ariaDescribedby as optional prop so aria-describedby attr can be set for `input` - to link errors correctly. 

# Links

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-367530
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-367490
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-502437
