### PR TITLE
fix(Checkbox): aria-label null if there's no label

### DIFF
--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -60,7 +60,7 @@ const Checkbox = (props: Props, providedRef: RefObject<HTMLInputElement>) => {
       style={style}
     >
       <VisuallyHidden>
-        <input {...inputProps} {...focusProps} aria-label={label || ariaLabel} ref={ref} />
+        <input {...inputProps} {...focusProps} aria-label={label || inputProps?.['aria-label']} ref={ref} />
       </VisuallyHidden>
       {checkbox}
       {label}

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -16,7 +16,7 @@ import Icon from '../Icon';
  * The Checkbox component.
  */
 const Checkbox = (props: Props, providedRef: RefObject<HTMLInputElement>) => {
-  const { className, isDisabled, label, isIndeterminate, id, style, ariaLabel} = props;
+  const { className, isDisabled, label, isIndeterminate, id, style } = props;
 
   const state = useToggleState(props);
   const internalRef = useRef<HTMLInputElement>();

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -16,7 +16,7 @@ import Icon from '../Icon';
  * The Checkbox component.
  */
 const Checkbox = (props: Props, providedRef: RefObject<HTMLInputElement>) => {
-  const { className, isDisabled, label, isIndeterminate, id, style } = props;
+  const { className, isDisabled, label, isIndeterminate, id, style, ariaLabel} = props;
 
   const state = useToggleState(props);
   const internalRef = useRef<HTMLInputElement>();
@@ -60,7 +60,7 @@ const Checkbox = (props: Props, providedRef: RefObject<HTMLInputElement>) => {
       style={style}
     >
       <VisuallyHidden>
-        <input {...inputProps} {...focusProps} aria-label={label} ref={ref} />
+        <input {...inputProps} {...focusProps} aria-label={ariaLabel || label} ref={ref} />
       </VisuallyHidden>
       {checkbox}
       {label}

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -60,7 +60,7 @@ const Checkbox = (props: Props, providedRef: RefObject<HTMLInputElement>) => {
       style={style}
     >
       <VisuallyHidden>
-        <input {...inputProps} {...focusProps} aria-label={ariaLabel || label} ref={ref} />
+        <input {...inputProps} {...focusProps} aria-label={label || ariaLabel} ref={ref} />
       </VisuallyHidden>
       {checkbox}
       {label}

--- a/src/components/Checkbox/Checkbox.types.ts
+++ b/src/components/Checkbox/Checkbox.types.ts
@@ -21,9 +21,4 @@ export interface Props extends Omit<CheckboxProps, 'children'> {
    * Custom style for overriding this component's CSS.
    */
   style?: CSSProperties;
-
-  /**
-   * Custom aria-label prop in case label is not passed.
-   */
-  ariaLabel?: string;
 }

--- a/src/components/Checkbox/Checkbox.types.ts
+++ b/src/components/Checkbox/Checkbox.types.ts
@@ -21,4 +21,9 @@ export interface Props extends Omit<CheckboxProps, 'children'> {
    * Custom style for overriding this component's CSS.
    */
   style?: CSSProperties;
+
+  /**
+   * Custom aria-label prop in case label is not passed.
+   */
+  ariaLabel?: string;
 }

--- a/src/components/Checkbox/Checkbox.unit.test.tsx
+++ b/src/components/Checkbox/Checkbox.unit.test.tsx
@@ -153,11 +153,11 @@ describe('<Checkbox />', () => {
 
       expect(element.getAttribute('aria-label')).toBe(label);
     });
-    it('should use ariaLabel prop when label prop not provided', async () => {
+    it('should use aria-label prop when label prop not provided', async () => {
       expect.assertions(1);
 
       const ariaLabel = 'test aria label';
-      const wrapper = await mountAndWait(<Checkbox ariaLabel={ariaLabel} />);
+      const wrapper = await mountAndWait(<Checkbox aria-label={ariaLabel} />);
       const element = wrapper.find('input').getDOMNode();
 
       expect(element.getAttribute('aria-label')).toBe(ariaLabel);

--- a/src/components/Checkbox/Checkbox.unit.test.tsx
+++ b/src/components/Checkbox/Checkbox.unit.test.tsx
@@ -143,24 +143,24 @@ describe('<Checkbox />', () => {
 
       expect(element.getAttribute('data-disabled')).toBe(disabled.toString());
     });
-    it('should use ariaLabel prop when provided', async () => {
-      expect.assertions(1);
-
-      const ariaLabel = 'test aria label';
-
-      const wrapper = await mountAndWait(<Checkbox ariaLabel={ariaLabel} />);
-      const element = wrapper.find('input').getDOMNode();
-
-      expect(element.getAttribute('aria-label')).toBe(ariaLabel);
-    });
-    it('should use label prop when ariaLabel prop not provided', async () => {
+    it('should use label prop for aria-label when provided', async () => {
       expect.assertions(1);
 
       const label = 'test label';
+
       const wrapper = await mountAndWait(<Checkbox label={label} />);
       const element = wrapper.find('input').getDOMNode();
 
       expect(element.getAttribute('aria-label')).toBe(label);
+    });
+    it('should use ariaLabel prop when label prop not provided', async () => {
+      expect.assertions(1);
+
+      const ariaLabel = 'test aria label';
+      const wrapper = await mountAndWait(<Checkbox ariaLabel={ariaLabel} />);
+      const element = wrapper.find('input').getDOMNode();
+
+      expect(element.getAttribute('aria-label')).toBe(ariaLabel);
     });
   });
 

--- a/src/components/Checkbox/Checkbox.unit.test.tsx
+++ b/src/components/Checkbox/Checkbox.unit.test.tsx
@@ -143,6 +143,25 @@ describe('<Checkbox />', () => {
 
       expect(element.getAttribute('data-disabled')).toBe(disabled.toString());
     });
+    it('should use ariaLabel prop when provided', async () => {
+      expect.assertions(1);
+
+      const ariaLabel = 'test aria label';
+
+      const wrapper = await mountAndWait(<Checkbox ariaLabel={ariaLabel} />);
+      const element = wrapper.find('input').getDOMNode();
+
+      expect(element.getAttribute('aria-label')).toBe(ariaLabel);
+    });
+    it('should use label prop when ariaLabel prop not provided', async () => {
+      expect.assertions(1);
+
+      const label = 'test label';
+      const wrapper = await mountAndWait(<Checkbox label={label} />);
+      const element = wrapper.find('input').getDOMNode();
+
+      expect(element.getAttribute('aria-label')).toBe(label);
+    });
   });
 
   describe('actions', () => {


### PR DESCRIPTION
# IMPORTANT

**Currently, this project is closed to any external contributions. Any pull request made against this project from external sources will likely be closed. If you would like to make changes to this project, please fork this project.**

# Guide

**This "Help" section can be deleted before submitting this pull request.**

*Update the name of this pull request to reflect the following shape:*

```
{type}/{scope?}/{message}
```

* **type** - A [conventional commit type](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional#type-enum) **REQUIRED**
* **scope** - The kabab-case scope of the changes in this request
* **message** - A short, kebab-case statement describing the changes **REQUIRED**

*Provide a general summary of the scope of the changes in this pull request.*

* [Readme](https://github.com/momentum-design/momentum-react-v2/blob/master/README.md)
* [Getting Started Guide](https://github.com/momentum-design/momentum-react-v2/blob/master/GETTING_STARTED.md)
* [Contributing Guide](https://github.com/momentum-design/momentum-react-v2/blob/master/CONTRIBUTING.md)

# Description

*The full description of the changes made in this request.*
- added ariaLabel prop to use in instances where there is no label passed
# Links
[https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-505167](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-505167)
*Links to relevent resources.*
