### PR TITLE
fix(eslint): don't read ref.current on render

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -63,6 +63,13 @@ module.exports = {
     },
   ],
   rules: {
+    'no-restricted-syntax': [
+      'warn',
+      {
+        'selector': "JSXAttribute > JSXExpressionContainer > MemberExpression[property.name='current']",
+        'message': 'Do not read ref.current on render. Either use useState instead of useRef to store the value, or read ref.current in a useEffect or event handler.'
+      }
+    ],
     quotes: ['error', 'single', { allowTemplateLiterals: true, avoidEscape: true }],
     'no-console': ['error', { allow: ['warn'] }],
     'no-debugger': 1,


### PR DESCRIPTION
# Description

add rule to warn some cases of ref.current being read during render

# Links

https://confluence-eng-gpk2.cisco.com/conf/display/WTWC/Use+useState+not+useRef+for+persistent+generated+ids

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-543350
