### PR TITLE
feat(meetingcontainer): titleTagName

### DIFF
--- a/src/components/MeetingContainer/MeetingContainer.tsx
+++ b/src/components/MeetingContainer/MeetingContainer.tsx
@@ -28,6 +28,7 @@ const MeetingContainer: FC<Props> = (props: Props) => {
     isDisabled,
     statusColor,
     titleType = DEFAULTS.TITLE_TYPE,
+    titleTagName,
     ...otherProps
   } = props;
   const title = meetingTitle || children;
@@ -64,7 +65,7 @@ const MeetingContainer: FC<Props> = (props: Props) => {
         )}
         <div className={STYLE.details}>
           <div>
-            <Text type={titleType} data-disabled={isDisabled}>
+            <Text tagName={titleTagName} type={titleType} data-disabled={isDisabled}>
               {title}
             </Text>
             {changedSpaceLink && <DividerDot />}

--- a/src/components/MeetingContainer/MeetingContainer.types.ts
+++ b/src/components/MeetingContainer/MeetingContainer.types.ts
@@ -5,7 +5,7 @@ import type { ButtonPillProps } from '../ButtonPill';
 import type { TagProps } from '../Tag';
 import type { AvatarProps } from '../Avatar';
 import type { ButtonHyperlinkProps } from '../ButtonHyperlink';
-import type { FontStyle } from '../Text/Text.types';
+import type { AllowedTagNames, FontStyle } from '../Text/Text.types';
 
 export type SupportedActionButton = ReactElement<ButtonPillProps | ButtonCircleProps>;
 export type SupportedTag = ReactElement<TagProps>;
@@ -78,4 +78,9 @@ export interface Props extends CardProps {
    * Takes title type
    */
   titleType?: FontStyle;
+
+  /**
+   * The tag name to use for the title
+   */
+  titleTagName?: AllowedTagNames;
 }

--- a/src/components/MeetingContainer/MeetingContainer.unit.test.tsx
+++ b/src/components/MeetingContainer/MeetingContainer.unit.test.tsx
@@ -462,6 +462,7 @@ describe('attributes', () => {
 
     expect(element).toBe(true);
   });
+
   it('should use titleType when provided', () => {
     const element = mount(
       <MeetingContainer meetingTitle={meetingTitle} titleType={TEXT_CONSTANTS.TYPES.TITLE} />
@@ -471,6 +472,15 @@ describe('attributes', () => {
       .getDOMNode();
 
     expect(element.getAttribute('data-type')).toBe(TEXT_CONSTANTS.TYPES.TITLE);
+  });
+
+  it('should use titleTagName when provided', () => {
+    const element = mount(<MeetingContainer meetingTitle={meetingTitle} titleTagName={'p'} />)
+      .find(Text)
+      .at(0)
+      .getDOMNode();
+
+    expect(element.tagName).toBe('P');
   });
   /* ...additional attribute tests... */
 


### PR DESCRIPTION
# Description

We sometimes need to modify the tagName used for the title. Added titleTagName prop to allow this.

# Links

*Links to relevent resources.*
