### PR TITLE
feat(text): tagName prop to override to tag

### DIFF
--- a/src/components/Text/Text.stories.tsx
+++ b/src/components/Text/Text.stories.tsx
@@ -52,7 +52,7 @@ TypesWithTagName.parameters = {
       return {
         type,
         children: type,
-        tagName: 'div',
+        tagName: 'small',
       };
     }),
   ],

--- a/src/components/Text/Text.stories.tsx
+++ b/src/components/Text/Text.stories.tsx
@@ -41,10 +41,27 @@ Types.parameters = {
   ],
 };
 
+const TypesWithTagName = MultiTemplate<TextProps>(Text).bind({});
+
+TypesWithTagName.argTypes = { ...argTypes };
+delete TypesWithTagName.argTypes.type;
+
+TypesWithTagName.parameters = {
+  variants: [
+    ...Object.values(TYPES).map((type) => {
+      return {
+        type,
+        children: type,
+        tagName: 'div',
+      };
+    }),
+  ],
+};
+
 const Fonts = MultiTemplate<TextProps>(Text).bind({});
 
 Fonts.argTypes = { ...argTypes };
-delete Types.argTypes.type;
+delete Fonts.argTypes.type;
 
 Fonts.parameters = {
   variants: [
@@ -112,4 +129,4 @@ FontsLegacy.parameters = {
   ],
 };
 
-export { Example, Types, Fonts, FontsLegacy };
+export { Example, Types, Fonts, FontsLegacy, TypesWithTagName };

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -1,14 +1,14 @@
 import React, { FC } from 'react';
 
 import { DEFAULTS, STYLE, TYPES } from './Text.constants';
-import { Props } from './Text.types';
+import { AllowedTagNames, Props } from './Text.types';
 import './Text.style.scss';
 import classnames from 'classnames';
 
 const Text: FC<Props> = (props: Props) => {
   const { children, type = DEFAULTS.TYPE, className, id, style, tagName, ...rest } = props;
 
-  const getTagName = (): keyof JSX.IntrinsicElements => {
+  const getTagName = (): AllowedTagNames => {
     switch (type) {
       case TYPES.DISPLAY:
       case TYPES.BANNER_TERTIARY:

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -6,38 +6,18 @@ import './Text.style.scss';
 import classnames from 'classnames';
 
 const Text: FC<Props> = (props: Props) => {
-  const { children, type = DEFAULTS.TYPE, className, id, style, ...rest } = props;
+  const { children, type = DEFAULTS.TYPE, className, id, style, tagName, ...rest } = props;
 
-  const getElement = () => {
+  const getTagName = (): keyof JSX.IntrinsicElements => {
     switch (type) {
       case TYPES.DISPLAY:
       case TYPES.BANNER_TERTIARY:
       case TYPES.BANNER_SECONDARY:
       case TYPES.BANNER_PRIMARY:
-        return (
-          <h1
-            className={classnames(STYLE.wrapper, className)}
-            data-type={type}
-            id={id}
-            style={style}
-            {...rest}
-          >
-            {children}
-          </h1>
-        );
+        return 'h1';
 
       case TYPES.TITLE:
-        return (
-          <h2
-            className={classnames(STYLE.wrapper, className)}
-            data-type={type}
-            id={id}
-            style={style}
-            {...rest}
-          >
-            {children}
-          </h2>
-        );
+        return 'h2';
 
       case TYPES.HEADER_PRIMARY:
       case TYPES.HIGHLIGHT_PRIMARY:
@@ -45,65 +25,37 @@ const Text: FC<Props> = (props: Props) => {
       case TYPES.HEADER_SECONDARY:
       case TYPES.HIGHLIGHT_SECONDARY:
       case TYPES.SUBHEADER_SECONDARY:
-        return (
-          <h3
-            className={classnames(STYLE.wrapper, className)}
-            data-type={type}
-            id={id}
-            style={style}
-            {...rest}
-          >
-            {children}
-          </h3>
-        );
+        return 'h3';
 
       case TYPES.BODY_PRIMARY:
       case TYPES.HYPERLINK_PRIMARY:
-        return (
-          <p
-            className={classnames(STYLE.wrapper, className)}
-            data-type={type}
-            id={id}
-            style={style}
-            {...rest}
-          >
-            {children}
-          </p>
-        );
+        return 'p';
 
       case TYPES.BODY_SECONDARY:
       case TYPES.HYPERLINK_SECONDARY:
       case TYPES.HIGHLIGHT_COMPACT:
       case TYPES.BODY_COMPACT:
       case TYPES.LABEL_COMPACT:
-        return (
-          <small
-            className={classnames(STYLE.wrapper, className)}
-            data-type={type}
-            id={id}
-            style={style}
-            {...rest}
-          >
-            {children}
-          </small>
-        );
+        return 'small';
 
       default:
-        return (
-          <p
-            className={classnames(STYLE.wrapper, className)}
-            data-type={type}
-            id={id}
-            style={style}
-            {...rest}
-          >
-            {children}
-          </p>
-        );
+        return 'p';
     }
   };
 
-  return getElement();
+  const TagName = tagName || getTagName();
+
+  return (
+    <TagName
+      className={classnames(STYLE.wrapper, className)}
+      data-type={type}
+      id={id}
+      style={style}
+      {...rest}
+    >
+      {children}
+    </TagName>
+  );
 };
 
 export default Text;

--- a/src/components/Text/Text.types.ts
+++ b/src/components/Text/Text.types.ts
@@ -1,4 +1,14 @@
 import { CSSProperties, ReactNode } from 'react';
+
+export type AllowedTagNames =
+  | (keyof JSX.IntrinsicElements & 'h1')
+  | 'h2'
+  | 'h3'
+  | 'h4'
+  | 'h5'
+  | 'h6'
+  | 'p'
+  | 'small';
 export interface Props {
   /**
    * Custom class to be able to override the component's CSS
@@ -23,7 +33,7 @@ export interface Props {
   /**
    * Override the tag used to surround the text
    */
-  tagName?: keyof JSX.IntrinsicElements;
+  tagName?: AllowedTagNames;
 }
 
 export type FontStyle =

--- a/src/components/Text/Text.types.ts
+++ b/src/components/Text/Text.types.ts
@@ -20,6 +20,10 @@ export interface Props {
    * Custom style for overriding this component's CSS.
    */
   style?: CSSProperties;
+  /**
+   * Override the tag used to surround the text
+   */
+  tagName?: keyof JSX.IntrinsicElements;
 }
 
 export type FontStyle =

--- a/src/components/Text/Text.unit.test.tsx
+++ b/src/components/Text/Text.unit.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import Text from '.';
-import { FontStyle } from './Text.types';
+import { AllowedTagNames, FontStyle } from './Text.types';
 
 import { TYPES, STYLE } from './Text.constants';
 
@@ -60,20 +60,23 @@ describe('Text', () => {
     expect(container).toMatchSnapshot();
   });
 
-  it('should match snapshot with type and tagName override', async () => {
-    expect.assertions(1);
+  it.each(['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'small'])(
+    'should match snapshot with type and tagName override',
+    async (tagName) => {
+      expect.assertions(1);
 
-    const texts = Object.values(TYPES).map((type, index) => {
-      return (
-        <Text key={index} type={type as FontStyle} tagName="p">
-          Example Text
-        </Text>
-      );
-    });
-    container = await mount(<div>{texts}</div>);
+      const texts = Object.values(TYPES).map((type, index) => {
+        return (
+          <Text key={index} type={type as FontStyle} tagName={tagName as AllowedTagNames}>
+            Example Text
+          </Text>
+        );
+      });
+      container = await mount(<div>{texts}</div>);
 
-    expect(container).toMatchSnapshot();
-  });
+      expect(container).toMatchSnapshot();
+    }
+  );
 
   describe('attributes', () => {
     it('should have its main class', () => {

--- a/src/components/Text/Text.unit.test.tsx
+++ b/src/components/Text/Text.unit.test.tsx
@@ -60,6 +60,21 @@ describe('Text', () => {
     expect(container).toMatchSnapshot();
   });
 
+  it('should match snapshot with type and tagName override', async () => {
+    expect.assertions(1);
+
+    const texts = Object.values(TYPES).map((type, index) => {
+      return (
+        <Text key={index} type={type as FontStyle} tagName="div">
+          Example Text
+        </Text>
+      );
+    });
+    container = await mount(<div>{texts}</div>);
+
+    expect(container).toMatchSnapshot();
+  });
+
   describe('attributes', () => {
     it('should have its main class', () => {
       expect.assertions(1);

--- a/src/components/Text/Text.unit.test.tsx
+++ b/src/components/Text/Text.unit.test.tsx
@@ -65,7 +65,7 @@ describe('Text', () => {
 
     const texts = Object.values(TYPES).map((type, index) => {
       return (
-        <Text key={index} type={type as FontStyle} tagName="div">
+        <Text key={index} type={type as FontStyle} tagName="p">
           Example Text
         </Text>
       );

--- a/src/components/Text/Text.unit.test.tsx.snap
+++ b/src/components/Text/Text.unit.test.tsx.snap
@@ -256,3 +256,224 @@ exports[`Text should match snapshot with type 1`] = `
   </Text>
 </div>
 `;
+
+exports[`Text should match snapshot with type and tagName override 1`] = `
+<div>
+  <Text
+    key="0"
+    tagName="div"
+    type="display"
+  >
+    <div
+      className="md-text-wrapper"
+      data-type="display"
+    >
+      Example Text
+    </div>
+  </Text>
+  <Text
+    key="1"
+    tagName="div"
+    type="banner-tertiary"
+  >
+    <div
+      className="md-text-wrapper"
+      data-type="banner-tertiary"
+    >
+      Example Text
+    </div>
+  </Text>
+  <Text
+    key="2"
+    tagName="div"
+    type="banner-primary"
+  >
+    <div
+      className="md-text-wrapper"
+      data-type="banner-primary"
+    >
+      Example Text
+    </div>
+  </Text>
+  <Text
+    key="3"
+    tagName="div"
+    type="banner-secondary"
+  >
+    <div
+      className="md-text-wrapper"
+      data-type="banner-secondary"
+    >
+      Example Text
+    </div>
+  </Text>
+  <Text
+    key="4"
+    tagName="div"
+    type="title"
+  >
+    <div
+      className="md-text-wrapper"
+      data-type="title"
+    >
+      Example Text
+    </div>
+  </Text>
+  <Text
+    key="5"
+    tagName="div"
+    type="header-primary"
+  >
+    <div
+      className="md-text-wrapper"
+      data-type="header-primary"
+    >
+      Example Text
+    </div>
+  </Text>
+  <Text
+    key="6"
+    tagName="div"
+    type="highlight-primary"
+  >
+    <div
+      className="md-text-wrapper"
+      data-type="highlight-primary"
+    >
+      Example Text
+    </div>
+  </Text>
+  <Text
+    key="7"
+    tagName="div"
+    type="subheader-primary"
+  >
+    <div
+      className="md-text-wrapper"
+      data-type="subheader-primary"
+    >
+      Example Text
+    </div>
+  </Text>
+  <Text
+    key="8"
+    tagName="div"
+    type="body-primary"
+  >
+    <div
+      className="md-text-wrapper"
+      data-type="body-primary"
+    >
+      Example Text
+    </div>
+  </Text>
+  <Text
+    key="9"
+    tagName="div"
+    type="hyperlink-primary"
+  >
+    <div
+      className="md-text-wrapper"
+      data-type="hyperlink-primary"
+    >
+      Example Text
+    </div>
+  </Text>
+  <Text
+    key="10"
+    tagName="div"
+    type="subheader-secondary"
+  >
+    <div
+      className="md-text-wrapper"
+      data-type="subheader-secondary"
+    >
+      Example Text
+    </div>
+  </Text>
+  <Text
+    key="11"
+    tagName="div"
+    type="highlight-secondary"
+  >
+    <div
+      className="md-text-wrapper"
+      data-type="highlight-secondary"
+    >
+      Example Text
+    </div>
+  </Text>
+  <Text
+    key="12"
+    tagName="div"
+    type="header-secondary"
+  >
+    <div
+      className="md-text-wrapper"
+      data-type="header-secondary"
+    >
+      Example Text
+    </div>
+  </Text>
+  <Text
+    key="13"
+    tagName="div"
+    type="body-secondary"
+  >
+    <div
+      className="md-text-wrapper"
+      data-type="body-secondary"
+    >
+      Example Text
+    </div>
+  </Text>
+  <Text
+    key="14"
+    tagName="div"
+    type="hyperlink-secondary"
+  >
+    <div
+      className="md-text-wrapper"
+      data-type="hyperlink-secondary"
+    >
+      Example Text
+    </div>
+  </Text>
+  <Text
+    key="15"
+    tagName="div"
+    type="highlight-compact"
+  >
+    <div
+      className="md-text-wrapper"
+      data-type="highlight-compact"
+    >
+      Example Text
+    </div>
+  </Text>
+  <Text
+    key="16"
+    tagName="div"
+    type="body-compact"
+  >
+    <div
+      className="md-text-wrapper"
+      data-type="body-compact"
+    >
+      Example Text
+    </div>
+  </Text>
+  <Text
+    key="17"
+    tagName="div"
+    type="label-compact"
+  >
+    <div
+      className="md-text-wrapper"
+      data-type="label-compact"
+    >
+      Example Text
+    </div>
+  </Text>
+</div>
+`;

--- a/src/components/Text/Text.unit.test.tsx.snap
+++ b/src/components/Text/Text.unit.test.tsx.snap
@@ -261,219 +261,219 @@ exports[`Text should match snapshot with type and tagName override 1`] = `
 <div>
   <Text
     key="0"
-    tagName="div"
+    tagName="p"
     type="display"
   >
-    <div
+    <p
       className="md-text-wrapper"
       data-type="display"
     >
       Example Text
-    </div>
+    </p>
   </Text>
   <Text
     key="1"
-    tagName="div"
+    tagName="p"
     type="banner-tertiary"
   >
-    <div
+    <p
       className="md-text-wrapper"
       data-type="banner-tertiary"
     >
       Example Text
-    </div>
+    </p>
   </Text>
   <Text
     key="2"
-    tagName="div"
+    tagName="p"
     type="banner-primary"
   >
-    <div
+    <p
       className="md-text-wrapper"
       data-type="banner-primary"
     >
       Example Text
-    </div>
+    </p>
   </Text>
   <Text
     key="3"
-    tagName="div"
+    tagName="p"
     type="banner-secondary"
   >
-    <div
+    <p
       className="md-text-wrapper"
       data-type="banner-secondary"
     >
       Example Text
-    </div>
+    </p>
   </Text>
   <Text
     key="4"
-    tagName="div"
+    tagName="p"
     type="title"
   >
-    <div
+    <p
       className="md-text-wrapper"
       data-type="title"
     >
       Example Text
-    </div>
+    </p>
   </Text>
   <Text
     key="5"
-    tagName="div"
+    tagName="p"
     type="header-primary"
   >
-    <div
+    <p
       className="md-text-wrapper"
       data-type="header-primary"
     >
       Example Text
-    </div>
+    </p>
   </Text>
   <Text
     key="6"
-    tagName="div"
+    tagName="p"
     type="highlight-primary"
   >
-    <div
+    <p
       className="md-text-wrapper"
       data-type="highlight-primary"
     >
       Example Text
-    </div>
+    </p>
   </Text>
   <Text
     key="7"
-    tagName="div"
+    tagName="p"
     type="subheader-primary"
   >
-    <div
+    <p
       className="md-text-wrapper"
       data-type="subheader-primary"
     >
       Example Text
-    </div>
+    </p>
   </Text>
   <Text
     key="8"
-    tagName="div"
+    tagName="p"
     type="body-primary"
   >
-    <div
+    <p
       className="md-text-wrapper"
       data-type="body-primary"
     >
       Example Text
-    </div>
+    </p>
   </Text>
   <Text
     key="9"
-    tagName="div"
+    tagName="p"
     type="hyperlink-primary"
   >
-    <div
+    <p
       className="md-text-wrapper"
       data-type="hyperlink-primary"
     >
       Example Text
-    </div>
+    </p>
   </Text>
   <Text
     key="10"
-    tagName="div"
+    tagName="p"
     type="subheader-secondary"
   >
-    <div
+    <p
       className="md-text-wrapper"
       data-type="subheader-secondary"
     >
       Example Text
-    </div>
+    </p>
   </Text>
   <Text
     key="11"
-    tagName="div"
+    tagName="p"
     type="highlight-secondary"
   >
-    <div
+    <p
       className="md-text-wrapper"
       data-type="highlight-secondary"
     >
       Example Text
-    </div>
+    </p>
   </Text>
   <Text
     key="12"
-    tagName="div"
+    tagName="p"
     type="header-secondary"
   >
-    <div
+    <p
       className="md-text-wrapper"
       data-type="header-secondary"
     >
       Example Text
-    </div>
+    </p>
   </Text>
   <Text
     key="13"
-    tagName="div"
+    tagName="p"
     type="body-secondary"
   >
-    <div
+    <p
       className="md-text-wrapper"
       data-type="body-secondary"
     >
       Example Text
-    </div>
+    </p>
   </Text>
   <Text
     key="14"
-    tagName="div"
+    tagName="p"
     type="hyperlink-secondary"
   >
-    <div
+    <p
       className="md-text-wrapper"
       data-type="hyperlink-secondary"
     >
       Example Text
-    </div>
+    </p>
   </Text>
   <Text
     key="15"
-    tagName="div"
+    tagName="p"
     type="highlight-compact"
   >
-    <div
+    <p
       className="md-text-wrapper"
       data-type="highlight-compact"
     >
       Example Text
-    </div>
+    </p>
   </Text>
   <Text
     key="16"
-    tagName="div"
+    tagName="p"
     type="body-compact"
   >
-    <div
+    <p
       className="md-text-wrapper"
       data-type="body-compact"
     >
       Example Text
-    </div>
+    </p>
   </Text>
   <Text
     key="17"
-    tagName="div"
+    tagName="p"
     type="label-compact"
   >
-    <div
+    <p
       className="md-text-wrapper"
       data-type="label-compact"
     >
       Example Text
-    </div>
+    </p>
   </Text>
 </div>
 `;

--- a/src/components/Text/Text.unit.test.tsx.snap
+++ b/src/components/Text/Text.unit.test.tsx.snap
@@ -261,6 +261,1332 @@ exports[`Text should match snapshot with type and tagName override 1`] = `
 <div>
   <Text
     key="0"
+    tagName="h1"
+    type="display"
+  >
+    <h1
+      className="md-text-wrapper"
+      data-type="display"
+    >
+      Example Text
+    </h1>
+  </Text>
+  <Text
+    key="1"
+    tagName="h1"
+    type="banner-tertiary"
+  >
+    <h1
+      className="md-text-wrapper"
+      data-type="banner-tertiary"
+    >
+      Example Text
+    </h1>
+  </Text>
+  <Text
+    key="2"
+    tagName="h1"
+    type="banner-primary"
+  >
+    <h1
+      className="md-text-wrapper"
+      data-type="banner-primary"
+    >
+      Example Text
+    </h1>
+  </Text>
+  <Text
+    key="3"
+    tagName="h1"
+    type="banner-secondary"
+  >
+    <h1
+      className="md-text-wrapper"
+      data-type="banner-secondary"
+    >
+      Example Text
+    </h1>
+  </Text>
+  <Text
+    key="4"
+    tagName="h1"
+    type="title"
+  >
+    <h1
+      className="md-text-wrapper"
+      data-type="title"
+    >
+      Example Text
+    </h1>
+  </Text>
+  <Text
+    key="5"
+    tagName="h1"
+    type="header-primary"
+  >
+    <h1
+      className="md-text-wrapper"
+      data-type="header-primary"
+    >
+      Example Text
+    </h1>
+  </Text>
+  <Text
+    key="6"
+    tagName="h1"
+    type="highlight-primary"
+  >
+    <h1
+      className="md-text-wrapper"
+      data-type="highlight-primary"
+    >
+      Example Text
+    </h1>
+  </Text>
+  <Text
+    key="7"
+    tagName="h1"
+    type="subheader-primary"
+  >
+    <h1
+      className="md-text-wrapper"
+      data-type="subheader-primary"
+    >
+      Example Text
+    </h1>
+  </Text>
+  <Text
+    key="8"
+    tagName="h1"
+    type="body-primary"
+  >
+    <h1
+      className="md-text-wrapper"
+      data-type="body-primary"
+    >
+      Example Text
+    </h1>
+  </Text>
+  <Text
+    key="9"
+    tagName="h1"
+    type="hyperlink-primary"
+  >
+    <h1
+      className="md-text-wrapper"
+      data-type="hyperlink-primary"
+    >
+      Example Text
+    </h1>
+  </Text>
+  <Text
+    key="10"
+    tagName="h1"
+    type="subheader-secondary"
+  >
+    <h1
+      className="md-text-wrapper"
+      data-type="subheader-secondary"
+    >
+      Example Text
+    </h1>
+  </Text>
+  <Text
+    key="11"
+    tagName="h1"
+    type="highlight-secondary"
+  >
+    <h1
+      className="md-text-wrapper"
+      data-type="highlight-secondary"
+    >
+      Example Text
+    </h1>
+  </Text>
+  <Text
+    key="12"
+    tagName="h1"
+    type="header-secondary"
+  >
+    <h1
+      className="md-text-wrapper"
+      data-type="header-secondary"
+    >
+      Example Text
+    </h1>
+  </Text>
+  <Text
+    key="13"
+    tagName="h1"
+    type="body-secondary"
+  >
+    <h1
+      className="md-text-wrapper"
+      data-type="body-secondary"
+    >
+      Example Text
+    </h1>
+  </Text>
+  <Text
+    key="14"
+    tagName="h1"
+    type="hyperlink-secondary"
+  >
+    <h1
+      className="md-text-wrapper"
+      data-type="hyperlink-secondary"
+    >
+      Example Text
+    </h1>
+  </Text>
+  <Text
+    key="15"
+    tagName="h1"
+    type="highlight-compact"
+  >
+    <h1
+      className="md-text-wrapper"
+      data-type="highlight-compact"
+    >
+      Example Text
+    </h1>
+  </Text>
+  <Text
+    key="16"
+    tagName="h1"
+    type="body-compact"
+  >
+    <h1
+      className="md-text-wrapper"
+      data-type="body-compact"
+    >
+      Example Text
+    </h1>
+  </Text>
+  <Text
+    key="17"
+    tagName="h1"
+    type="label-compact"
+  >
+    <h1
+      className="md-text-wrapper"
+      data-type="label-compact"
+    >
+      Example Text
+    </h1>
+  </Text>
+</div>
+`;
+
+exports[`Text should match snapshot with type and tagName override 2`] = `
+<div>
+  <Text
+    key="0"
+    tagName="h2"
+    type="display"
+  >
+    <h2
+      className="md-text-wrapper"
+      data-type="display"
+    >
+      Example Text
+    </h2>
+  </Text>
+  <Text
+    key="1"
+    tagName="h2"
+    type="banner-tertiary"
+  >
+    <h2
+      className="md-text-wrapper"
+      data-type="banner-tertiary"
+    >
+      Example Text
+    </h2>
+  </Text>
+  <Text
+    key="2"
+    tagName="h2"
+    type="banner-primary"
+  >
+    <h2
+      className="md-text-wrapper"
+      data-type="banner-primary"
+    >
+      Example Text
+    </h2>
+  </Text>
+  <Text
+    key="3"
+    tagName="h2"
+    type="banner-secondary"
+  >
+    <h2
+      className="md-text-wrapper"
+      data-type="banner-secondary"
+    >
+      Example Text
+    </h2>
+  </Text>
+  <Text
+    key="4"
+    tagName="h2"
+    type="title"
+  >
+    <h2
+      className="md-text-wrapper"
+      data-type="title"
+    >
+      Example Text
+    </h2>
+  </Text>
+  <Text
+    key="5"
+    tagName="h2"
+    type="header-primary"
+  >
+    <h2
+      className="md-text-wrapper"
+      data-type="header-primary"
+    >
+      Example Text
+    </h2>
+  </Text>
+  <Text
+    key="6"
+    tagName="h2"
+    type="highlight-primary"
+  >
+    <h2
+      className="md-text-wrapper"
+      data-type="highlight-primary"
+    >
+      Example Text
+    </h2>
+  </Text>
+  <Text
+    key="7"
+    tagName="h2"
+    type="subheader-primary"
+  >
+    <h2
+      className="md-text-wrapper"
+      data-type="subheader-primary"
+    >
+      Example Text
+    </h2>
+  </Text>
+  <Text
+    key="8"
+    tagName="h2"
+    type="body-primary"
+  >
+    <h2
+      className="md-text-wrapper"
+      data-type="body-primary"
+    >
+      Example Text
+    </h2>
+  </Text>
+  <Text
+    key="9"
+    tagName="h2"
+    type="hyperlink-primary"
+  >
+    <h2
+      className="md-text-wrapper"
+      data-type="hyperlink-primary"
+    >
+      Example Text
+    </h2>
+  </Text>
+  <Text
+    key="10"
+    tagName="h2"
+    type="subheader-secondary"
+  >
+    <h2
+      className="md-text-wrapper"
+      data-type="subheader-secondary"
+    >
+      Example Text
+    </h2>
+  </Text>
+  <Text
+    key="11"
+    tagName="h2"
+    type="highlight-secondary"
+  >
+    <h2
+      className="md-text-wrapper"
+      data-type="highlight-secondary"
+    >
+      Example Text
+    </h2>
+  </Text>
+  <Text
+    key="12"
+    tagName="h2"
+    type="header-secondary"
+  >
+    <h2
+      className="md-text-wrapper"
+      data-type="header-secondary"
+    >
+      Example Text
+    </h2>
+  </Text>
+  <Text
+    key="13"
+    tagName="h2"
+    type="body-secondary"
+  >
+    <h2
+      className="md-text-wrapper"
+      data-type="body-secondary"
+    >
+      Example Text
+    </h2>
+  </Text>
+  <Text
+    key="14"
+    tagName="h2"
+    type="hyperlink-secondary"
+  >
+    <h2
+      className="md-text-wrapper"
+      data-type="hyperlink-secondary"
+    >
+      Example Text
+    </h2>
+  </Text>
+  <Text
+    key="15"
+    tagName="h2"
+    type="highlight-compact"
+  >
+    <h2
+      className="md-text-wrapper"
+      data-type="highlight-compact"
+    >
+      Example Text
+    </h2>
+  </Text>
+  <Text
+    key="16"
+    tagName="h2"
+    type="body-compact"
+  >
+    <h2
+      className="md-text-wrapper"
+      data-type="body-compact"
+    >
+      Example Text
+    </h2>
+  </Text>
+  <Text
+    key="17"
+    tagName="h2"
+    type="label-compact"
+  >
+    <h2
+      className="md-text-wrapper"
+      data-type="label-compact"
+    >
+      Example Text
+    </h2>
+  </Text>
+</div>
+`;
+
+exports[`Text should match snapshot with type and tagName override 3`] = `
+<div>
+  <Text
+    key="0"
+    tagName="h3"
+    type="display"
+  >
+    <h3
+      className="md-text-wrapper"
+      data-type="display"
+    >
+      Example Text
+    </h3>
+  </Text>
+  <Text
+    key="1"
+    tagName="h3"
+    type="banner-tertiary"
+  >
+    <h3
+      className="md-text-wrapper"
+      data-type="banner-tertiary"
+    >
+      Example Text
+    </h3>
+  </Text>
+  <Text
+    key="2"
+    tagName="h3"
+    type="banner-primary"
+  >
+    <h3
+      className="md-text-wrapper"
+      data-type="banner-primary"
+    >
+      Example Text
+    </h3>
+  </Text>
+  <Text
+    key="3"
+    tagName="h3"
+    type="banner-secondary"
+  >
+    <h3
+      className="md-text-wrapper"
+      data-type="banner-secondary"
+    >
+      Example Text
+    </h3>
+  </Text>
+  <Text
+    key="4"
+    tagName="h3"
+    type="title"
+  >
+    <h3
+      className="md-text-wrapper"
+      data-type="title"
+    >
+      Example Text
+    </h3>
+  </Text>
+  <Text
+    key="5"
+    tagName="h3"
+    type="header-primary"
+  >
+    <h3
+      className="md-text-wrapper"
+      data-type="header-primary"
+    >
+      Example Text
+    </h3>
+  </Text>
+  <Text
+    key="6"
+    tagName="h3"
+    type="highlight-primary"
+  >
+    <h3
+      className="md-text-wrapper"
+      data-type="highlight-primary"
+    >
+      Example Text
+    </h3>
+  </Text>
+  <Text
+    key="7"
+    tagName="h3"
+    type="subheader-primary"
+  >
+    <h3
+      className="md-text-wrapper"
+      data-type="subheader-primary"
+    >
+      Example Text
+    </h3>
+  </Text>
+  <Text
+    key="8"
+    tagName="h3"
+    type="body-primary"
+  >
+    <h3
+      className="md-text-wrapper"
+      data-type="body-primary"
+    >
+      Example Text
+    </h3>
+  </Text>
+  <Text
+    key="9"
+    tagName="h3"
+    type="hyperlink-primary"
+  >
+    <h3
+      className="md-text-wrapper"
+      data-type="hyperlink-primary"
+    >
+      Example Text
+    </h3>
+  </Text>
+  <Text
+    key="10"
+    tagName="h3"
+    type="subheader-secondary"
+  >
+    <h3
+      className="md-text-wrapper"
+      data-type="subheader-secondary"
+    >
+      Example Text
+    </h3>
+  </Text>
+  <Text
+    key="11"
+    tagName="h3"
+    type="highlight-secondary"
+  >
+    <h3
+      className="md-text-wrapper"
+      data-type="highlight-secondary"
+    >
+      Example Text
+    </h3>
+  </Text>
+  <Text
+    key="12"
+    tagName="h3"
+    type="header-secondary"
+  >
+    <h3
+      className="md-text-wrapper"
+      data-type="header-secondary"
+    >
+      Example Text
+    </h3>
+  </Text>
+  <Text
+    key="13"
+    tagName="h3"
+    type="body-secondary"
+  >
+    <h3
+      className="md-text-wrapper"
+      data-type="body-secondary"
+    >
+      Example Text
+    </h3>
+  </Text>
+  <Text
+    key="14"
+    tagName="h3"
+    type="hyperlink-secondary"
+  >
+    <h3
+      className="md-text-wrapper"
+      data-type="hyperlink-secondary"
+    >
+      Example Text
+    </h3>
+  </Text>
+  <Text
+    key="15"
+    tagName="h3"
+    type="highlight-compact"
+  >
+    <h3
+      className="md-text-wrapper"
+      data-type="highlight-compact"
+    >
+      Example Text
+    </h3>
+  </Text>
+  <Text
+    key="16"
+    tagName="h3"
+    type="body-compact"
+  >
+    <h3
+      className="md-text-wrapper"
+      data-type="body-compact"
+    >
+      Example Text
+    </h3>
+  </Text>
+  <Text
+    key="17"
+    tagName="h3"
+    type="label-compact"
+  >
+    <h3
+      className="md-text-wrapper"
+      data-type="label-compact"
+    >
+      Example Text
+    </h3>
+  </Text>
+</div>
+`;
+
+exports[`Text should match snapshot with type and tagName override 4`] = `
+<div>
+  <Text
+    key="0"
+    tagName="h4"
+    type="display"
+  >
+    <h4
+      className="md-text-wrapper"
+      data-type="display"
+    >
+      Example Text
+    </h4>
+  </Text>
+  <Text
+    key="1"
+    tagName="h4"
+    type="banner-tertiary"
+  >
+    <h4
+      className="md-text-wrapper"
+      data-type="banner-tertiary"
+    >
+      Example Text
+    </h4>
+  </Text>
+  <Text
+    key="2"
+    tagName="h4"
+    type="banner-primary"
+  >
+    <h4
+      className="md-text-wrapper"
+      data-type="banner-primary"
+    >
+      Example Text
+    </h4>
+  </Text>
+  <Text
+    key="3"
+    tagName="h4"
+    type="banner-secondary"
+  >
+    <h4
+      className="md-text-wrapper"
+      data-type="banner-secondary"
+    >
+      Example Text
+    </h4>
+  </Text>
+  <Text
+    key="4"
+    tagName="h4"
+    type="title"
+  >
+    <h4
+      className="md-text-wrapper"
+      data-type="title"
+    >
+      Example Text
+    </h4>
+  </Text>
+  <Text
+    key="5"
+    tagName="h4"
+    type="header-primary"
+  >
+    <h4
+      className="md-text-wrapper"
+      data-type="header-primary"
+    >
+      Example Text
+    </h4>
+  </Text>
+  <Text
+    key="6"
+    tagName="h4"
+    type="highlight-primary"
+  >
+    <h4
+      className="md-text-wrapper"
+      data-type="highlight-primary"
+    >
+      Example Text
+    </h4>
+  </Text>
+  <Text
+    key="7"
+    tagName="h4"
+    type="subheader-primary"
+  >
+    <h4
+      className="md-text-wrapper"
+      data-type="subheader-primary"
+    >
+      Example Text
+    </h4>
+  </Text>
+  <Text
+    key="8"
+    tagName="h4"
+    type="body-primary"
+  >
+    <h4
+      className="md-text-wrapper"
+      data-type="body-primary"
+    >
+      Example Text
+    </h4>
+  </Text>
+  <Text
+    key="9"
+    tagName="h4"
+    type="hyperlink-primary"
+  >
+    <h4
+      className="md-text-wrapper"
+      data-type="hyperlink-primary"
+    >
+      Example Text
+    </h4>
+  </Text>
+  <Text
+    key="10"
+    tagName="h4"
+    type="subheader-secondary"
+  >
+    <h4
+      className="md-text-wrapper"
+      data-type="subheader-secondary"
+    >
+      Example Text
+    </h4>
+  </Text>
+  <Text
+    key="11"
+    tagName="h4"
+    type="highlight-secondary"
+  >
+    <h4
+      className="md-text-wrapper"
+      data-type="highlight-secondary"
+    >
+      Example Text
+    </h4>
+  </Text>
+  <Text
+    key="12"
+    tagName="h4"
+    type="header-secondary"
+  >
+    <h4
+      className="md-text-wrapper"
+      data-type="header-secondary"
+    >
+      Example Text
+    </h4>
+  </Text>
+  <Text
+    key="13"
+    tagName="h4"
+    type="body-secondary"
+  >
+    <h4
+      className="md-text-wrapper"
+      data-type="body-secondary"
+    >
+      Example Text
+    </h4>
+  </Text>
+  <Text
+    key="14"
+    tagName="h4"
+    type="hyperlink-secondary"
+  >
+    <h4
+      className="md-text-wrapper"
+      data-type="hyperlink-secondary"
+    >
+      Example Text
+    </h4>
+  </Text>
+  <Text
+    key="15"
+    tagName="h4"
+    type="highlight-compact"
+  >
+    <h4
+      className="md-text-wrapper"
+      data-type="highlight-compact"
+    >
+      Example Text
+    </h4>
+  </Text>
+  <Text
+    key="16"
+    tagName="h4"
+    type="body-compact"
+  >
+    <h4
+      className="md-text-wrapper"
+      data-type="body-compact"
+    >
+      Example Text
+    </h4>
+  </Text>
+  <Text
+    key="17"
+    tagName="h4"
+    type="label-compact"
+  >
+    <h4
+      className="md-text-wrapper"
+      data-type="label-compact"
+    >
+      Example Text
+    </h4>
+  </Text>
+</div>
+`;
+
+exports[`Text should match snapshot with type and tagName override 5`] = `
+<div>
+  <Text
+    key="0"
+    tagName="h5"
+    type="display"
+  >
+    <h5
+      className="md-text-wrapper"
+      data-type="display"
+    >
+      Example Text
+    </h5>
+  </Text>
+  <Text
+    key="1"
+    tagName="h5"
+    type="banner-tertiary"
+  >
+    <h5
+      className="md-text-wrapper"
+      data-type="banner-tertiary"
+    >
+      Example Text
+    </h5>
+  </Text>
+  <Text
+    key="2"
+    tagName="h5"
+    type="banner-primary"
+  >
+    <h5
+      className="md-text-wrapper"
+      data-type="banner-primary"
+    >
+      Example Text
+    </h5>
+  </Text>
+  <Text
+    key="3"
+    tagName="h5"
+    type="banner-secondary"
+  >
+    <h5
+      className="md-text-wrapper"
+      data-type="banner-secondary"
+    >
+      Example Text
+    </h5>
+  </Text>
+  <Text
+    key="4"
+    tagName="h5"
+    type="title"
+  >
+    <h5
+      className="md-text-wrapper"
+      data-type="title"
+    >
+      Example Text
+    </h5>
+  </Text>
+  <Text
+    key="5"
+    tagName="h5"
+    type="header-primary"
+  >
+    <h5
+      className="md-text-wrapper"
+      data-type="header-primary"
+    >
+      Example Text
+    </h5>
+  </Text>
+  <Text
+    key="6"
+    tagName="h5"
+    type="highlight-primary"
+  >
+    <h5
+      className="md-text-wrapper"
+      data-type="highlight-primary"
+    >
+      Example Text
+    </h5>
+  </Text>
+  <Text
+    key="7"
+    tagName="h5"
+    type="subheader-primary"
+  >
+    <h5
+      className="md-text-wrapper"
+      data-type="subheader-primary"
+    >
+      Example Text
+    </h5>
+  </Text>
+  <Text
+    key="8"
+    tagName="h5"
+    type="body-primary"
+  >
+    <h5
+      className="md-text-wrapper"
+      data-type="body-primary"
+    >
+      Example Text
+    </h5>
+  </Text>
+  <Text
+    key="9"
+    tagName="h5"
+    type="hyperlink-primary"
+  >
+    <h5
+      className="md-text-wrapper"
+      data-type="hyperlink-primary"
+    >
+      Example Text
+    </h5>
+  </Text>
+  <Text
+    key="10"
+    tagName="h5"
+    type="subheader-secondary"
+  >
+    <h5
+      className="md-text-wrapper"
+      data-type="subheader-secondary"
+    >
+      Example Text
+    </h5>
+  </Text>
+  <Text
+    key="11"
+    tagName="h5"
+    type="highlight-secondary"
+  >
+    <h5
+      className="md-text-wrapper"
+      data-type="highlight-secondary"
+    >
+      Example Text
+    </h5>
+  </Text>
+  <Text
+    key="12"
+    tagName="h5"
+    type="header-secondary"
+  >
+    <h5
+      className="md-text-wrapper"
+      data-type="header-secondary"
+    >
+      Example Text
+    </h5>
+  </Text>
+  <Text
+    key="13"
+    tagName="h5"
+    type="body-secondary"
+  >
+    <h5
+      className="md-text-wrapper"
+      data-type="body-secondary"
+    >
+      Example Text
+    </h5>
+  </Text>
+  <Text
+    key="14"
+    tagName="h5"
+    type="hyperlink-secondary"
+  >
+    <h5
+      className="md-text-wrapper"
+      data-type="hyperlink-secondary"
+    >
+      Example Text
+    </h5>
+  </Text>
+  <Text
+    key="15"
+    tagName="h5"
+    type="highlight-compact"
+  >
+    <h5
+      className="md-text-wrapper"
+      data-type="highlight-compact"
+    >
+      Example Text
+    </h5>
+  </Text>
+  <Text
+    key="16"
+    tagName="h5"
+    type="body-compact"
+  >
+    <h5
+      className="md-text-wrapper"
+      data-type="body-compact"
+    >
+      Example Text
+    </h5>
+  </Text>
+  <Text
+    key="17"
+    tagName="h5"
+    type="label-compact"
+  >
+    <h5
+      className="md-text-wrapper"
+      data-type="label-compact"
+    >
+      Example Text
+    </h5>
+  </Text>
+</div>
+`;
+
+exports[`Text should match snapshot with type and tagName override 6`] = `
+<div>
+  <Text
+    key="0"
+    tagName="h6"
+    type="display"
+  >
+    <h6
+      className="md-text-wrapper"
+      data-type="display"
+    >
+      Example Text
+    </h6>
+  </Text>
+  <Text
+    key="1"
+    tagName="h6"
+    type="banner-tertiary"
+  >
+    <h6
+      className="md-text-wrapper"
+      data-type="banner-tertiary"
+    >
+      Example Text
+    </h6>
+  </Text>
+  <Text
+    key="2"
+    tagName="h6"
+    type="banner-primary"
+  >
+    <h6
+      className="md-text-wrapper"
+      data-type="banner-primary"
+    >
+      Example Text
+    </h6>
+  </Text>
+  <Text
+    key="3"
+    tagName="h6"
+    type="banner-secondary"
+  >
+    <h6
+      className="md-text-wrapper"
+      data-type="banner-secondary"
+    >
+      Example Text
+    </h6>
+  </Text>
+  <Text
+    key="4"
+    tagName="h6"
+    type="title"
+  >
+    <h6
+      className="md-text-wrapper"
+      data-type="title"
+    >
+      Example Text
+    </h6>
+  </Text>
+  <Text
+    key="5"
+    tagName="h6"
+    type="header-primary"
+  >
+    <h6
+      className="md-text-wrapper"
+      data-type="header-primary"
+    >
+      Example Text
+    </h6>
+  </Text>
+  <Text
+    key="6"
+    tagName="h6"
+    type="highlight-primary"
+  >
+    <h6
+      className="md-text-wrapper"
+      data-type="highlight-primary"
+    >
+      Example Text
+    </h6>
+  </Text>
+  <Text
+    key="7"
+    tagName="h6"
+    type="subheader-primary"
+  >
+    <h6
+      className="md-text-wrapper"
+      data-type="subheader-primary"
+    >
+      Example Text
+    </h6>
+  </Text>
+  <Text
+    key="8"
+    tagName="h6"
+    type="body-primary"
+  >
+    <h6
+      className="md-text-wrapper"
+      data-type="body-primary"
+    >
+      Example Text
+    </h6>
+  </Text>
+  <Text
+    key="9"
+    tagName="h6"
+    type="hyperlink-primary"
+  >
+    <h6
+      className="md-text-wrapper"
+      data-type="hyperlink-primary"
+    >
+      Example Text
+    </h6>
+  </Text>
+  <Text
+    key="10"
+    tagName="h6"
+    type="subheader-secondary"
+  >
+    <h6
+      className="md-text-wrapper"
+      data-type="subheader-secondary"
+    >
+      Example Text
+    </h6>
+  </Text>
+  <Text
+    key="11"
+    tagName="h6"
+    type="highlight-secondary"
+  >
+    <h6
+      className="md-text-wrapper"
+      data-type="highlight-secondary"
+    >
+      Example Text
+    </h6>
+  </Text>
+  <Text
+    key="12"
+    tagName="h6"
+    type="header-secondary"
+  >
+    <h6
+      className="md-text-wrapper"
+      data-type="header-secondary"
+    >
+      Example Text
+    </h6>
+  </Text>
+  <Text
+    key="13"
+    tagName="h6"
+    type="body-secondary"
+  >
+    <h6
+      className="md-text-wrapper"
+      data-type="body-secondary"
+    >
+      Example Text
+    </h6>
+  </Text>
+  <Text
+    key="14"
+    tagName="h6"
+    type="hyperlink-secondary"
+  >
+    <h6
+      className="md-text-wrapper"
+      data-type="hyperlink-secondary"
+    >
+      Example Text
+    </h6>
+  </Text>
+  <Text
+    key="15"
+    tagName="h6"
+    type="highlight-compact"
+  >
+    <h6
+      className="md-text-wrapper"
+      data-type="highlight-compact"
+    >
+      Example Text
+    </h6>
+  </Text>
+  <Text
+    key="16"
+    tagName="h6"
+    type="body-compact"
+  >
+    <h6
+      className="md-text-wrapper"
+      data-type="body-compact"
+    >
+      Example Text
+    </h6>
+  </Text>
+  <Text
+    key="17"
+    tagName="h6"
+    type="label-compact"
+  >
+    <h6
+      className="md-text-wrapper"
+      data-type="label-compact"
+    >
+      Example Text
+    </h6>
+  </Text>
+</div>
+`;
+
+exports[`Text should match snapshot with type and tagName override 7`] = `
+<div>
+  <Text
+    key="0"
     tagName="p"
     type="display"
   >
@@ -474,6 +1800,227 @@ exports[`Text should match snapshot with type and tagName override 1`] = `
     >
       Example Text
     </p>
+  </Text>
+</div>
+`;
+
+exports[`Text should match snapshot with type and tagName override 8`] = `
+<div>
+  <Text
+    key="0"
+    tagName="small"
+    type="display"
+  >
+    <small
+      className="md-text-wrapper"
+      data-type="display"
+    >
+      Example Text
+    </small>
+  </Text>
+  <Text
+    key="1"
+    tagName="small"
+    type="banner-tertiary"
+  >
+    <small
+      className="md-text-wrapper"
+      data-type="banner-tertiary"
+    >
+      Example Text
+    </small>
+  </Text>
+  <Text
+    key="2"
+    tagName="small"
+    type="banner-primary"
+  >
+    <small
+      className="md-text-wrapper"
+      data-type="banner-primary"
+    >
+      Example Text
+    </small>
+  </Text>
+  <Text
+    key="3"
+    tagName="small"
+    type="banner-secondary"
+  >
+    <small
+      className="md-text-wrapper"
+      data-type="banner-secondary"
+    >
+      Example Text
+    </small>
+  </Text>
+  <Text
+    key="4"
+    tagName="small"
+    type="title"
+  >
+    <small
+      className="md-text-wrapper"
+      data-type="title"
+    >
+      Example Text
+    </small>
+  </Text>
+  <Text
+    key="5"
+    tagName="small"
+    type="header-primary"
+  >
+    <small
+      className="md-text-wrapper"
+      data-type="header-primary"
+    >
+      Example Text
+    </small>
+  </Text>
+  <Text
+    key="6"
+    tagName="small"
+    type="highlight-primary"
+  >
+    <small
+      className="md-text-wrapper"
+      data-type="highlight-primary"
+    >
+      Example Text
+    </small>
+  </Text>
+  <Text
+    key="7"
+    tagName="small"
+    type="subheader-primary"
+  >
+    <small
+      className="md-text-wrapper"
+      data-type="subheader-primary"
+    >
+      Example Text
+    </small>
+  </Text>
+  <Text
+    key="8"
+    tagName="small"
+    type="body-primary"
+  >
+    <small
+      className="md-text-wrapper"
+      data-type="body-primary"
+    >
+      Example Text
+    </small>
+  </Text>
+  <Text
+    key="9"
+    tagName="small"
+    type="hyperlink-primary"
+  >
+    <small
+      className="md-text-wrapper"
+      data-type="hyperlink-primary"
+    >
+      Example Text
+    </small>
+  </Text>
+  <Text
+    key="10"
+    tagName="small"
+    type="subheader-secondary"
+  >
+    <small
+      className="md-text-wrapper"
+      data-type="subheader-secondary"
+    >
+      Example Text
+    </small>
+  </Text>
+  <Text
+    key="11"
+    tagName="small"
+    type="highlight-secondary"
+  >
+    <small
+      className="md-text-wrapper"
+      data-type="highlight-secondary"
+    >
+      Example Text
+    </small>
+  </Text>
+  <Text
+    key="12"
+    tagName="small"
+    type="header-secondary"
+  >
+    <small
+      className="md-text-wrapper"
+      data-type="header-secondary"
+    >
+      Example Text
+    </small>
+  </Text>
+  <Text
+    key="13"
+    tagName="small"
+    type="body-secondary"
+  >
+    <small
+      className="md-text-wrapper"
+      data-type="body-secondary"
+    >
+      Example Text
+    </small>
+  </Text>
+  <Text
+    key="14"
+    tagName="small"
+    type="hyperlink-secondary"
+  >
+    <small
+      className="md-text-wrapper"
+      data-type="hyperlink-secondary"
+    >
+      Example Text
+    </small>
+  </Text>
+  <Text
+    key="15"
+    tagName="small"
+    type="highlight-compact"
+  >
+    <small
+      className="md-text-wrapper"
+      data-type="highlight-compact"
+    >
+      Example Text
+    </small>
+  </Text>
+  <Text
+    key="16"
+    tagName="small"
+    type="body-compact"
+  >
+    <small
+      className="md-text-wrapper"
+      data-type="body-compact"
+    >
+      Example Text
+    </small>
+  </Text>
+  <Text
+    key="17"
+    tagName="small"
+    type="label-compact"
+  >
+    <small
+      className="md-text-wrapper"
+      data-type="label-compact"
+    >
+      Example Text
+    </small>
   </Text>
 </div>
 `;


### PR DESCRIPTION
# Description

Add the prop tagName to allow the overriding of the tag used for the text component. The tagName prop is optional and if not supplied, the default tagName for each type will be used.

# Links

*Links to relevent resources.*
