### PR TITLE
fix(aria-toolbar-item): extra props should be passed to children but not override children props

### DIFF
--- a/src/components/AriaToolbarItem/AriaToolbarItem.tsx
+++ b/src/components/AriaToolbarItem/AriaToolbarItem.tsx
@@ -5,6 +5,7 @@ import React, { forwardRef, useCallback } from 'react';
 import { useKeyboard } from '@react-aria/interactions';
 import { useAriaToolbarContext } from '../AriaToolbar/AriaToolbar.utils';
 import { useProvidedRef } from '../../utils/useProvidedRef';
+import { defaults } from 'lodash';
 
 const AriaToolbarItem = forwardRef<HTMLButtonElement, Props>((props, providedRef) => {
   const { children, itemIndex, ...rest } = props;
@@ -52,26 +53,29 @@ const AriaToolbarItem = forwardRef<HTMLButtonElement, Props>((props, providedRef
 
       const { setCurrentFocus, buttonRefs, currentFocus } = ariaToolbarContext;
 
-      return {
-        ...rest,
-        tabIndex: index === (currentFocus || 0) ? 0 : -1,
-        ref: (element: HTMLButtonElement) => {
-          buttonRefs.current[index] = element;
-          ref.current = element;
+      return defaults(
+        {
+          tabIndex: index === (currentFocus || 0) ? 0 : -1,
+          ref: (element: HTMLButtonElement) => {
+            buttonRefs.current[index] = element;
+            ref.current = element;
+          },
+          onFocus: (event) => {
+            setCurrentFocus?.(index);
+            child.props?.onFocus?.(event);
+          },
+          onPress: () => {
+            setCurrentFocus?.(index);
+            child.props?.onPress?.();
+          },
+          useNativeKeyDown: true,
+          ...keyboardProps,
         },
-        onFocus: (event) => {
-          setCurrentFocus?.(index);
-          child.props?.onFocus?.(event);
-        },
-        onPress: () => {
-          setCurrentFocus?.(index);
-          child.props?.onPress?.();
-        },
-        useNativeKeyDown: true,
-        ...keyboardProps,
-      };
+        children?.props, // specified props of children should take precedent over drilled props from parent
+        rest
+      );
     },
-    [ariaToolbarContext?.currentFocus]
+    [ariaToolbarContext?.currentFocus, rest, children]
   );
 
   return React.cloneElement(children, getPropsForChildren(children, itemIndex));

--- a/src/components/AriaToolbarItem/AriaToolbarItem.unit.test.tsx
+++ b/src/components/AriaToolbarItem/AriaToolbarItem.unit.test.tsx
@@ -37,11 +37,18 @@ describe('<AriaToolbarItem />', () => {
 
   describe('attributes', () => {
     it('passes extra props to children', () => {
-      const container = mountWithContext(<TestComponent aria-haspopup="dialog" />);
+      const container = mountWithContext(
+        <AriaToolbarItem itemIndex={0} aria-haspopup="tree">
+          <ButtonPill aria-haspopup="dialog" aria-label="label text">
+            Test
+          </ButtonPill>
+        </AriaToolbarItem>
+      );
 
       expect(container.find('ButtonPill').props()).toEqual({
         children: 'Test',
-        'aria-haspopup': 'dialog',
+        'aria-haspopup': 'dialog', // item has "tree", but children has "dialog", children's props takes precedent
+        'aria-label': 'label text',
         onFocus: expect.any(Function),
         onKeyDown: expect.any(Function),
         onKeyUp: undefined,


### PR DESCRIPTION
# Description

props specified on the children should take precedent over what's passed into the toolbar item

# Links

*Links to relevent resources.*
