### PR TITLE
feat(menutrigger): expose triggerComponentRef which ref to button

### DIFF
--- a/src/components/MenuTrigger/MenuTrigger.tsx
+++ b/src/components/MenuTrigger/MenuTrigger.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactElement, useRef, Children, useState, useEffect, useCallback } from 'react';
+import React, { ReactElement, useRef, Children, useState, useEffect, useImperativeHandle, forwardRef, ForwardedRef, RefObject } from 'react';
 import classnames from 'classnames';
 
 import { STYLE, DEFAULTS } from './MenuTrigger.constants';
@@ -14,7 +14,7 @@ import type { PopoverInstance, VariantType } from '../Popover/Popover.types';
 import type { FocusStrategy } from '@react-types/shared';
 import type { PlacementType } from '../ModalArrow/ModalArrow.types';
 
-const MenuTrigger: FC<Props> = (props: Props) => {
+const MenuTrigger = forwardRef((props: Props, ref: ForwardedRef<{triggerComponentRef: RefObject<HTMLButtonElement>}>) => {
   const {
     className,
     id,
@@ -35,6 +35,10 @@ const MenuTrigger: FC<Props> = (props: Props) => {
   const [popoverInstance, setPopoverInstance] = useState<PopoverInstance>();
 
   const buttonRef = useRef<HTMLButtonElement>();
+
+  useImperativeHandle(ref, () => ({
+      triggerComponentRef: buttonRef,
+    }), []);
 
   const [...menus] = Children.toArray(children);
 
@@ -139,6 +143,6 @@ const MenuTrigger: FC<Props> = (props: Props) => {
       })}
     </Popover>
   );
-};
+});
 
 export default MenuTrigger;

--- a/src/components/MenuTrigger/MenuTrigger.unit.test.tsx
+++ b/src/components/MenuTrigger/MenuTrigger.unit.test.tsx
@@ -273,6 +273,23 @@ describe('<MenuTrigger /> - React Testing Library', () => {
       expect(button.getAttribute('aria-haspopup')).toBe('true');
     });
 
+    it('exposes triggerComponentRef which references the button element', async () => {
+      const ref = {
+        current: {
+          triggerComponentRef: {
+            current: null,
+          },
+        },
+      };
+
+      render(<MenuTrigger {...defaultProps} ref={ref} />);
+
+      const button = screen.getByRole('button', { name: 'Open Menu' });
+      
+      // Assert that the triggerComponentRef in the ref is the same as the button element
+      expect(ref.current.triggerComponentRef.current).toBe(button);
+    });
+
     it('triggerComponent can have aria-haspopup as passed in props', async () => {
       render(
         <MenuTrigger

--- a/src/components/MenuTrigger/MenuTrigger.unit.test.tsx.snap
+++ b/src/components/MenuTrigger/MenuTrigger.unit.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot 1`] = `
-<MenuTrigger
+<ForwardRef
   aria-label="Menu Trigger Component "
   isOpen={true}
   triggerComponent={
@@ -2190,11 +2190,11 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot 1`] = `
       </ForwardRef(TippyWrapper)>
     </LazyTippy>
   </Popover>
-</MenuTrigger>
+</ForwardRef>
 `;
 
 exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with className 1`] = `
-<MenuTrigger
+<ForwardRef
   aria-label="Menu Trigger Component "
   className="example-class"
   isOpen={true}
@@ -4384,11 +4384,11 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with className 
       </ForwardRef(TippyWrapper)>
     </LazyTippy>
   </Popover>
-</MenuTrigger>
+</ForwardRef>
 `;
 
 exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with color 1`] = `
-<MenuTrigger
+<ForwardRef
   aria-label="Menu Trigger Component "
   color="secondary"
   isOpen={true}
@@ -6578,11 +6578,11 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with color 1`] 
       </ForwardRef(TippyWrapper)>
     </LazyTippy>
   </Popover>
-</MenuTrigger>
+</ForwardRef>
 `;
 
 exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with id 1`] = `
-<MenuTrigger
+<ForwardRef
   aria-label="Menu Trigger Component "
   id="example-id"
   isOpen={true}
@@ -8776,11 +8776,11 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with id 1`] = `
       </ForwardRef(TippyWrapper)>
     </LazyTippy>
   </Popover>
-</MenuTrigger>
+</ForwardRef>
 `;
 
 exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with placement 1`] = `
-<MenuTrigger
+<ForwardRef
   aria-label="Menu Trigger Component "
   isOpen={true}
   placement="top"
@@ -10970,11 +10970,11 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with placement 
       </ForwardRef(TippyWrapper)>
     </LazyTippy>
   </Popover>
-</MenuTrigger>
+</ForwardRef>
 `;
 
 exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with showArrow 1`] = `
-<MenuTrigger
+<ForwardRef
   aria-label="Menu Trigger Component "
   isOpen={true}
   showArrow={true}
@@ -13230,11 +13230,11 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with showArrow 
       </ForwardRef(TippyWrapper)>
     </LazyTippy>
   </Popover>
-</MenuTrigger>
+</ForwardRef>
 `;
 
 exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with style 1`] = `
-<MenuTrigger
+<ForwardRef
   aria-label="Menu Trigger Component "
   isOpen={true}
   style={
@@ -15444,11 +15444,11 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with style 1`] 
       </ForwardRef(TippyWrapper)>
     </LazyTippy>
   </Popover>
-</MenuTrigger>
+</ForwardRef>
 `;
 
 exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with variant 1`] = `
-<MenuTrigger
+<ForwardRef
   aria-label="Menu Trigger Component "
   isOpen={true}
   triggerComponent={
@@ -17638,11 +17638,11 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with variant 1`
       </ForwardRef(TippyWrapper)>
     </LazyTippy>
   </Popover>
-</MenuTrigger>
+</ForwardRef>
 `;
 
 exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with zIndex 1`] = `
-<MenuTrigger
+<ForwardRef
   aria-label="Menu Trigger Component "
   isOpen={true}
   triggerComponent={
@@ -19836,5 +19836,5 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with zIndex 1`]
       </ForwardRef(TippyWrapper)>
     </LazyTippy>
   </Popover>
-</MenuTrigger>
+</ForwardRef>
 `;


### PR DESCRIPTION
# Description
Exposes triggerComponentRef which references the button element, this is required by Cantina when the trigger button opens a modal and that modal opens another modal - on closing 2nd modal we should have reference to this trigger button to focus back
*The full description of the changes made in this request.*

# Links

*Links to relevent resources.*
