### PR TITLE
Alert only the string

### DIFF
--- a/src/components/NotificationSystem/NotificationSystem.stories.tsx
+++ b/src/components/NotificationSystem/NotificationSystem.stories.tsx
@@ -48,6 +48,34 @@ Example.args = {
   ariaLabel: 'Notification System',
 };
 
+const NonStringContent = Template<NotificationSystemProps>((args: NotificationSystemProps) => {
+  return (
+    <>
+      <ButtonPill
+        onPress={() =>
+          NotificationSystem.notify(
+            <NotificationTemplate
+              ariaLabel="Non String Content Notification"
+              content={<div role="alert">I am the notification</div>}
+            />,
+            { attention: ATTENTION.MEDIUM }
+          )
+        }
+      >
+        Trigger a new low attention notification
+      </ButtonPill>
+      <NotificationSystem {...args} limit={3} />
+    </>
+  );
+}).bind({});
+
+NonStringContent.argTypes = { ...argTypes };
+
+NonStringContent.args = {
+  position: POSITION.TOP_RIGHT,
+  ariaLabel: 'Notification System',
+};
+
 const Important = Template<NotificationSystemProps>((args: NotificationSystemProps) => {
   return (
     <>
@@ -263,4 +291,4 @@ MultipleSystems.args = {
   ariaLabel: 'Notification System',
 };
 
-export { Example, Important, Mixed, UpdateContent, ResetTimer, MultipleSystems };
+export { Example, Important, Mixed, UpdateContent, ResetTimer, MultipleSystems, NonStringContent };

--- a/src/components/NotificationSystem/NotificationSystem.stories.tsx
+++ b/src/components/NotificationSystem/NotificationSystem.stories.tsx
@@ -56,7 +56,7 @@ const NonStringContent = Template<NotificationSystemProps>((args: NotificationSy
           NotificationSystem.notify(
             <NotificationTemplate
               ariaLabel="Non String Content Notification"
-              content={<div role="alert">I am the notification</div>}
+              content={<div>This is a notification</div>}
             />,
             { attention: ATTENTION.MEDIUM }
           )

--- a/src/components/NotificationSystem/NotificationSystem.tsx
+++ b/src/components/NotificationSystem/NotificationSystem.tsx
@@ -28,7 +28,7 @@ const NotificationSystem: FC<Props> & CompoundProps = (props: Props) => {
     toastClassName,
     bodyClassName,
     containerClassName,
-    ariaLabel
+    ariaLabel,
   } = props;
 
   const slideAndBlur = cssTransition({
@@ -66,12 +66,14 @@ const NotificationSystem: FC<Props> & CompoundProps = (props: Props) => {
         position={position}
         limit={limit}
         containerId={getContainerID(id, attentionOrder[0])}
+        role="generic"
       />
       <ToastContainer
         {...commonProps}
         position={position}
         limit={limit}
         containerId={getContainerID(id, attentionOrder[1])}
+        role="generic"
       />
     </section>
   );

--- a/src/components/NotificationSystem/NotificationSystem.unit.test.tsx
+++ b/src/components/NotificationSystem/NotificationSystem.unit.test.tsx
@@ -1,5 +1,5 @@
 import React, { CSSProperties, ReactNode, isValidElement } from 'react';
-import { act, render, screen, waitFor, waitForElementToBeRemoved } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, waitForElementToBeRemoved } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import NotificationSystem from './';
@@ -357,35 +357,36 @@ describe('<NotificationSystem />', () => {
       });
     });
 
-    it('should show a notification after notify has been fired and disappears after dismiss has been fired', async () => {
-      expect.assertions(4);
+    // it.only('should show a notification after notify has been fired and disappears after dismiss has been fired', async () => {
+    //   // expect.assertions(4);
 
-      render(<NotificationSystem ariaLabel="test" />);
+    //   render(<NotificationSystem ariaLabel="test" />);
 
-      const toastId = '12345';
-      act(() => {
-        NotificationSystem.notify(<NotificationTemplate content={textContent} />, {
-          autoClose: false,
-          toastId,
-        });
-      });
+    //   const toastId = '12345';
+    //   act(() => {
+    //     NotificationSystem.notify(<NotificationTemplate content={textContent} />, {
+    //       autoClose: false,
+    //       toastId,
+    //     });
+    //   });
 
-      // wait till the toast shows up on the screen:
-      const toast = await screen.findByRole('alert');
-      expect(toast).toBeVisible();
-      expect(toast).toHaveTextContent(textContent);
+    //   // wait till the toast shows up on the screen:
+    //   const toast = await screen.findByRole('alert');
+    //   expect(toast).toBeVisible();
+    //   expect(toast).toHaveTextContent(textContent);
 
-      expect(NotificationSystem.isActive(toastId)).toBeTruthy();
+    //   expect(NotificationSystem.isActive(toastId)).toBeTruthy();
 
-      // dismiss the toast again
-      act(() => {
-        NotificationSystem.dismiss(toastId);
-      });
-
-      // check if toast got removed and the toast is not active anymore
-      await waitForElementToBeRemoved(() => screen.queryByRole('alert'));
-      expect(NotificationSystem.isActive(toastId)).toBeFalsy();
-    });
+    //   // dismiss the toast again
+    //   act(() => {
+    //    NotificationSystem.dismiss(toastId);
+    //   });
+      
+    //   fireEvent.animationEnd(screen.getByText(textContent));
+    //   // check if toast got removed and the toast is not active anymore
+    //   await waitForElementToBeRemoved(screen.getByText(textContent));
+    //   // expect(NotificationSystem.isActive(toastId)).toBeFalsy();
+    // });
 
     it('should close the `medium attention` notification after clicking on the close button', async () => {
       expect.assertions(4);
@@ -417,9 +418,10 @@ describe('<NotificationSystem />', () => {
       // dismiss the toast by clicking the close button
 
       await user.click(closeButton);
+      fireEvent.animationEnd(screen.getByText(textContent));
 
       // check if toast got removed and the toast is not active anymore
-      await waitForElementToBeRemoved(() => screen.queryByRole('alert'));
+      await waitForElementToBeRemoved(screen.getByText(textContent));
       expect(NotificationSystem.isActive(toastId)).toBeFalsy();
     });
 

--- a/src/components/NotificationSystem/NotificationSystem.unit.test.tsx
+++ b/src/components/NotificationSystem/NotificationSystem.unit.test.tsx
@@ -359,7 +359,6 @@ describe('<NotificationSystem />', () => {
     
     it('should show a notification after notify has been fired and disappears after dismiss has been fired', async () => {
       jest.useFakeTimers();
-      
       render(<NotificationSystem ariaLabel="test" />);
 
       const toastId = '12345';
@@ -376,12 +375,10 @@ describe('<NotificationSystem />', () => {
       expect(toast).toHaveTextContent(textContent);
 
       expect(NotificationSystem.isActive(toastId)).toBeTruthy();
-      
       // dismiss the toast again
       act(() => {
        NotificationSystem.dismiss(toastId);
-      });
-      
+      }); 
       jest.advanceTimersByTime(1000);
       fireEvent.animationEnd(screen.getByText(textContent));
 

--- a/src/components/NotificationSystem/NotificationSystem.unit.test.tsx
+++ b/src/components/NotificationSystem/NotificationSystem.unit.test.tsx
@@ -356,37 +356,41 @@ describe('<NotificationSystem />', () => {
         return 0;
       });
     });
-
-    // it.only('should show a notification after notify has been fired and disappears after dismiss has been fired', async () => {
-    //   // expect.assertions(4);
-
-    //   render(<NotificationSystem ariaLabel="test" />);
-
-    //   const toastId = '12345';
-    //   act(() => {
-    //     NotificationSystem.notify(<NotificationTemplate content={textContent} />, {
-    //       autoClose: false,
-    //       toastId,
-    //     });
-    //   });
-
-    //   // wait till the toast shows up on the screen:
-    //   const toast = await screen.findByRole('alert');
-    //   expect(toast).toBeVisible();
-    //   expect(toast).toHaveTextContent(textContent);
-
-    //   expect(NotificationSystem.isActive(toastId)).toBeTruthy();
-
-    //   // dismiss the toast again
-    //   act(() => {
-    //    NotificationSystem.dismiss(toastId);
-    //   });
+    
+    it('should show a notification after notify has been fired and disappears after dismiss has been fired', async () => {
+      jest.useFakeTimers();
       
-    //   fireEvent.animationEnd(screen.getByText(textContent));
-    //   // check if toast got removed and the toast is not active anymore
-    //   await waitForElementToBeRemoved(screen.getByText(textContent));
-    //   // expect(NotificationSystem.isActive(toastId)).toBeFalsy();
-    // });
+      render(<NotificationSystem ariaLabel="test" />);
+
+      const toastId = '12345';
+      act(() => {
+        NotificationSystem.notify(<NotificationTemplate content={textContent} />, {
+          autoClose: false,
+          toastId,
+        });
+      });
+
+      // wait till the toast shows up on the screen:
+      const toast = await screen.findByRole('alert');
+      expect(toast).toBeVisible();
+      expect(toast).toHaveTextContent(textContent);
+
+      expect(NotificationSystem.isActive(toastId)).toBeTruthy();
+      
+      // dismiss the toast again
+      act(() => {
+       NotificationSystem.dismiss(toastId);
+      });
+      
+      jest.advanceTimersByTime(1000);
+      fireEvent.animationEnd(screen.getByText(textContent));
+
+      // check if toast got removed and the toast is not active anymore
+      await waitForElementToBeRemoved(screen.getByText(textContent));
+      expect(NotificationSystem.isActive(toastId)).toBeFalsy();
+      jest.clearAllTimers();
+      jest.useRealTimers();
+    });
 
     it('should close the `medium attention` notification after clicking on the close button', async () => {
       expect.assertions(4);

--- a/src/components/NotificationSystem/NotificationSystem.unit.test.tsx
+++ b/src/components/NotificationSystem/NotificationSystem.unit.test.tsx
@@ -46,7 +46,7 @@ describe('<NotificationSystem />', () => {
     containerClassName,
     bodyClassName,
     toastClassName,
-    ariaLabel
+    ariaLabel,
   }: PrepareForSnapshotProps) => {
     const { container } = render(
       <NotificationSystem
@@ -86,7 +86,10 @@ describe('<NotificationSystem />', () => {
   describe('snapshot', () => {
     it('should match snapshot', async () => {
       expect.assertions(1);
-      const { container } = await waitForNotificationToAppear({ content, ariaLabel: ariaLabelMock });
+      const { container } = await waitForNotificationToAppear({
+        content,
+        ariaLabel: ariaLabelMock,
+      });
 
       expect(container).toMatchSnapshot();
     });
@@ -95,7 +98,11 @@ describe('<NotificationSystem />', () => {
       expect.assertions(1);
       const className = 'example-class';
 
-      const { container } = await waitForNotificationToAppear({ content, className, ariaLabel: ariaLabelMock });
+      const { container } = await waitForNotificationToAppear({
+        content,
+        className,
+        ariaLabel: ariaLabelMock,
+      });
 
       expect(container).toMatchSnapshot();
     });
@@ -104,7 +111,11 @@ describe('<NotificationSystem />', () => {
       expect.assertions(1);
 
       const id = 'example-id';
-      const { container } = await waitForNotificationToAppear({ content, id, ariaLabel: ariaLabelMock });
+      const { container } = await waitForNotificationToAppear({
+        content,
+        id,
+        ariaLabel: ariaLabelMock,
+      });
 
       expect(container).toMatchSnapshot();
     });
@@ -113,7 +124,11 @@ describe('<NotificationSystem />', () => {
       expect.assertions(1);
 
       const style = { color: 'pink' };
-      const { container } = await waitForNotificationToAppear({ content, style, ariaLabel: ariaLabelMock });
+      const { container } = await waitForNotificationToAppear({
+        content,
+        style,
+        ariaLabel: ariaLabelMock,
+      });
 
       expect(container).toMatchSnapshot();
     });
@@ -124,7 +139,7 @@ describe('<NotificationSystem />', () => {
       const { container } = await waitForNotificationToAppear({
         content,
         position: NotificationSystem.POSITION.BOTTOM_RIGHT,
-        ariaLabel: ariaLabelMock
+        ariaLabel: ariaLabelMock,
       });
 
       expect(container).toMatchSnapshot();
@@ -136,7 +151,7 @@ describe('<NotificationSystem />', () => {
       const { container } = await waitForNotificationToAppear({
         content,
         attention: NotificationSystem.ATTENTION.MEDIUM,
-        ariaLabel: ariaLabelMock
+        ariaLabel: ariaLabelMock,
       });
 
       expect(container).toMatchSnapshot();
@@ -148,7 +163,7 @@ describe('<NotificationSystem />', () => {
       const { container } = await waitForNotificationToAppear({
         content,
         zIndex: 9898,
-        ariaLabel: ariaLabelMock
+        ariaLabel: ariaLabelMock,
       });
 
       expect(container).toMatchSnapshot();
@@ -160,7 +175,7 @@ describe('<NotificationSystem />', () => {
       const { container } = await waitForNotificationToAppear({
         content,
         enterAnimation: 'slideInBottom',
-        ariaLabel: ariaLabelMock
+        ariaLabel: ariaLabelMock,
       });
 
       expect(container).toMatchSnapshot();
@@ -172,7 +187,7 @@ describe('<NotificationSystem />', () => {
       const { container } = await waitForNotificationToAppear({
         content,
         newestOnTop: false,
-        ariaLabel: ariaLabelMock
+        ariaLabel: ariaLabelMock,
       });
 
       expect(container).toMatchSnapshot();
@@ -184,7 +199,7 @@ describe('<NotificationSystem />', () => {
       const { container } = await waitForNotificationToAppear({
         content,
         toastClassName: 'toast',
-        ariaLabel: ariaLabelMock
+        ariaLabel: ariaLabelMock,
       });
 
       expect(container).toMatchSnapshot();
@@ -196,7 +211,7 @@ describe('<NotificationSystem />', () => {
       const { container } = await waitForNotificationToAppear({
         content,
         bodyClassName: 'body-toast',
-        ariaLabel: ariaLabelMock
+        ariaLabel: ariaLabelMock,
       });
 
       expect(container).toMatchSnapshot();
@@ -208,7 +223,7 @@ describe('<NotificationSystem />', () => {
       const { container } = await waitForNotificationToAppear({
         content,
         bodyClassName: 'container',
-        ariaLabel: ariaLabelMock
+        ariaLabel: ariaLabelMock,
       });
 
       expect(container).toMatchSnapshot();
@@ -219,8 +234,8 @@ describe('<NotificationSystem />', () => {
 
       const { container } = await waitForNotificationToAppear({
         content,
-        limit: 5, 
-        ariaLabel: ariaLabelMock
+        limit: 5,
+        ariaLabel: ariaLabelMock,
       });
 
       expect(container).toMatchSnapshot();
@@ -230,8 +245,8 @@ describe('<NotificationSystem />', () => {
       expect.assertions(1);
 
       const { container } = await waitForNotificationToAppear({
-        content: textContent, 
-        ariaLabel: ariaLabelMock
+        content: textContent,
+        ariaLabel: ariaLabelMock,
       });
 
       expect(container).toMatchSnapshot();
@@ -240,8 +255,8 @@ describe('<NotificationSystem />', () => {
     it('should match snapshot if notification content is not a free string', async () => {
       expect.assertions(1);
       const { container } = await waitForNotificationToAppear({
-        content, 
-        ariaLabel: ariaLabelMock
+        content,
+        ariaLabel: ariaLabelMock,
       });
       expect(container).toMatchSnapshot();
     });
@@ -249,8 +264,8 @@ describe('<NotificationSystem />', () => {
     it('should match snapshot with ariaLabel provided', async () => {
       expect.assertions(1);
       const { container } = await waitForNotificationToAppear({
-        content, 
-        ariaLabel: 'test'
+        content,
+        ariaLabel: 'test',
       });
       expect(container).toMatchSnapshot();
     });
@@ -276,7 +291,7 @@ describe('<NotificationSystem />', () => {
         position,
         attention,
         zIndex,
-        ariaLabel: ariaLabelMock
+        ariaLabel: ariaLabelMock,
       });
 
       const notificationContainer = container.querySelector(`section[data-position="${position}"]`);
@@ -302,7 +317,7 @@ describe('<NotificationSystem />', () => {
         content,
         limit: toastLimit,
         id: '1234567',
-        ariaLabel: ariaLabelMock
+        ariaLabel: ariaLabelMock,
       });
 
       act(() => {
@@ -335,10 +350,17 @@ describe('<NotificationSystem />', () => {
   });
 
   describe('actions', () => {
+    beforeAll(() => {
+      jest.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+        cb(0);
+        return 0;
+      });
+    });
+
     it('should show a notification after notify has been fired and disappears after dismiss has been fired', async () => {
       expect.assertions(4);
 
-      render(<NotificationSystem ariaLabel='test'/>);
+      render(<NotificationSystem ariaLabel="test" />);
 
       const toastId = '12345';
       act(() => {
@@ -366,10 +388,10 @@ describe('<NotificationSystem />', () => {
     });
 
     it('should close the `medium attention` notification after clicking on the close button', async () => {
-      expect.assertions(5);
+      expect.assertions(4);
       const user = userEvent.setup();
 
-      render(<NotificationSystem ariaLabel='test' />);
+      render(<NotificationSystem ariaLabel="test" />);
 
       const closeButtonText = 'Close';
       const toastId = '12345';
@@ -397,13 +419,12 @@ describe('<NotificationSystem />', () => {
       await user.click(closeButton);
 
       // check if toast got removed and the toast is not active anymore
-      const toastAfterRemoval = screen.queryByRole('alert');
-      expect(toastAfterRemoval).not.toBeInTheDocument();
+      await waitForElementToBeRemoved(() => screen.queryByRole('alert'));
       expect(NotificationSystem.isActive(toastId)).toBeFalsy();
     });
 
     it('should update an existing notification', async () => {
-      render(<NotificationSystem ariaLabel='test' />);
+      render(<NotificationSystem ariaLabel="test" />);
 
       const toastId = '12345';
       const newcontent = 'this is a new text';
@@ -439,8 +460,8 @@ describe('<NotificationSystem />', () => {
       const secondSystemId = 'id234';
       render(
         <>
-          <NotificationSystem id={firstSystemId} ariaLabel='test' />
-          <NotificationSystem id={secondSystemId} ariaLabel='test' />
+          <NotificationSystem id={firstSystemId} ariaLabel="test" />
+          <NotificationSystem id={secondSystemId} ariaLabel="test" />
         </>
       );
 

--- a/src/components/NotificationSystem/NotificationSystem.unit.test.tsx
+++ b/src/components/NotificationSystem/NotificationSystem.unit.test.tsx
@@ -383,7 +383,7 @@ describe('<NotificationSystem />', () => {
       fireEvent.animationEnd(screen.getByText(textContent));
 
       // check if toast got removed and the toast is not active anymore
-      await waitForElementToBeRemoved(screen.getByText(textContent));
+      await waitForElementToBeRemoved(() => screen.queryByText(textContent));
       expect(NotificationSystem.isActive(toastId)).toBeFalsy();
       jest.clearAllTimers();
       jest.useRealTimers();
@@ -422,7 +422,7 @@ describe('<NotificationSystem />', () => {
       fireEvent.animationEnd(screen.getByText(textContent));
 
       // check if toast got removed and the toast is not active anymore
-      await waitForElementToBeRemoved(screen.getByText(textContent));
+      await waitForElementToBeRemoved(() => screen.queryByText(textContent));
       expect(NotificationSystem.isActive(toastId)).toBeFalsy();
     });
 

--- a/src/components/NotificationSystem/NotificationSystem.unit.test.tsx.snap
+++ b/src/components/NotificationSystem/NotificationSystem.unit.test.tsx.snap
@@ -64,6 +64,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot 1`] = `
                   </div>
                   <div
                     class="md-toast-notification-content"
+                    role="alert"
                   >
                     <button>
                       This is a test
@@ -306,6 +307,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot if notification c
                   </div>
                   <div
                     class="md-toast-notification-content"
+                    role="alert"
                   >
                     <button>
                       This is a test
@@ -427,6 +429,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot when limit is set
                   </div>
                   <div
                     class="md-toast-notification-content"
+                    role="alert"
                   >
                     <button>
                       This is a test
@@ -548,6 +551,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with ariaLabel pr
                   </div>
                   <div
                     class="md-toast-notification-content"
+                    role="alert"
                   >
                     <button>
                       This is a test
@@ -669,6 +673,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with body class n
                   </div>
                   <div
                     class="md-toast-notification-content"
+                    role="alert"
                   >
                     <button>
                       This is a test
@@ -790,6 +795,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with className 1`
                   </div>
                   <div
                     class="md-toast-notification-content"
+                    role="alert"
                   >
                     <button>
                       This is a test
@@ -911,6 +917,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with container cl
                   </div>
                   <div
                     class="md-toast-notification-content"
+                    role="alert"
                   >
                     <button>
                       This is a test
@@ -1028,6 +1035,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with different at
                   </div>
                   <div
                     class="md-toast-notification-content"
+                    role="alert"
                   >
                     <button>
                       This is a test
@@ -1142,6 +1150,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with different po
                   </div>
                   <div
                     class="md-toast-notification-content"
+                    role="alert"
                   >
                     <button>
                       This is a test
@@ -1267,6 +1276,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with different zI
                   </div>
                   <div
                     class="md-toast-notification-content"
+                    role="alert"
                   >
                     <button>
                       This is a test
@@ -1388,6 +1398,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with enter animat
                   </div>
                   <div
                     class="md-toast-notification-content"
+                    role="alert"
                   >
                     <button>
                       This is a test
@@ -1509,6 +1520,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with id 1`] = `
                   </div>
                   <div
                     class="md-toast-notification-content"
+                    role="alert"
                   >
                     <button>
                       This is a test
@@ -1630,6 +1642,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with newest on to
                   </div>
                   <div
                     class="md-toast-notification-content"
+                    role="alert"
                   >
                     <button>
                       This is a test
@@ -1751,6 +1764,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with style 1`] = 
                   </div>
                   <div
                     class="md-toast-notification-content"
+                    role="alert"
                   >
                     <button>
                       This is a test
@@ -1872,6 +1886,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with toast class 
                   </div>
                   <div
                     class="md-toast-notification-content"
+                    role="alert"
                   >
                     <button>
                       This is a test

--- a/src/components/NotificationSystem/NotificationSystem.unit.test.tsx.snap
+++ b/src/components/NotificationSystem/NotificationSystem.unit.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot 1`] = `
                 data-elevation="0"
                 data-padded="true"
                 data-round="50"
-                role="generic"
+                role="dialog"
               >
                 <div
                   class="md-toast-notification-body"
@@ -157,7 +157,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot if notification c
                 data-elevation="0"
                 data-padded="true"
                 data-round="50"
-                role="generic"
+                role="dialog"
               >
                 <div
                   class="md-toast-notification-body"
@@ -277,7 +277,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot if notification c
                 data-elevation="0"
                 data-padded="true"
                 data-round="50"
-                role="generic"
+                role="dialog"
               >
                 <div
                   class="md-toast-notification-body"
@@ -398,7 +398,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot when limit is set
                 data-elevation="0"
                 data-padded="true"
                 data-round="50"
-                role="generic"
+                role="dialog"
               >
                 <div
                   class="md-toast-notification-body"
@@ -519,7 +519,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with ariaLabel pr
                 data-elevation="0"
                 data-padded="true"
                 data-round="50"
-                role="generic"
+                role="dialog"
               >
                 <div
                   class="md-toast-notification-body"
@@ -640,7 +640,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with body class n
                 data-elevation="0"
                 data-padded="true"
                 data-round="50"
-                role="generic"
+                role="dialog"
               >
                 <div
                   class="md-toast-notification-body"
@@ -761,7 +761,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with className 1`
                 data-elevation="0"
                 data-padded="true"
                 data-round="50"
-                role="generic"
+                role="dialog"
               >
                 <div
                   class="md-toast-notification-body"
@@ -882,7 +882,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with container cl
                 data-elevation="0"
                 data-padded="true"
                 data-round="50"
-                role="generic"
+                role="dialog"
               >
                 <div
                   class="md-toast-notification-body"
@@ -999,7 +999,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with different at
                 data-elevation="0"
                 data-padded="true"
                 data-round="50"
-                role="generic"
+                role="dialog"
               >
                 <div
                   class="md-toast-notification-body"
@@ -1113,7 +1113,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with different po
                 data-elevation="0"
                 data-padded="true"
                 data-round="50"
-                role="generic"
+                role="dialog"
               >
                 <div
                   class="md-toast-notification-body"
@@ -1238,7 +1238,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with different zI
                 data-elevation="0"
                 data-padded="true"
                 data-round="50"
-                role="generic"
+                role="dialog"
               >
                 <div
                   class="md-toast-notification-body"
@@ -1359,7 +1359,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with enter animat
                 data-elevation="0"
                 data-padded="true"
                 data-round="50"
-                role="generic"
+                role="dialog"
               >
                 <div
                   class="md-toast-notification-body"
@@ -1480,7 +1480,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with id 1`] = `
                 data-elevation="0"
                 data-padded="true"
                 data-round="50"
-                role="generic"
+                role="dialog"
               >
                 <div
                   class="md-toast-notification-body"
@@ -1601,7 +1601,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with newest on to
                 data-elevation="0"
                 data-padded="true"
                 data-round="50"
-                role="generic"
+                role="dialog"
               >
                 <div
                   class="md-toast-notification-body"
@@ -1722,7 +1722,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with style 1`] = 
                 data-elevation="0"
                 data-padded="true"
                 data-round="50"
-                role="generic"
+                role="dialog"
               >
                 <div
                   class="md-toast-notification-body"
@@ -1843,7 +1843,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with toast class 
                 data-elevation="0"
                 data-padded="true"
                 data-round="50"
-                role="generic"
+                role="dialog"
               >
                 <div
                   class="md-toast-notification-body"

--- a/src/components/NotificationSystem/NotificationSystem.unit.test.tsx.snap
+++ b/src/components/NotificationSystem/NotificationSystem.unit.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot 1`] = `
         >
           <div
             class="Toastify__toast-body"
-            role="alert"
+            role="generic"
           >
             <div>
               <div
@@ -147,7 +147,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot if notification c
         >
           <div
             class="Toastify__toast-body"
-            role="alert"
+            role="generic"
           >
             <div>
               <div
@@ -186,6 +186,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot if notification c
                   <p
                     class="md-text-wrapper md-toast-notification-content"
                     data-type="body-primary"
+                    role="alert"
                   >
                     This is a test
                   </p>
@@ -267,7 +268,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot if notification c
         >
           <div
             class="Toastify__toast-body"
-            role="alert"
+            role="generic"
           >
             <div>
               <div
@@ -388,7 +389,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot when limit is set
         >
           <div
             class="Toastify__toast-body"
-            role="alert"
+            role="generic"
           >
             <div>
               <div
@@ -509,7 +510,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with ariaLabel pr
         >
           <div
             class="Toastify__toast-body"
-            role="alert"
+            role="generic"
           >
             <div>
               <div
@@ -630,7 +631,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with body class n
         >
           <div
             class="Toastify__toast-body body-toast"
-            role="alert"
+            role="generic"
           >
             <div>
               <div
@@ -751,7 +752,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with className 1`
         >
           <div
             class="Toastify__toast-body"
-            role="alert"
+            role="generic"
           >
             <div>
               <div
@@ -872,7 +873,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with container cl
         >
           <div
             class="Toastify__toast-body container"
-            role="alert"
+            role="generic"
           >
             <div>
               <div
@@ -989,7 +990,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with different at
         >
           <div
             class="Toastify__toast-body"
-            role="alert"
+            role="generic"
           >
             <div>
               <div
@@ -1103,7 +1104,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with different po
         >
           <div
             class="Toastify__toast-body"
-            role="alert"
+            role="generic"
           >
             <div>
               <div
@@ -1228,7 +1229,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with different zI
         >
           <div
             class="Toastify__toast-body"
-            role="alert"
+            role="generic"
           >
             <div>
               <div
@@ -1349,7 +1350,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with enter animat
         >
           <div
             class="Toastify__toast-body"
-            role="alert"
+            role="generic"
           >
             <div>
               <div
@@ -1470,7 +1471,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with id 1`] = `
         >
           <div
             class="Toastify__toast-body"
-            role="alert"
+            role="generic"
           >
             <div>
               <div
@@ -1591,7 +1592,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with newest on to
         >
           <div
             class="Toastify__toast-body"
-            role="alert"
+            role="generic"
           >
             <div>
               <div
@@ -1712,7 +1713,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with style 1`] = 
         >
           <div
             class="Toastify__toast-body"
-            role="alert"
+            role="generic"
           >
             <div>
               <div
@@ -1833,7 +1834,7 @@ exports[`<NotificationSystem /> snapshot should match snapshot with toast class 
         >
           <div
             class="Toastify__toast-body"
-            role="alert"
+            role="generic"
           >
             <div>
               <div

--- a/src/components/NotificationSystem/NotificationTemplate.tsx
+++ b/src/components/NotificationSystem/NotificationTemplate.tsx
@@ -33,13 +33,18 @@ interface NotificationTemplateProps {
    * Custom class for overriding this component's CSS.
    */
   className?: string;
+
+  /**
+   * aria-label used for the toast notification.
+   */
+  ariaLabel?: string;
 }
 
 /**
  * NOTE: this component is only used for the stories
  */
 const NotificationTemplate: FC<NotificationTemplateProps> = (props: NotificationTemplateProps) => {
-  const { content, closeToast, closeButtonText, className } = props;
+  const { content, closeToast, closeButtonText, className, ariaLabel } = props;
 
   const handleClose = React.useCallback((e: PressEvent) => {
     closeToast?.(e as unknown as React.MouseEvent<HTMLElement, MouseEvent>);
@@ -49,6 +54,7 @@ const NotificationTemplate: FC<NotificationTemplateProps> = (props: Notification
     <ToastNotification
       content={content}
       onClose={handleClose}
+      ariaLabel={ariaLabel}
       leadingVisual={
         <Icon
           name="info-circle"

--- a/src/components/Text/Text.types.ts
+++ b/src/components/Text/Text.types.ts
@@ -34,6 +34,10 @@ export interface Props {
    * Override the tag used to surround the text
    */
   tagName?: AllowedTagNames;
+  /**
+   * role of the component
+   */
+  role?: string;
 }
 
 export type FontStyle =

--- a/src/components/ToastNotification/ToastNotification.tsx
+++ b/src/components/ToastNotification/ToastNotification.tsx
@@ -24,7 +24,6 @@ const ToastNotification: FC<Props> = (props: Props) => {
       id={id}
       style={style}
       round={50}
-      role="generic"
       ariaModal={false}
     >
       <div className={STYLE.body}>

--- a/src/components/ToastNotification/ToastNotification.tsx
+++ b/src/components/ToastNotification/ToastNotification.tsx
@@ -14,8 +14,17 @@ import Text from '../Text';
  * The ToastNotification component.
  */
 const ToastNotification: FC<Props> = (props: Props) => {
-  const { className, id, style, content, leadingVisual, buttonGroup, onClose, closeButtonLabel } =
-    props;
+  const {
+    className,
+    id,
+    style,
+    content,
+    leadingVisual,
+    buttonGroup,
+    onClose,
+    closeButtonLabel,
+    ariaLabel,
+  } = props;
 
   return (
     <ModalContainer
@@ -25,13 +34,14 @@ const ToastNotification: FC<Props> = (props: Props) => {
       style={style}
       round={50}
       ariaModal={false}
+      aria-label={ariaLabel}
     >
       <div className={STYLE.body}>
         {leadingVisual && (
           <div className={classnames(className, STYLE.leadingVisual)}>{leadingVisual}</div>
         )}
         {isString(content) ? (
-          <Text className={classnames(className, STYLE.content)} type="body-primary">
+          <Text role="alert" className={classnames(className, STYLE.content)} type="body-primary">
             {content}
           </Text>
         ) : (

--- a/src/components/ToastNotification/ToastNotification.tsx
+++ b/src/components/ToastNotification/ToastNotification.tsx
@@ -45,7 +45,9 @@ const ToastNotification: FC<Props> = (props: Props) => {
             {content}
           </Text>
         ) : (
-          <div className={classnames(className, STYLE.content)}>{content}</div>
+          <div role="alert" className={classnames(className, STYLE.content)}>
+            {content}
+          </div>
         )}
         {onClose && (
           <div className={classnames(className, STYLE.closeButton)}>

--- a/src/components/ToastNotification/ToastNotification.types.ts
+++ b/src/components/ToastNotification/ToastNotification.types.ts
@@ -49,4 +49,9 @@ export interface Props {
    * Close button's aria-label
    */
   closeButtonLabel?: string;
+
+  /**
+   * aria-label used for the toast notification.
+   */
+  ariaLabel?: string;
 }

--- a/src/components/ToastNotification/ToastNotification.unit.test.tsx.snap
+++ b/src/components/ToastNotification/ToastNotification.unit.test.tsx.snap
@@ -400,6 +400,7 @@ exports[`<ToastNotification /> snapshot should match snapshot with non string co
       >
         <div
           className="md-toast-notification-content"
+          role="alert"
         >
           <button>
             Example text

--- a/src/components/ToastNotification/ToastNotification.unit.test.tsx.snap
+++ b/src/components/ToastNotification/ToastNotification.unit.test.tsx.snap
@@ -8,7 +8,6 @@ exports[`<ToastNotification /> snapshot should match snapshot 1`] = `
     ariaModal={false}
     className="md-toast-notification-wrapper"
     isPadded={true}
-    role="generic"
     round={50}
   >
     <div
@@ -18,7 +17,7 @@ exports[`<ToastNotification /> snapshot should match snapshot 1`] = `
       data-elevation={0}
       data-padded={true}
       data-round={50}
-      role="generic"
+      role="dialog"
     >
       <div
         className="md-toast-notification-body"
@@ -63,7 +62,6 @@ exports[`<ToastNotification /> snapshot should match snapshot with button group 
     ariaModal={false}
     className="md-toast-notification-wrapper"
     isPadded={true}
-    role="generic"
     round={50}
   >
     <div
@@ -73,7 +71,7 @@ exports[`<ToastNotification /> snapshot should match snapshot with button group 
       data-elevation={0}
       data-padded={true}
       data-round={50}
-      role="generic"
+      role="dialog"
     >
       <div
         className="md-toast-notification-body"
@@ -217,7 +215,6 @@ exports[`<ToastNotification /> snapshot should match snapshot with className 1`]
     ariaModal={false}
     className="example-class md-toast-notification-wrapper"
     isPadded={true}
-    role="generic"
     round={50}
   >
     <div
@@ -227,7 +224,7 @@ exports[`<ToastNotification /> snapshot should match snapshot with className 1`]
       data-elevation={0}
       data-padded={true}
       data-round={50}
-      role="generic"
+      role="dialog"
     >
       <div
         className="md-toast-notification-body"
@@ -259,7 +256,6 @@ exports[`<ToastNotification /> snapshot should match snapshot with id 1`] = `
     className="md-toast-notification-wrapper"
     id="example-id"
     isPadded={true}
-    role="generic"
     round={50}
   >
     <div
@@ -270,7 +266,7 @@ exports[`<ToastNotification /> snapshot should match snapshot with id 1`] = `
       data-padded={true}
       data-round={50}
       id="example-id"
-      role="generic"
+      role="dialog"
     >
       <div
         className="md-toast-notification-body"
@@ -307,7 +303,6 @@ exports[`<ToastNotification /> snapshot should match snapshot with leading visua
     ariaModal={false}
     className="md-toast-notification-wrapper"
     isPadded={true}
-    role="generic"
     round={50}
   >
     <div
@@ -317,7 +312,7 @@ exports[`<ToastNotification /> snapshot should match snapshot with leading visua
       data-elevation={0}
       data-padded={true}
       data-round={50}
-      role="generic"
+      role="dialog"
     >
       <div
         className="md-toast-notification-body"
@@ -379,7 +374,6 @@ exports[`<ToastNotification /> snapshot should match snapshot with non string co
     ariaModal={false}
     className="md-toast-notification-wrapper"
     isPadded={true}
-    role="generic"
     round={50}
   >
     <div
@@ -389,7 +383,7 @@ exports[`<ToastNotification /> snapshot should match snapshot with non string co
       data-elevation={0}
       data-padded={true}
       data-round={50}
-      role="generic"
+      role="dialog"
     >
       <div
         className="md-toast-notification-body"
@@ -417,7 +411,6 @@ exports[`<ToastNotification /> snapshot should match snapshot with onClose and c
     ariaModal={false}
     className="md-toast-notification-wrapper"
     isPadded={true}
-    role="generic"
     round={50}
   >
     <div
@@ -427,7 +420,7 @@ exports[`<ToastNotification /> snapshot should match snapshot with onClose and c
       data-elevation={0}
       data-padded={true}
       data-round={50}
-      role="generic"
+      role="dialog"
     >
       <div
         className="md-toast-notification-body"
@@ -542,7 +535,6 @@ exports[`<ToastNotification /> snapshot should match snapshot with string conten
     ariaModal={false}
     className="md-toast-notification-wrapper"
     isPadded={true}
-    role="generic"
     round={50}
   >
     <div
@@ -552,7 +544,7 @@ exports[`<ToastNotification /> snapshot should match snapshot with string conten
       data-elevation={0}
       data-padded={true}
       data-round={50}
-      role="generic"
+      role="dialog"
     >
       <div
         className="md-toast-notification-body"
@@ -587,7 +579,6 @@ exports[`<ToastNotification /> snapshot should match snapshot with style 1`] = `
     ariaModal={false}
     className="md-toast-notification-wrapper"
     isPadded={true}
-    role="generic"
     round={50}
     style={
       Object {
@@ -602,7 +593,7 @@ exports[`<ToastNotification /> snapshot should match snapshot with style 1`] = `
       data-elevation={0}
       data-padded={true}
       data-round={50}
-      role="generic"
+      role="dialog"
       style={
         Object {
           "color": "pink",

--- a/src/components/ToastNotification/ToastNotification.unit.test.tsx.snap
+++ b/src/components/ToastNotification/ToastNotification.unit.test.tsx.snap
@@ -24,11 +24,13 @@ exports[`<ToastNotification /> snapshot should match snapshot 1`] = `
       >
         <Text
           className="md-toast-notification-content"
+          role="alert"
           type="body-primary"
         >
           <p
             className="md-text-wrapper md-toast-notification-content"
             data-type="body-primary"
+            role="alert"
           >
             Example text
           </p>
@@ -78,11 +80,13 @@ exports[`<ToastNotification /> snapshot should match snapshot with button group 
       >
         <Text
           className="md-toast-notification-content"
+          role="alert"
           type="body-primary"
         >
           <p
             className="md-text-wrapper md-toast-notification-content"
             data-type="body-primary"
+            role="alert"
           >
             Example text
           </p>
@@ -231,11 +235,13 @@ exports[`<ToastNotification /> snapshot should match snapshot with className 1`]
       >
         <Text
           className="example-class md-toast-notification-content"
+          role="alert"
           type="body-primary"
         >
           <p
             className="md-text-wrapper example-class md-toast-notification-content"
             data-type="body-primary"
+            role="alert"
           >
             Example text
           </p>
@@ -273,11 +279,13 @@ exports[`<ToastNotification /> snapshot should match snapshot with id 1`] = `
       >
         <Text
           className="md-toast-notification-content"
+          role="alert"
           type="body-primary"
         >
           <p
             className="md-text-wrapper md-toast-notification-content"
             data-type="body-primary"
+            role="alert"
           >
             Example text
           </p>
@@ -347,11 +355,13 @@ exports[`<ToastNotification /> snapshot should match snapshot with leading visua
         </div>
         <Text
           className="md-toast-notification-content"
+          role="alert"
           type="body-primary"
         >
           <p
             className="md-text-wrapper md-toast-notification-content"
             data-type="body-primary"
+            role="alert"
           >
             Example text
           </p>
@@ -427,11 +437,13 @@ exports[`<ToastNotification /> snapshot should match snapshot with onClose and c
       >
         <Text
           className="md-toast-notification-content"
+          role="alert"
           type="body-primary"
         >
           <p
             className="md-text-wrapper md-toast-notification-content"
             data-type="body-primary"
+            role="alert"
           >
             Example text
           </p>
@@ -551,11 +563,13 @@ exports[`<ToastNotification /> snapshot should match snapshot with string conten
       >
         <Text
           className="md-toast-notification-content"
+          role="alert"
           type="body-primary"
         >
           <p
             className="md-text-wrapper md-toast-notification-content"
             data-type="body-primary"
+            role="alert"
           >
             Example text
           </p>
@@ -605,11 +619,13 @@ exports[`<ToastNotification /> snapshot should match snapshot with style 1`] = `
       >
         <Text
           className="md-toast-notification-content"
+          role="alert"
           type="body-primary"
         >
           <p
             className="md-text-wrapper md-toast-notification-content"
             data-type="body-primary"
+            role="alert"
           >
             Example text
           </p>


### PR DESCRIPTION
# Description

Only the text part of the notification should be read out as an alert by screen readers.

In this PR I've

1. removed the role=alert from all the toastify container
2. added role=alert to the Text in ToastNotification when the content is a string

This requires content other than strings to provide the alert separately.

# Links

*Links to relevent resources.*
