### PR TITLE
fix(a11y): alertcontainer-region

### DIFF
--- a/src/legacy/AlertContainer/index.js
+++ b/src/legacy/AlertContainer/index.js
@@ -8,20 +8,20 @@ import PropTypes from 'prop-types';
 **/
 class AlertContainer extends React.Component {
   render() {
-    const { children, className, position, ...otherProps } = this.props;
+    const { children, className, position, ariaLabel, ...otherProps } = this.props;
 
     return (
-      <div
+      <section
         className={
           'md-alert__container' +
           ` md-alert__container--${position}` +
           `${(className && ` ${className}`) || ''}`
         }
+        aria-label={ariaLabel}
         {...otherProps}
-        role="alert"
       >
         {children}
-      </div>
+      </section>
     );
   }
 }
@@ -33,6 +33,8 @@ AlertContainer.defaultProps = {
 };
 
 AlertContainer.propTypes = {
+  /** @prop Required aria-label */
+  ariaLabel: PropTypes.string.isRequired,
   /** @prop Children Nodes to Render inside container | null */
   children: PropTypes.node,
   /** @prop Optional css class string | '' */

--- a/src/legacy/AlertContainer/tests/index.spec.js
+++ b/src/legacy/AlertContainer/tests/index.spec.js
@@ -5,65 +5,72 @@ import { Alert, AlertContainer } from '@momentum-ui/react-collaboration';
 describe('tests for <AlertContainer />', () => {
   const alertTitle = 'Now Hear This!';
   const alertMessage = 'Unit tesing like a boss!';
+  const alertAriaLabel = 'test aria label';
 
   it('should match SnapShot', () => {
-    const container = mount(<AlertContainer />);
+    const container = mount(<AlertContainer ariaLabel={alertAriaLabel} />);
 
     expect(container).toMatchSnapshot();
   });
 
   it('should pass className prop', () => {
-    const container = mount(<AlertContainer className="testing" />);
+    const container = mount(<AlertContainer className="testing" ariaLabel={alertAriaLabel} />);
 
-    expect(container.find('.testing').exists()).toEqual(true);
+    expect(container.find('section.testing').exists()).toEqual(true);
     expect(container.find('AlertContainer').hasClass('testing')).toEqual(true);
   });
 
+  it('should pass ariaLabel prop', () => {
+    const container = mount(<AlertContainer className="testing" ariaLabel={alertAriaLabel} />);
+
+    expect(container.find('section.testing').props()['aria-label']).toBe(alertAriaLabel);
+  });
+
   it('should render a div in bottom-right by default', () => {
-    const container = shallow(<AlertContainer />);
+    const container = shallow(<AlertContainer ariaLabel={alertAriaLabel}/>);
 
     expect(container.find('.md-alert__container--bottom-right').length).toEqual(1);
   });
 
   it('should honor position prop when top-left is passed in', () => {
-    const container = shallow(<AlertContainer position={'top-left'} />);
+    const container = shallow(<AlertContainer position={'top-left'} ariaLabel={alertAriaLabel}/>);
 
     expect(container.find('.md-alert__container--top-left').length).toEqual(1);
   });
 
   it('should honor position prop when top-center is passed in', () => {
-    const container = shallow(<AlertContainer position={'top-center'} />);
+    const container = shallow(<AlertContainer position={'top-center'} ariaLabel={alertAriaLabel}/>);
 
     expect(container.find('.md-alert__container--top-center').length).toEqual(1);
   });
 
   it('should honor position prop when top-right is passed in', () => {
-    const container = shallow(<AlertContainer position={'top-right'} />);
+    const container = shallow(<AlertContainer position={'top-right'} ariaLabel={alertAriaLabel}/>);
 
     expect(container.find('.md-alert__container--top-right').length).toEqual(1);
   });
 
   it('should honor position prop when bottom-left is passed in', () => {
-    const container = shallow(<AlertContainer position={'bottom-left'} />);
+    const container = shallow(<AlertContainer position={'bottom-left'} ariaLabel={alertAriaLabel}/>);
 
     expect(container.find('.md-alert__container--bottom-left').length).toEqual(1);
   });
 
   it('should honor position prop when bottom-center is passed in', () => {
-    const container = shallow(<AlertContainer position={'bottom-center'} />);
+    const container = shallow(<AlertContainer position={'bottom-center'} ariaLabel={alertAriaLabel}/>);
 
     expect(container.find('.md-alert__container--bottom-center').length).toEqual(1);
   });
 
   it('should honor position prop when bottom-right is passed in', () => {
-    const container = shallow(<AlertContainer position={'bottom-right'} />);
+    const container = shallow(<AlertContainer position={'bottom-right'} ariaLabel={alertAriaLabel}/>);
 
     expect(container.find('.md-alert__container--bottom-right').length).toEqual(1);
   });
 
   it('should render an info Alert when info() is called', () => {
     const container = mount(
-      <AlertContainer>
+      <AlertContainer ariaLabel={alertAriaLabel}>
         <Alert title={alertTitle} message={alertMessage} type="info" show closable={false} />
       </AlertContainer>
     );
@@ -73,7 +80,7 @@ describe('tests for <AlertContainer />', () => {
 
   it('should render a success Alert when success() is called', () => {
     const container = mount(
-      <AlertContainer>
+      <AlertContainer ariaLabel={alertAriaLabel}>
         <Alert title={alertTitle} message={alertMessage} type="success" show closable={false} />
       </AlertContainer>
     );
@@ -84,7 +91,7 @@ describe('tests for <AlertContainer />', () => {
 
   it('should render a warning Alert when warning() is called', () => {
     const container = mount(
-      <AlertContainer>
+      <AlertContainer ariaLabel={alertAriaLabel}>
         <Alert title={alertTitle} message={alertMessage} type="warning" show closable={false} />
       </AlertContainer>
     );
@@ -94,7 +101,7 @@ describe('tests for <AlertContainer />', () => {
 
   it('should render an error Alert when error() is called', () => {
     const container = mount(
-      <AlertContainer>
+      <AlertContainer ariaLabel={alertAriaLabel}>
         <Alert title={alertTitle} message={alertMessage} type="error" show closable={false} />
       </AlertContainer>
     );
@@ -104,7 +111,7 @@ describe('tests for <AlertContainer />', () => {
 
   it('should pass any other HTML props to Alert', () => {
     const container = mount(
-      <AlertContainer>
+      <AlertContainer ariaLabel={alertAriaLabel}>
         <Alert
           title={alertTitle}
           message={alertMessage}
@@ -120,7 +127,7 @@ describe('tests for <AlertContainer />', () => {
   });
 
   it('should pass otherProps to container', () => {
-    const container = shallow(<AlertContainer id="testid" />);
+    const container = shallow(<AlertContainer id="testid" ariaLabel={alertAriaLabel}/>);
 
     expect(container.find('#testid').exists()).toEqual(true);
   });

--- a/src/legacy/AlertContainer/tests/index.spec.js.snap
+++ b/src/legacy/AlertContainer/tests/index.spec.js.snap
@@ -2,12 +2,13 @@
 
 exports[`tests for <AlertContainer /> should match SnapShot 1`] = `
 <AlertContainer
+  ariaLabel="test aria label"
   className=""
   position="bottom-right"
 >
-  <div
+  <section
+    aria-label="test aria label"
     className="md-alert__container md-alert__container--bottom-right"
-    role="alert"
   />
 </AlertContainer>
 `;


### PR DESCRIPTION
# Description

Fix the alertcontainer by converting it to a section and apply a aria-label to it, which makes it a role=region.
This fix had to be made to the legacy component, since its still in use.

