### PR TITLE
fix(toast): use text to have proper tag

### DIFF
--- a/src/components/Toast/Toast.constants.ts
+++ b/src/components/Toast/Toast.constants.ts
@@ -1,6 +1,10 @@
+import { AllowedTagNames } from '../Text/Text.types';
+
 const CLASS_PREFIX = 'md-toast';
 
-const DEFAULTS = {};
+const DEFAULTS = {
+  HEADING_LEVEL_2: 'h2' as AllowedTagNames,
+};
 
 const STYLE = {
   controls: `${CLASS_PREFIX}-controls`,

--- a/src/components/Toast/Toast.stories.args.ts
+++ b/src/components/Toast/Toast.stories.args.ts
@@ -66,4 +66,16 @@ export default {
       },
     },
   },
+  titleTagName: {
+    description: '`<Toast />` title. This overrides header tag.',
+    control: { type: 'text' },
+    table: {
+      type: {
+        summary: 'string',
+      },
+      defaultValue: {
+        summary: 'h2',
+      },
+    },
+  },
 };

--- a/src/components/Toast/Toast.stories.args.ts
+++ b/src/components/Toast/Toast.stories.args.ts
@@ -67,7 +67,7 @@ export default {
     },
   },
   titleTagName: {
-    description: '`<Toast />` title. This overrides header tag.',
+    description: '`<Toast />` title tag name to be used instead of the default',
     control: { type: 'text' },
     table: {
       type: {

--- a/src/components/Toast/Toast.stories.tsx
+++ b/src/components/Toast/Toast.stories.tsx
@@ -45,6 +45,37 @@ const commonButtons = (
   </ButtonGroup>
 );
 
+const ExampleWithTagName = Template<ToastProps>(Toast).bind({});
+
+ExampleWithTagName.argTypes = { ...argTypes };
+
+ExampleWithTagName.args = {
+  content: (
+    <ToastContent action="Action" actionColor="success" actions={commonButtons} actor="Actor">
+      Lorem ipsum dolor site aw aetns ctetuer adipiscing
+    </ToastContent>
+  ),
+  controls: [
+    <ButtonControl key={0} control="close" />,
+    <ButtonControl key={1} control="maximize" />,
+    <ButtonControl key={2} control="minimize" />,
+  ],
+  details: (
+    <ToastDetails
+      image={<Avatar initials="T" />}
+      info="Information"
+      infoColor="join"
+      subject="Subject"
+    >
+      Details Title
+    </ToastDetails>
+  ),
+  title: 'Toast Title',
+  titleTagName: 'h3',
+};
+
+
+
 const Example = Template<ToastProps>(Toast).bind({});
 
 Example.argTypes = { ...argTypes };
@@ -262,4 +293,4 @@ Common.parameters = {
   ],
 };
 
-export { Example, Layouts, Common };
+export { Example, Layouts, Common, ExampleWithTagName };

--- a/src/components/Toast/Toast.style.scss
+++ b/src/components/Toast/Toast.style.scss
@@ -13,7 +13,6 @@
 
     > .md-toast-title {
       flex-grow: 1;
-      font-size: 0.75rem;
       margin-left: 0.75rem;
     }
 

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -5,7 +5,7 @@ import ToastContent, { ToastContentProps } from '../ToastContent';
 import ToastDetails, { ToastDetailsProps } from '../ToastDetails';
 import Text from '../Text';
 
-import { STYLE } from './Toast.constants';
+import { STYLE, DEFAULTS } from './Toast.constants';
 import { Props } from './Toast.types';
 import './Toast.style.scss';
 
@@ -38,9 +38,7 @@ const Toast: FC<Props> = (props: Props) => {
 
   const titleComponent = title ? (
     <div className={STYLE.header}>
-      <Text tagName={titleTagName || 'h2'} type="label-compact" className={STYLE.title}>
-      {title}
-      </Text>
+      <Text tagName={titleTagName || DEFAULTS.HEADING_LEVEL_2} type="label-compact" className={STYLE.title}>{title}</Text>
       {controlsComponent}
     </div>
   ) : null;

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -3,6 +3,7 @@ import classnames from 'classnames';
 
 import ToastContent, { ToastContentProps } from '../ToastContent';
 import ToastDetails, { ToastDetailsProps } from '../ToastDetails';
+import Text from '../Text';
 
 import { STYLE } from './Toast.constants';
 import { Props } from './Toast.types';
@@ -12,7 +13,7 @@ import './Toast.style.scss';
  * The `<Toast />` component.
  */
 const Toast: FC<Props> = (props: Props) => {
-  const { ariaLive, children, className, content, controls, details, id, style, title } = props;
+  const { ariaLive, children, className, content, controls, details, id, style, title, titleTagName } = props;
 
   const childrenArray = Children.toArray(children);
 
@@ -37,7 +38,9 @@ const Toast: FC<Props> = (props: Props) => {
 
   const titleComponent = title ? (
     <div className={STYLE.header}>
-      <div className={STYLE.title}>{title}</div>
+      <Text tagName={titleTagName || 'h2'} type="label-compact" className={STYLE.title}>
+      {title}
+      </Text>
       {controlsComponent}
     </div>
   ) : null;

--- a/src/components/Toast/Toast.types.ts
+++ b/src/components/Toast/Toast.types.ts
@@ -3,6 +3,7 @@ import { CSSProperties, ReactElement } from 'react';
 import { ButtonControlProps } from '../ButtonControl';
 import { ToastContentProps } from '../ToastContent';
 import { ToastDetailsProps } from '../ToastDetails';
+import { AllowedTagNames } from '../Text/Text.types';
 import type { AriaAttributes } from 'react';
 
 export type SupportedChildren = ToastContentProps | ToastDetailsProps;
@@ -54,4 +55,9 @@ export interface Props {
    * Title for the header-bar of this Toast.
    */
   title?: string;
+
+  /**
+ * Override the tag used to surround the text
+ */
+  titleTagName?: AllowedTagNames;
 }

--- a/src/components/Toast/Toast.unit.test.tsx
+++ b/src/components/Toast/Toast.unit.test.tsx
@@ -9,6 +9,7 @@ import ButtonPill from '../ButtonPill';
 import Icon from '../Icon';
 import ToastContent, { ToastContentProps } from '../ToastContent';
 import ToastDetails, { ToastDetailsProps, TOAST_DETAILS_CONSTANTS } from '../ToastDetails';
+import Text from '../Text';
 
 import Toast, { TOAST_CONSTANTS as CONSTANTS } from './';
 
@@ -261,7 +262,7 @@ describe('<Toast />', () => {
     });
 
     it('should have provided controls when controls and title props are provided', async () => {
-      expect.assertions(1);
+      // expect.assertions(1);
 
       const wrapper = await mountAndWait(
         <Toast controls={controls} title="Toast Title">
@@ -274,6 +275,40 @@ describe('<Toast />', () => {
       const target = element.getElementsByClassName(CONSTANTS.STYLE.controls)[0];
 
       expect(target.childNodes.length === controls.length).toBe(true);
+    });
+
+    it('checks that default titleTagName is h2', async () => {
+
+      const wrapper = await mountAndWait(
+        <Toast controls={controls} title="Toast Title">
+          {content}
+          {details}
+        </Toast>
+      );
+
+      expect(wrapper.find(Text).props()).toEqual({
+        tagName: 'h2',
+        type: 'label-compact',
+        className: 'md-toast-title',
+        children: 'Toast Title'
+      });
+    });
+
+    it('checks provided titleTagName', async () => {
+
+      const wrapper = await mountAndWait(
+        <Toast controls={controls} title="Toast Title" titleTagName='h3'>
+          {content}
+          {details}
+        </Toast>
+      );
+
+      expect(wrapper.find(Text).props()).toEqual({
+        tagName: 'h3',
+        type: 'label-compact',
+        className: 'md-toast-title',
+        children: 'Toast Title'
+      });
     });
 
     it('should pass provided controls to ToastDetails when controls prop is provided without title', async () => {

--- a/src/components/Toast/Toast.unit.test.tsx
+++ b/src/components/Toast/Toast.unit.test.tsx
@@ -262,7 +262,7 @@ describe('<Toast />', () => {
     });
 
     it('should have provided controls when controls and title props are provided', async () => {
-      // expect.assertions(1);
+      expect.assertions(1);
 
       const wrapper = await mountAndWait(
         <Toast controls={controls} title="Toast Title">

--- a/src/components/Toast/Toast.unit.test.tsx.snap
+++ b/src/components/Toast/Toast.unit.test.tsx.snap
@@ -5305,11 +5305,18 @@ exports[`<Toast /> snapshot should match snapshot with title 1`] = `
     <div
       className="md-toast-header"
     >
-      <div
+      <Text
         className="md-toast-title"
+        tagName="h2"
+        type="label-compact"
       >
-        Title
-      </div>
+        <h2
+          className="md-text-wrapper md-toast-title"
+          data-type="label-compact"
+        >
+          Title
+        </h2>
+      </Text>
       <div
         className="md-toast-controls"
       >


### PR DESCRIPTION
# IMPORTANT

**Currently, this project is closed to any external contributions. Any pull request made against this project from external sources will likely be closed. If you would like to make changes to this project, please fork this project.**

# Guide

**This "Help" section can be deleted before submitting this pull request.**

*Update the name of this pull request to reflect the following shape:*

```
{type}/{scope?}/{message}
```

* **type** - A [conventional commit type](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional#type-enum) **REQUIRED**
* **scope** - The kabab-case scope of the changes in this request
* **message** - A short, kebab-case statement describing the changes **REQUIRED**

*Provide a general summary of the scope of the changes in this pull request.*

* [Readme](https://github.com/momentum-design/momentum-react-v2/blob/master/README.md)
* [Getting Started Guide](https://github.com/momentum-design/momentum-react-v2/blob/master/GETTING_STARTED.md)
* [Contributing Guide](https://github.com/momentum-design/momentum-react-v2/blob/master/CONTRIBUTING.md)

# Description
By deafult titleTagName is h2 but can be overridden by providing titleTagName 
*The full description of the changes made in this request.*
Fixes https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-539891
Which fixes heading issue for toast in [SPARK-506083](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-506083)

![image](https://github.com/momentum-design/momentum-react-v2/assets/82164376/e3d316af-e134-447a-beff-a2258533ae45)

