### PR TITLE
fix(a11y): toastnotification role override

### DIFF
--- a/src/components/NotificationSystem/NotificationSystem.unit.test.tsx.snap
+++ b/src/components/NotificationSystem/NotificationSystem.unit.test.tsx.snap
@@ -30,13 +30,13 @@ exports[`<NotificationSystem /> snapshot should match snapshot 1`] = `
           >
             <div>
               <div
-                aria-modal="true"
+                aria-modal="false"
                 class="md-toast-notification-wrapper md-modal-container-wrapper"
                 data-color="primary"
                 data-elevation="0"
                 data-padded="true"
                 data-round="50"
-                role="dialog"
+                role="generic"
               >
                 <div
                   class="md-toast-notification-body"
@@ -151,13 +151,13 @@ exports[`<NotificationSystem /> snapshot should match snapshot if notification c
           >
             <div>
               <div
-                aria-modal="true"
+                aria-modal="false"
                 class="md-toast-notification-wrapper md-modal-container-wrapper"
                 data-color="primary"
                 data-elevation="0"
                 data-padded="true"
                 data-round="50"
-                role="dialog"
+                role="generic"
               >
                 <div
                   class="md-toast-notification-body"
@@ -271,13 +271,13 @@ exports[`<NotificationSystem /> snapshot should match snapshot if notification c
           >
             <div>
               <div
-                aria-modal="true"
+                aria-modal="false"
                 class="md-toast-notification-wrapper md-modal-container-wrapper"
                 data-color="primary"
                 data-elevation="0"
                 data-padded="true"
                 data-round="50"
-                role="dialog"
+                role="generic"
               >
                 <div
                   class="md-toast-notification-body"
@@ -392,13 +392,13 @@ exports[`<NotificationSystem /> snapshot should match snapshot when limit is set
           >
             <div>
               <div
-                aria-modal="true"
+                aria-modal="false"
                 class="md-toast-notification-wrapper md-modal-container-wrapper"
                 data-color="primary"
                 data-elevation="0"
                 data-padded="true"
                 data-round="50"
-                role="dialog"
+                role="generic"
               >
                 <div
                   class="md-toast-notification-body"
@@ -513,13 +513,13 @@ exports[`<NotificationSystem /> snapshot should match snapshot with ariaLabel pr
           >
             <div>
               <div
-                aria-modal="true"
+                aria-modal="false"
                 class="md-toast-notification-wrapper md-modal-container-wrapper"
                 data-color="primary"
                 data-elevation="0"
                 data-padded="true"
                 data-round="50"
-                role="dialog"
+                role="generic"
               >
                 <div
                   class="md-toast-notification-body"
@@ -634,13 +634,13 @@ exports[`<NotificationSystem /> snapshot should match snapshot with body class n
           >
             <div>
               <div
-                aria-modal="true"
+                aria-modal="false"
                 class="md-toast-notification-wrapper md-modal-container-wrapper"
                 data-color="primary"
                 data-elevation="0"
                 data-padded="true"
                 data-round="50"
-                role="dialog"
+                role="generic"
               >
                 <div
                   class="md-toast-notification-body"
@@ -755,13 +755,13 @@ exports[`<NotificationSystem /> snapshot should match snapshot with className 1`
           >
             <div>
               <div
-                aria-modal="true"
+                aria-modal="false"
                 class="md-toast-notification-wrapper md-modal-container-wrapper"
                 data-color="primary"
                 data-elevation="0"
                 data-padded="true"
                 data-round="50"
-                role="dialog"
+                role="generic"
               >
                 <div
                   class="md-toast-notification-body"
@@ -876,13 +876,13 @@ exports[`<NotificationSystem /> snapshot should match snapshot with container cl
           >
             <div>
               <div
-                aria-modal="true"
+                aria-modal="false"
                 class="md-toast-notification-wrapper md-modal-container-wrapper"
                 data-color="primary"
                 data-elevation="0"
                 data-padded="true"
                 data-round="50"
-                role="dialog"
+                role="generic"
               >
                 <div
                   class="md-toast-notification-body"
@@ -993,13 +993,13 @@ exports[`<NotificationSystem /> snapshot should match snapshot with different at
           >
             <div>
               <div
-                aria-modal="true"
+                aria-modal="false"
                 class="md-toast-notification-wrapper md-modal-container-wrapper"
                 data-color="primary"
                 data-elevation="0"
                 data-padded="true"
                 data-round="50"
-                role="dialog"
+                role="generic"
               >
                 <div
                   class="md-toast-notification-body"
@@ -1107,13 +1107,13 @@ exports[`<NotificationSystem /> snapshot should match snapshot with different po
           >
             <div>
               <div
-                aria-modal="true"
+                aria-modal="false"
                 class="md-toast-notification-wrapper md-modal-container-wrapper"
                 data-color="primary"
                 data-elevation="0"
                 data-padded="true"
                 data-round="50"
-                role="dialog"
+                role="generic"
               >
                 <div
                   class="md-toast-notification-body"
@@ -1232,13 +1232,13 @@ exports[`<NotificationSystem /> snapshot should match snapshot with different zI
           >
             <div>
               <div
-                aria-modal="true"
+                aria-modal="false"
                 class="md-toast-notification-wrapper md-modal-container-wrapper"
                 data-color="primary"
                 data-elevation="0"
                 data-padded="true"
                 data-round="50"
-                role="dialog"
+                role="generic"
               >
                 <div
                   class="md-toast-notification-body"
@@ -1353,13 +1353,13 @@ exports[`<NotificationSystem /> snapshot should match snapshot with enter animat
           >
             <div>
               <div
-                aria-modal="true"
+                aria-modal="false"
                 class="md-toast-notification-wrapper md-modal-container-wrapper"
                 data-color="primary"
                 data-elevation="0"
                 data-padded="true"
                 data-round="50"
-                role="dialog"
+                role="generic"
               >
                 <div
                   class="md-toast-notification-body"
@@ -1474,13 +1474,13 @@ exports[`<NotificationSystem /> snapshot should match snapshot with id 1`] = `
           >
             <div>
               <div
-                aria-modal="true"
+                aria-modal="false"
                 class="md-toast-notification-wrapper md-modal-container-wrapper"
                 data-color="primary"
                 data-elevation="0"
                 data-padded="true"
                 data-round="50"
-                role="dialog"
+                role="generic"
               >
                 <div
                   class="md-toast-notification-body"
@@ -1595,13 +1595,13 @@ exports[`<NotificationSystem /> snapshot should match snapshot with newest on to
           >
             <div>
               <div
-                aria-modal="true"
+                aria-modal="false"
                 class="md-toast-notification-wrapper md-modal-container-wrapper"
                 data-color="primary"
                 data-elevation="0"
                 data-padded="true"
                 data-round="50"
-                role="dialog"
+                role="generic"
               >
                 <div
                   class="md-toast-notification-body"
@@ -1716,13 +1716,13 @@ exports[`<NotificationSystem /> snapshot should match snapshot with style 1`] = 
           >
             <div>
               <div
-                aria-modal="true"
+                aria-modal="false"
                 class="md-toast-notification-wrapper md-modal-container-wrapper"
                 data-color="primary"
                 data-elevation="0"
                 data-padded="true"
                 data-round="50"
-                role="dialog"
+                role="generic"
               >
                 <div
                   class="md-toast-notification-body"
@@ -1837,13 +1837,13 @@ exports[`<NotificationSystem /> snapshot should match snapshot with toast class 
           >
             <div>
               <div
-                aria-modal="true"
+                aria-modal="false"
                 class="md-toast-notification-wrapper md-modal-container-wrapper"
                 data-color="primary"
                 data-elevation="0"
                 data-padded="true"
                 data-round="50"
-                role="dialog"
+                role="generic"
               >
                 <div
                   class="md-toast-notification-body"

--- a/src/components/ToastNotification/ToastNotification.tsx
+++ b/src/components/ToastNotification/ToastNotification.tsx
@@ -24,6 +24,8 @@ const ToastNotification: FC<Props> = (props: Props) => {
       id={id}
       style={style}
       round={50}
+      role="generic"
+      ariaModal={false}
     >
       <div className={STYLE.body}>
         {leadingVisual && (

--- a/src/components/ToastNotification/ToastNotification.unit.test.tsx.snap
+++ b/src/components/ToastNotification/ToastNotification.unit.test.tsx.snap
@@ -5,18 +5,20 @@ exports[`<ToastNotification /> snapshot should match snapshot 1`] = `
   content="Example text"
 >
   <ModalContainer
+    ariaModal={false}
     className="md-toast-notification-wrapper"
     isPadded={true}
+    role="generic"
     round={50}
   >
     <div
-      aria-modal={true}
+      aria-modal={false}
       className="md-toast-notification-wrapper md-modal-container-wrapper"
       data-color="primary"
       data-elevation={0}
       data-padded={true}
       data-round={50}
-      role="dialog"
+      role="generic"
     >
       <div
         className="md-toast-notification-body"
@@ -58,18 +60,20 @@ exports[`<ToastNotification /> snapshot should match snapshot with button group 
   content="Example text"
 >
   <ModalContainer
+    ariaModal={false}
     className="md-toast-notification-wrapper"
     isPadded={true}
+    role="generic"
     round={50}
   >
     <div
-      aria-modal={true}
+      aria-modal={false}
       className="md-toast-notification-wrapper md-modal-container-wrapper"
       data-color="primary"
       data-elevation={0}
       data-padded={true}
       data-round={50}
-      role="dialog"
+      role="generic"
     >
       <div
         className="md-toast-notification-body"
@@ -210,18 +214,20 @@ exports[`<ToastNotification /> snapshot should match snapshot with className 1`]
   content="Example text"
 >
   <ModalContainer
+    ariaModal={false}
     className="example-class md-toast-notification-wrapper"
     isPadded={true}
+    role="generic"
     round={50}
   >
     <div
-      aria-modal={true}
+      aria-modal={false}
       className="example-class md-toast-notification-wrapper md-modal-container-wrapper"
       data-color="primary"
       data-elevation={0}
       data-padded={true}
       data-round={50}
-      role="dialog"
+      role="generic"
     >
       <div
         className="md-toast-notification-body"
@@ -249,20 +255,22 @@ exports[`<ToastNotification /> snapshot should match snapshot with id 1`] = `
   id="example-id"
 >
   <ModalContainer
+    ariaModal={false}
     className="md-toast-notification-wrapper"
     id="example-id"
     isPadded={true}
+    role="generic"
     round={50}
   >
     <div
-      aria-modal={true}
+      aria-modal={false}
       className="md-toast-notification-wrapper md-modal-container-wrapper"
       data-color="primary"
       data-elevation={0}
       data-padded={true}
       data-round={50}
       id="example-id"
-      role="dialog"
+      role="generic"
     >
       <div
         className="md-toast-notification-body"
@@ -296,18 +304,20 @@ exports[`<ToastNotification /> snapshot should match snapshot with leading visua
   }
 >
   <ModalContainer
+    ariaModal={false}
     className="md-toast-notification-wrapper"
     isPadded={true}
+    role="generic"
     round={50}
   >
     <div
-      aria-modal={true}
+      aria-modal={false}
       className="md-toast-notification-wrapper md-modal-container-wrapper"
       data-color="primary"
       data-elevation={0}
       data-padded={true}
       data-round={50}
-      role="dialog"
+      role="generic"
     >
       <div
         className="md-toast-notification-body"
@@ -366,18 +376,20 @@ exports[`<ToastNotification /> snapshot should match snapshot with non string co
   }
 >
   <ModalContainer
+    ariaModal={false}
     className="md-toast-notification-wrapper"
     isPadded={true}
+    role="generic"
     round={50}
   >
     <div
-      aria-modal={true}
+      aria-modal={false}
       className="md-toast-notification-wrapper md-modal-container-wrapper"
       data-color="primary"
       data-elevation={0}
       data-padded={true}
       data-round={50}
-      role="dialog"
+      role="generic"
     >
       <div
         className="md-toast-notification-body"
@@ -402,18 +414,20 @@ exports[`<ToastNotification /> snapshot should match snapshot with onClose and c
   onClose={[Function]}
 >
   <ModalContainer
+    ariaModal={false}
     className="md-toast-notification-wrapper"
     isPadded={true}
+    role="generic"
     round={50}
   >
     <div
-      aria-modal={true}
+      aria-modal={false}
       className="md-toast-notification-wrapper md-modal-container-wrapper"
       data-color="primary"
       data-elevation={0}
       data-padded={true}
       data-round={50}
-      role="dialog"
+      role="generic"
     >
       <div
         className="md-toast-notification-body"
@@ -525,18 +539,20 @@ exports[`<ToastNotification /> snapshot should match snapshot with string conten
   content="Example text"
 >
   <ModalContainer
+    ariaModal={false}
     className="md-toast-notification-wrapper"
     isPadded={true}
+    role="generic"
     round={50}
   >
     <div
-      aria-modal={true}
+      aria-modal={false}
       className="md-toast-notification-wrapper md-modal-container-wrapper"
       data-color="primary"
       data-elevation={0}
       data-padded={true}
       data-round={50}
-      role="dialog"
+      role="generic"
     >
       <div
         className="md-toast-notification-body"
@@ -568,8 +584,10 @@ exports[`<ToastNotification /> snapshot should match snapshot with style 1`] = `
   }
 >
   <ModalContainer
+    ariaModal={false}
     className="md-toast-notification-wrapper"
     isPadded={true}
+    role="generic"
     round={50}
     style={
       Object {
@@ -578,13 +596,13 @@ exports[`<ToastNotification /> snapshot should match snapshot with style 1`] = `
     }
   >
     <div
-      aria-modal={true}
+      aria-modal={false}
       className="md-toast-notification-wrapper md-modal-container-wrapper"
       data-color="primary"
       data-elevation={0}
       data-padded={true}
       data-round={50}
-      role="dialog"
+      role="generic"
       style={
         Object {
           "color": "pink",


### PR DESCRIPTION
# Description

Due to the change in the Modalcontainer the ToastNotification component also has now a role="dialog" set (since ModalContainer is used for it). This is not correct, since the toast is not supposed to be role="dialog", but role="alert" (which gets inferred by Tippy). In this case i have overridden the role with "generic" and set ariaModal to false to remove all the overrides (i couldn't find a better way without changing too much implementation)
