### PR TITLE
fix(SearchInput): onkeydown to handle shift tab and escape cases

### DIFF
--- a/src/components/SearchInput/SearchInput.tsx
+++ b/src/components/SearchInput/SearchInput.tsx
@@ -45,12 +45,8 @@ const SearchInput = (props: Props, ref: RefObject<HTMLInputElement>): ReactEleme
   const { onKeyDown, ...otherAriaInputProps } = ariaInputProps;
 
   const internalOnKeyDown = (e) => {
-    // When the input is empty, pressing escape should be
-    // propagated to the parent so that popovers can close
-    if (e.key === 'Escape' && !state.value) {
-      containerRef.current.dispatchEvent(new KeyboardEvent('keydown', e));
-    }
-
+    // for propagating events to parent components
+    e.continuePropagation();
     onKeyDown(e);
   };
 


### PR DESCRIPTION
# IMPORTANT

**Currently, this project is closed to any external contributions. Any pull request made against this project from external sources will likely be closed. If you would like to make changes to this project, please fork this project.**

# Guide

**This "Help" section can be deleted before submitting this pull request.**

*Update the name of this pull request to reflect the following shape:*

```
{type}/{scope?}/{message}
```

* **type** - A [conventional commit type](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional#type-enum) **REQUIRED**
* **scope** - The kabab-case scope of the changes in this request
* **message** - A short, kebab-case statement describing the changes **REQUIRED**

*Provide a general summary of the scope of the changes in this pull request.*

* [Readme](https://github.com/momentum-design/momentum-react-v2/blob/master/README.md)
* [Getting Started Guide](https://github.com/momentum-design/momentum-react-v2/blob/master/GETTING_STARTED.md)
* [Contributing Guide](https://github.com/momentum-design/momentum-react-v2/blob/master/CONTRIBUTING.md)

# Description

*The full description of the changes made in this request.*
- Shifttab in breakout session manager dialog would move focus to outside of dialog. Event wasn't propagating upward so the focus wasn't being properly trapped in the dialog. 

Focus on search element
![Screenshot 2024-07-03 at 10 57 52 AM](https://github.com/momentum-design/momentum-react-v2/assets/18541184/ee1399b2-2c7b-474d-86e4-c68483f70a4e)

After hitting shift tab, focus on more panels button outside of dialog
![Screenshot 2024-07-03 at 11 00 34 AM](https://github.com/momentum-design/momentum-react-v2/assets/18541184/fff33e43-3808-4d8b-840f-3dbe3aa5846c)


# Links
*Links to relevent resources.*
[https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-505167](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-505167)
