### PR TITLE
fix(overlay-alert): fix for OverlayAlert closing if triggerElement is TooltipPopoverCombo

### DIFF
--- a/src/components/OverlayAlert/OverlayAlert.unit.test.tsx
+++ b/src/components/OverlayAlert/OverlayAlert.unit.test.tsx
@@ -462,7 +462,7 @@ describe('<OverlayAlert />', () => {
       const Component = () => {
         return (
           <>
-            <OverlayAlert onClose={onCloseMock}>
+            <OverlayAlert onClose={onCloseMock} controls={<ButtonControl control='close' onPress={onCloseMock}/>}>
               <Tooltip triggerComponent={<button>button1</button>} type="none">
                 Tooltip text
               </Tooltip>
@@ -512,7 +512,7 @@ describe('<OverlayAlert />', () => {
       const Component = () => {
         return (
           <>
-            <OverlayAlert onClose={onCloseMock}>
+            <OverlayAlert onClose={onCloseMock} controls={<ButtonControl control='close' onPress={onCloseMock}/>}>
               <Popover
                 triggerComponent={<button>button1</button>}
                 hideOnEsc={false}
@@ -560,7 +560,7 @@ describe('<OverlayAlert />', () => {
       const Component = () => {
         return (
           <>
-            <OverlayAlert onClose={onCloseMock}>
+            <OverlayAlert onClose={onCloseMock}controls={<ButtonControl control='close' onPress={onCloseMock}/>}>
               <Popover triggerComponent={<button>button1</button>} interactive>
                 <button>button2</button>
               </Popover>
@@ -615,7 +615,7 @@ describe('<OverlayAlert />', () => {
       const Component = () => {
         return (
           <>
-            <OverlayAlert onClose={onCloseMock}>
+            <OverlayAlert onClose={onCloseMock} controls={<ButtonControl control='close' onPress={onCloseMock}/>}>
               <Popover triggerComponent={<button>button1</button>} interactive hideOnEsc={false}>
                 <button>button2</button>
               </Popover>

--- a/src/components/OverlayAlert/OverlayAlert.unit.test.tsx
+++ b/src/components/OverlayAlert/OverlayAlert.unit.test.tsx
@@ -462,7 +462,7 @@ describe('<OverlayAlert />', () => {
       const Component = () => {
         return (
           <>
-            <OverlayAlert onClose={onCloseMock} controls={<ButtonControl control='close' onPress={onCloseMock}/>}>
+            <OverlayAlert onClose={onCloseMock}>
               <Tooltip triggerComponent={<button>button1</button>} type="none">
                 Tooltip text
               </Tooltip>
@@ -512,7 +512,7 @@ describe('<OverlayAlert />', () => {
       const Component = () => {
         return (
           <>
-            <OverlayAlert onClose={onCloseMock} controls={<ButtonControl control='close' onPress={onCloseMock}/>}>
+            <OverlayAlert onClose={onCloseMock}>
               <Popover
                 triggerComponent={<button>button1</button>}
                 hideOnEsc={false}
@@ -560,7 +560,7 @@ describe('<OverlayAlert />', () => {
       const Component = () => {
         return (
           <>
-            <OverlayAlert onClose={onCloseMock}controls={<ButtonControl control='close' onPress={onCloseMock}/>}>
+            <OverlayAlert onClose={onCloseMock}>
               <Popover triggerComponent={<button>button1</button>} interactive>
                 <button>button2</button>
               </Popover>
@@ -615,7 +615,7 @@ describe('<OverlayAlert />', () => {
       const Component = () => {
         return (
           <>
-            <OverlayAlert onClose={onCloseMock} controls={<ButtonControl control='close' onPress={onCloseMock}/>}>
+            <OverlayAlert onClose={onCloseMock}>
               <Popover triggerComponent={<button>button1</button>} interactive hideOnEsc={false}>
                 <button>button2</button>
               </Popover>

--- a/src/components/Popover/tippy-plugins/hideOnEscPlugin.ts
+++ b/src/components/Popover/tippy-plugins/hideOnEscPlugin.ts
@@ -30,11 +30,7 @@ const addInstance = (instance: TippyInstance) => {
   openedTippyInstances.push(instance);
 
   // Send custom event that tippy instance is shown on screen. This event is listened for in instances of OverlayAlert to prevent it from closing unintentionally.
-  //
-  // We do this in the next event cycle because, if we don't, and the first element focused in an OverlayAlert is the trigger of a tooltip, then the event is
-  // dispatched before the OverlayAlert is mounted. (Use setTimeout without delay to execute code in the
-  // next event cycle, see https://developer.mozilla.org/en-US/docs/Web/API/setTimeout#delay)
-  setTimeout(() => dispatchEvent(EventType.TIPPY_INSTANCE_ADDED, instance));
+  dispatchEvent(EventType.TIPPY_INSTANCE_ADDED, instance);
 };
 
 /**

--- a/src/hooks/useShouldCloseOnEsc.ts
+++ b/src/hooks/useShouldCloseOnEsc.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useLayoutEffect, useState } from 'react';
 
 import * as PopoverEvents from '../components/Popover/Popover.events';
 
@@ -41,7 +41,7 @@ export const useShouldCloseOnEsc = (): { shouldCloseOnEsc: boolean } => {
     });
   };
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const addId = PopoverEvents.addListener(PopoverEvents.EventType.TIPPY_INSTANCE_ADDED, add);
     const removeId = PopoverEvents.addListener(
       PopoverEvents.EventType.TIPPY_INSTANCE_REMOVED,


### PR DESCRIPTION
# Description

There was a race condition where
1. TooltipPopoverCombo opened
2. Item in Popover opened an OverlyAlert
3. Popover closed
4. OverlayAlert opened and started tracking popover instances
5. Tooltip of TooltipPopoverCombo opened
6. OverlayAlert couldn't close because the tooltip was supposedly open (although not visible...)

# Links

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-538778
