### PR TITLE
fix(a11y): checkbox id duplicate

### DIFF
--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -52,6 +52,9 @@ const Checkbox = (props: Props, providedRef: RefObject<HTMLInputElement>) => {
     </div>
   );
 
+  // remove id from input to only apply it to the label
+  delete inputProps.id;
+
   return (
     <label
       className={classnames(STYLE.wrapper, className)}

--- a/src/components/Checkbox/Checkbox.unit.test.tsx.snap
+++ b/src/components/Checkbox/Checkbox.unit.test.tsx.snap
@@ -193,7 +193,6 @@ exports[`<Checkbox /> snapshot should match snapshot with id 1`] = `
           aria-checked={false}
           checked={false}
           disabled={false}
-          id="example-id"
           onBlur={[Function]}
           onChange={[Function]}
           onClick={[Function]}


### PR DESCRIPTION
# Description

- According to a11y duplicate id's should be avoided. At the moment the id is passed to the label and input. This fix will make sure to pass through the id only to the label, not the input itself to avoid duplication. This is also tested by the a11y tests in Storybook (not failing anymore with this fix).
