### PR TITLE
fix(button-circle): justify content in center

### DIFF
--- a/src/components/ButtonCircle/ButtonCircle.style.scss
+++ b/src/components/ButtonCircle/ButtonCircle.style.scss
@@ -622,7 +622,7 @@
   border-radius: 100vh;
   display: flex;
   flex-shrink: 0;
-  justify-content: space-evenly;
+  justify-content: center;
 
   &[data-size='64'] {
     font-size: 1.6rem;


### PR DESCRIPTION
# Description

Not sure when this broke, but sometime in the past 10 months. Icons on smaller ButtonCircles are not centred properly

|Before|After|
|---|---|
|![Screenshot 2024-07-01 at 11 44 49](https://github.com/momentum-design/momentum-react-v2/assets/86778628/7db53cfe-4282-47ad-bfd3-67c34c5bc5c5)|![Screenshot 2024-07-01 at 11 44 53](https://github.com/momentum-design/momentum-react-v2/assets/86778628/fbdb0995-5f97-4009-b8c1-93a8e3c1aeb3)|



# Links

This will fix the following issues

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-538760
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-538761
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-538762
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-538764

and possible others I've missed in the app