### PR TITLE
feat(reaction-aria-toolbar): changes

### DIFF
--- a/src/components/AriaToolbar/AriaToolbar.constants.ts
+++ b/src/components/AriaToolbar/AriaToolbar.constants.ts
@@ -2,6 +2,7 @@ const CLASS_PREFIX = 'md-aria-toolbar';
 
 const DEFAULTS = {
   ORIENTATION: 'horizontal',
+  SHOULD_RENDER_AS_BUTTON_GROUP: false,
 };
 
 const STYLE = {

--- a/src/components/AriaToolbar/AriaToolbar.stories.args.ts
+++ b/src/components/AriaToolbar/AriaToolbar.stories.args.ts
@@ -25,6 +25,55 @@ const ariaToolbarArgTypes = {
       },
     },
   },
+  ariaToolbarItemsSize: {
+    description: 'The number of items in the toolbar',
+    control: { type: 'number' },
+    table: {
+      type: {
+        summary: 'number',
+      },
+      defaultValue: {
+        summary: 'undefined',
+      },
+    },
+  },
+  shouldRenderAsButtonGroup: {
+    description: 'Determines if the toolbar should render as a button group',
+    control: { type: 'boolean' },
+    table: {
+      type: {
+        summary: 'boolean',
+      },
+      defaultValue: {
+        summary: 'false',
+      },
+    },
+  },
+  buttonGroupProps: {
+    description: 'Props to pass to the ButtonGroup component',
+    control: { type: 'object' },
+    table: {
+      type: {
+        summary: 'ButtonGroupProps',
+      },
+      defaultValue: {
+        summary: 'undefined',
+      },
+    },
+  },
+  orientation: {
+    description: 'The orientation of the toolbar',
+    options: ['horizontal', 'vertical'],
+    control: { type: 'select' },
+    table: {
+      type: {
+        summary: 'string',
+      },
+      defaultValue: {
+        summary: 'horizontal',
+      },
+    },
+  },
 };
 
 export { ariaToolbarArgTypes };

--- a/src/components/AriaToolbar/AriaToolbar.stories.tsx
+++ b/src/components/AriaToolbar/AriaToolbar.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { DocumentationPage } from '../../storybook/helper.stories.docs';
 import StyleDocs from '../../storybook/docs.stories.style.mdx';
 
-import AriaToolbar from './';
+import AriaToolbar, { AriaToolbarProps } from './';
 import Documentation from './AriaToolbar.stories.docs.mdx';
 import ButtonCircle from '../ButtonCircle';
 import ButtonPill from '../ButtonPill';
@@ -12,6 +12,8 @@ import Popover from '../Popover';
 import argTypes from './AriaToolbar.stories.args';
 import { Props } from './AriaToolbar.types';
 import AriaToolbarItem from '../AriaToolbarItem';
+import { Template } from '../../storybook/helper.stories.templates';
+import { action } from '@storybook/addon-actions';
 
 export default {
   title: 'Momentum UI/AriaToolbar',
@@ -205,4 +207,35 @@ const IncludesPopoverAndTooltips = () => {
 
 IncludesPopoverAndTooltips.argTypes = argTypes;
 
-export { Horizontal, Vertical, WithinPopover, IncludesPopoverAndTooltips };
+const RenderedAsButtonGroup = Template<AriaToolbarProps>(AriaToolbar).bind({});
+
+RenderedAsButtonGroup.argTypes = { ...argTypes };
+RenderedAsButtonGroup.args = {
+  ariaToolbarItemsSize: 3,
+  orientation: 'horizontal',
+  ariaLabel: 'Example aria toolbar rendered as button group.',
+  shouldRenderAsButtonGroup: true,
+  buttonGroupProps: {
+    round: true,
+    separator: true,
+  },
+  children: [
+    <AriaToolbarItem itemIndex={0}>
+      <ButtonCircle ghost onPress={action('press item 0')}>
+        1
+      </ButtonCircle>
+    </AriaToolbarItem>,
+    <AriaToolbarItem itemIndex={1}>
+      <ButtonCircle ghost onPress={action('press item 1')}>
+        2
+      </ButtonCircle>
+    </AriaToolbarItem>,
+    <AriaToolbarItem itemIndex={2}>
+      <ButtonCircle ghost onPress={action('press item 2')}>
+        3
+      </ButtonCircle>
+    </AriaToolbarItem>,
+  ],
+};
+
+export { Horizontal, Vertical, WithinPopover, IncludesPopoverAndTooltips, RenderedAsButtonGroup };

--- a/src/components/AriaToolbar/AriaToolbar.stories.tsx
+++ b/src/components/AriaToolbar/AriaToolbar.stories.tsx
@@ -10,6 +10,8 @@ import ButtonSimple from '../ButtonSimple';
 import Popover from '../Popover';
 
 import argTypes from './AriaToolbar.stories.args';
+import { Props } from './AriaToolbar.types';
+import AriaToolbarItem from '../AriaToolbarItem';
 
 export default {
   title: 'Momentum UI/AriaToolbar',
@@ -27,18 +29,25 @@ const onPressHandler = () => {
   input.value = input.value + 'a';
 };
 
-const Horizontal = (props) => {
+const Horizontal = (props: Partial<Props>) => {
   return (
     <>
       <AriaToolbar
         ariaLabel="toolbar 1"
         ariaControls="textInput"
         style={{ display: 'flex', columnGap: '0.5rem', marginBottom: '1rem' }}
+        ariaToolbarItemsSize={3}
         {...props}
       >
-        <ButtonPill onPress={onPressHandler}>Item 1</ButtonPill>
-        <ButtonCircle onPress={onPressHandler}>2</ButtonCircle>
-        <ButtonCircle onPress={onPressHandler}>3</ButtonCircle>
+        <AriaToolbarItem itemIndex={0}>
+          <ButtonPill onPress={onPressHandler}>Item 1</ButtonPill>
+        </AriaToolbarItem>
+        <AriaToolbarItem itemIndex={1}>
+          <ButtonCircle onPress={onPressHandler}>2</ButtonCircle>
+        </AriaToolbarItem>
+        <AriaToolbarItem itemIndex={2}>
+          <ButtonCircle onPress={onPressHandler}>3</ButtonCircle>
+        </AriaToolbarItem>
       </AriaToolbar>
       <input type="text" id="textInput" aria-label="A text input" />
     </>
@@ -55,10 +64,19 @@ const Vertical = () => {
         ariaControls="textInput"
         ariaLabel="toolbar 1"
         style={{ display: 'flex', rowGap: '0.5rem', flexDirection: 'column' }}
+        ariaToolbarItemsSize={3}
       >
-        <ButtonCircle onPress={onPressHandler}>1</ButtonCircle>
-        <ButtonCircle onPress={onPressHandler}>2</ButtonCircle>
-        <ButtonCircle onPress={onPressHandler}>3</ButtonCircle>
+        <AriaToolbarItem itemIndex={0}>
+          <ButtonCircle onPress={onPressHandler}>1</ButtonCircle>
+        </AriaToolbarItem>
+
+        <AriaToolbarItem itemIndex={1}>
+          <ButtonCircle onPress={onPressHandler}>2</ButtonCircle>
+        </AriaToolbarItem>
+
+        <AriaToolbarItem itemIndex={2}>
+          <ButtonCircle onPress={onPressHandler}>3</ButtonCircle>
+        </AriaToolbarItem>
       </AriaToolbar>
       <AriaToolbar
         orientation="vertical"
@@ -71,10 +89,19 @@ const Vertical = () => {
           marginTop: '1rem',
           marginBottom: '1rem',
         }}
+        ariaToolbarItemsSize={3}
       >
-        <ButtonCircle onPress={onPressHandler}>1</ButtonCircle>
-        <ButtonCircle onPress={onPressHandler}>2</ButtonCircle>
-        <ButtonCircle onPress={onPressHandler}>3</ButtonCircle>
+        <AriaToolbarItem itemIndex={0}>
+          <ButtonCircle onPress={onPressHandler}>1</ButtonCircle>
+        </AriaToolbarItem>
+
+        <AriaToolbarItem itemIndex={1}>
+          <ButtonCircle onPress={onPressHandler}>2</ButtonCircle>
+        </AriaToolbarItem>
+
+        <AriaToolbarItem itemIndex={2}>
+          <ButtonCircle onPress={onPressHandler}>3</ButtonCircle>
+        </AriaToolbarItem>
       </AriaToolbar>
       <input type="text" id="textInput" aria-label="A text input" />
     </>
@@ -83,16 +110,32 @@ const Vertical = () => {
 
 const WithinPopover = () => {
   return (
-    <Popover trigger="click" interactive triggerComponent={<ButtonSimple style={{ margin: '10rem auto', display: 'flex' }}>Click me!</ButtonSimple>}>
+    <>
+      <Popover
+        trigger="click"
+        interactive
+        triggerComponent={
+          <ButtonSimple style={{ margin: '10rem auto', display: 'flex' }}>Click me!</ButtonSimple>
+        }
+      >
         <AriaToolbar
           orientation="vertical"
           ariaControls="textInput"
           ariaLabel="toolbar 1"
           style={{ display: 'flex', rowGap: '0.5rem', flexDirection: 'column' }}
+          ariaToolbarItemsSize={3}
         >
-          <ButtonCircle onPress={onPressHandler}>1</ButtonCircle>
-          <ButtonCircle onPress={onPressHandler}>2</ButtonCircle>
-          <ButtonCircle onPress={onPressHandler}>3</ButtonCircle>
+          <AriaToolbarItem itemIndex={0}>
+            <ButtonCircle onPress={onPressHandler}>1</ButtonCircle>
+          </AriaToolbarItem>
+
+          <AriaToolbarItem itemIndex={1}>
+            <ButtonCircle onPress={onPressHandler}>2</ButtonCircle>
+          </AriaToolbarItem>
+
+          <AriaToolbarItem itemIndex={2}>
+            <ButtonCircle onPress={onPressHandler}>3</ButtonCircle>
+          </AriaToolbarItem>
         </AriaToolbar>
         <AriaToolbar
           orientation="vertical"
@@ -105,14 +148,61 @@ const WithinPopover = () => {
             marginTop: '1rem',
             marginBottom: '1rem',
           }}
+          ariaToolbarItemsSize={3}
         >
-          <ButtonCircle onPress={onPressHandler}>1</ButtonCircle>
-          <ButtonCircle onPress={onPressHandler}>2</ButtonCircle>
-          <ButtonCircle onPress={onPressHandler}>3</ButtonCircle>
-        </AriaToolbar>
-    </Popover>
+          <AriaToolbarItem itemIndex={0}>
+            <ButtonCircle onPress={onPressHandler}>1</ButtonCircle>
+          </AriaToolbarItem>
 
+          <AriaToolbarItem itemIndex={1}>
+            <ButtonCircle onPress={onPressHandler}>2</ButtonCircle>
+          </AriaToolbarItem>
+
+          <AriaToolbarItem itemIndex={2}>
+            <ButtonCircle onPress={onPressHandler}>3</ButtonCircle>
+          </AriaToolbarItem>
+        </AriaToolbar>
+      </Popover>
+      <input type="text" id="textInput" aria-label="A text input" />
+    </>
   );
 };
 
-export { Horizontal, Vertical, WithinPopover };
+const IncludesPopoverAndTooltips = () => {
+  return (
+    <>
+      <AriaToolbar
+        orientation="vertical"
+        ariaControls="textInput"
+        ariaLabel="toolbar 1"
+        style={{ display: 'flex', rowGap: '0.5rem', flexDirection: 'column' }}
+        ariaToolbarItemsSize={3}
+      >
+        <Popover
+          trigger="click"
+          interactive
+          triggerComponent={
+            <AriaToolbarItem itemIndex={0}>
+              <ButtonCircle onPress={onPressHandler}>1</ButtonCircle>
+            </AriaToolbarItem>
+          }
+        >
+          This is some content.
+        </Popover>
+
+        <AriaToolbarItem itemIndex={1}>
+          <ButtonCircle onPress={onPressHandler}>2</ButtonCircle>
+        </AriaToolbarItem>
+
+        <AriaToolbarItem itemIndex={2}>
+          <ButtonCircle onPress={onPressHandler}>3</ButtonCircle>
+        </AriaToolbarItem>
+      </AriaToolbar>
+      <input type="text" id="textInput" aria-label="A text input" />
+    </>
+  );
+};
+
+IncludesPopoverAndTooltips.argTypes = argTypes;
+
+export { Horizontal, Vertical, WithinPopover, IncludesPopoverAndTooltips };

--- a/src/components/AriaToolbar/AriaToolbar.stories.tsx
+++ b/src/components/AriaToolbar/AriaToolbar.stories.tsx
@@ -220,17 +220,17 @@ RenderedAsButtonGroup.args = {
     separator: true,
   },
   children: [
-    <AriaToolbarItem itemIndex={0}>
+    <AriaToolbarItem itemIndex={0} key={'item 0'}>
       <ButtonCircle ghost onPress={action('press item 0')}>
         1
       </ButtonCircle>
     </AriaToolbarItem>,
-    <AriaToolbarItem itemIndex={1}>
+    <AriaToolbarItem itemIndex={1} key={'item 1'}>
       <ButtonCircle ghost onPress={action('press item 1')}>
         2
       </ButtonCircle>
     </AriaToolbarItem>,
-    <AriaToolbarItem itemIndex={2}>
+    <AriaToolbarItem itemIndex={2} key={'item 2'}>
       <ButtonCircle ghost onPress={action('press item 2')}>
         3
       </ButtonCircle>

--- a/src/components/AriaToolbar/AriaToolbar.stories.tsx
+++ b/src/components/AriaToolbar/AriaToolbar.stories.tsx
@@ -181,8 +181,7 @@ const IncludesPopoverAndTooltips = () => {
         ariaToolbarItemsSize={3}
       >
         <Popover
-          trigger="click"
-          interactive
+          trigger="mouseenter focus"
           triggerComponent={
             <AriaToolbarItem itemIndex={0}>
               <ButtonCircle onPress={onPressHandler}>1</ButtonCircle>

--- a/src/components/AriaToolbar/AriaToolbar.tsx
+++ b/src/components/AriaToolbar/AriaToolbar.tsx
@@ -57,7 +57,7 @@ const AriaToolbar: FC<Props> = (props: Props) => {
   const renderBody = () => {
     if (shouldRenderAsButtonGroup) {
       return (
-        <ButtonGroup {...buttonGroupProps} {...commonProps}>
+        <ButtonGroup {...buttonGroupProps} {...commonProps} orientation={orientation}>
           {children}
         </ButtonGroup>
       );

--- a/src/components/AriaToolbar/AriaToolbar.tsx
+++ b/src/components/AriaToolbar/AriaToolbar.tsx
@@ -1,14 +1,13 @@
-import React, { FC, useRef, useState, useEffect, useCallback, ReactElement } from 'react';
+import React, { FC, useRef, useState, useEffect, useCallback } from 'react';
 import classnames from 'classnames';
 
 import { DEFAULTS, STYLE } from './AriaToolbar.constants';
 import { Props } from './AriaToolbar.types';
-import { useKeyboard } from '@react-aria/interactions';
-import { map } from 'lodash';
 import ButtonGroup from '../ButtonGroup';
+import { AriaToolbarContext } from './AriaToolbar.utils';
 
 /**
- * The AriaToolbar component. A style-less component implementing the Aria Toolbar pattern
+ * The AriaToolbar component. A style-less by default or button-group styled component implementing the Aria Toolbar pattern
  * see https://www.w3.org/WAI/ARIA/apg/patterns/toolbar
  */
 const AriaToolbar: FC<Props> = (props: Props) => {
@@ -18,101 +17,33 @@ const AriaToolbar: FC<Props> = (props: Props) => {
     id,
     style,
     children,
-    orientation = DEFAULTS.ORIENTATION,
+    orientation = DEFAULTS.ORIENTATION as Props['orientation'],
     shouldRenderAsButtonGroup = DEFAULTS.SHOULD_RENDER_AS_BUTTON_GROUP,
     onTabPress,
     ariaControls,
     buttonGroupProps,
+    ariaToolbarItemsSize,
   } = props;
 
   const [currentFocus, setCurrentFocus] = useState(undefined);
 
-  const validChildren = React.Children.toArray(children);
-  const numChildren = validChildren.length;
-
   const buttonRefs = useRef({});
-
-  const { keyboardProps } = useKeyboard({
-    onKeyDown: (e) => {
-      // for the escape key (and other key presses), continue propagation to let Popovers / Modals know that
-      // they should close
-      e.continuePropagation();
-
-      switch (e.key) {
-        case orientation === 'horizontal' ? 'ArrowLeft' : 'ArrowUp':
-          e.preventDefault();
-          setCurrentFocus((numChildren + (currentFocus || 0) - 1) % numChildren);
-          break;
-
-        case orientation === 'horizontal' ? 'ArrowRight' : 'ArrowDown':
-          e.preventDefault();
-          setCurrentFocus((numChildren + (currentFocus || 0) + 1) % numChildren);
-          break;
-
-        case 'Tab': {
-          if (onTabPress) {
-            onTabPress(e);
-          }
-          break;
-        }
-
-        default:
-          break;
-      }
-    },
-  });
 
   useEffect(() => {
     buttonRefs.current[currentFocus]?.focus();
   }, [currentFocus]);
 
-  const getPropsForChildren = useCallback(
-    (child, index) => {
-      return {
-        tabIndex: index === (currentFocus || 0) ? 0 : -1,
-        ref: (e) => {
-          buttonRefs.current[index] = e;
-          if (child.ref) {
-            child.ref(e);
-          }
-        },
-        onFocus: (e) => {
-          setCurrentFocus(index);
-          if (child.props.onFocus) {
-            child.props.onFocus(e);
-          }
-        },
-        onPress: () => {
-          setCurrentFocus(index);
-          if (child.props.onPress) {
-            child.props.onPress();
-          }
-        },
-        useNativeKeyDown: true,
-        ...keyboardProps,
-      };
-    },
-    [currentFocus]
+  const getContext = useCallback(
+    () => ({
+      currentFocus,
+      setCurrentFocus,
+      orientation,
+      onTabPress,
+      ariaToolbarItemsSize,
+      buttonRefs,
+    }),
+    [currentFocus, setCurrentFocus, orientation, onTabPress, ariaToolbarItemsSize, buttonRefs]
   );
-
-  const renderBody = () => {
-    return map(validChildren as React.ReactElement[], (child, index) => {
-      // checks if the child has a triggerComponent (i.e. it's a Tooltip)
-      // in which case we need to clone the trigger...
-      if (child.props.triggerComponent) {
-        const triggerComponent = React.Children.only(child.props.triggerComponent);
-
-        return React.cloneElement(child, {
-          triggerComponent: React.cloneElement(
-            triggerComponent,
-            getPropsForChildren(triggerComponent, index)
-          ),
-        });
-      } else {
-        return React.cloneElement(child, getPropsForChildren(child, index));
-      }
-    });
-  };
 
   const commonProps = {
     className: classnames(className, STYLE.wrapper),
@@ -123,15 +54,21 @@ const AriaToolbar: FC<Props> = (props: Props) => {
     role: 'toolbar',
   };
 
-  if (shouldRenderAsButtonGroup) {
-    return (
-      <ButtonGroup {...buttonGroupProps} {...commonProps}>
-        {renderBody()}
-      </ButtonGroup>
-    );
-  } else {
-    return <div {...commonProps}>{renderBody()}</div>;
-  }
+  const renderBody = () => {
+    if (shouldRenderAsButtonGroup) {
+      return (
+        <ButtonGroup {...buttonGroupProps} {...commonProps}>
+          {children}
+        </ButtonGroup>
+      );
+    } else {
+      return <div {...commonProps}>{children}</div>;
+    }
+  };
+
+  return (
+    <AriaToolbarContext.Provider value={getContext()}>{renderBody()}</AriaToolbarContext.Provider>
+  );
 };
 
 export default AriaToolbar;

--- a/src/components/AriaToolbar/AriaToolbar.tsx
+++ b/src/components/AriaToolbar/AriaToolbar.tsx
@@ -1,10 +1,11 @@
-import React, { FC, useRef, useState, useEffect } from 'react';
+import React, { FC, useRef, useState, useEffect, useCallback, ReactElement } from 'react';
 import classnames from 'classnames';
 
 import { DEFAULTS, STYLE } from './AriaToolbar.constants';
 import { Props } from './AriaToolbar.types';
 import { useKeyboard } from '@react-aria/interactions';
 import { map } from 'lodash';
+import ButtonGroup from '../ButtonGroup';
 
 /**
  * The AriaToolbar component. A style-less component implementing the Aria Toolbar pattern
@@ -18,8 +19,10 @@ const AriaToolbar: FC<Props> = (props: Props) => {
     style,
     children,
     orientation = DEFAULTS.ORIENTATION,
+    shouldRenderAsButtonGroup = DEFAULTS.SHOULD_RENDER_AS_BUTTON_GROUP,
     onTabPress,
     ariaControls,
+    buttonGroupProps,
   } = props;
 
   const [currentFocus, setCurrentFocus] = useState(undefined);
@@ -34,7 +37,7 @@ const AriaToolbar: FC<Props> = (props: Props) => {
       // for the escape key (and other key presses), continue propagation to let Popovers / Modals know that
       // they should close
       e.continuePropagation();
-      
+
       switch (e.key) {
         case orientation === 'horizontal' ? 'ArrowLeft' : 'ArrowUp':
           e.preventDefault();
@@ -48,7 +51,7 @@ const AriaToolbar: FC<Props> = (props: Props) => {
 
         case 'Tab': {
           if (onTabPress) {
-            onTabPress();
+            onTabPress(e);
           }
           break;
         }
@@ -63,42 +66,72 @@ const AriaToolbar: FC<Props> = (props: Props) => {
     buttonRefs.current[currentFocus]?.focus();
   }, [currentFocus]);
 
-  return (
-    <div
-      aria-label={ariaLabel}
-      aria-controls={ariaControls}
-      role="toolbar"
-      className={classnames(className, STYLE.wrapper)}
-      id={id}
-      style={style}
-    >
-      {map(validChildren, (child, index) => {
-        return React.cloneElement(child, {
-          tabIndex: index === (currentFocus || 0) ? 0 : -1,
-          ref: (e) => {
-            buttonRefs.current[index] = e;
-            if (child.ref) {
-              child.ref(e);
-            }
-          },
-          onFocus: (e) => {
-            setCurrentFocus(index);
-            if (child.props.onFocus) {
-              child.props.onFocus(e);
-            }
-          },
-          onPress: () => {
-            setCurrentFocus(index);
-            if (child.props.onPress) {
-              child.props.onPress();
-            }
-          },
-          useNativeKeyDown: true,
-          ...keyboardProps,
-        });
-      })}
-    </div>
+  const getPropsForChildren = useCallback(
+    (child, index) => {
+      return {
+        tabIndex: index === (currentFocus || 0) ? 0 : -1,
+        ref: (e) => {
+          buttonRefs.current[index] = e;
+          if (child.ref) {
+            child.ref(e);
+          }
+        },
+        onFocus: (e) => {
+          setCurrentFocus(index);
+          if (child.props.onFocus) {
+            child.props.onFocus(e);
+          }
+        },
+        onPress: () => {
+          setCurrentFocus(index);
+          if (child.props.onPress) {
+            child.props.onPress();
+          }
+        },
+        useNativeKeyDown: true,
+        ...keyboardProps,
+      };
+    },
+    [currentFocus]
   );
+
+  const renderBody = () => {
+    return map(validChildren as React.ReactElement[], (child, index) => {
+      // checks if the child has a triggerComponent (i.e. it's a Tooltip)
+      // in which case we need to clone the trigger...
+      if (child.props.triggerComponent) {
+        const triggerComponent = React.Children.only(child.props.triggerComponent);
+
+        return React.cloneElement(child, {
+          triggerComponent: React.cloneElement(
+            triggerComponent,
+            getPropsForChildren(triggerComponent, index)
+          ),
+        });
+      } else {
+        return React.cloneElement(child, getPropsForChildren(child, index));
+      }
+    });
+  };
+
+  const commonProps = {
+    className: classnames(className, STYLE.wrapper),
+    id: id,
+    style: style,
+    'aria-label': ariaLabel,
+    'aria-controls': ariaControls,
+    role: 'toolbar',
+  };
+
+  if (shouldRenderAsButtonGroup) {
+    return (
+      <ButtonGroup {...buttonGroupProps} {...commonProps}>
+        {renderBody()}
+      </ButtonGroup>
+    );
+  } else {
+    return <div {...commonProps}>{renderBody()}</div>;
+  }
 };
 
 export default AriaToolbar;

--- a/src/components/AriaToolbar/AriaToolbar.types.ts
+++ b/src/components/AriaToolbar/AriaToolbar.types.ts
@@ -1,4 +1,5 @@
 import { CSSProperties, ReactNode } from 'react';
+import { ButtonGroupProps } from '../ButtonGroup';
 
 export interface Props {
   /**
@@ -43,5 +44,15 @@ export interface Props {
    * This handler is called when tab is pressed by one of the elements
    * within the toolbar.
    */
-  onTabPress?: () => void;
+  onTabPress?: (e: React.KeyboardEvent) => void;
+
+  /**
+   * This prop is used to determine if the toolbar should render as a button group.
+   */
+  shouldRenderAsButtonGroup?: boolean;
+
+  /**
+   * Props to pass to the ButtonGroup component
+   */
+  buttonGroupProps?: ButtonGroupProps;
 }

--- a/src/components/AriaToolbar/AriaToolbar.types.ts
+++ b/src/components/AriaToolbar/AriaToolbar.types.ts
@@ -1,11 +1,15 @@
-import { CSSProperties, ReactNode } from 'react';
+import { CSSProperties, MutableRefObject, ReactElement } from 'react';
 import { ButtonGroupProps } from '../ButtonGroup';
+import { SupportedComponents } from '../ButtonGroup/ButtonGroup.types';
 
 export interface Props {
   /**
    * Child components of this AriaToolbar.
    */
-  children?: ReactNode;
+  children?:
+    | ReactElement<SupportedComponents>
+    | Array<ReactElement<SupportedComponents>>
+    | Array<HTMLElement>;
 
   /**
    * Custom class for overriding this component's CSS.
@@ -55,4 +59,19 @@ export interface Props {
    * Props to pass to the ButtonGroup component
    */
   buttonGroupProps?: ButtonGroupProps;
+
+  /**
+   * Provides context on how many toolbar items are in the aria toolbar. This information is used
+   * to calculate the correct item focus.
+   */
+  ariaToolbarItemsSize: number;
+}
+
+export interface AriaToolbarContextValue {
+  currentFocus?: number;
+  setCurrentFocus?: (newFocus: number) => void;
+  buttonRefs?: MutableRefObject<Record<string, HTMLButtonElement>>;
+  orientation: Props['orientation'];
+  onTabPress: Props['onTabPress'];
+  ariaToolbarItemsSize: number;
 }

--- a/src/components/AriaToolbar/AriaToolbar.unit.test.tsx
+++ b/src/components/AriaToolbar/AriaToolbar.unit.test.tsx
@@ -7,13 +7,14 @@ import { triggerPress } from '../../../test/utils';
 import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
+import AriaToolbarItem from '../AriaToolbarItem';
 
 describe('<AriaToolbar />', () => {
   describe('snapshot', () => {
     it('should match snapshot', () => {
       expect.assertions(1);
 
-      const container = mount(<AriaToolbar ariaLabel="test" />);
+      const container = mount(<AriaToolbar ariaLabel="test" ariaToolbarItemsSize={0} />);
 
       expect(container).toMatchSnapshot();
     });
@@ -23,7 +24,9 @@ describe('<AriaToolbar />', () => {
 
       const className = 'example-class';
 
-      const container = mount(<AriaToolbar ariaLabel="test" className={className} />);
+      const container = mount(
+        <AriaToolbar ariaLabel="test" className={className} ariaToolbarItemsSize={0} />
+      );
 
       expect(container).toMatchSnapshot();
     });
@@ -33,7 +36,7 @@ describe('<AriaToolbar />', () => {
 
       const id = 'example-id';
 
-      const container = mount(<AriaToolbar ariaLabel="test" id={id} />);
+      const container = mount(<AriaToolbar ariaLabel="test" id={id} ariaToolbarItemsSize={0} />);
 
       expect(container).toMatchSnapshot();
     });
@@ -43,7 +46,9 @@ describe('<AriaToolbar />', () => {
 
       const style = { color: 'pink' };
 
-      const container = mount(<AriaToolbar ariaLabel="test" style={style} />);
+      const container = mount(
+        <AriaToolbar ariaLabel="test" style={style} ariaToolbarItemsSize={0} />
+      );
 
       expect(container).toMatchSnapshot();
     });
@@ -52,10 +57,16 @@ describe('<AriaToolbar />', () => {
       expect.assertions(4);
 
       const container = mount(
-        <AriaToolbar ariaLabel="test">
-          <ButtonSimple />
-          <ButtonSimple />
-          <ButtonSimple />
+        <AriaToolbar ariaLabel="test" ariaToolbarItemsSize={3}>
+          <AriaToolbarItem itemIndex={0}>
+            <ButtonSimple />
+          </AriaToolbarItem>
+          <AriaToolbarItem itemIndex={1}>
+            <ButtonSimple />
+          </AriaToolbarItem>
+          <AriaToolbarItem itemIndex={2}>
+            <ButtonSimple />
+          </AriaToolbarItem>
         </AriaToolbar>
       );
 
@@ -74,27 +85,20 @@ describe('<AriaToolbar />', () => {
       expect(container).toMatchSnapshot();
     });
 
-    it('should not render invalid elements', () => {
-      expect.assertions(1);
-
-      const container = mount(
-        <AriaToolbar orientation="vertical" ariaLabel="test">
-          <ButtonSimple />
-          {null}
-        </AriaToolbar>
-      );
-
-      expect(container).toMatchSnapshot();
-    });
-
     it('should set tab index appropriately - vertical orientation', () => {
       expect.assertions(4);
 
       const container = mount(
-        <AriaToolbar orientation="vertical" ariaLabel="test">
-          <ButtonSimple />
-          <ButtonSimple />
-          <ButtonSimple />
+        <AriaToolbar orientation="vertical" ariaLabel="test" ariaToolbarItemsSize={3}>
+          <AriaToolbarItem itemIndex={0}>
+            <ButtonSimple />
+          </AriaToolbarItem>
+          <AriaToolbarItem itemIndex={1}>
+            <ButtonSimple />
+          </AriaToolbarItem>
+          <AriaToolbarItem itemIndex={2}>
+            <ButtonSimple />
+          </AriaToolbarItem>
         </AriaToolbar>
       );
 
@@ -117,10 +121,16 @@ describe('<AriaToolbar />', () => {
       expect.assertions(7);
       const user = userEvent.setup();
       const { getAllByRole, container } = render(
-        <AriaToolbar orientation="vertical" ariaLabel="test">
-          <ButtonSimple />
-          <ButtonSimple />
-          <ButtonSimple />
+        <AriaToolbar orientation="vertical" ariaLabel="test" ariaToolbarItemsSize={3}>
+          <AriaToolbarItem itemIndex={0}>
+            <ButtonSimple />
+          </AriaToolbarItem>
+          <AriaToolbarItem itemIndex={1}>
+            <ButtonSimple />
+          </AriaToolbarItem>
+          <AriaToolbarItem itemIndex={2}>
+            <ButtonSimple />
+          </AriaToolbarItem>
         </AriaToolbar>
       );
 
@@ -149,7 +159,7 @@ describe('<AriaToolbar />', () => {
     it('should have its wrapper class', () => {
       expect.assertions(1);
 
-      const element = mount(<AriaToolbar ariaLabel="test" />)
+      const element = mount(<AriaToolbar ariaLabel="test" ariaToolbarItemsSize={0} />)
         .find(AriaToolbar)
         .getDOMNode();
 
@@ -161,7 +171,9 @@ describe('<AriaToolbar />', () => {
 
       const className = 'example-class';
 
-      const element = mount(<AriaToolbar ariaLabel="test" className={className} />)
+      const element = mount(
+        <AriaToolbar ariaLabel="test" className={className} ariaToolbarItemsSize={0} />
+      )
         .find(AriaToolbar)
         .getDOMNode();
 
@@ -173,7 +185,7 @@ describe('<AriaToolbar />', () => {
 
       const id = 'example-id';
 
-      const element = mount(<AriaToolbar ariaLabel="test" id={id} />)
+      const element = mount(<AriaToolbar ariaLabel="test" id={id} ariaToolbarItemsSize={0} />)
         .find(AriaToolbar)
         .getDOMNode();
 
@@ -186,7 +198,7 @@ describe('<AriaToolbar />', () => {
       const style = { color: 'pink' };
       const styleString = 'color: pink;';
 
-      const element = mount(<AriaToolbar ariaLabel="test" style={style} />)
+      const element = mount(<AriaToolbar ariaLabel="test" style={style} ariaToolbarItemsSize={0} />)
         .find(AriaToolbar)
         .getDOMNode();
 
@@ -198,7 +210,9 @@ describe('<AriaToolbar />', () => {
 
       const ariaControls = 'testid';
 
-      const element = mount(<AriaToolbar ariaLabel="test" ariaControls={ariaControls} />)
+      const element = mount(
+        <AriaToolbar ariaLabel="test" ariaControls={ariaControls} ariaToolbarItemsSize={0} />
+      )
         .find(AriaToolbar)
         .getDOMNode();
 
@@ -210,7 +224,7 @@ describe('<AriaToolbar />', () => {
 
       const ariaLabel = 'test label';
 
-      const element = mount(<AriaToolbar ariaLabel={ariaLabel} />)
+      const element = mount(<AriaToolbar ariaLabel={ariaLabel} ariaToolbarItemsSize={0} />)
         .find(AriaToolbar)
         .getDOMNode();
 
@@ -225,8 +239,10 @@ describe('<AriaToolbar />', () => {
       const onTabPress = jest.fn();
 
       const element = mount(
-        <AriaToolbar ariaLabel="test" onTabPress={onTabPress}>
-          <ButtonSimple>test button</ButtonSimple>
+        <AriaToolbar ariaLabel="test" onTabPress={onTabPress} ariaToolbarItemsSize={1}>
+          <AriaToolbarItem itemIndex={0}>
+            <ButtonSimple>test button</ButtonSimple>
+          </AriaToolbarItem>
         </AriaToolbar>
       );
 
@@ -241,8 +257,10 @@ describe('<AriaToolbar />', () => {
       const onPress = jest.fn();
 
       const element = mount(
-        <AriaToolbar ariaLabel="test">
-          <ButtonSimple onPress={onPress}>test button</ButtonSimple>
+        <AriaToolbar ariaLabel="test" ariaToolbarItemsSize={1}>
+          <AriaToolbarItem itemIndex={0}>
+            <ButtonSimple onPress={onPress}>test button</ButtonSimple>
+          </AriaToolbarItem>
         </AriaToolbar>
       );
 
@@ -257,11 +275,12 @@ describe('<AriaToolbar />', () => {
       const element = mount(
         // eslint-disable-next-line jsx-a11y/no-static-element-interactions
         <div onKeyDown={onKeyDown}>
-          <AriaToolbar ariaLabel="test" >
-            <ButtonSimple>test button</ButtonSimple>
+          <AriaToolbar ariaLabel="test" ariaToolbarItemsSize={1}>
+            <AriaToolbarItem itemIndex={0}>
+              <ButtonSimple>test button</ButtonSimple>
+            </AriaToolbarItem>
           </AriaToolbar>
         </div>
-
       );
 
       element.find(ButtonSimple).simulate('keyDown', { key: 'Escape' });

--- a/src/components/AriaToolbar/AriaToolbar.unit.test.tsx.snap
+++ b/src/components/AriaToolbar/AriaToolbar.unit.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`<AriaToolbar /> snapshot should match snapshot 1`] = `
 <AriaToolbar
   ariaLabel="test"
+  ariaToolbarItemsSize={0}
 >
   <div
     aria-label="test"
@@ -15,6 +16,7 @@ exports[`<AriaToolbar /> snapshot should match snapshot 1`] = `
 exports[`<AriaToolbar /> snapshot should match snapshot with className 1`] = `
 <AriaToolbar
   ariaLabel="test"
+  ariaToolbarItemsSize={0}
   className="example-class"
 >
   <div
@@ -28,6 +30,7 @@ exports[`<AriaToolbar /> snapshot should match snapshot with className 1`] = `
 exports[`<AriaToolbar /> snapshot should match snapshot with id 1`] = `
 <AriaToolbar
   ariaLabel="test"
+  ariaToolbarItemsSize={0}
   id="example-id"
 >
   <div
@@ -42,6 +45,7 @@ exports[`<AriaToolbar /> snapshot should match snapshot with id 1`] = `
 exports[`<AriaToolbar /> snapshot should match snapshot with style 1`] = `
 <AriaToolbar
   ariaLabel="test"
+  ariaToolbarItemsSize={0}
   style={
     Object {
       "color": "pink",
@@ -61,167 +65,129 @@ exports[`<AriaToolbar /> snapshot should match snapshot with style 1`] = `
 </AriaToolbar>
 `;
 
-exports[`<AriaToolbar /> snapshot should not render invalid elements 1`] = `
-<AriaToolbar
-  ariaLabel="test"
-  orientation="vertical"
->
-  <div
-    aria-label="test"
-    className="md-aria-toolbar-wrapper"
-    role="toolbar"
-  >
-    <ButtonSimple
-      key=".0"
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onPress={[Function]}
-      tabIndex={0}
-      useNativeKeyDown={true}
-    >
-      <FocusRing>
-        <FocusRing
-          focusClass="md-focus-ring-wrapper children"
-          focusRingClass="md-focus-ring-wrapper children"
-        >
-          <button
-            className="md-button-simple-wrapper"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onDragStart={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchCancel={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            type="button"
-          />
-        </FocusRing>
-      </FocusRing>
-    </ButtonSimple>
-  </div>
-</AriaToolbar>
-`;
-
 exports[`<AriaToolbar /> snapshot should set tab index appropriately - horizontal orientation 1`] = `
 <AriaToolbar
   ariaLabel="test"
+  ariaToolbarItemsSize={3}
 >
   <div
     aria-label="test"
     className="md-aria-toolbar-wrapper"
     role="toolbar"
   >
-    <ButtonSimple
-      key=".0"
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onPress={[Function]}
-      tabIndex={0}
-      useNativeKeyDown={true}
+    <ForwardRef
+      itemIndex={0}
     >
-      <FocusRing>
-        <FocusRing
-          focusClass="md-focus-ring-wrapper children"
-          focusRingClass="md-focus-ring-wrapper children"
-        >
-          <button
-            className="md-button-simple-wrapper"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onDragStart={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchCancel={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            type="button"
-          />
+      <ButtonSimple
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onPress={[Function]}
+        tabIndex={0}
+        useNativeKeyDown={true}
+      >
+        <FocusRing>
+          <FocusRing
+            focusClass="md-focus-ring-wrapper children"
+            focusRingClass="md-focus-ring-wrapper children"
+          >
+            <button
+              className="md-button-simple-wrapper"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onDragStart={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+              onTouchCancel={[Function]}
+              onTouchEnd={[Function]}
+              onTouchMove={[Function]}
+              onTouchStart={[Function]}
+              type="button"
+            />
+          </FocusRing>
         </FocusRing>
-      </FocusRing>
-    </ButtonSimple>
-    <ButtonSimple
-      key=".1"
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onPress={[Function]}
-      tabIndex={-1}
-      useNativeKeyDown={true}
+      </ButtonSimple>
+    </ForwardRef>
+    <ForwardRef
+      itemIndex={1}
     >
-      <FocusRing>
-        <FocusRing
-          focusClass="md-focus-ring-wrapper children"
-          focusRingClass="md-focus-ring-wrapper children"
-        >
-          <button
-            className="md-button-simple-wrapper"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onDragStart={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchCancel={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            tabIndex={-1}
-            type="button"
-          />
+      <ButtonSimple
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onPress={[Function]}
+        tabIndex={-1}
+        useNativeKeyDown={true}
+      >
+        <FocusRing>
+          <FocusRing
+            focusClass="md-focus-ring-wrapper children"
+            focusRingClass="md-focus-ring-wrapper children"
+          >
+            <button
+              className="md-button-simple-wrapper"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onDragStart={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+              onTouchCancel={[Function]}
+              onTouchEnd={[Function]}
+              onTouchMove={[Function]}
+              onTouchStart={[Function]}
+              tabIndex={-1}
+              type="button"
+            />
+          </FocusRing>
         </FocusRing>
-      </FocusRing>
-    </ButtonSimple>
-    <ButtonSimple
-      key=".2"
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onPress={[Function]}
-      tabIndex={-1}
-      useNativeKeyDown={true}
+      </ButtonSimple>
+    </ForwardRef>
+    <ForwardRef
+      itemIndex={2}
     >
-      <FocusRing>
-        <FocusRing
-          focusClass="md-focus-ring-wrapper children"
-          focusRingClass="md-focus-ring-wrapper children"
-        >
-          <button
-            className="md-button-simple-wrapper"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onDragStart={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchCancel={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            tabIndex={-1}
-            type="button"
-          />
+      <ButtonSimple
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onPress={[Function]}
+        tabIndex={-1}
+        useNativeKeyDown={true}
+      >
+        <FocusRing>
+          <FocusRing
+            focusClass="md-focus-ring-wrapper children"
+            focusRingClass="md-focus-ring-wrapper children"
+          >
+            <button
+              className="md-button-simple-wrapper"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onDragStart={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+              onTouchCancel={[Function]}
+              onTouchEnd={[Function]}
+              onTouchMove={[Function]}
+              onTouchStart={[Function]}
+              tabIndex={-1}
+              type="button"
+            />
+          </FocusRing>
         </FocusRing>
-      </FocusRing>
-    </ButtonSimple>
+      </ButtonSimple>
+    </ForwardRef>
   </div>
 </AriaToolbar>
 `;
@@ -229,116 +195,126 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - horizonta
 exports[`<AriaToolbar /> snapshot should set tab index appropriately - horizontal orientation 2`] = `
 <AriaToolbar
   ariaLabel="test"
+  ariaToolbarItemsSize={3}
 >
   <div
     aria-label="test"
     className="md-aria-toolbar-wrapper"
     role="toolbar"
   >
-    <ButtonSimple
-      key=".0"
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onPress={[Function]}
-      tabIndex={-1}
-      useNativeKeyDown={true}
+    <ForwardRef
+      itemIndex={0}
     >
-      <FocusRing>
-        <FocusRing
-          focusClass="md-focus-ring-wrapper children"
-          focusRingClass="md-focus-ring-wrapper children"
-        >
-          <button
-            className="md-button-simple-wrapper"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onDragStart={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchCancel={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            tabIndex={-1}
-            type="button"
-          />
+      <ButtonSimple
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onPress={[Function]}
+        tabIndex={-1}
+        useNativeKeyDown={true}
+      >
+        <FocusRing>
+          <FocusRing
+            focusClass="md-focus-ring-wrapper children"
+            focusRingClass="md-focus-ring-wrapper children"
+          >
+            <button
+              className="md-button-simple-wrapper"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onDragStart={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+              onTouchCancel={[Function]}
+              onTouchEnd={[Function]}
+              onTouchMove={[Function]}
+              onTouchStart={[Function]}
+              tabIndex={-1}
+              type="button"
+            />
+          </FocusRing>
         </FocusRing>
-      </FocusRing>
-    </ButtonSimple>
-    <ButtonSimple
-      key=".1"
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onPress={[Function]}
-      tabIndex={-1}
-      useNativeKeyDown={true}
+      </ButtonSimple>
+    </ForwardRef>
+    <ForwardRef
+      itemIndex={1}
     >
-      <FocusRing>
-        <FocusRing
-          focusClass="md-focus-ring-wrapper children"
-          focusRingClass="md-focus-ring-wrapper children"
-        >
-          <button
-            className="md-button-simple-wrapper"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onDragStart={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchCancel={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            tabIndex={-1}
-            type="button"
-          />
+      <ButtonSimple
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onPress={[Function]}
+        tabIndex={-1}
+        useNativeKeyDown={true}
+      >
+        <FocusRing>
+          <FocusRing
+            focusClass="md-focus-ring-wrapper children"
+            focusRingClass="md-focus-ring-wrapper children"
+          >
+            <button
+              className="md-button-simple-wrapper"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onDragStart={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+              onTouchCancel={[Function]}
+              onTouchEnd={[Function]}
+              onTouchMove={[Function]}
+              onTouchStart={[Function]}
+              tabIndex={-1}
+              type="button"
+            />
+          </FocusRing>
         </FocusRing>
-      </FocusRing>
-    </ButtonSimple>
-    <ButtonSimple
-      key=".2"
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onPress={[Function]}
-      tabIndex={0}
-      useNativeKeyDown={true}
+      </ButtonSimple>
+    </ForwardRef>
+    <ForwardRef
+      itemIndex={2}
     >
-      <FocusRing>
-        <FocusRing
-          focusClass="md-focus-ring-wrapper children"
-          focusRingClass="md-focus-ring-wrapper children"
-        >
-          <button
-            className="md-button-simple-wrapper"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onDragStart={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchCancel={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            type="button"
-          />
+      <ButtonSimple
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onPress={[Function]}
+        tabIndex={0}
+        useNativeKeyDown={true}
+      >
+        <FocusRing>
+          <FocusRing
+            focusClass="md-focus-ring-wrapper children"
+            focusRingClass="md-focus-ring-wrapper children"
+          >
+            <button
+              className="md-button-simple-wrapper"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onDragStart={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+              onTouchCancel={[Function]}
+              onTouchEnd={[Function]}
+              onTouchMove={[Function]}
+              onTouchStart={[Function]}
+              type="button"
+            />
+          </FocusRing>
         </FocusRing>
-      </FocusRing>
-    </ButtonSimple>
+      </ButtonSimple>
+    </ForwardRef>
   </div>
 </AriaToolbar>
 `;
@@ -346,116 +322,126 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - horizonta
 exports[`<AriaToolbar /> snapshot should set tab index appropriately - horizontal orientation 3`] = `
 <AriaToolbar
   ariaLabel="test"
+  ariaToolbarItemsSize={3}
 >
   <div
     aria-label="test"
     className="md-aria-toolbar-wrapper"
     role="toolbar"
   >
-    <ButtonSimple
-      key=".0"
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onPress={[Function]}
-      tabIndex={-1}
-      useNativeKeyDown={true}
+    <ForwardRef
+      itemIndex={0}
     >
-      <FocusRing>
-        <FocusRing
-          focusClass="md-focus-ring-wrapper children"
-          focusRingClass="md-focus-ring-wrapper children"
-        >
-          <button
-            className="md-button-simple-wrapper"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onDragStart={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchCancel={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            tabIndex={-1}
-            type="button"
-          />
+      <ButtonSimple
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onPress={[Function]}
+        tabIndex={-1}
+        useNativeKeyDown={true}
+      >
+        <FocusRing>
+          <FocusRing
+            focusClass="md-focus-ring-wrapper children"
+            focusRingClass="md-focus-ring-wrapper children"
+          >
+            <button
+              className="md-button-simple-wrapper"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onDragStart={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+              onTouchCancel={[Function]}
+              onTouchEnd={[Function]}
+              onTouchMove={[Function]}
+              onTouchStart={[Function]}
+              tabIndex={-1}
+              type="button"
+            />
+          </FocusRing>
         </FocusRing>
-      </FocusRing>
-    </ButtonSimple>
-    <ButtonSimple
-      key=".1"
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onPress={[Function]}
-      tabIndex={0}
-      useNativeKeyDown={true}
+      </ButtonSimple>
+    </ForwardRef>
+    <ForwardRef
+      itemIndex={1}
     >
-      <FocusRing>
-        <FocusRing
-          focusClass="md-focus-ring-wrapper children"
-          focusRingClass="md-focus-ring-wrapper children"
-        >
-          <button
-            className="md-button-simple-wrapper"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onDragStart={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchCancel={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            type="button"
-          />
+      <ButtonSimple
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onPress={[Function]}
+        tabIndex={0}
+        useNativeKeyDown={true}
+      >
+        <FocusRing>
+          <FocusRing
+            focusClass="md-focus-ring-wrapper children"
+            focusRingClass="md-focus-ring-wrapper children"
+          >
+            <button
+              className="md-button-simple-wrapper"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onDragStart={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+              onTouchCancel={[Function]}
+              onTouchEnd={[Function]}
+              onTouchMove={[Function]}
+              onTouchStart={[Function]}
+              type="button"
+            />
+          </FocusRing>
         </FocusRing>
-      </FocusRing>
-    </ButtonSimple>
-    <ButtonSimple
-      key=".2"
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onPress={[Function]}
-      tabIndex={-1}
-      useNativeKeyDown={true}
+      </ButtonSimple>
+    </ForwardRef>
+    <ForwardRef
+      itemIndex={2}
     >
-      <FocusRing>
-        <FocusRing
-          focusClass="md-focus-ring-wrapper children"
-          focusRingClass="md-focus-ring-wrapper children"
-        >
-          <button
-            className="md-button-simple-wrapper"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onDragStart={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchCancel={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            tabIndex={-1}
-            type="button"
-          />
+      <ButtonSimple
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onPress={[Function]}
+        tabIndex={-1}
+        useNativeKeyDown={true}
+      >
+        <FocusRing>
+          <FocusRing
+            focusClass="md-focus-ring-wrapper children"
+            focusRingClass="md-focus-ring-wrapper children"
+          >
+            <button
+              className="md-button-simple-wrapper"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onDragStart={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+              onTouchCancel={[Function]}
+              onTouchEnd={[Function]}
+              onTouchMove={[Function]}
+              onTouchStart={[Function]}
+              tabIndex={-1}
+              type="button"
+            />
+          </FocusRing>
         </FocusRing>
-      </FocusRing>
-    </ButtonSimple>
+      </ButtonSimple>
+    </ForwardRef>
   </div>
 </AriaToolbar>
 `;
@@ -463,116 +449,126 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - horizonta
 exports[`<AriaToolbar /> snapshot should set tab index appropriately - horizontal orientation 4`] = `
 <AriaToolbar
   ariaLabel="test"
+  ariaToolbarItemsSize={3}
 >
   <div
     aria-label="test"
     className="md-aria-toolbar-wrapper"
     role="toolbar"
   >
-    <ButtonSimple
-      key=".0"
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onPress={[Function]}
-      tabIndex={-1}
-      useNativeKeyDown={true}
+    <ForwardRef
+      itemIndex={0}
     >
-      <FocusRing>
-        <FocusRing
-          focusClass="md-focus-ring-wrapper children"
-          focusRingClass="md-focus-ring-wrapper children"
-        >
-          <button
-            className="md-button-simple-wrapper"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onDragStart={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchCancel={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            tabIndex={-1}
-            type="button"
-          />
+      <ButtonSimple
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onPress={[Function]}
+        tabIndex={-1}
+        useNativeKeyDown={true}
+      >
+        <FocusRing>
+          <FocusRing
+            focusClass="md-focus-ring-wrapper children"
+            focusRingClass="md-focus-ring-wrapper children"
+          >
+            <button
+              className="md-button-simple-wrapper"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onDragStart={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+              onTouchCancel={[Function]}
+              onTouchEnd={[Function]}
+              onTouchMove={[Function]}
+              onTouchStart={[Function]}
+              tabIndex={-1}
+              type="button"
+            />
+          </FocusRing>
         </FocusRing>
-      </FocusRing>
-    </ButtonSimple>
-    <ButtonSimple
-      key=".1"
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onPress={[Function]}
-      tabIndex={-1}
-      useNativeKeyDown={true}
+      </ButtonSimple>
+    </ForwardRef>
+    <ForwardRef
+      itemIndex={1}
     >
-      <FocusRing>
-        <FocusRing
-          focusClass="md-focus-ring-wrapper children"
-          focusRingClass="md-focus-ring-wrapper children"
-        >
-          <button
-            className="md-button-simple-wrapper"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onDragStart={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchCancel={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            tabIndex={-1}
-            type="button"
-          />
+      <ButtonSimple
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onPress={[Function]}
+        tabIndex={-1}
+        useNativeKeyDown={true}
+      >
+        <FocusRing>
+          <FocusRing
+            focusClass="md-focus-ring-wrapper children"
+            focusRingClass="md-focus-ring-wrapper children"
+          >
+            <button
+              className="md-button-simple-wrapper"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onDragStart={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+              onTouchCancel={[Function]}
+              onTouchEnd={[Function]}
+              onTouchMove={[Function]}
+              onTouchStart={[Function]}
+              tabIndex={-1}
+              type="button"
+            />
+          </FocusRing>
         </FocusRing>
-      </FocusRing>
-    </ButtonSimple>
-    <ButtonSimple
-      key=".2"
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onPress={[Function]}
-      tabIndex={0}
-      useNativeKeyDown={true}
+      </ButtonSimple>
+    </ForwardRef>
+    <ForwardRef
+      itemIndex={2}
     >
-      <FocusRing>
-        <FocusRing
-          focusClass="md-focus-ring-wrapper children"
-          focusRingClass="md-focus-ring-wrapper children"
-        >
-          <button
-            className="md-button-simple-wrapper"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onDragStart={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchCancel={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            type="button"
-          />
+      <ButtonSimple
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onPress={[Function]}
+        tabIndex={0}
+        useNativeKeyDown={true}
+      >
+        <FocusRing>
+          <FocusRing
+            focusClass="md-focus-ring-wrapper children"
+            focusRingClass="md-focus-ring-wrapper children"
+          >
+            <button
+              className="md-button-simple-wrapper"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onDragStart={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+              onTouchCancel={[Function]}
+              onTouchEnd={[Function]}
+              onTouchMove={[Function]}
+              onTouchStart={[Function]}
+              type="button"
+            />
+          </FocusRing>
         </FocusRing>
-      </FocusRing>
-    </ButtonSimple>
+      </ButtonSimple>
+    </ForwardRef>
   </div>
 </AriaToolbar>
 `;
@@ -580,6 +576,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - horizonta
 exports[`<AriaToolbar /> snapshot should set tab index appropriately - vertical orientation 1`] = `
 <AriaToolbar
   ariaLabel="test"
+  ariaToolbarItemsSize={3}
   orientation="vertical"
 >
   <div
@@ -587,110 +584,119 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - vertical 
     className="md-aria-toolbar-wrapper"
     role="toolbar"
   >
-    <ButtonSimple
-      key=".0"
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onPress={[Function]}
-      tabIndex={0}
-      useNativeKeyDown={true}
+    <ForwardRef
+      itemIndex={0}
     >
-      <FocusRing>
-        <FocusRing
-          focusClass="md-focus-ring-wrapper children"
-          focusRingClass="md-focus-ring-wrapper children"
-        >
-          <button
-            className="md-button-simple-wrapper"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onDragStart={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchCancel={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            type="button"
-          />
+      <ButtonSimple
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onPress={[Function]}
+        tabIndex={0}
+        useNativeKeyDown={true}
+      >
+        <FocusRing>
+          <FocusRing
+            focusClass="md-focus-ring-wrapper children"
+            focusRingClass="md-focus-ring-wrapper children"
+          >
+            <button
+              className="md-button-simple-wrapper"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onDragStart={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+              onTouchCancel={[Function]}
+              onTouchEnd={[Function]}
+              onTouchMove={[Function]}
+              onTouchStart={[Function]}
+              type="button"
+            />
+          </FocusRing>
         </FocusRing>
-      </FocusRing>
-    </ButtonSimple>
-    <ButtonSimple
-      key=".1"
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onPress={[Function]}
-      tabIndex={-1}
-      useNativeKeyDown={true}
+      </ButtonSimple>
+    </ForwardRef>
+    <ForwardRef
+      itemIndex={1}
     >
-      <FocusRing>
-        <FocusRing
-          focusClass="md-focus-ring-wrapper children"
-          focusRingClass="md-focus-ring-wrapper children"
-        >
-          <button
-            className="md-button-simple-wrapper"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onDragStart={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchCancel={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            tabIndex={-1}
-            type="button"
-          />
+      <ButtonSimple
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onPress={[Function]}
+        tabIndex={-1}
+        useNativeKeyDown={true}
+      >
+        <FocusRing>
+          <FocusRing
+            focusClass="md-focus-ring-wrapper children"
+            focusRingClass="md-focus-ring-wrapper children"
+          >
+            <button
+              className="md-button-simple-wrapper"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onDragStart={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+              onTouchCancel={[Function]}
+              onTouchEnd={[Function]}
+              onTouchMove={[Function]}
+              onTouchStart={[Function]}
+              tabIndex={-1}
+              type="button"
+            />
+          </FocusRing>
         </FocusRing>
-      </FocusRing>
-    </ButtonSimple>
-    <ButtonSimple
-      key=".2"
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onPress={[Function]}
-      tabIndex={-1}
-      useNativeKeyDown={true}
+      </ButtonSimple>
+    </ForwardRef>
+    <ForwardRef
+      itemIndex={2}
     >
-      <FocusRing>
-        <FocusRing
-          focusClass="md-focus-ring-wrapper children"
-          focusRingClass="md-focus-ring-wrapper children"
-        >
-          <button
-            className="md-button-simple-wrapper"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onDragStart={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchCancel={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            tabIndex={-1}
-            type="button"
-          />
+      <ButtonSimple
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onPress={[Function]}
+        tabIndex={-1}
+        useNativeKeyDown={true}
+      >
+        <FocusRing>
+          <FocusRing
+            focusClass="md-focus-ring-wrapper children"
+            focusRingClass="md-focus-ring-wrapper children"
+          >
+            <button
+              className="md-button-simple-wrapper"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onDragStart={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+              onTouchCancel={[Function]}
+              onTouchEnd={[Function]}
+              onTouchMove={[Function]}
+              onTouchStart={[Function]}
+              tabIndex={-1}
+              type="button"
+            />
+          </FocusRing>
         </FocusRing>
-      </FocusRing>
-    </ButtonSimple>
+      </ButtonSimple>
+    </ForwardRef>
   </div>
 </AriaToolbar>
 `;
@@ -698,6 +704,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - vertical 
 exports[`<AriaToolbar /> snapshot should set tab index appropriately - vertical orientation 2`] = `
 <AriaToolbar
   ariaLabel="test"
+  ariaToolbarItemsSize={3}
   orientation="vertical"
 >
   <div
@@ -705,110 +712,119 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - vertical 
     className="md-aria-toolbar-wrapper"
     role="toolbar"
   >
-    <ButtonSimple
-      key=".0"
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onPress={[Function]}
-      tabIndex={-1}
-      useNativeKeyDown={true}
+    <ForwardRef
+      itemIndex={0}
     >
-      <FocusRing>
-        <FocusRing
-          focusClass="md-focus-ring-wrapper children"
-          focusRingClass="md-focus-ring-wrapper children"
-        >
-          <button
-            className="md-button-simple-wrapper"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onDragStart={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchCancel={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            tabIndex={-1}
-            type="button"
-          />
+      <ButtonSimple
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onPress={[Function]}
+        tabIndex={-1}
+        useNativeKeyDown={true}
+      >
+        <FocusRing>
+          <FocusRing
+            focusClass="md-focus-ring-wrapper children"
+            focusRingClass="md-focus-ring-wrapper children"
+          >
+            <button
+              className="md-button-simple-wrapper"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onDragStart={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+              onTouchCancel={[Function]}
+              onTouchEnd={[Function]}
+              onTouchMove={[Function]}
+              onTouchStart={[Function]}
+              tabIndex={-1}
+              type="button"
+            />
+          </FocusRing>
         </FocusRing>
-      </FocusRing>
-    </ButtonSimple>
-    <ButtonSimple
-      key=".1"
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onPress={[Function]}
-      tabIndex={-1}
-      useNativeKeyDown={true}
+      </ButtonSimple>
+    </ForwardRef>
+    <ForwardRef
+      itemIndex={1}
     >
-      <FocusRing>
-        <FocusRing
-          focusClass="md-focus-ring-wrapper children"
-          focusRingClass="md-focus-ring-wrapper children"
-        >
-          <button
-            className="md-button-simple-wrapper"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onDragStart={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchCancel={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            tabIndex={-1}
-            type="button"
-          />
+      <ButtonSimple
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onPress={[Function]}
+        tabIndex={-1}
+        useNativeKeyDown={true}
+      >
+        <FocusRing>
+          <FocusRing
+            focusClass="md-focus-ring-wrapper children"
+            focusRingClass="md-focus-ring-wrapper children"
+          >
+            <button
+              className="md-button-simple-wrapper"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onDragStart={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+              onTouchCancel={[Function]}
+              onTouchEnd={[Function]}
+              onTouchMove={[Function]}
+              onTouchStart={[Function]}
+              tabIndex={-1}
+              type="button"
+            />
+          </FocusRing>
         </FocusRing>
-      </FocusRing>
-    </ButtonSimple>
-    <ButtonSimple
-      key=".2"
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onPress={[Function]}
-      tabIndex={0}
-      useNativeKeyDown={true}
+      </ButtonSimple>
+    </ForwardRef>
+    <ForwardRef
+      itemIndex={2}
     >
-      <FocusRing>
-        <FocusRing
-          focusClass="md-focus-ring-wrapper children"
-          focusRingClass="md-focus-ring-wrapper children"
-        >
-          <button
-            className="md-button-simple-wrapper"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onDragStart={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchCancel={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            type="button"
-          />
+      <ButtonSimple
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onPress={[Function]}
+        tabIndex={0}
+        useNativeKeyDown={true}
+      >
+        <FocusRing>
+          <FocusRing
+            focusClass="md-focus-ring-wrapper children"
+            focusRingClass="md-focus-ring-wrapper children"
+          >
+            <button
+              className="md-button-simple-wrapper"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onDragStart={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+              onTouchCancel={[Function]}
+              onTouchEnd={[Function]}
+              onTouchMove={[Function]}
+              onTouchStart={[Function]}
+              type="button"
+            />
+          </FocusRing>
         </FocusRing>
-      </FocusRing>
-    </ButtonSimple>
+      </ButtonSimple>
+    </ForwardRef>
   </div>
 </AriaToolbar>
 `;
@@ -816,6 +832,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - vertical 
 exports[`<AriaToolbar /> snapshot should set tab index appropriately - vertical orientation 3`] = `
 <AriaToolbar
   ariaLabel="test"
+  ariaToolbarItemsSize={3}
   orientation="vertical"
 >
   <div
@@ -823,110 +840,119 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - vertical 
     className="md-aria-toolbar-wrapper"
     role="toolbar"
   >
-    <ButtonSimple
-      key=".0"
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onPress={[Function]}
-      tabIndex={-1}
-      useNativeKeyDown={true}
+    <ForwardRef
+      itemIndex={0}
     >
-      <FocusRing>
-        <FocusRing
-          focusClass="md-focus-ring-wrapper children"
-          focusRingClass="md-focus-ring-wrapper children"
-        >
-          <button
-            className="md-button-simple-wrapper"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onDragStart={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchCancel={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            tabIndex={-1}
-            type="button"
-          />
+      <ButtonSimple
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onPress={[Function]}
+        tabIndex={-1}
+        useNativeKeyDown={true}
+      >
+        <FocusRing>
+          <FocusRing
+            focusClass="md-focus-ring-wrapper children"
+            focusRingClass="md-focus-ring-wrapper children"
+          >
+            <button
+              className="md-button-simple-wrapper"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onDragStart={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+              onTouchCancel={[Function]}
+              onTouchEnd={[Function]}
+              onTouchMove={[Function]}
+              onTouchStart={[Function]}
+              tabIndex={-1}
+              type="button"
+            />
+          </FocusRing>
         </FocusRing>
-      </FocusRing>
-    </ButtonSimple>
-    <ButtonSimple
-      key=".1"
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onPress={[Function]}
-      tabIndex={0}
-      useNativeKeyDown={true}
+      </ButtonSimple>
+    </ForwardRef>
+    <ForwardRef
+      itemIndex={1}
     >
-      <FocusRing>
-        <FocusRing
-          focusClass="md-focus-ring-wrapper children"
-          focusRingClass="md-focus-ring-wrapper children"
-        >
-          <button
-            className="md-button-simple-wrapper"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onDragStart={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchCancel={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            type="button"
-          />
+      <ButtonSimple
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onPress={[Function]}
+        tabIndex={0}
+        useNativeKeyDown={true}
+      >
+        <FocusRing>
+          <FocusRing
+            focusClass="md-focus-ring-wrapper children"
+            focusRingClass="md-focus-ring-wrapper children"
+          >
+            <button
+              className="md-button-simple-wrapper"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onDragStart={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+              onTouchCancel={[Function]}
+              onTouchEnd={[Function]}
+              onTouchMove={[Function]}
+              onTouchStart={[Function]}
+              type="button"
+            />
+          </FocusRing>
         </FocusRing>
-      </FocusRing>
-    </ButtonSimple>
-    <ButtonSimple
-      key=".2"
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onPress={[Function]}
-      tabIndex={-1}
-      useNativeKeyDown={true}
+      </ButtonSimple>
+    </ForwardRef>
+    <ForwardRef
+      itemIndex={2}
     >
-      <FocusRing>
-        <FocusRing
-          focusClass="md-focus-ring-wrapper children"
-          focusRingClass="md-focus-ring-wrapper children"
-        >
-          <button
-            className="md-button-simple-wrapper"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onDragStart={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchCancel={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            tabIndex={-1}
-            type="button"
-          />
+      <ButtonSimple
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onPress={[Function]}
+        tabIndex={-1}
+        useNativeKeyDown={true}
+      >
+        <FocusRing>
+          <FocusRing
+            focusClass="md-focus-ring-wrapper children"
+            focusRingClass="md-focus-ring-wrapper children"
+          >
+            <button
+              className="md-button-simple-wrapper"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onDragStart={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+              onTouchCancel={[Function]}
+              onTouchEnd={[Function]}
+              onTouchMove={[Function]}
+              onTouchStart={[Function]}
+              tabIndex={-1}
+              type="button"
+            />
+          </FocusRing>
         </FocusRing>
-      </FocusRing>
-    </ButtonSimple>
+      </ButtonSimple>
+    </ForwardRef>
   </div>
 </AriaToolbar>
 `;
@@ -934,6 +960,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - vertical 
 exports[`<AriaToolbar /> snapshot should set tab index appropriately - vertical orientation 4`] = `
 <AriaToolbar
   ariaLabel="test"
+  ariaToolbarItemsSize={3}
   orientation="vertical"
 >
   <div
@@ -941,110 +968,119 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - vertical 
     className="md-aria-toolbar-wrapper"
     role="toolbar"
   >
-    <ButtonSimple
-      key=".0"
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onPress={[Function]}
-      tabIndex={-1}
-      useNativeKeyDown={true}
+    <ForwardRef
+      itemIndex={0}
     >
-      <FocusRing>
-        <FocusRing
-          focusClass="md-focus-ring-wrapper children"
-          focusRingClass="md-focus-ring-wrapper children"
-        >
-          <button
-            className="md-button-simple-wrapper"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onDragStart={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchCancel={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            tabIndex={-1}
-            type="button"
-          />
+      <ButtonSimple
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onPress={[Function]}
+        tabIndex={-1}
+        useNativeKeyDown={true}
+      >
+        <FocusRing>
+          <FocusRing
+            focusClass="md-focus-ring-wrapper children"
+            focusRingClass="md-focus-ring-wrapper children"
+          >
+            <button
+              className="md-button-simple-wrapper"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onDragStart={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+              onTouchCancel={[Function]}
+              onTouchEnd={[Function]}
+              onTouchMove={[Function]}
+              onTouchStart={[Function]}
+              tabIndex={-1}
+              type="button"
+            />
+          </FocusRing>
         </FocusRing>
-      </FocusRing>
-    </ButtonSimple>
-    <ButtonSimple
-      key=".1"
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onPress={[Function]}
-      tabIndex={-1}
-      useNativeKeyDown={true}
+      </ButtonSimple>
+    </ForwardRef>
+    <ForwardRef
+      itemIndex={1}
     >
-      <FocusRing>
-        <FocusRing
-          focusClass="md-focus-ring-wrapper children"
-          focusRingClass="md-focus-ring-wrapper children"
-        >
-          <button
-            className="md-button-simple-wrapper"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onDragStart={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchCancel={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            tabIndex={-1}
-            type="button"
-          />
+      <ButtonSimple
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onPress={[Function]}
+        tabIndex={-1}
+        useNativeKeyDown={true}
+      >
+        <FocusRing>
+          <FocusRing
+            focusClass="md-focus-ring-wrapper children"
+            focusRingClass="md-focus-ring-wrapper children"
+          >
+            <button
+              className="md-button-simple-wrapper"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onDragStart={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+              onTouchCancel={[Function]}
+              onTouchEnd={[Function]}
+              onTouchMove={[Function]}
+              onTouchStart={[Function]}
+              tabIndex={-1}
+              type="button"
+            />
+          </FocusRing>
         </FocusRing>
-      </FocusRing>
-    </ButtonSimple>
-    <ButtonSimple
-      key=".2"
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onPress={[Function]}
-      tabIndex={0}
-      useNativeKeyDown={true}
+      </ButtonSimple>
+    </ForwardRef>
+    <ForwardRef
+      itemIndex={2}
     >
-      <FocusRing>
-        <FocusRing
-          focusClass="md-focus-ring-wrapper children"
-          focusRingClass="md-focus-ring-wrapper children"
-        >
-          <button
-            className="md-button-simple-wrapper"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onDragStart={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchCancel={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            type="button"
-          />
+      <ButtonSimple
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onPress={[Function]}
+        tabIndex={0}
+        useNativeKeyDown={true}
+      >
+        <FocusRing>
+          <FocusRing
+            focusClass="md-focus-ring-wrapper children"
+            focusRingClass="md-focus-ring-wrapper children"
+          >
+            <button
+              className="md-button-simple-wrapper"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onDragStart={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+              onTouchCancel={[Function]}
+              onTouchEnd={[Function]}
+              onTouchMove={[Function]}
+              onTouchStart={[Function]}
+              type="button"
+            />
+          </FocusRing>
         </FocusRing>
-      </FocusRing>
-    </ButtonSimple>
+      </ButtonSimple>
+    </ForwardRef>
   </div>
 </AriaToolbar>
 `;

--- a/src/components/AriaToolbar/AriaToolbar.utils.ts
+++ b/src/components/AriaToolbar/AriaToolbar.utils.ts
@@ -1,0 +1,6 @@
+import React, { useContext } from 'react';
+import { AriaToolbarContextValue } from './AriaToolbar.types';
+
+export const AriaToolbarContext = React.createContext<AriaToolbarContextValue>(null);
+
+export const useAriaToolbarContext = (): AriaToolbarContextValue => useContext(AriaToolbarContext);

--- a/src/components/AriaToolbarItem/AriaToolbarItem.tsx
+++ b/src/components/AriaToolbarItem/AriaToolbarItem.tsx
@@ -1,0 +1,84 @@
+import { Props } from './AriaToolbarItem.types';
+
+import React, { forwardRef, useCallback } from 'react';
+
+import { useKeyboard } from '@react-aria/interactions';
+import { useAriaToolbarContext } from '../AriaToolbar/AriaToolbar.utils';
+
+const AriaToolbarItem = forwardRef<HTMLButtonElement, Props>((props, providedRef) => {
+  const { children, itemIndex } = props;
+
+  const {
+    currentFocus,
+    setCurrentFocus,
+    buttonRefs,
+    orientation,
+    onTabPress,
+    ariaToolbarItemsSize,
+  } = useAriaToolbarContext();
+
+  const { keyboardProps } = useKeyboard({
+    onKeyDown: (e) => {
+      // for the escape key (and other key presses), continue propagation to let Popovers / Modals know that
+      // they should close
+      e.continuePropagation();
+
+      switch (e.key) {
+        case orientation === 'horizontal' ? 'ArrowLeft' : 'ArrowUp':
+          e.preventDefault();
+          setCurrentFocus((ariaToolbarItemsSize + (currentFocus || 0) - 1) % ariaToolbarItemsSize);
+          break;
+
+        case orientation === 'horizontal' ? 'ArrowRight' : 'ArrowDown':
+          e.preventDefault();
+          setCurrentFocus((ariaToolbarItemsSize + (currentFocus || 0) + 1) % ariaToolbarItemsSize);
+          break;
+
+        case 'Tab': {
+          if (onTabPress) {
+            onTabPress(e);
+          }
+          break;
+        }
+
+        default:
+          break;
+      }
+    },
+  });
+
+  const getPropsForChildren = useCallback(
+    (child, index) => {
+      return {
+        tabIndex: index === (currentFocus || 0) ? 0 : -1,
+        ref: (e: HTMLButtonElement) => {
+          buttonRefs.current[index] = e;
+          if (providedRef) {
+            if (typeof providedRef === 'function') {
+              providedRef(e);
+            }
+          }
+        },
+        onFocus: (e) => {
+          setCurrentFocus(index);
+          if (child.props.onFocus) {
+            child.props.onFocus(e);
+          }
+        },
+        onPress: () => {
+          setCurrentFocus(index);
+          if (child.props.onPress) {
+            child.props.onPress();
+          }
+        },
+        useNativeKeyDown: true,
+        ...keyboardProps,
+      };
+    },
+    [currentFocus]
+  );
+
+  return React.cloneElement(children, getPropsForChildren(children, itemIndex));
+});
+
+export default AriaToolbarItem;

--- a/src/components/AriaToolbarItem/AriaToolbarItem.tsx
+++ b/src/components/AriaToolbarItem/AriaToolbarItem.tsx
@@ -8,14 +8,7 @@ import { useAriaToolbarContext } from '../AriaToolbar/AriaToolbar.utils';
 const AriaToolbarItem = forwardRef<HTMLButtonElement, Props>((props, providedRef) => {
   const { children, itemIndex } = props;
 
-  const {
-    currentFocus,
-    setCurrentFocus,
-    buttonRefs,
-    orientation,
-    onTabPress,
-    ariaToolbarItemsSize,
-  } = useAriaToolbarContext();
+  const ariaToolbarContext = useAriaToolbarContext();
 
   const { keyboardProps } = useKeyboard({
     onKeyDown: (e) => {
@@ -24,19 +17,29 @@ const AriaToolbarItem = forwardRef<HTMLButtonElement, Props>((props, providedRef
       e.continuePropagation();
 
       switch (e.key) {
-        case orientation === 'horizontal' ? 'ArrowLeft' : 'ArrowUp':
+        case ariaToolbarContext?.orientation === 'horizontal' ? 'ArrowLeft' : 'ArrowUp':
           e.preventDefault();
-          setCurrentFocus((ariaToolbarItemsSize + (currentFocus || 0) - 1) % ariaToolbarItemsSize);
+          ariaToolbarContext?.setCurrentFocus(
+            (ariaToolbarContext?.ariaToolbarItemsSize +
+              (ariaToolbarContext?.currentFocus || 0) -
+              1) %
+              ariaToolbarContext?.ariaToolbarItemsSize
+          );
           break;
 
-        case orientation === 'horizontal' ? 'ArrowRight' : 'ArrowDown':
+        case ariaToolbarContext?.orientation === 'horizontal' ? 'ArrowRight' : 'ArrowDown':
           e.preventDefault();
-          setCurrentFocus((ariaToolbarItemsSize + (currentFocus || 0) + 1) % ariaToolbarItemsSize);
+          ariaToolbarContext?.setCurrentFocus(
+            (ariaToolbarContext?.ariaToolbarItemsSize +
+              (ariaToolbarContext?.currentFocus || 0) +
+              1) %
+              ariaToolbarContext?.ariaToolbarItemsSize
+          );
           break;
 
         case 'Tab': {
-          if (onTabPress) {
-            onTabPress(e);
+          if (ariaToolbarContext?.onTabPress) {
+            ariaToolbarContext?.onTabPress(e);
           }
           break;
         }
@@ -50,23 +53,25 @@ const AriaToolbarItem = forwardRef<HTMLButtonElement, Props>((props, providedRef
   const getPropsForChildren = useCallback(
     (child, index) => {
       return {
-        tabIndex: index === (currentFocus || 0) ? 0 : -1,
+        tabIndex: index === (ariaToolbarContext?.currentFocus || 0) ? 0 : -1,
         ref: (e: HTMLButtonElement) => {
-          buttonRefs.current[index] = e;
-          if (providedRef) {
-            if (typeof providedRef === 'function') {
-              providedRef(e);
+          if (ariaToolbarContext.buttonRefs.current) {
+            ariaToolbarContext.buttonRefs.current[index] = e;
+            if (providedRef) {
+              if (typeof providedRef === 'function') {
+                providedRef(e);
+              }
             }
           }
         },
         onFocus: (e) => {
-          setCurrentFocus(index);
+          ariaToolbarContext?.setCurrentFocus(index);
           if (child.props.onFocus) {
             child.props.onFocus(e);
           }
         },
         onPress: () => {
-          setCurrentFocus(index);
+          ariaToolbarContext?.setCurrentFocus(index);
           if (child.props.onPress) {
             child.props.onPress();
           }
@@ -75,7 +80,7 @@ const AriaToolbarItem = forwardRef<HTMLButtonElement, Props>((props, providedRef
         ...keyboardProps,
       };
     },
-    [currentFocus]
+    [ariaToolbarContext?.currentFocus]
   );
 
   return React.cloneElement(children, getPropsForChildren(children, itemIndex));

--- a/src/components/AriaToolbarItem/AriaToolbarItem.types.ts
+++ b/src/components/AriaToolbarItem/AriaToolbarItem.types.ts
@@ -1,4 +1,4 @@
-import { CSSProperties, ReactElement, ReactNode } from 'react';
+import { ReactElement } from 'react';
 
 export interface Props {
   /**

--- a/src/components/AriaToolbarItem/AriaToolbarItem.types.ts
+++ b/src/components/AriaToolbarItem/AriaToolbarItem.types.ts
@@ -1,0 +1,13 @@
+import { CSSProperties, ReactElement, ReactNode } from 'react';
+
+export interface Props {
+  /**
+   * Child components of this AriaToolbarItem.
+   */
+  children: ReactElement;
+
+  /**
+   * The index of this item in the toolbar. Used for focus.
+   */
+  itemIndex: number;
+}

--- a/src/components/AriaToolbarItem/AriaToolbarItem.unit.test.tsx
+++ b/src/components/AriaToolbarItem/AriaToolbarItem.unit.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import AriaToolbarItem from './';
+import ButtonPill from '../ButtonPill';
+import { AriaToolbarContext } from '../AriaToolbar/AriaToolbar.utils';
+
+const TestComponent = (props) => {
+  return <AriaToolbarItem itemIndex={0} {...props} children={<ButtonPill>Test</ButtonPill>} />;
+};
+
+const mountWithContext = (component) =>
+  mount(component, {
+    wrappingComponent: AriaToolbarContext.Provider,
+    wrappingComponentProps: {
+      value: {
+        currentFocus: 0,
+        setCurrentFocus: jest.fn(),
+        buttonRefs: { current: [{ focus: jest.fn() }] },
+        orientation: 'horizontal',
+        onTabPress: jest.fn(),
+        ariaToolbarItemsSize: 1,
+      },
+    },
+  });
+
+describe('<AriaToolbarItem />', () => {
+  describe('snapshot', () => {
+    it('should match snapshot', () => {
+      expect.assertions(1);
+
+      const container = mountWithContext(<TestComponent />);
+
+      expect(container).toMatchSnapshot();
+    });
+  });
+
+  // keyboard interaction is tested in AriaToolbar.unit.test.tsx
+});

--- a/src/components/AriaToolbarItem/AriaToolbarItem.unit.test.tsx.snap
+++ b/src/components/AriaToolbarItem/AriaToolbarItem.unit.test.tsx.snap
@@ -1,0 +1,73 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<AriaToolbarItem /> snapshot should match snapshot 1`] = `
+<TestComponent>
+  <ForwardRef
+    itemIndex={0}
+  >
+    <ButtonPill
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onPress={[Function]}
+      tabIndex={0}
+      useNativeKeyDown={true}
+    >
+      <ButtonSimple
+        aria-disabled={false}
+        className="md-button-pill-wrapper"
+        data-color="primary"
+        data-disabled={false}
+        data-ghost={false}
+        data-grown={false}
+        data-inverted={false}
+        data-outline={false}
+        data-shallow-disabled={false}
+        data-size={40}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onPress={[Function]}
+        tabIndex={0}
+        useNativeKeyDown={true}
+      >
+        <FocusRing>
+          <FocusRing
+            focusClass="md-focus-ring-wrapper children"
+            focusRingClass="md-focus-ring-wrapper children"
+          >
+            <button
+              className="md-button-pill-wrapper md-button-simple-wrapper"
+              data-color="primary"
+              data-disabled={false}
+              data-ghost={false}
+              data-grown={false}
+              data-inverted={false}
+              data-outline={false}
+              data-shallow-disabled={false}
+              data-size={40}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onDragStart={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+              onTouchCancel={[Function]}
+              onTouchEnd={[Function]}
+              onTouchMove={[Function]}
+              onTouchStart={[Function]}
+              type="button"
+            >
+              <span>
+                Test
+              </span>
+            </button>
+          </FocusRing>
+        </FocusRing>
+      </ButtonSimple>
+    </ButtonPill>
+  </ForwardRef>
+</TestComponent>
+`;

--- a/src/components/AriaToolbarItem/index.ts
+++ b/src/components/AriaToolbarItem/index.ts
@@ -1,0 +1,6 @@
+import { default as AriaToolbarItem } from './AriaToolbarItem';
+import { Props } from './AriaToolbarItem.types';
+
+export type AriaToolbarItemProps = Props;
+
+export default AriaToolbarItem;

--- a/src/components/Avatar/Avatar.unit.test.tsx
+++ b/src/components/Avatar/Avatar.unit.test.tsx
@@ -178,8 +178,7 @@ describe('Avatar', () => {
       const actionLabel = 'Action';
 
       const container = await mountAndWait(
-        // eslint-disable-next-line no-console
-        <Avatar  actionLabel={actionLabel} onPress={()=>{console.log('onPress');}}/>
+        <Avatar actionLabel={actionLabel} onPress={jest.fn()} />
       );
 
       expect(container).toMatchSnapshot();

--- a/src/components/Avatar/Avatar.unit.test.tsx.snap
+++ b/src/components/Avatar/Avatar.unit.test.tsx.snap
@@ -31,12 +31,12 @@ exports[`Avatar snapshot should match snapshot 1`] = `
 exports[`Avatar snapshot should match snapshot with actionLabel 1`] = `
 <Avatar
   actionLabel="Action"
-  onPress={[Function]}
+  onPress={[MockFunction]}
 >
   <ButtonSimple
     aria-label="Action"
     className="md-avatar-button-wrapper"
-    onPress={[Function]}
+    onPress={[MockFunction]}
     useNativeKeyDown={true}
   >
     <FocusRing>

--- a/src/components/OverlayAlert/OverlayAlert.stories.tsx
+++ b/src/components/OverlayAlert/OverlayAlert.stories.tsx
@@ -13,7 +13,6 @@ import OverlayAlert, { OverlayAlertProps } from './';
 import argTypes from './OverlayAlert.stories.args';
 import Documentation from './OverlayAlert.stories.docs.mdx';
 import Tooltip from '../Tooltip';
-import TooltipPopoverCombo from '../TooltipPopoverCombo';
 
 export default {
   title: 'Momentum UI/OverlayAlert',

--- a/src/components/Popover/Popover.stories.tsx
+++ b/src/components/Popover/Popover.stories.tsx
@@ -18,6 +18,7 @@ import Avatar from '../Avatar';
 import MeetingListItem from '../MeetingListItem';
 import SearchInput from '../SearchInput';
 import List from '../List';
+import AriaToolbarItem from '../AriaToolbarItem';
 
 export default {
   title: 'Momentum UI/Popover',
@@ -140,13 +141,21 @@ const PopoverWithFirstFocus = (props) => {
 
   return (
     <Popover firstFocusElement={ref} {...props}>
-      <AriaToolbar ariaLabel="toolbar">
-        <ButtonPill key={1}>1</ButtonPill>
-        <ButtonPill key={2} ref={setRef}>
-          2
-        </ButtonPill>
-        <ButtonPill key={3}>3</ButtonPill>
-        <ButtonPill key={4}>4</ButtonPill>
+      <AriaToolbar ariaToolbarItemsSize={4} ariaLabel="toolbar">
+        <AriaToolbarItem itemIndex={0}>
+          <ButtonPill key={1}>1</ButtonPill>
+        </AriaToolbarItem>
+        <AriaToolbarItem itemIndex={1}>
+          <ButtonPill key={2} ref={setRef}>
+            2
+          </ButtonPill>
+        </AriaToolbarItem>
+        <AriaToolbarItem itemIndex={2}>
+          <ButtonPill key={3}>3</ButtonPill>
+        </AriaToolbarItem>
+        <AriaToolbarItem itemIndex={3}>
+          <ButtonPill key={4}>4</ButtonPill>
+        </AriaToolbarItem>
       </AriaToolbar>
     </Popover>
   );

--- a/src/components/ReactionButton/ReactionButton.style.scss
+++ b/src/components/ReactionButton/ReactionButton.style.scss
@@ -3,14 +3,9 @@
   background-color: rgba(0, 0, 0, 1);
   background-color: var(--mds-color-theme-groupedbackground-primary-normal);
 
-  &:hover {
-    background-color: rgba(255, 255, 255, 0.07);
-    background-color: var(--mds-color-theme-button-secondary-hover);
-  }
-
   &[data-reacted='true'] {
-    background-color: rgba(255, 255, 255, 0.11);
-    background-color: var(--mds-color-theme-background-primary-active);
+    background-color: rgba(255, 255, 255, 0.11) !important;
+    background-color: var(--mds-color-theme-background-primary-active) !important;
   }
 
   .md-reaction-wrapper {

--- a/src/components/ReactionButton/ReactionButton.tsx
+++ b/src/components/ReactionButton/ReactionButton.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, RefObject, forwardRef } from 'react';
 import classnames from 'classnames';
 import ButtonCircle, { ButtonCircleSize } from '../ButtonCircle';
 
@@ -9,22 +9,24 @@ import './ReactionButton.style.scss';
 /**
  * Button within the ReactionPicker
  */
-const ReactionButton: FC<Props> = (props: Props) => {
+const ReactionButton = forwardRef((props: Props, ref: RefObject<HTMLButtonElement>) => {
   const { className, children, id, reacted, style, ...otherProps } = props;
   delete otherProps.size;
   return (
     <ButtonCircle
+      ref={ref}
       className={classnames(className, STYLE.wrapper)}
       data-reacted={reacted || DEFAULTS.REACTED}
       id={id}
       size={DEFAULTS.SIZE as ButtonCircleSize}
       style={style}
+      ghost
       {...otherProps}
     >
       {children}
     </ButtonCircle>
   );
-};
+});
 
 ReactionButton.displayName = 'ReactionButton';
 

--- a/src/components/ReactionButton/ReactionButton.unit.test.tsx.snap
+++ b/src/components/ReactionButton/ReactionButton.unit.test.tsx.snap
@@ -5,6 +5,7 @@ exports[`<ReactionButton /> snapshot should match snapshot 1`] = `
   <ButtonCircle
     className="md-reaction-button-wrapper"
     data-reacted={false}
+    ghost={true}
     size={32}
   >
     <ButtonSimple
@@ -12,7 +13,7 @@ exports[`<ReactionButton /> snapshot should match snapshot 1`] = `
       className="md-button-circle-wrapper md-reaction-button-wrapper"
       data-color="primary"
       data-disabled={false}
-      data-ghost={false}
+      data-ghost={true}
       data-inverted={false}
       data-multiple-children={false}
       data-outline={false}
@@ -29,7 +30,7 @@ exports[`<ReactionButton /> snapshot should match snapshot 1`] = `
             className="md-button-circle-wrapper md-reaction-button-wrapper md-button-simple-wrapper"
             data-color="primary"
             data-disabled={false}
-            data-ghost={false}
+            data-ghost={true}
             data-inverted={false}
             data-multiple-children={false}
             data-outline={false}
@@ -76,6 +77,7 @@ exports[`<ReactionButton /> snapshot should match snapshot with className 1`] = 
   <ButtonCircle
     className="example-class md-reaction-button-wrapper"
     data-reacted={false}
+    ghost={true}
     size={32}
   >
     <ButtonSimple
@@ -83,7 +85,7 @@ exports[`<ReactionButton /> snapshot should match snapshot with className 1`] = 
       className="md-button-circle-wrapper example-class md-reaction-button-wrapper"
       data-color="primary"
       data-disabled={false}
-      data-ghost={false}
+      data-ghost={true}
       data-inverted={false}
       data-multiple-children={false}
       data-outline={false}
@@ -100,7 +102,7 @@ exports[`<ReactionButton /> snapshot should match snapshot with className 1`] = 
             className="md-button-circle-wrapper example-class md-reaction-button-wrapper md-button-simple-wrapper"
             data-color="primary"
             data-disabled={false}
-            data-ghost={false}
+            data-ghost={true}
             data-inverted={false}
             data-multiple-children={false}
             data-outline={false}
@@ -147,6 +149,7 @@ exports[`<ReactionButton /> snapshot should match snapshot with id 1`] = `
   <ButtonCircle
     className="md-reaction-button-wrapper"
     data-reacted={false}
+    ghost={true}
     id="example-id"
     size={32}
   >
@@ -155,7 +158,7 @@ exports[`<ReactionButton /> snapshot should match snapshot with id 1`] = `
       className="md-button-circle-wrapper md-reaction-button-wrapper"
       data-color="primary"
       data-disabled={false}
-      data-ghost={false}
+      data-ghost={true}
       data-inverted={false}
       data-multiple-children={false}
       data-outline={false}
@@ -173,7 +176,7 @@ exports[`<ReactionButton /> snapshot should match snapshot with id 1`] = `
             className="md-button-circle-wrapper md-reaction-button-wrapper md-button-simple-wrapper"
             data-color="primary"
             data-disabled={false}
-            data-ghost={false}
+            data-ghost={true}
             data-inverted={false}
             data-multiple-children={false}
             data-outline={false}
@@ -221,6 +224,7 @@ exports[`<ReactionButton /> snapshot should match snapshot with reacted 1`] = `
   <ButtonCircle
     className="md-reaction-button-wrapper"
     data-reacted={true}
+    ghost={true}
     size={32}
   >
     <ButtonSimple
@@ -228,7 +232,7 @@ exports[`<ReactionButton /> snapshot should match snapshot with reacted 1`] = `
       className="md-button-circle-wrapper md-reaction-button-wrapper"
       data-color="primary"
       data-disabled={false}
-      data-ghost={false}
+      data-ghost={true}
       data-inverted={false}
       data-multiple-children={false}
       data-outline={false}
@@ -245,7 +249,7 @@ exports[`<ReactionButton /> snapshot should match snapshot with reacted 1`] = `
             className="md-button-circle-wrapper md-reaction-button-wrapper md-button-simple-wrapper"
             data-color="primary"
             data-disabled={false}
-            data-ghost={false}
+            data-ghost={true}
             data-inverted={false}
             data-multiple-children={false}
             data-outline={false}
@@ -296,6 +300,7 @@ exports[`<ReactionButton /> snapshot should match snapshot with style 1`] = `
   <ButtonCircle
     className="md-reaction-button-wrapper"
     data-reacted={false}
+    ghost={true}
     size={32}
     style={
       Object {
@@ -308,7 +313,7 @@ exports[`<ReactionButton /> snapshot should match snapshot with style 1`] = `
       className="md-button-circle-wrapper md-reaction-button-wrapper"
       data-color="primary"
       data-disabled={false}
-      data-ghost={false}
+      data-ghost={true}
       data-inverted={false}
       data-multiple-children={false}
       data-outline={false}
@@ -330,7 +335,7 @@ exports[`<ReactionButton /> snapshot should match snapshot with style 1`] = `
             className="md-button-circle-wrapper md-reaction-button-wrapper md-button-simple-wrapper"
             data-color="primary"
             data-disabled={false}
-            data-ghost={false}
+            data-ghost={true}
             data-inverted={false}
             data-multiple-children={false}
             data-outline={false}

--- a/src/components/ReactionPicker/ReactionPicker.stories.tsx
+++ b/src/components/ReactionPicker/ReactionPicker.stories.tsx
@@ -10,6 +10,7 @@ import ReactionButton from '../ReactionButton';
 import argTypes from './ReactionPicker.stories.args';
 import Documentation from './ReactionPicker.stories.docs.mdx';
 import Text from '../Text';
+import AriaToolbarItem from '../AriaToolbarItem';
 
 const reactionChildren = [
   <Tooltip
@@ -17,32 +18,46 @@ const reactionChildren = [
     placement="top"
     variant="small"
     triggerComponent={
-      <ReactionButton key="1">
-        <Reaction name="celebrate" autoPlay />
-      </ReactionButton>
+      <AriaToolbarItem itemIndex={0}>
+        <ReactionButton key="1">
+          <Reaction name="celebrate" autoPlay />
+        </ReactionButton>
+      </AriaToolbarItem>
     }
   >
     <Text type="body-compact">Celebrate!</Text>
   </Tooltip>,
+  <AriaToolbarItem itemIndex={1}>
+    <ReactionButton key="2">
+      <Reaction name="heart" autoPlay />
+    </ReactionButton>
+  </AriaToolbarItem>,
 
-  <ReactionButton key="2">
-    <Reaction name="heart" autoPlay />
-  </ReactionButton>,
-  <ReactionButton key="3">
-    <Reaction name="thumb_up_yellow" autoPlay />
-  </ReactionButton>,
-  <ReactionButton reacted key="4">
-    <Reaction name="smile" autoPlay />
-  </ReactionButton>,
-  <ReactionButton key="5">
-    <Reaction name="haha" autoPlay />
-  </ReactionButton>,
-  <ReactionButton key="6">
-    <Reaction name="wow" autoPlay />
-  </ReactionButton>,
-  <ReactionButton key="7">
-    <Reaction name="sad" autoPlay />
-  </ReactionButton>,
+  <AriaToolbarItem itemIndex={2}>
+    <ReactionButton key="3">
+      <Reaction name="thumb_up_yellow" autoPlay />
+    </ReactionButton>
+  </AriaToolbarItem>,
+  <AriaToolbarItem itemIndex={3}>
+    <ReactionButton reacted key="4">
+      <Reaction name="smile" autoPlay />
+    </ReactionButton>
+  </AriaToolbarItem>,
+  <AriaToolbarItem itemIndex={4}>
+    <ReactionButton key="5">
+      <Reaction name="haha" autoPlay />
+    </ReactionButton>
+  </AriaToolbarItem>,
+  <AriaToolbarItem itemIndex={5}>
+    <ReactionButton key="6">
+      <Reaction name="wow" autoPlay />
+    </ReactionButton>
+  </AriaToolbarItem>,
+  <AriaToolbarItem itemIndex={6}>
+    <ReactionButton key="7">
+      <Reaction name="sad" autoPlay />
+    </ReactionButton>
+  </AriaToolbarItem>,
 ];
 
 export default {
@@ -57,6 +72,8 @@ export default {
   subComponents: { ReactionButton },
   args: {
     children: reactionChildren,
+    // 7 because there are 7 reactions at the top.
+    ariaToolbarItemsSize: 7,
   },
 };
 

--- a/src/components/ReactionPicker/ReactionPicker.stories.tsx
+++ b/src/components/ReactionPicker/ReactionPicker.stories.tsx
@@ -5,14 +5,26 @@ import StyleDocs from '../../storybook/docs.stories.style.mdx';
 
 import ReactionPicker, { ReactionPickerProps } from './';
 import Reaction from '../Reaction';
+import Tooltip from '../Tooltip';
 import ReactionButton from '../ReactionButton';
 import argTypes from './ReactionPicker.stories.args';
 import Documentation from './ReactionPicker.stories.docs.mdx';
+import Text from '../Text';
 
 const reactionChildren = [
-  <ReactionButton key="1">
-    <Reaction name="celebrate" autoPlay />
-  </ReactionButton>,
+  <Tooltip
+    type="label"
+    placement="top"
+    variant="small"
+    triggerComponent={
+      <ReactionButton key="1">
+        <Reaction name="celebrate" autoPlay />
+      </ReactionButton>
+    }
+  >
+    <Text type="body-compact">Celebrate!</Text>
+  </Tooltip>,
+
   <ReactionButton key="2">
     <Reaction name="heart" autoPlay />
   </ReactionButton>,

--- a/src/components/ReactionPicker/ReactionPicker.stories.tsx
+++ b/src/components/ReactionPicker/ReactionPicker.stories.tsx
@@ -14,6 +14,7 @@ import AriaToolbarItem from '../AriaToolbarItem';
 
 const reactionChildren = [
   <Tooltip
+    key={'item-1'}
     type="label"
     placement="top"
     variant="small"
@@ -27,33 +28,33 @@ const reactionChildren = [
   >
     <Text type="body-compact">Celebrate!</Text>
   </Tooltip>,
-  <AriaToolbarItem itemIndex={1}>
+  <AriaToolbarItem itemIndex={1} key={'item-2'}>
     <ReactionButton key="2">
       <Reaction name="heart" autoPlay />
     </ReactionButton>
   </AriaToolbarItem>,
 
-  <AriaToolbarItem itemIndex={2}>
+  <AriaToolbarItem itemIndex={2} key={'item-3'}>
     <ReactionButton key="3">
       <Reaction name="thumb_up_yellow" autoPlay />
     </ReactionButton>
   </AriaToolbarItem>,
-  <AriaToolbarItem itemIndex={3}>
+  <AriaToolbarItem itemIndex={3} key={'item-4'}>
     <ReactionButton reacted key="4">
       <Reaction name="smile" autoPlay />
     </ReactionButton>
   </AriaToolbarItem>,
-  <AriaToolbarItem itemIndex={4}>
+  <AriaToolbarItem itemIndex={4} key={'item-5'}>
     <ReactionButton key="5">
       <Reaction name="haha" autoPlay />
     </ReactionButton>
   </AriaToolbarItem>,
-  <AriaToolbarItem itemIndex={5}>
+  <AriaToolbarItem itemIndex={5} key={'item-6'}>
     <ReactionButton key="6">
       <Reaction name="wow" autoPlay />
     </ReactionButton>
   </AriaToolbarItem>,
-  <AriaToolbarItem itemIndex={6}>
+  <AriaToolbarItem itemIndex={6} key={'item-7'}>
     <ReactionButton key="7">
       <Reaction name="sad" autoPlay />
     </ReactionButton>

--- a/src/components/ReactionPicker/ReactionPicker.style.scss
+++ b/src/components/ReactionPicker/ReactionPicker.style.scss
@@ -5,26 +5,12 @@
   border: 0.0625rem solid rgba(255, 255, 255, 0.2);
   border: 0.0625rem solid var(--mds-color-theme-outline-secondary-normal);
   box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.16), 0 0 0.0625rem rgba(0, 0, 0, 0.16);
-  overflow: hidden;
-
-  .md-reaction-button-wrapper {
-    margin: 0 0.125rem;
-    border-radius: 100vh;
-  }
-
-  &[data-round='true'] {
-    border-radius: 100vh;
-
-    &[data-spaced='false'] {
-      > * {
-        &:first-child {
-          border-radius: 100vh;
-        }
-
-        &:last-child {
-          border-radius: 100vh;
-        }
-      }
-    }
-  }
+  overflow: visible;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  justify-content: center;
+  width: fit-content;
+  margin: 0 0.125rem;
+  border-radius: 100vh;
 }

--- a/src/components/ReactionPicker/ReactionPicker.tsx
+++ b/src/components/ReactionPicker/ReactionPicker.tsx
@@ -1,22 +1,25 @@
-import React, { FC } from 'react';
+import React, { FC, useRef } from 'react';
 import classnames from 'classnames';
 
 import { STYLE } from './ReactionPicker.constants';
 import { Props } from './ReactionPicker.types';
 import './ReactionPicker.style.scss';
-import ButtonGroup from '../ButtonGroup';
+import AriaToolbar from '../AriaToolbar';
 
 const ReactionPicker: FC<Props> = (props: Props) => {
-  const { children, className, id, style } = props;
+  const { children, className, id, style, ariaLabel, ...other } = props;
+
   return (
-    <ButtonGroup
+    <AriaToolbar
+      ariaLabel={ariaLabel}
       className={classnames(className, STYLE.wrapper)}
       id={id}
-      round={true}
       style={style}
+      orientation="horizontal"
+      {...other}
     >
       {children}
-    </ButtonGroup>
+    </AriaToolbar>
   );
 };
 

--- a/src/components/ReactionPicker/ReactionPicker.types.ts
+++ b/src/components/ReactionPicker/ReactionPicker.types.ts
@@ -1,26 +1,7 @@
 import { CSSProperties, ReactElement } from 'react';
 
 import { ReactionButtonProps } from '../ReactionButton';
+import { AriaToolbarProps } from '../AriaToolbar';
 
 export type SupportedChildren = ReactionButtonProps;
-export interface Props {
-  /**
-   * Child components of this ReactionPicker.
-   */
-  children?: ReactElement<SupportedChildren> | Array<ReactElement<SupportedChildren>>;
-
-  /**
-   * Custom class for overriding this component's CSS.
-   */
-  className?: string;
-
-  /**
-   * Custom id for overriding this component's CSS.
-   */
-  id?: string;
-
-  /**
-   * Custom style for overriding this component's CSS.
-   */
-  style?: CSSProperties;
-}
+export type Props = AriaToolbarProps

--- a/src/components/ReactionPicker/ReactionPicker.unit.test.tsx
+++ b/src/components/ReactionPicker/ReactionPicker.unit.test.tsx
@@ -3,13 +3,16 @@ import { mount } from 'enzyme';
 
 import ReactionPicker, { REACTION_PICKER_CONSTANTS as CONSTANTS } from './';
 import ReactionButton from '../ReactionButton';
+import AriaToolbarItem from '../AriaToolbarItem';
 
 describe('<ReactionPicker />', () => {
   describe('snapshot', () => {
     it('should match snapshot', () => {
       expect.assertions(1);
 
-      const container = mount(<ReactionPicker />);
+      const container = mount(
+        <ReactionPicker ariaToolbarItemsSize={0} ariaLabel="test-aria-label" />
+      );
 
       expect(container).toMatchSnapshot();
     });
@@ -19,7 +22,13 @@ describe('<ReactionPicker />', () => {
 
       const className = 'example-class';
 
-      const container = mount(<ReactionPicker className={className} />);
+      const container = mount(
+        <ReactionPicker
+          className={className}
+          ariaToolbarItemsSize={0}
+          ariaLabel="test-aria-label"
+        />
+      );
 
       expect(container).toMatchSnapshot();
     });
@@ -29,7 +38,9 @@ describe('<ReactionPicker />', () => {
 
       const id = 'example-id';
 
-      const container = mount(<ReactionPicker id={id} />);
+      const container = mount(
+        <ReactionPicker id={id} ariaToolbarItemsSize={0} ariaLabel="test-aria-label" />
+      );
 
       expect(container).toMatchSnapshot();
     });
@@ -39,7 +50,9 @@ describe('<ReactionPicker />', () => {
 
       const style = { color: 'pink' };
 
-      const container = mount(<ReactionPicker style={style} />);
+      const container = mount(
+        <ReactionPicker style={style} ariaToolbarItemsSize={0} ariaLabel="test-aria-label" />
+      );
 
       expect(container).toMatchSnapshot();
     });
@@ -47,9 +60,17 @@ describe('<ReactionPicker />', () => {
     it('should match snapshot with children', () => {
       expect.assertions(1);
 
-      const children = <ReactionButton />;
+      const children = (
+        <AriaToolbarItem itemIndex={0}>
+          <ReactionButton />
+        </AriaToolbarItem>
+      );
 
-      const container = mount(<ReactionPicker>{children}</ReactionPicker>);
+      const container = mount(
+        <ReactionPicker ariaToolbarItemsSize={1} ariaLabel="test-aria-label">
+          {children}
+        </ReactionPicker>
+      );
 
       expect(container).toMatchSnapshot();
     });
@@ -59,7 +80,7 @@ describe('<ReactionPicker />', () => {
     it('should have its wrapper class', () => {
       expect.assertions(1);
 
-      const element = mount(<ReactionPicker />)
+      const element = mount(<ReactionPicker ariaToolbarItemsSize={0} ariaLabel="test-aria-label" />)
         .find(ReactionPicker)
         .getDOMNode();
 
@@ -71,7 +92,13 @@ describe('<ReactionPicker />', () => {
 
       const className = 'example-class';
 
-      const element = mount(<ReactionPicker className={className} />)
+      const element = mount(
+        <ReactionPicker
+          className={className}
+          ariaToolbarItemsSize={0}
+          ariaLabel="test-aria-label"
+        />
+      )
         .find(ReactionPicker)
         .getDOMNode();
 
@@ -83,7 +110,9 @@ describe('<ReactionPicker />', () => {
 
       const id = 'example-id';
 
-      const element = mount(<ReactionPicker id={id} />)
+      const element = mount(
+        <ReactionPicker id={id} ariaToolbarItemsSize={0} ariaLabel="test-aria-label" />
+      )
         .find(ReactionPicker)
         .getDOMNode();
 
@@ -96,7 +125,9 @@ describe('<ReactionPicker />', () => {
       const style = { color: 'pink' };
       const styleString = 'color: pink;';
 
-      const element = mount(<ReactionPicker style={style} />)
+      const element = mount(
+        <ReactionPicker style={style} ariaToolbarItemsSize={0} ariaLabel="test-aria-label" />
+      )
         .find(ReactionPicker)
         .getDOMNode();
 

--- a/src/components/ReactionPicker/ReactionPicker.unit.test.tsx.snap
+++ b/src/components/ReactionPicker/ReactionPicker.unit.test.tsx.snap
@@ -1,151 +1,182 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<ReactionPicker /> snapshot should match snapshot 1`] = `
-<ReactionPicker>
-  <ButtonGroup
+<ReactionPicker
+  ariaLabel="test-aria-label"
+  ariaToolbarItemsSize={0}
+>
+  <AriaToolbar
+    ariaLabel="test-aria-label"
+    ariaToolbarItemsSize={0}
     className="md-reaction-picker-wrapper"
-    round={true}
+    orientation="horizontal"
   >
     <div
-      className="md-button-group-wrapper md-reaction-picker-wrapper"
-      data-compressed={false}
-      data-orientation="horizontal"
-      data-round={true}
-      data-separator={false}
-      data-spaced={false}
+      aria-label="test-aria-label"
+      className="md-reaction-picker-wrapper md-aria-toolbar-wrapper"
+      role="toolbar"
     />
-  </ButtonGroup>
+  </AriaToolbar>
 </ReactionPicker>
 `;
 
 exports[`<ReactionPicker /> snapshot should match snapshot with children 1`] = `
-<ReactionPicker>
-  <ButtonGroup
+<ReactionPicker
+  ariaLabel="test-aria-label"
+  ariaToolbarItemsSize={1}
+>
+  <AriaToolbar
+    ariaLabel="test-aria-label"
+    ariaToolbarItemsSize={1}
     className="md-reaction-picker-wrapper"
-    round={true}
+    orientation="horizontal"
   >
     <div
-      className="md-button-group-wrapper md-reaction-picker-wrapper"
-      data-compressed={false}
-      data-orientation="horizontal"
-      data-round={true}
-      data-separator={false}
-      data-spaced={false}
+      aria-label="test-aria-label"
+      className="md-reaction-picker-wrapper md-aria-toolbar-wrapper"
+      role="toolbar"
     >
-      <ReactionButton>
-        <ButtonCircle
-          className="md-reaction-button-wrapper"
-          data-reacted={false}
-          size={32}
+      <ForwardRef
+        itemIndex={0}
+      >
+        <ReactionButton
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onPress={[Function]}
+          tabIndex={0}
+          useNativeKeyDown={true}
         >
-          <ButtonSimple
-            aria-disabled={false}
-            className="md-button-circle-wrapper md-reaction-button-wrapper"
-            data-color="primary"
-            data-disabled={false}
-            data-ghost={false}
-            data-inverted={false}
-            data-multiple-children={false}
-            data-outline={false}
+          <ButtonCircle
+            className="md-reaction-button-wrapper"
             data-reacted={false}
-            data-shallow-disabled={false}
-            data-size={32}
+            ghost={true}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onPress={[Function]}
+            size={32}
+            tabIndex={0}
+            useNativeKeyDown={true}
           >
-            <FocusRing>
-              <FocusRing
-                focusClass="md-focus-ring-wrapper children"
-                focusRingClass="md-focus-ring-wrapper children"
-              >
-                <button
-                  className="md-button-circle-wrapper md-reaction-button-wrapper md-button-simple-wrapper"
-                  data-color="primary"
-                  data-disabled={false}
-                  data-ghost={false}
-                  data-inverted={false}
-                  data-multiple-children={false}
-                  data-outline={false}
-                  data-reacted={false}
-                  data-shallow-disabled={false}
-                  data-size={32}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onDragStart={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchCancel={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  type="button"
-                />
+            <ButtonSimple
+              aria-disabled={false}
+              className="md-button-circle-wrapper md-reaction-button-wrapper"
+              data-color="primary"
+              data-disabled={false}
+              data-ghost={true}
+              data-inverted={false}
+              data-multiple-children={false}
+              data-outline={false}
+              data-reacted={false}
+              data-shallow-disabled={false}
+              data-size={32}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onPress={[Function]}
+              tabIndex={0}
+              useNativeKeyDown={true}
+            >
+              <FocusRing>
+                <FocusRing
+                  focusClass="md-focus-ring-wrapper children"
+                  focusRingClass="md-focus-ring-wrapper children"
+                >
+                  <button
+                    className="md-button-circle-wrapper md-reaction-button-wrapper md-button-simple-wrapper"
+                    data-color="primary"
+                    data-disabled={false}
+                    data-ghost={true}
+                    data-inverted={false}
+                    data-multiple-children={false}
+                    data-outline={false}
+                    data-reacted={false}
+                    data-shallow-disabled={false}
+                    data-size={32}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onDragStart={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchCancel={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchMove={[Function]}
+                    onTouchStart={[Function]}
+                    type="button"
+                  />
+                </FocusRing>
               </FocusRing>
-            </FocusRing>
-          </ButtonSimple>
-        </ButtonCircle>
-      </ReactionButton>
+            </ButtonSimple>
+          </ButtonCircle>
+        </ReactionButton>
+      </ForwardRef>
     </div>
-  </ButtonGroup>
+  </AriaToolbar>
 </ReactionPicker>
 `;
 
 exports[`<ReactionPicker /> snapshot should match snapshot with className 1`] = `
 <ReactionPicker
+  ariaLabel="test-aria-label"
+  ariaToolbarItemsSize={0}
   className="example-class"
 >
-  <ButtonGroup
+  <AriaToolbar
+    ariaLabel="test-aria-label"
+    ariaToolbarItemsSize={0}
     className="example-class md-reaction-picker-wrapper"
-    round={true}
+    orientation="horizontal"
   >
     <div
-      className="md-button-group-wrapper example-class md-reaction-picker-wrapper"
-      data-compressed={false}
-      data-orientation="horizontal"
-      data-round={true}
-      data-separator={false}
-      data-spaced={false}
+      aria-label="test-aria-label"
+      className="example-class md-reaction-picker-wrapper md-aria-toolbar-wrapper"
+      role="toolbar"
     />
-  </ButtonGroup>
+  </AriaToolbar>
 </ReactionPicker>
 `;
 
 exports[`<ReactionPicker /> snapshot should match snapshot with id 1`] = `
 <ReactionPicker
+  ariaLabel="test-aria-label"
+  ariaToolbarItemsSize={0}
   id="example-id"
 >
-  <ButtonGroup
+  <AriaToolbar
+    ariaLabel="test-aria-label"
+    ariaToolbarItemsSize={0}
     className="md-reaction-picker-wrapper"
     id="example-id"
-    round={true}
+    orientation="horizontal"
   >
     <div
-      className="md-button-group-wrapper md-reaction-picker-wrapper"
-      data-compressed={false}
-      data-orientation="horizontal"
-      data-round={true}
-      data-separator={false}
-      data-spaced={false}
+      aria-label="test-aria-label"
+      className="md-reaction-picker-wrapper md-aria-toolbar-wrapper"
       id="example-id"
+      role="toolbar"
     />
-  </ButtonGroup>
+  </AriaToolbar>
 </ReactionPicker>
 `;
 
 exports[`<ReactionPicker /> snapshot should match snapshot with style 1`] = `
 <ReactionPicker
+  ariaLabel="test-aria-label"
+  ariaToolbarItemsSize={0}
   style={
     Object {
       "color": "pink",
     }
   }
 >
-  <ButtonGroup
+  <AriaToolbar
+    ariaLabel="test-aria-label"
+    ariaToolbarItemsSize={0}
     className="md-reaction-picker-wrapper"
-    round={true}
+    orientation="horizontal"
     style={
       Object {
         "color": "pink",
@@ -153,18 +184,15 @@ exports[`<ReactionPicker /> snapshot should match snapshot with style 1`] = `
     }
   >
     <div
-      className="md-button-group-wrapper md-reaction-picker-wrapper"
-      data-compressed={false}
-      data-orientation="horizontal"
-      data-round={true}
-      data-separator={false}
-      data-spaced={false}
+      aria-label="test-aria-label"
+      className="md-reaction-picker-wrapper md-aria-toolbar-wrapper"
+      role="toolbar"
       style={
         Object {
           "color": "pink",
         }
       }
     />
-  </ButtonGroup>
+  </AriaToolbar>
 </ReactionPicker>
 `;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -65,6 +65,7 @@ export { default as Chip } from './Chip';
 export { default as RadioGroup } from './RadioGroup';
 export { default as NotificationSystem } from './NotificationSystem';
 export { default as AriaToolbar } from './AriaToolbar';
+export { default as AriaToolbarItem } from './AriaToolbarItem';
 export { default as Slider } from './Slider';
 export { default as ComboBox } from './ComboBox';
 export { default as AriaGroup } from './AriaGroup';

--- a/src/index.js
+++ b/src/index.js
@@ -178,6 +178,7 @@ export {
   Chip as ChipNext,
   NotificationSystem,
   AriaToolbar,
+  AriaToolbarItem,
   Slider as SliderNext,
   ComboBox as ComboBoxNext,
   AriaGroup,

--- a/src/utils/useProvidedRef.test.ts
+++ b/src/utils/useProvidedRef.test.ts
@@ -1,0 +1,26 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useProvidedRef } from './useProvidedRef';
+
+describe('useProvidedRef', () => {
+  it('should return an internal ref with initial value if no ref is provided', () => {
+    const { result } = renderHook(() => useProvidedRef(null, 'initial'));
+    expect(result.current.current).toBe('initial');
+  });
+
+  it('should use the provided object ref', () => {
+    const providedRef = { current: 'provided' };
+    const { result } = renderHook(() => useProvidedRef(providedRef));
+
+    expect(result.current).toBe(providedRef);
+    expect(result.current.current).toBe('provided');
+  });
+
+  it('should call the provided function ref', () => {
+    const refCallback = jest.fn();
+    const { result } = renderHook(() => useProvidedRef(refCallback, 'initial'));
+
+    expect(refCallback).toHaveBeenCalledWith('initial');
+    expect(result.current).toBe({ current: 'initial' });
+    expect(result.current.current).toBe('initial');
+  });
+});

--- a/src/utils/useProvidedRef.test.ts
+++ b/src/utils/useProvidedRef.test.ts
@@ -20,7 +20,6 @@ describe('useProvidedRef', () => {
     const { result } = renderHook(() => useProvidedRef(refCallback, 'initial'));
 
     expect(refCallback).toHaveBeenCalledWith('initial');
-    expect(result.current).toBe({ current: 'initial' });
     expect(result.current.current).toBe('initial');
   });
 });

--- a/src/utils/useProvidedRef.ts
+++ b/src/utils/useProvidedRef.ts
@@ -1,0 +1,26 @@
+import React, { useRef, useLayoutEffect } from 'react';
+
+/**
+ * Utility hook to merge provided with internal ref.
+ * It works with both callback refs and normal object ref.
+ * @param providedRef
+ * @param initialValue
+ * @returns
+ */
+export const useProvidedRef = <T>(providedRef: React.ForwardedRef<T>, initialValue: T = null) => {
+  let ref = useRef<T>(initialValue);
+
+  if (providedRef && typeof providedRef !== 'function') {
+    ref = providedRef;
+  }
+
+  useLayoutEffect(() => {
+    if (providedRef) {
+      if (typeof providedRef === 'function') {
+        providedRef(ref.current);
+      }
+    }
+  }, []);
+
+  return ref;
+};

--- a/src/utils/useProvidedRef.ts
+++ b/src/utils/useProvidedRef.ts
@@ -7,7 +7,10 @@ import React, { useRef, useLayoutEffect } from 'react';
  * @param initialValue
  * @returns
  */
-export const useProvidedRef = <T>(providedRef: React.ForwardedRef<T>, initialValue: T = null) => {
+export const useProvidedRef = <T>(
+  providedRef: React.ForwardedRef<T>,
+  initialValue: T = null
+): React.MutableRefObject<T> => {
   let ref = useRef<T>(initialValue);
 
   if (providedRef && typeof providedRef !== 'function') {


### PR DESCRIPTION
# Description

> [!CAUTION]
> This PR is introducing **Breaking Changes**
PR With Cantina migration will be raised soon. (to accompany the release of this new changes).

*The full description of the changes made in this request.*
- refactor AriaToolbar
  - introduce new AriaToolbarItem to be able to explicitly describe which elements are the toolbar items (this is useful in situations where we might have Popovers, or Tooltips as immediate children to the AriaToolbar component. Previously it assumes that the immediate children is the actual button, but that's not the case all the time.
  - add direct support for automatic wrap aria toolbar in button group, to facilitate easier styling (out of the box)

# Links
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-505327

*Links to relevent resources.*
