### PR TITLE
fix(toggle buttons): add ariaStateKey prop to determine whether aria-pressed or aria-expanded is used for selected state

### DIFF
--- a/src/components/ButtonCircleToggle/ButtonCircleToggle.constants.ts
+++ b/src/components/ButtonCircleToggle/ButtonCircleToggle.constants.ts
@@ -7,6 +7,7 @@ const DEFAULTS = {
   OUTLINE: undefined,
   GHOST: true,
   DISABLED: false,
+  ARIA_STATE_KEY: 'aria-pressed',
 };
 
 const STYLE = {

--- a/src/components/ButtonCircleToggle/ButtonCircleToggle.tsx
+++ b/src/components/ButtonCircleToggle/ButtonCircleToggle.tsx
@@ -12,6 +12,7 @@ import { chain } from '@react-aria/utils';
 
 const ButtonCircleToggle = forwardRef((props: Props, providedRef: RefObject<HTMLButtonElement>) => {
   const {
+    ariaStateKey = DEFAULTS.ARIA_STATE_KEY,
     children,
     className,
     ghost = DEFAULTS.GHOST,
@@ -40,7 +41,7 @@ const ButtonCircleToggle = forwardRef((props: Props, providedRef: RefObject<HTML
       size={size as ButtonCircleSize}
       data-selected={state.isSelected || DEFAULTS.SELECTED}
       onPress={chain(state.toggle, onPress)}
-      aria-pressed={state.isSelected}
+      {...{ [ariaStateKey]: state.isSelected }}
       {...otherProps}
       ref={ref}
     >

--- a/src/components/ButtonCircleToggle/ButtonCircleToggle.types.ts
+++ b/src/components/ButtonCircleToggle/ButtonCircleToggle.types.ts
@@ -3,4 +3,9 @@ import { AriaButtonProps, AriaToggleButtonProps } from '@react-types/button';
 
 export interface Props
   extends Omit<ButtonCircleProps, keyof AriaButtonProps>,
-    AriaToggleButtonProps {}
+    AriaToggleButtonProps {
+  /**
+   * Whether pressed state should set 'aria-pressed' (default) or 'aria-expanded'
+   */
+  ariaStateKey?: 'aria-pressed' | 'aria-expanded';
+}

--- a/src/components/ButtonCircleToggle/ButtonCircleToggle.unit.test.tsx
+++ b/src/components/ButtonCircleToggle/ButtonCircleToggle.unit.test.tsx
@@ -73,6 +73,32 @@ describe('<ButtonCircleToggle />', () => {
 
       expect(container).toMatchSnapshot();
     });
+
+    it("should match snapshot with ariaStateKey being 'aria-expanded' and isSelected being true", () => {
+      expect.assertions(1);
+
+      const ariaStateKey = 'aria-expanded';
+      const isSelected = true;
+
+      const container = mount(
+        <ButtonCircleToggle ariaStateKey={ariaStateKey} isSelected={isSelected} />
+      );
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it("should match snapshot with ariaStateKey being 'aria-expanded' and isSelected being false", () => {
+      expect.assertions(1);
+
+      const ariaStateKey = 'aria-expanded';
+      const isSelected = false;
+
+      const container = mount(
+        <ButtonCircleToggle ariaStateKey={ariaStateKey} isSelected={isSelected} />
+      );
+
+      expect(container).toMatchSnapshot();
+    });
   });
 
   describe('attributes', () => {
@@ -121,6 +147,38 @@ describe('<ButtonCircleToggle />', () => {
 
       expect(element.getAttribute('data-selected')).toBe(`${isSelected}`);
     });
+
+    it.each([[false], [true]])(
+      'should use default ariaStateKey when ariaStateKey is not provided (isSelected=%s)',
+      (isSelected) => {
+        expect.assertions(2);
+
+        const element = mount(<ButtonCircleToggle isSelected={isSelected} />)
+          .find(ButtonCircleToggle)
+          .getDOMNode();
+
+        expect(element.getAttribute('aria-pressed')).toBe(`${isSelected}`);
+        expect(element.getAttribute('aria-expanded')).toBe(null);
+      }
+    );
+
+    it.each([[false], [true]])(
+      'should use provided ariaStateKey when ariaStateKey is provided (isSelected=%s)',
+      (isSelected) => {
+        expect.assertions(2);
+
+        const ariaStateKey = 'aria-expanded';
+
+        const element = mount(
+          <ButtonCircleToggle ariaStateKey={ariaStateKey} isSelected={isSelected} />
+        )
+          .find(ButtonCircleToggle)
+          .getDOMNode();
+
+        expect(element.getAttribute('aria-pressed')).toBe(null);
+        expect(element.getAttribute('aria-expanded')).toBe(`${isSelected}`);
+      }
+    );
   });
 
   describe('actions', () => {

--- a/src/components/ButtonCircleToggle/ButtonCircleToggle.unit.test.tsx.snap
+++ b/src/components/ButtonCircleToggle/ButtonCircleToggle.unit.test.tsx.snap
@@ -71,6 +71,158 @@ exports[`<ButtonCircleToggle /> snapshot should match snapshot 1`] = `
 </ButtonCircleToggle>
 `;
 
+exports[`<ButtonCircleToggle /> snapshot should match snapshot with ariaStateKey being 'aria-expanded' and isSelected being false 1`] = `
+<ButtonCircleToggle
+  ariaStateKey="aria-expanded"
+  isSelected={false}
+>
+  <ButtonCircle
+    aria-expanded={false}
+    className="md-button-circle-toggle-wrapper"
+    data-selected={false}
+    disabled={false}
+    ghost={true}
+    isSelected={false}
+    onPress={[Function]}
+    size={40}
+  >
+    <ButtonSimple
+      aria-disabled={false}
+      aria-expanded={false}
+      className="md-button-circle-wrapper md-button-circle-toggle-wrapper"
+      data-color="primary"
+      data-disabled={false}
+      data-ghost={true}
+      data-inverted={false}
+      data-multiple-children={false}
+      data-outline={false}
+      data-selected={false}
+      data-shallow-disabled={false}
+      data-size={40}
+      isDisabled={false}
+      isSelected={false}
+      onPress={[Function]}
+    >
+      <FocusRing
+        disabled={false}
+      >
+        <FocusRing
+          disabled={false}
+          focusClass="md-focus-ring-wrapper children"
+          focusRingClass="md-focus-ring-wrapper children"
+        >
+          <button
+            aria-expanded={false}
+            className="md-button-circle-wrapper md-button-circle-toggle-wrapper md-button-simple-wrapper"
+            data-color="primary"
+            data-disabled={false}
+            data-ghost={true}
+            data-inverted={false}
+            data-multiple-children={false}
+            data-outline={false}
+            data-selected={false}
+            data-shallow-disabled={false}
+            data-size={40}
+            disabled={false}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onDragStart={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchCancel={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            type="button"
+          />
+        </FocusRing>
+      </FocusRing>
+    </ButtonSimple>
+  </ButtonCircle>
+</ButtonCircleToggle>
+`;
+
+exports[`<ButtonCircleToggle /> snapshot should match snapshot with ariaStateKey being 'aria-expanded' and isSelected being true 1`] = `
+<ButtonCircleToggle
+  ariaStateKey="aria-expanded"
+  isSelected={true}
+>
+  <ButtonCircle
+    aria-expanded={true}
+    className="md-button-circle-toggle-wrapper"
+    data-selected={true}
+    disabled={false}
+    ghost={true}
+    isSelected={true}
+    onPress={[Function]}
+    size={40}
+  >
+    <ButtonSimple
+      aria-disabled={false}
+      aria-expanded={true}
+      className="md-button-circle-wrapper md-button-circle-toggle-wrapper"
+      data-color="primary"
+      data-disabled={false}
+      data-ghost={true}
+      data-inverted={false}
+      data-multiple-children={false}
+      data-outline={false}
+      data-selected={true}
+      data-shallow-disabled={false}
+      data-size={40}
+      isDisabled={false}
+      isSelected={true}
+      onPress={[Function]}
+    >
+      <FocusRing
+        disabled={false}
+      >
+        <FocusRing
+          disabled={false}
+          focusClass="md-focus-ring-wrapper children"
+          focusRingClass="md-focus-ring-wrapper children"
+        >
+          <button
+            aria-expanded={true}
+            className="md-button-circle-wrapper md-button-circle-toggle-wrapper md-button-simple-wrapper"
+            data-color="primary"
+            data-disabled={false}
+            data-ghost={true}
+            data-inverted={false}
+            data-multiple-children={false}
+            data-outline={false}
+            data-selected={true}
+            data-shallow-disabled={false}
+            data-size={40}
+            disabled={false}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onDragStart={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchCancel={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            type="button"
+          />
+        </FocusRing>
+      </FocusRing>
+    </ButtonSimple>
+  </ButtonCircle>
+</ButtonCircleToggle>
+`;
+
 exports[`<ButtonCircleToggle /> snapshot should match snapshot with ghost being false 1`] = `
 <ButtonCircleToggle
   ghost={false}

--- a/src/components/ButtonPillToggle/ButtonPillToggle.constants.ts
+++ b/src/components/ButtonPillToggle/ButtonPillToggle.constants.ts
@@ -7,6 +7,7 @@ const DEFAULTS = {
   OUTLINE: undefined,
   GHOST: true,
   DISABLED: false,
+  ARIA_STATE_KEY: 'aria-pressed',
 };
 
 const STYLE = {

--- a/src/components/ButtonPillToggle/ButtonPillToggle.tsx
+++ b/src/components/ButtonPillToggle/ButtonPillToggle.tsx
@@ -11,6 +11,7 @@ import { chain } from '@react-aria/utils';
 
 const ButtonPillToggle = forwardRef((props: Props, providedRef: RefObject<HTMLButtonElement>) => {
   const {
+    ariaStateKey = DEFAULTS.ARIA_STATE_KEY,
     children,
     className,
     ghost = DEFAULTS.GHOST,
@@ -39,7 +40,7 @@ const ButtonPillToggle = forwardRef((props: Props, providedRef: RefObject<HTMLBu
       size={size}
       data-selected={state.isSelected || DEFAULTS.SELECTED}
       onPress={chain(state.toggle, onPress)}
-      aria-pressed={state.isSelected}
+      {...{ [ariaStateKey]: state.isSelected }}
       {...otherProps}
       ref={ref}
     >

--- a/src/components/ButtonPillToggle/ButtonPillToggle.types.ts
+++ b/src/components/ButtonPillToggle/ButtonPillToggle.types.ts
@@ -1,6 +1,9 @@
 import { ButtonPillProps } from '../ButtonPill';
 import { AriaButtonProps, AriaToggleButtonProps } from '@react-types/button';
 
-export interface Props
-  extends Omit<ButtonPillProps, keyof AriaButtonProps>,
-    AriaToggleButtonProps {}
+export interface Props extends Omit<ButtonPillProps, keyof AriaButtonProps>, AriaToggleButtonProps {
+  /**
+   * Whether pressed state should set 'aria-pressed' (default) or 'aria-expanded'
+   */
+  ariaStateKey?: 'aria-pressed' | 'aria-expanded';
+}

--- a/src/components/ButtonPillToggle/ButtonPillToggle.unit.test.tsx
+++ b/src/components/ButtonPillToggle/ButtonPillToggle.unit.test.tsx
@@ -73,6 +73,32 @@ describe('<ButtonPillToggle />', () => {
 
       expect(container).toMatchSnapshot();
     });
+
+    it("should match snapshot with ariaStateKey being 'aria-expanded' and isSelected being true", () => {
+      expect.assertions(1);
+
+      const ariaStateKey = 'aria-expanded';
+      const isSelected = true;
+
+      const container = mount(
+        <ButtonPillToggle ariaStateKey={ariaStateKey} isSelected={isSelected} />
+      );
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it("should match snapshot with ariaStateKey being 'aria-expanded' and isSelected being false", () => {
+      expect.assertions(1);
+
+      const ariaStateKey = 'aria-expanded';
+      const isSelected = false;
+
+      const container = mount(
+        <ButtonPillToggle ariaStateKey={ariaStateKey} isSelected={isSelected} />
+      );
+
+      expect(container).toMatchSnapshot();
+    });
   });
 
   describe('attributes', () => {
@@ -121,6 +147,38 @@ describe('<ButtonPillToggle />', () => {
 
       expect(element.getAttribute('data-selected')).toBe(`${isSelected}`);
     });
+
+    it.each([[false], [true]])(
+      'should use default ariaStateKey when ariaStateKey is not provided (isSelected=%s)',
+      (isSelected) => {
+        expect.assertions(2);
+
+        const element = mount(<ButtonPillToggle isSelected={isSelected} />)
+          .find(ButtonPillToggle)
+          .getDOMNode();
+
+        expect(element.getAttribute('aria-pressed')).toBe(`${isSelected}`);
+        expect(element.getAttribute('aria-expanded')).toBe(null);
+      }
+    );
+
+    it.each([[false], [true]])(
+      'should use provided ariaStateKey when ariaStateKey is provided (isSelected=%s)',
+      (isSelected) => {
+        expect.assertions(2);
+
+        const ariaStateKey = 'aria-expanded';
+
+        const element = mount(
+          <ButtonPillToggle ariaStateKey={ariaStateKey} isSelected={isSelected} />
+        )
+          .find(ButtonPillToggle)
+          .getDOMNode();
+
+        expect(element.getAttribute('aria-pressed')).toBe(null);
+        expect(element.getAttribute('aria-expanded')).toBe(`${isSelected}`);
+      }
+    );
   });
 
   describe('actions', () => {

--- a/src/components/ButtonPillToggle/ButtonPillToggle.unit.test.tsx.snap
+++ b/src/components/ButtonPillToggle/ButtonPillToggle.unit.test.tsx.snap
@@ -71,6 +71,158 @@ exports[`<ButtonPillToggle /> snapshot should match snapshot 1`] = `
 </ButtonPillToggle>
 `;
 
+exports[`<ButtonPillToggle /> snapshot should match snapshot with ariaStateKey being 'aria-expanded' and isSelected being false 1`] = `
+<ButtonPillToggle
+  ariaStateKey="aria-expanded"
+  isSelected={false}
+>
+  <ButtonPill
+    aria-expanded={false}
+    className="md-button-pill-toggle-wrapper"
+    data-selected={false}
+    disabled={false}
+    ghost={true}
+    isSelected={false}
+    onPress={[Function]}
+    size={40}
+  >
+    <ButtonSimple
+      aria-disabled={false}
+      aria-expanded={false}
+      className="md-button-pill-wrapper md-button-pill-toggle-wrapper"
+      data-color="primary"
+      data-disabled={false}
+      data-ghost={true}
+      data-grown={false}
+      data-inverted={false}
+      data-outline={false}
+      data-selected={false}
+      data-shallow-disabled={false}
+      data-size={40}
+      isDisabled={false}
+      isSelected={false}
+      onPress={[Function]}
+    >
+      <FocusRing
+        disabled={false}
+      >
+        <FocusRing
+          disabled={false}
+          focusClass="md-focus-ring-wrapper children"
+          focusRingClass="md-focus-ring-wrapper children"
+        >
+          <button
+            aria-expanded={false}
+            className="md-button-pill-wrapper md-button-pill-toggle-wrapper md-button-simple-wrapper"
+            data-color="primary"
+            data-disabled={false}
+            data-ghost={true}
+            data-grown={false}
+            data-inverted={false}
+            data-outline={false}
+            data-selected={false}
+            data-shallow-disabled={false}
+            data-size={40}
+            disabled={false}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onDragStart={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchCancel={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            type="button"
+          />
+        </FocusRing>
+      </FocusRing>
+    </ButtonSimple>
+  </ButtonPill>
+</ButtonPillToggle>
+`;
+
+exports[`<ButtonPillToggle /> snapshot should match snapshot with ariaStateKey being 'aria-expanded' and isSelected being true 1`] = `
+<ButtonPillToggle
+  ariaStateKey="aria-expanded"
+  isSelected={true}
+>
+  <ButtonPill
+    aria-expanded={true}
+    className="md-button-pill-toggle-wrapper"
+    data-selected={true}
+    disabled={false}
+    ghost={true}
+    isSelected={true}
+    onPress={[Function]}
+    size={40}
+  >
+    <ButtonSimple
+      aria-disabled={false}
+      aria-expanded={true}
+      className="md-button-pill-wrapper md-button-pill-toggle-wrapper"
+      data-color="primary"
+      data-disabled={false}
+      data-ghost={true}
+      data-grown={false}
+      data-inverted={false}
+      data-outline={false}
+      data-selected={true}
+      data-shallow-disabled={false}
+      data-size={40}
+      isDisabled={false}
+      isSelected={true}
+      onPress={[Function]}
+    >
+      <FocusRing
+        disabled={false}
+      >
+        <FocusRing
+          disabled={false}
+          focusClass="md-focus-ring-wrapper children"
+          focusRingClass="md-focus-ring-wrapper children"
+        >
+          <button
+            aria-expanded={true}
+            className="md-button-pill-wrapper md-button-pill-toggle-wrapper md-button-simple-wrapper"
+            data-color="primary"
+            data-disabled={false}
+            data-ghost={true}
+            data-grown={false}
+            data-inverted={false}
+            data-outline={false}
+            data-selected={true}
+            data-shallow-disabled={false}
+            data-size={40}
+            disabled={false}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onDragStart={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchCancel={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            type="button"
+          />
+        </FocusRing>
+      </FocusRing>
+    </ButtonSimple>
+  </ButtonPill>
+</ButtonPillToggle>
+`;
+
 exports[`<ButtonPillToggle /> snapshot should match snapshot with ghost being false 1`] = `
 <ButtonPillToggle
   ghost={false}

--- a/src/storybook/helper.stories.argtypes.ts
+++ b/src/storybook/helper.stories.argtypes.ts
@@ -708,6 +708,19 @@ const commonAriaButtonToggle = {
       },
     },
   },
+  ariaStateKey: {
+    description: "Whether pressed state should set 'aria-pressed' or 'aria-expanded'",
+    options: ['aria-pressed', 'aria-expanded'],
+    control: { type: 'select' },
+    table: {
+      type: {
+        summary: 'string',
+      },
+      defaultValue: {
+        summary: 'aria-pressed',
+      },
+    },
+  },
 };
 
 const commonStyles = {


### PR DESCRIPTION
# Description

In ButtonCircleToggle and ButtonPillToggle, add ariaStateKey prop to determine whether aria-pressed or aria-expanded is used for selected state

# Links

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-505240 (see comment)
