### PR TITLE
Revert "feat(aria-toolbar-item): pass props to children"

### DIFF
--- a/src/components/AriaToolbarItem/AriaToolbarItem.tsx
+++ b/src/components/AriaToolbarItem/AriaToolbarItem.tsx
@@ -7,7 +7,7 @@ import { useAriaToolbarContext } from '../AriaToolbar/AriaToolbar.utils';
 import { useProvidedRef } from '../../utils/useProvidedRef';
 
 const AriaToolbarItem = forwardRef<HTMLButtonElement, Props>((props, providedRef) => {
-  const { children, itemIndex, ...rest } = props;
+  const { children, itemIndex } = props;
 
   const ariaToolbarContext = useAriaToolbarContext();
 
@@ -53,7 +53,6 @@ const AriaToolbarItem = forwardRef<HTMLButtonElement, Props>((props, providedRef
       const { setCurrentFocus, buttonRefs, currentFocus } = ariaToolbarContext;
 
       return {
-        ...rest,
         tabIndex: index === (currentFocus || 0) ? 0 : -1,
         ref: (element: HTMLButtonElement) => {
           buttonRefs.current[index] = element;

--- a/src/components/AriaToolbarItem/AriaToolbarItem.unit.test.tsx
+++ b/src/components/AriaToolbarItem/AriaToolbarItem.unit.test.tsx
@@ -35,13 +35,14 @@ describe('<AriaToolbarItem />', () => {
     });
   });
 
-  describe('attributes', () => {
+  describe('behaviour', () => {
     it('passes extra props to children', () => {
-      const container = mountWithContext(<TestComponent aria-haspopup="dialog" />);
+      const container = mountWithContext(<TestComponent extra="prop" more="extra props" />);
 
       expect(container.find('ButtonPill').props()).toEqual({
         children: 'Test',
-        'aria-haspopup': 'dialog',
+        extra: 'prop',
+        more: 'extra props',
         onFocus: expect.any(Function),
         onKeyDown: expect.any(Function),
         onKeyUp: undefined,

--- a/src/components/AriaToolbarItem/AriaToolbarItem.unit.test.tsx
+++ b/src/components/AriaToolbarItem/AriaToolbarItem.unit.test.tsx
@@ -35,23 +35,5 @@ describe('<AriaToolbarItem />', () => {
     });
   });
 
-  describe('behaviour', () => {
-    it('passes extra props to children', () => {
-      const container = mountWithContext(<TestComponent extra="prop" more="extra props" />);
-
-      expect(container.find('ButtonPill').props()).toEqual({
-        children: 'Test',
-        extra: 'prop',
-        more: 'extra props',
-        onFocus: expect.any(Function),
-        onKeyDown: expect.any(Function),
-        onKeyUp: undefined,
-        onPress: expect.any(Function),
-        tabIndex: 0,
-        useNativeKeyDown: true,
-      });
-    });
-  });
-
   // keyboard interaction is tested in AriaToolbar.unit.test.tsx
 });


### PR DESCRIPTION
Reverts momentum-design/momentum-react-v2#553

it was allowing parent props to override specified props of the children, breaking a few things in webex webapp