### PR TITLE
fix(a11y): aria changes in searchinput

### DIFF
--- a/src/components/SearchInput/SearchInput.constants.ts
+++ b/src/components/SearchInput/SearchInput.constants.ts
@@ -7,7 +7,15 @@ const HEIGHTS = [28, 32] as const;
 
 const ARIA_ROLES = {
   COMBOBOX: 'combobox',
-  SEARCHBOX: 'searchbox',
+};
+
+const WARNINGS = {
+  ISCOMBOBOX_1_ISEXPANDED_0:
+    'MRV2: Momentum requires the isExpanded prop for SearchInput with Combobox for accessibiltity compliance.',
+  ISCOMBOBOX_0_CONTROLS_1:
+    'MRV2: Momentum requires isCombobox set to true if using the controls prop.',
+  ISCOMBOBOX_0_ISEXPANDED_1:
+    'MRV2: Momentum requires isCombobox set to true if using the isExpanded prop.',
 };
 
 const ICON_HEIGHT_MAPPING: Record<SearchFieldHeight, IconScale> = {
@@ -17,7 +25,7 @@ const ICON_HEIGHT_MAPPING: Record<SearchFieldHeight, IconScale> = {
 
 const DEFAULTS = {
   HEIGHT: 32,
-  IS_COMBOBOX: false,
+  ISCOMBOBOX: false,
 } as const;
 
 const STYLE = {
@@ -28,4 +36,4 @@ const STYLE = {
   clear: `${CLASS_PREFIX}-clear`,
 };
 
-export { CLASS_PREFIX, ARIA_ROLES, HEIGHTS, ICON_HEIGHT_MAPPING, DEFAULTS, STYLE };
+export { CLASS_PREFIX, ARIA_ROLES, WARNINGS, HEIGHTS, ICON_HEIGHT_MAPPING, DEFAULTS, STYLE };

--- a/src/components/SearchInput/SearchInput.constants.ts
+++ b/src/components/SearchInput/SearchInput.constants.ts
@@ -5,6 +5,11 @@ const CLASS_PREFIX = 'md-search-input';
 
 const HEIGHTS = [28, 32] as const;
 
+const ARIA_ROLES = {
+  COMBOBOX: 'combobox',
+  SEARCHBOX: 'searchbox',
+};
+
 const ICON_HEIGHT_MAPPING: Record<SearchFieldHeight, IconScale> = {
   28: 12,
   32: 16,
@@ -12,6 +17,7 @@ const ICON_HEIGHT_MAPPING: Record<SearchFieldHeight, IconScale> = {
 
 const DEFAULTS = {
   HEIGHT: 32,
+  IS_COMBOBOX: false,
 } as const;
 
 const STYLE = {
@@ -22,4 +28,4 @@ const STYLE = {
   clear: `${CLASS_PREFIX}-clear`,
 };
 
-export { CLASS_PREFIX, HEIGHTS, ICON_HEIGHT_MAPPING, DEFAULTS, STYLE };
+export { CLASS_PREFIX, ARIA_ROLES, HEIGHTS, ICON_HEIGHT_MAPPING, DEFAULTS, STYLE };

--- a/src/components/SearchInput/SearchInput.tsx
+++ b/src/components/SearchInput/SearchInput.tsx
@@ -34,18 +34,18 @@ const SearchInput = (props: Props, ref: RefObject<HTMLInputElement>): ReactEleme
     label,
     isDisabled,
     height = DEFAULTS.HEIGHT,
-    controls,
+    ariaControls,
     isCombobox = DEFAULTS.ISCOMBOBOX,
-    isExpanded,
+    isComboboxExpanded,
   } = props;
 
-  if (isCombobox && isExpanded === undefined) {
+  if (isCombobox && isComboboxExpanded === undefined) {
     console.warn(WARNINGS.ISCOMBOBOX_1_ISEXPANDED_0);
   }
-  if (!isCombobox && !!controls) {
+  if (!isCombobox && !!ariaControls) {
     console.warn(WARNINGS.ISCOMBOBOX_0_CONTROLS_1);
   }
-  if (!isCombobox && typeof isExpanded === 'boolean') {
+  if (!isCombobox && typeof isComboboxExpanded === 'boolean') {
     console.warn(WARNINGS.ISCOMBOBOX_0_ISEXPANDED_1);
   }
 
@@ -87,8 +87,8 @@ const SearchInput = (props: Props, ref: RefObject<HTMLInputElement>): ReactEleme
 
   const inputElement = isCombobox ? (
     <input
-      aria-controls={controls}
-      aria-expanded={isExpanded}
+      aria-controls={ariaControls}
+      aria-expanded={isComboboxExpanded}
       role={ARIA_ROLES.COMBOBOX}
       {...inputProps}
       {...focusProps}

--- a/src/components/SearchInput/SearchInput.tsx
+++ b/src/components/SearchInput/SearchInput.tsx
@@ -4,7 +4,13 @@ import React, { ReactElement, useRef, RefObject, forwardRef } from 'react';
 import classnames from 'classnames';
 
 import ButtonSimple from '../ButtonSimple';
-import { STYLE, DEFAULTS, ICON_HEIGHT_MAPPING, ARIA_ROLES } from './SearchInput.constants';
+import {
+  STYLE,
+  DEFAULTS,
+  ICON_HEIGHT_MAPPING,
+  ARIA_ROLES,
+  WARNINGS,
+} from './SearchInput.constants';
 import { Props } from './SearchInput.types';
 import './SearchInput.style.scss';
 import { useSearchField } from '@react-aria/searchfield';
@@ -29,17 +35,18 @@ const SearchInput = (props: Props, ref: RefObject<HTMLInputElement>): ReactEleme
     isDisabled,
     height = DEFAULTS.HEIGHT,
     controls,
-    isCombobox = DEFAULTS.IS_COMBOBOX,
+    isCombobox = DEFAULTS.ISCOMBOBOX,
     isExpanded,
   } = props;
 
   if (isCombobox && isExpanded === undefined) {
-    console.warn(
-      'MRV2: Momentum requires the isExpanded prop for SearchInput with Combobox for accessibiltity compliance.'
-    );
+    console.warn(WARNINGS.ISCOMBOBOX_1_ISEXPANDED_0);
+  }
+  if (!isCombobox && !!controls) {
+    console.warn(WARNINGS.ISCOMBOBOX_0_CONTROLS_1);
   }
   if (!isCombobox && typeof isExpanded === 'boolean') {
-    console.warn('MRV2: Momentum requires isCombobox set to true if using the isExpanded prop.');
+    console.warn(WARNINGS.ISCOMBOBOX_0_ISEXPANDED_1);
   }
 
   const state = useSearchFieldState(props);
@@ -88,7 +95,7 @@ const SearchInput = (props: Props, ref: RefObject<HTMLInputElement>): ReactEleme
       ref={inputRef}
     />
   ) : (
-    <input role={ARIA_ROLES.SEARCHBOX} {...inputProps} {...focusProps} ref={inputRef} />
+    <input {...inputProps} {...focusProps} ref={inputRef} />
   );
 
   return (

--- a/src/components/SearchInput/SearchInput.tsx
+++ b/src/components/SearchInput/SearchInput.tsx
@@ -78,6 +78,19 @@ const SearchInput = (props: Props, ref: RefObject<HTMLInputElement>): ReactEleme
     }
   };
 
+  const inputElement = isCombobox ? (
+    <input
+      aria-controls={controls}
+      aria-expanded={isExpanded}
+      role={ARIA_ROLES.COMBOBOX}
+      {...inputProps}
+      {...focusProps}
+      ref={inputRef}
+    />
+  ) : (
+    <input role={ARIA_ROLES.SEARCHBOX} {...inputProps} {...focusProps} ref={inputRef} />
+  );
+
   return (
     <div
       className={classnames(className, STYLE.wrapper)}
@@ -88,9 +101,6 @@ const SearchInput = (props: Props, ref: RefObject<HTMLInputElement>): ReactEleme
       data-focus={isFocused}
       data-height={height}
       ref={containerRef}
-      aria-controls={controls}
-      aria-expanded={isExpanded}
-      role={isCombobox ? ARIA_ROLES.COMBOBOX : ARIA_ROLES.SEARCHBOX}
     >
       {label && (
         <label htmlFor={labelProps.htmlFor} {...labelProps}>
@@ -109,9 +119,7 @@ const SearchInput = (props: Props, ref: RefObject<HTMLInputElement>): ReactEleme
           />
         )}
       </div>
-      <div className={STYLE.container}>
-        <input {...inputProps} {...focusProps} ref={inputRef} />
-      </div>
+      <div className={STYLE.container}>{inputElement}</div>
       {!!state.value && !isDisabled && (
         <ButtonSimple
           className={STYLE.clear}

--- a/src/components/SearchInput/SearchInput.tsx
+++ b/src/components/SearchInput/SearchInput.tsx
@@ -31,7 +31,6 @@ const SearchInput = (props: Props, ref: RefObject<HTMLInputElement>): ReactEleme
     ariaControls,
     isCombobox = DEFAULTS.IS_COMBOBOX,
     isExpanded,
-    role = isCombobox ? ARIA_ROLES.COMBOBOX : ARIA_ROLES.SEARCHBOX,
   } = props;
 
   if (isCombobox && isExpanded === undefined) {
@@ -91,7 +90,7 @@ const SearchInput = (props: Props, ref: RefObject<HTMLInputElement>): ReactEleme
       ref={containerRef}
       aria-controls={ariaControls}
       aria-expanded={isExpanded}
-      role={role}
+      role={isCombobox ? ARIA_ROLES.COMBOBOX : ARIA_ROLES.SEARCHBOX}
     >
       {label && (
         <label htmlFor={labelProps.htmlFor} {...labelProps}>

--- a/src/components/SearchInput/SearchInput.tsx
+++ b/src/components/SearchInput/SearchInput.tsx
@@ -4,7 +4,7 @@ import React, { ReactElement, useRef, RefObject, forwardRef } from 'react';
 import classnames from 'classnames';
 
 import ButtonSimple from '../ButtonSimple';
-import { STYLE, DEFAULTS, ICON_HEIGHT_MAPPING } from './SearchInput.constants';
+import { STYLE, DEFAULTS, ICON_HEIGHT_MAPPING, ARIA_ROLES } from './SearchInput.constants';
 import { Props } from './SearchInput.types';
 import './SearchInput.style.scss';
 import { useSearchField } from '@react-aria/searchfield';
@@ -29,8 +29,20 @@ const SearchInput = (props: Props, ref: RefObject<HTMLInputElement>): ReactEleme
     isDisabled,
     height = DEFAULTS.HEIGHT,
     ariaControls,
-    ariaExpanded,
+    isCombobox = DEFAULTS.IS_COMBOBOX,
+    isExpanded,
+    role = isCombobox ? ARIA_ROLES.COMBOBOX : ARIA_ROLES.SEARCHBOX,
   } = props;
+
+  if (isCombobox && isExpanded === undefined) {
+    console.warn(
+      'MRV2: Momentum requires the isExpanded prop for SearchInput with Combobox for accessibiltity compliance.'
+    );
+  }
+  if (!isCombobox && typeof isExpanded === 'boolean') {
+    console.warn('MRV2: Momentum requires isCombobox set to true if using the isExpanded prop.');
+  }
+
   const state = useSearchFieldState(props);
   const componentRef = useRef(null);
   const inputRef = ref || componentRef;
@@ -78,7 +90,8 @@ const SearchInput = (props: Props, ref: RefObject<HTMLInputElement>): ReactEleme
       data-height={height}
       ref={containerRef}
       aria-controls={ariaControls}
-      aria-expanded={ariaExpanded}
+      aria-expanded={isExpanded}
+      role={role}
     >
       {label && (
         <label htmlFor={labelProps.htmlFor} {...labelProps}>

--- a/src/components/SearchInput/SearchInput.tsx
+++ b/src/components/SearchInput/SearchInput.tsx
@@ -28,6 +28,8 @@ const SearchInput = (props: Props, ref: RefObject<HTMLInputElement>): ReactEleme
     label,
     isDisabled,
     height = DEFAULTS.HEIGHT,
+    ariaControls,
+    ariaExpanded,
   } = props;
   const state = useSearchFieldState(props);
   const componentRef = useRef(null);
@@ -75,6 +77,8 @@ const SearchInput = (props: Props, ref: RefObject<HTMLInputElement>): ReactEleme
       data-focus={isFocused}
       data-height={height}
       ref={containerRef}
+      aria-controls={ariaControls}
+      aria-expanded={ariaExpanded}
     >
       {label && (
         <label htmlFor={labelProps.htmlFor} {...labelProps}>

--- a/src/components/SearchInput/SearchInput.tsx
+++ b/src/components/SearchInput/SearchInput.tsx
@@ -28,7 +28,7 @@ const SearchInput = (props: Props, ref: RefObject<HTMLInputElement>): ReactEleme
     label,
     isDisabled,
     height = DEFAULTS.HEIGHT,
-    ariaControls,
+    controls,
     isCombobox = DEFAULTS.IS_COMBOBOX,
     isExpanded,
   } = props;
@@ -88,7 +88,7 @@ const SearchInput = (props: Props, ref: RefObject<HTMLInputElement>): ReactEleme
       data-focus={isFocused}
       data-height={height}
       ref={containerRef}
-      aria-controls={ariaControls}
+      aria-controls={controls}
       aria-expanded={isExpanded}
       role={isCombobox ? ARIA_ROLES.COMBOBOX : ARIA_ROLES.SEARCHBOX}
     >

--- a/src/components/SearchInput/SearchInput.types.ts
+++ b/src/components/SearchInput/SearchInput.types.ts
@@ -92,12 +92,12 @@ export interface Props extends AriaSearchFieldProps {
   height?: SearchFieldHeight;
 
   /**
-   * aria-expanded attribute, indicates if the controlled element is expanded/collapsed
-   */
-  ariaExpanded?: boolean;
-
-  /**
    * aria-controls attribute, the HTML ID of the element that this SearchInput relates to
    */
   ariaControls?: string;
+
+  /**
+   * aria-expanded attribute, indicates if the controlled element is expanded/collapsed
+   */
+  ariaExpanded?: boolean;
 }

--- a/src/components/SearchInput/SearchInput.types.ts
+++ b/src/components/SearchInput/SearchInput.types.ts
@@ -97,7 +97,19 @@ export interface Props extends AriaSearchFieldProps {
   ariaControls?: string;
 
   /**
-   * aria-expanded attribute, indicates if the controlled element is expanded/collapsed
+   * Whether SearchInput is being used with a role of combobox or not
    */
-  ariaExpanded?: boolean;
+  isCombobox?: boolean;
+
+  /**
+   * While isCombobox=true, whether the combobox is expanded/collapsed,
+   * used for the aria-expanded attribute
+   */
+  isExpanded?: boolean;
+
+  /**
+   * Aria role for accessibility, custom prop or else it will be
+   * 'searchbox' by default or 'combobox' if isCombobox=true
+   */
+  role?: string;
 }

--- a/src/components/SearchInput/SearchInput.types.ts
+++ b/src/components/SearchInput/SearchInput.types.ts
@@ -98,7 +98,7 @@ export interface Props extends AriaSearchFieldProps {
   controls?: string;
 
   /**
-   * Whether SearchInput is being used with a role of combobox or else searchbox
+   * Whether SearchInput is being used with a role of combobox or not
    */
   isCombobox?: boolean;
 

--- a/src/components/SearchInput/SearchInput.types.ts
+++ b/src/components/SearchInput/SearchInput.types.ts
@@ -90,4 +90,14 @@ export interface Props extends AriaSearchFieldProps {
    * @default 32
    */
   height?: SearchFieldHeight;
+
+  /**
+   * aria-expanded attribute, indicates if the controlled element is expanded/collapsed
+   */
+  ariaExpanded?: boolean;
+
+  /**
+   * aria-controls attribute, the HTML ID of the element that this SearchInput relates to
+   */
+  ariaControls?: string;
 }

--- a/src/components/SearchInput/SearchInput.types.ts
+++ b/src/components/SearchInput/SearchInput.types.ts
@@ -92,12 +92,13 @@ export interface Props extends AriaSearchFieldProps {
   height?: SearchFieldHeight;
 
   /**
-   * aria-controls attribute, the HTML ID of the element that this SearchInput relates to
+   * While isCombobox=true, the HTML ID of the element that this SearchInput relates to,
+   * used for the aria-controls attribute
    */
   controls?: string;
 
   /**
-   * Whether SearchInput is being used with a role of combobox or not
+   * Whether SearchInput is being used with a role of combobox or else searchbox
    */
   isCombobox?: boolean;
 

--- a/src/components/SearchInput/SearchInput.types.ts
+++ b/src/components/SearchInput/SearchInput.types.ts
@@ -106,10 +106,4 @@ export interface Props extends AriaSearchFieldProps {
    * used for the aria-expanded attribute
    */
   isExpanded?: boolean;
-
-  /**
-   * Aria role for accessibility, custom prop or else it will be
-   * 'searchbox' by default or 'combobox' if isCombobox=true
-   */
-  role?: string;
 }

--- a/src/components/SearchInput/SearchInput.types.ts
+++ b/src/components/SearchInput/SearchInput.types.ts
@@ -94,7 +94,7 @@ export interface Props extends AriaSearchFieldProps {
   /**
    * aria-controls attribute, the HTML ID of the element that this SearchInput relates to
    */
-  ariaControls?: string;
+  controls?: string;
 
   /**
    * Whether SearchInput is being used with a role of combobox or not

--- a/src/components/SearchInput/SearchInput.types.ts
+++ b/src/components/SearchInput/SearchInput.types.ts
@@ -95,7 +95,7 @@ export interface Props extends AriaSearchFieldProps {
    * While isCombobox=true, the HTML ID of the element that this SearchInput relates to,
    * used for the aria-controls attribute
    */
-  controls?: string;
+  ariaControls?: string;
 
   /**
    * Whether SearchInput is being used with a role of combobox or not
@@ -106,5 +106,5 @@ export interface Props extends AriaSearchFieldProps {
    * While isCombobox=true, whether the combobox is expanded/collapsed,
    * used for the aria-expanded attribute
    */
-  isExpanded?: boolean;
+  isComboboxExpanded?: boolean;
 }

--- a/src/components/SearchInput/SearchInput.unit.test.tsx
+++ b/src/components/SearchInput/SearchInput.unit.test.tsx
@@ -6,6 +6,7 @@ import Icon from '../Icon';
 import SearchInput, { SEARCH_INPUT_CONSTANTS as CONSTANTS } from '.';
 import { act } from 'react-dom/test-utils';
 import ButtonSimple from '../ButtonSimple';
+import { WARNINGS } from './SearchInput.constants';
 
 const testTranslations = {
   empty: 'empty',
@@ -269,6 +270,45 @@ describe('<SearchInput />', () => {
 
       expect(element.getAttribute('aria-expanded')).toBe('false');
     });
+    it('should have no aria-controls or aria-expanded attributes when isCombobox is not provided', async () => {
+      expect.assertions(2);
+
+      const element = (
+        await mountAndWait(
+          <SearchInput
+            controls="list-element"
+            isExpanded={false}
+            searching={true}
+            clearButtonAriaLabel="Clear"
+          />
+        )
+      )
+        .find('input')
+        .getDOMNode();
+
+      expect(element.getAttribute('controls')).toBeNull();
+      expect(element.getAttribute('isExpanded')).toBeNull();
+    });
+    it('should have no aria-controls or aria-expanded attributes when isCombobox=false', async () => {
+      expect.assertions(2);
+
+      const element = (
+        await mountAndWait(
+          <SearchInput
+            isCombobox={false}
+            controls="list-element"
+            isExpanded={false}
+            searching={true}
+            clearButtonAriaLabel="Clear"
+          />
+        )
+      )
+        .find('input')
+        .getDOMNode();
+
+      expect(element.getAttribute('controls')).toBeNull();
+      expect(element.getAttribute('isExpanded')).toBeNull();
+    });
     it('should console warn when isCombobox is provided without isExpanded', async () => {
       expect.assertions(1);
       const logSpy = jest.spyOn(global.console, 'warn');
@@ -277,9 +317,24 @@ describe('<SearchInput />', () => {
         <SearchInput isCombobox={true} searching={true} clearButtonAriaLabel="Clear" />
       );
 
-      expect(logSpy).toHaveBeenCalledWith(
-        'MRV2: Momentum requires the isExpanded prop for SearchInput with Combobox for accessibiltity compliance.'
+      expect(logSpy).toHaveBeenCalledWith(WARNINGS.ISCOMBOBOX_1_ISEXPANDED_0);
+
+      logSpy.mockRestore();
+    });
+    it('should console warn when controls is provided without isCombobox', async () => {
+      expect.assertions(1);
+      const logSpy = jest.spyOn(global.console, 'warn');
+
+      await mountAndWait(
+        <SearchInput
+          isExpanded={false}
+          controls={'list-element'}
+          searching={true}
+          clearButtonAriaLabel="Clear"
+        />
       );
+
+      expect(logSpy).toHaveBeenCalledWith(WARNINGS.ISCOMBOBOX_0_CONTROLS_1);
 
       logSpy.mockRestore();
     });
@@ -288,16 +343,18 @@ describe('<SearchInput />', () => {
       const logSpy = jest.spyOn(global.console, 'warn');
 
       await mountAndWait(
-        <SearchInput isExpanded={false} searching={true} clearButtonAriaLabel="Clear" />
+        <SearchInput
+          isExpanded={false}
+          controls={'list-element'}
+          searching={true}
+          clearButtonAriaLabel="Clear"
+        />
       );
 
-      expect(logSpy).toHaveBeenCalledWith(
-        'MRV2: Momentum requires isCombobox set to true if using the isExpanded prop.'
-      );
+      expect(logSpy).toHaveBeenCalledWith(WARNINGS.ISCOMBOBOX_0_ISEXPANDED_1);
 
       logSpy.mockRestore();
     });
-
     it('should have the combobox role attribute when isCombobox is provided', async () => {
       expect.assertions(1);
 
@@ -315,17 +372,6 @@ describe('<SearchInput />', () => {
         .getDOMNode();
 
       expect(element.getAttribute('role')).toBe('combobox');
-    });
-    it('should have the searchbox role attribute when isCombobox is not provided', async () => {
-      expect.assertions(1);
-
-      const element = (
-        await mountAndWait(<SearchInput searching={true} clearButtonAriaLabel="Clear" />)
-      )
-        .find('input')
-        .getDOMNode();
-
-      expect(element.getAttribute('role')).toBe('searchbox');
     });
 
     it('should pass label to the label', async () => {

--- a/src/components/SearchInput/SearchInput.unit.test.tsx
+++ b/src/components/SearchInput/SearchInput.unit.test.tsx
@@ -224,12 +224,12 @@ describe('<SearchInput />', () => {
 
       expect(element.getAttribute('aria-label')).toBe('search');
     });
-    it('should have the aria-controls attribute when ariaControls is provided', async () => {
+    it('should have the aria-controls attribute when controls is provided', async () => {
       expect.assertions(1);
 
       const element = (
         await mountAndWait(
-          <SearchInput ariaControls="list-element" searching={true} clearButtonAriaLabel="Clear" />
+          <SearchInput controls="list-element" searching={true} clearButtonAriaLabel="Clear" />
         )
       )
         .find(SearchInput)

--- a/src/components/SearchInput/SearchInput.unit.test.tsx
+++ b/src/components/SearchInput/SearchInput.unit.test.tsx
@@ -242,13 +242,13 @@ describe('<SearchInput />', () => {
 
       const element = (
         await mountAndWait(
-          <SearchInput ariaExpanded={true} searching={true} clearButtonAriaLabel="Clear" />
+          <SearchInput ariaExpanded={false} searching={true} clearButtonAriaLabel="Clear" />
         )
       )
         .find(SearchInput)
         .getDOMNode();
 
-      expect(element.getAttribute('aria-expanded')).toBe(true);
+      expect(element.getAttribute('aria-expanded')).toBe('false');
     });
 
     it('should pass label to the label', async () => {

--- a/src/components/SearchInput/SearchInput.unit.test.tsx
+++ b/src/components/SearchInput/SearchInput.unit.test.tsx
@@ -242,13 +242,13 @@ describe('<SearchInput />', () => {
 
       const element = (
         await mountAndWait(
-          <SearchInput ariaExpanded={false} searching={true} clearButtonAriaLabel="Clear" />
+          <SearchInput ariaExpanded={true} searching={true} clearButtonAriaLabel="Clear" />
         )
       )
         .find(SearchInput)
         .getDOMNode();
 
-      expect(element.getAttribute('aria-expanded')).toBe(false);
+      expect(element.getAttribute('aria-expanded')).toBe(true);
     });
 
     it('should pass label to the label', async () => {
@@ -276,8 +276,8 @@ describe('<SearchInput />', () => {
     });
 
     it('should work with autofocus', async () => {
-      // eslint-disable-next-line jsx-a11y/no-autofocus
       await mountAndWait(
+        // eslint-disable-next-line jsx-a11y/no-autofocus
         <SearchInput autoFocus aria-label="search" value="test" clearButtonAriaLabel="Clear" />
       );
     });

--- a/src/components/SearchInput/SearchInput.unit.test.tsx
+++ b/src/components/SearchInput/SearchInput.unit.test.tsx
@@ -128,7 +128,7 @@ describe('<SearchInput />', () => {
       expect.assertions(1);
 
       const container = await mountComponent(
-        <SearchInput isCombobox={true} isExpanded={false} clearButtonAriaLabel="Clear" />
+        <SearchInput isCombobox={true} isComboboxExpanded={false} clearButtonAriaLabel="Clear" />
       );
 
       expect(container).toMatchSnapshot();
@@ -234,14 +234,14 @@ describe('<SearchInput />', () => {
 
       expect(element.getAttribute('aria-label')).toBe('search');
     });
-    it('should have the aria-controls attribute when isComboxbox=true and controls is provided', async () => {
+    it('should have the aria-controls attribute when isComboxbox=true and ariaControls is provided', async () => {
       expect.assertions(1);
 
       const element = (
         await mountAndWait(
           <SearchInput
+            ariaControls="list-element"
             isCombobox={true}
-            controls="list-element"
             searching={true}
             clearButtonAriaLabel="Clear"
           />
@@ -252,14 +252,14 @@ describe('<SearchInput />', () => {
 
       expect(element.getAttribute('aria-controls')).toBe('list-element');
     });
-    it('should have the aria-expanded attribute when isComboxbox=true and isExpanded is provided', async () => {
+    it('should have the aria-expanded attribute when isComboxbox=true and isComboboxExpanded is provided', async () => {
       expect.assertions(1);
 
       const element = (
         await mountAndWait(
           <SearchInput
             isCombobox={true}
-            isExpanded={false}
+            isComboboxExpanded={false}
             searching={true}
             clearButtonAriaLabel="Clear"
           />
@@ -276,8 +276,8 @@ describe('<SearchInput />', () => {
       const element = (
         await mountAndWait(
           <SearchInput
-            controls="list-element"
-            isExpanded={false}
+            ariaControls="list-element"
+            isComboboxExpanded={false}
             searching={true}
             clearButtonAriaLabel="Clear"
           />
@@ -286,8 +286,8 @@ describe('<SearchInput />', () => {
         .find('input')
         .getDOMNode();
 
-      expect(element.getAttribute('controls')).toBeNull();
-      expect(element.getAttribute('isExpanded')).toBeNull();
+      expect(element.getAttribute('aria-controls')).toBeNull();
+      expect(element.getAttribute('aria-expanded')).toBeNull();
     });
     it('should have no aria-controls or aria-expanded attributes when isCombobox=false', async () => {
       expect.assertions(2);
@@ -295,9 +295,9 @@ describe('<SearchInput />', () => {
       const element = (
         await mountAndWait(
           <SearchInput
+            ariaControls="list-element"
             isCombobox={false}
-            controls="list-element"
-            isExpanded={false}
+            isComboboxExpanded={false}
             searching={true}
             clearButtonAriaLabel="Clear"
           />
@@ -306,10 +306,10 @@ describe('<SearchInput />', () => {
         .find('input')
         .getDOMNode();
 
-      expect(element.getAttribute('controls')).toBeNull();
-      expect(element.getAttribute('isExpanded')).toBeNull();
+      expect(element.getAttribute('aria-controls')).toBeNull();
+      expect(element.getAttribute('aria-expanded')).toBeNull();
     });
-    it('should console warn when isCombobox is provided without isExpanded', async () => {
+    it('should console warn when isCombobox is provided without isComboboxExpanded', async () => {
       expect.assertions(1);
       const logSpy = jest.spyOn(global.console, 'warn');
 
@@ -321,14 +321,14 @@ describe('<SearchInput />', () => {
 
       logSpy.mockRestore();
     });
-    it('should console warn when controls is provided without isCombobox', async () => {
+    it('should console warn when ariaControls is provided without isCombobox', async () => {
       expect.assertions(1);
       const logSpy = jest.spyOn(global.console, 'warn');
 
       await mountAndWait(
         <SearchInput
-          isExpanded={false}
-          controls={'list-element'}
+          ariaControls="list-element"
+          isComboboxExpanded={false}
           searching={true}
           clearButtonAriaLabel="Clear"
         />
@@ -338,14 +338,14 @@ describe('<SearchInput />', () => {
 
       logSpy.mockRestore();
     });
-    it('should console warn when isExpanded is provided without isCombobox', async () => {
+    it('should console warn when isComboboxExpanded is provided without isCombobox', async () => {
       expect.assertions(1);
       const logSpy = jest.spyOn(global.console, 'warn');
 
       await mountAndWait(
         <SearchInput
-          isExpanded={false}
-          controls={'list-element'}
+          ariaControls="list-element"
+          isComboboxExpanded={false}
           searching={true}
           clearButtonAriaLabel="Clear"
         />
@@ -362,7 +362,7 @@ describe('<SearchInput />', () => {
         await mountAndWait(
           <SearchInput
             isCombobox={true}
-            isExpanded={false}
+            isComboboxExpanded={false}
             searching={true}
             clearButtonAriaLabel="Clear"
           />

--- a/src/components/SearchInput/SearchInput.unit.test.tsx
+++ b/src/components/SearchInput/SearchInput.unit.test.tsx
@@ -237,18 +237,76 @@ describe('<SearchInput />', () => {
 
       expect(element.getAttribute('aria-controls')).toBe('list-element');
     });
-    it('should have the aria expanded attribute when provided', async () => {
+    it('should have the aria expanded attribute when isExpanded are provided', async () => {
       expect.assertions(1);
 
       const element = (
         await mountAndWait(
-          <SearchInput ariaExpanded={false} searching={true} clearButtonAriaLabel="Clear" />
+          <SearchInput isExpanded={false} searching={true} clearButtonAriaLabel="Clear" />
         )
       )
         .find(SearchInput)
         .getDOMNode();
 
       expect(element.getAttribute('aria-expanded')).toBe('false');
+    });
+    it('should console warn when isCombobox is provided without isExpanded', async () => {
+      expect.assertions(1);
+      const logSpy = jest.spyOn(global.console, 'warn');
+
+      await mountAndWait(
+        <SearchInput isCombobox={true} searching={true} clearButtonAriaLabel="Clear" />
+      );
+
+      expect(logSpy).toHaveBeenCalledWith(
+        'MRV2: Momentum requires the isExpanded prop for SearchInput with Combobox for accessibiltity compliance.'
+      );
+
+      logSpy.mockRestore();
+    });
+    it('should console warn when isExpanded is provided without isCombobox', async () => {
+      expect.assertions(1);
+      const logSpy = jest.spyOn(global.console, 'warn');
+
+      await mountAndWait(
+        <SearchInput isExpanded={false} searching={true} clearButtonAriaLabel="Clear" />
+      );
+
+      expect(logSpy).toHaveBeenCalledWith(
+        'MRV2: Momentum requires isCombobox set to true if using the isExpanded prop.'
+      );
+
+      logSpy.mockRestore();
+    });
+
+    it('should have the combobox role attribute when isCombobox is provided', async () => {
+      expect.assertions(1);
+
+      const element = (
+        await mountAndWait(
+          <SearchInput
+            isCombobox={true}
+            isExpanded={false}
+            searching={true}
+            clearButtonAriaLabel="Clear"
+          />
+        )
+      )
+        .find(SearchInput)
+        .getDOMNode();
+
+      expect(element.getAttribute('role')).toBe('combobox');
+    });
+    it('should have the searchbox role attribute when isCombobox is not provided', async () => {
+      expect.assertions(1);
+
+      const element = (
+        await mountAndWait(<SearchInput searching={true} clearButtonAriaLabel="Clear" />)
+      )
+        .find(SearchInput)
+        .getDOMNode();
+
+      expect(element.getAttribute('role')).toBe('searchbox');
     });
 
     it('should pass label to the label', async () => {

--- a/src/components/SearchInput/SearchInput.unit.test.tsx
+++ b/src/components/SearchInput/SearchInput.unit.test.tsx
@@ -224,28 +224,38 @@ describe('<SearchInput />', () => {
 
       expect(element.getAttribute('aria-label')).toBe('search');
     });
-    it('should have the aria-controls attribute when controls is provided', async () => {
+    it('should have the aria-controls attribute when isComboxbox=true and controls is provided', async () => {
       expect.assertions(1);
 
       const element = (
         await mountAndWait(
-          <SearchInput controls="list-element" searching={true} clearButtonAriaLabel="Clear" />
+          <SearchInput
+            isCombobox={true}
+            controls="list-element"
+            searching={true}
+            clearButtonAriaLabel="Clear"
+          />
         )
       )
-        .find(SearchInput)
+        .find('input')
         .getDOMNode();
 
       expect(element.getAttribute('aria-controls')).toBe('list-element');
     });
-    it('should have the aria-expanded attribute when isExpanded is provided', async () => {
+    it('should have the aria-expanded attribute when isComboxbox=true and isExpanded is provided', async () => {
       expect.assertions(1);
 
       const element = (
         await mountAndWait(
-          <SearchInput isExpanded={false} searching={true} clearButtonAriaLabel="Clear" />
+          <SearchInput
+            isCombobox={true}
+            isExpanded={false}
+            searching={true}
+            clearButtonAriaLabel="Clear"
+          />
         )
       )
-        .find(SearchInput)
+        .find('input')
         .getDOMNode();
 
       expect(element.getAttribute('aria-expanded')).toBe('false');
@@ -292,7 +302,7 @@ describe('<SearchInput />', () => {
           />
         )
       )
-        .find(SearchInput)
+        .find('input')
         .getDOMNode();
 
       expect(element.getAttribute('role')).toBe('combobox');
@@ -303,7 +313,7 @@ describe('<SearchInput />', () => {
       const element = (
         await mountAndWait(<SearchInput searching={true} clearButtonAriaLabel="Clear" />)
       )
-        .find(SearchInput)
+        .find('input')
         .getDOMNode();
 
       expect(element.getAttribute('role')).toBe('searchbox');

--- a/src/components/SearchInput/SearchInput.unit.test.tsx
+++ b/src/components/SearchInput/SearchInput.unit.test.tsx
@@ -224,7 +224,7 @@ describe('<SearchInput />', () => {
 
       expect(element.getAttribute('aria-label')).toBe('search');
     });
-    it('should have the aria controls attribute when provided', async () => {
+    it('should have the aria-controls attribute when ariaControls is provided', async () => {
       expect.assertions(1);
 
       const element = (
@@ -237,7 +237,7 @@ describe('<SearchInput />', () => {
 
       expect(element.getAttribute('aria-controls')).toBe('list-element');
     });
-    it('should have the aria expanded attribute when isExpanded are provided', async () => {
+    it('should have the aria-expanded attribute when isExpanded is provided', async () => {
       expect.assertions(1);
 
       const element = (

--- a/src/components/SearchInput/SearchInput.unit.test.tsx
+++ b/src/components/SearchInput/SearchInput.unit.test.tsx
@@ -248,7 +248,7 @@ describe('<SearchInput />', () => {
         .find(SearchInput)
         .getDOMNode();
 
-      expect(element.getAttribute('aria-expanded')).toBeFalsy();
+      expect(element.getAttribute('aria-expanded')).toBe(false);
     });
 
     it('should pass label to the label', async () => {

--- a/src/components/SearchInput/SearchInput.unit.test.tsx
+++ b/src/components/SearchInput/SearchInput.unit.test.tsx
@@ -229,7 +229,7 @@ describe('<SearchInput />', () => {
 
       const element = (
         await mountAndWait(
-          <SearchInput aria-controls="list-element" searching={true} clearButtonAriaLabel="Clear" />
+          <SearchInput ariaControls="list-element" searching={true} clearButtonAriaLabel="Clear" />
         )
       )
         .find(SearchInput)
@@ -242,7 +242,7 @@ describe('<SearchInput />', () => {
 
       const element = (
         await mountAndWait(
-          <SearchInput aria-expanded={false} searching={true} clearButtonAriaLabel="Clear" />
+          <SearchInput ariaExpanded={false} searching={true} clearButtonAriaLabel="Clear" />
         )
       )
         .find(SearchInput)

--- a/src/components/SearchInput/SearchInput.unit.test.tsx
+++ b/src/components/SearchInput/SearchInput.unit.test.tsx
@@ -123,6 +123,15 @@ describe('<SearchInput />', () => {
 
       expect(container).toMatchSnapshot();
     });
+    it('should match snapshot when isCombobox is true', async () => {
+      expect.assertions(1);
+
+      const container = await mountComponent(
+        <SearchInput isCombobox={true} isExpanded={false} clearButtonAriaLabel="Clear" />
+      );
+
+      expect(container).toMatchSnapshot();
+    });
   });
 
   describe('attributes', () => {

--- a/src/components/SearchInput/SearchInput.unit.test.tsx
+++ b/src/components/SearchInput/SearchInput.unit.test.tsx
@@ -25,7 +25,9 @@ describe('<SearchInput />', () => {
     it('should match snapshot', async () => {
       expect.assertions(1);
 
-      const container = await mountComponent(<SearchInput aria-label="search" clearButtonAriaLabel='Clear' />);
+      const container = await mountComponent(
+        <SearchInput aria-label="search" clearButtonAriaLabel="Clear" />
+      );
 
       expect(container).toMatchSnapshot();
     });
@@ -36,7 +38,7 @@ describe('<SearchInput />', () => {
       const className = 'example-class';
 
       const container = await mountComponent(
-        <SearchInput aria-label="search" className={className} clearButtonAriaLabel='Clear' />
+        <SearchInput aria-label="search" className={className} clearButtonAriaLabel="Clear" />
       );
 
       expect(container).toMatchSnapshot();
@@ -47,7 +49,9 @@ describe('<SearchInput />', () => {
 
       const id = 'example-id';
 
-      const container = await mountComponent(<SearchInput aria-label="search" id={id} clearButtonAriaLabel='Clear'/>);
+      const container = await mountComponent(
+        <SearchInput aria-label="search" id={id} clearButtonAriaLabel="Clear" />
+      );
 
       expect(container).toMatchSnapshot();
     });
@@ -55,7 +59,9 @@ describe('<SearchInput />', () => {
     it('should match snapshot with a label', async () => {
       expect.assertions(1);
 
-      const container = await mountComponent(<SearchInput label="search" aria-label="search" clearButtonAriaLabel='Clear'/>);
+      const container = await mountComponent(
+        <SearchInput label="search" aria-label="search" clearButtonAriaLabel="Clear" />
+      );
 
       expect(container).toMatchSnapshot();
     });
@@ -65,7 +71,9 @@ describe('<SearchInput />', () => {
 
       const style = { color: 'pink' };
 
-      const container = await mountComponent(<SearchInput aria-label="search" style={style} clearButtonAriaLabel='Clear'/>);
+      const container = await mountComponent(
+        <SearchInput aria-label="search" style={style} clearButtonAriaLabel="Clear" />
+      );
 
       expect(container).toMatchSnapshot();
     });
@@ -73,7 +81,9 @@ describe('<SearchInput />', () => {
     it('should match snapshot when searching', async () => {
       expect.assertions(1);
 
-      const container = await mountComponent(<SearchInput aria-label="search" searching={true} clearButtonAriaLabel='Clear'/>);
+      const container = await mountComponent(
+        <SearchInput aria-label="search" searching={true} clearButtonAriaLabel="Clear" />
+      );
 
       expect(container).toMatchSnapshot();
     });
@@ -81,7 +91,9 @@ describe('<SearchInput />', () => {
     it('should match snapshot with height', async () => {
       expect.assertions(1);
 
-      const container = await mountComponent(<SearchInput aria-label="search" height={28} clearButtonAriaLabel='Clear'/>);
+      const container = await mountComponent(
+        <SearchInput aria-label="search" height={28} clearButtonAriaLabel="Clear" />
+      );
 
       expect(container).toMatchSnapshot();
     });
@@ -93,7 +105,7 @@ describe('<SearchInput />', () => {
         <SearchInput
           aria-label="search"
           value="From: someone"
-          clearButtonAriaLabel='Clear'
+          clearButtonAriaLabel="Clear"
           filters={[
             {
               term: 'from',
@@ -117,7 +129,9 @@ describe('<SearchInput />', () => {
     it('should have its wrapper class', async () => {
       expect.assertions(1);
 
-      const element = (await mountAndWait(<SearchInput aria-label="search" clearButtonAriaLabel='Clear'/>))
+      const element = (
+        await mountAndWait(<SearchInput aria-label="search" clearButtonAriaLabel="Clear" />)
+      )
         .find(SearchInput)
         .getDOMNode();
 
@@ -130,7 +144,9 @@ describe('<SearchInput />', () => {
       const className = 'example-class';
 
       const element = (
-        await mountAndWait(<SearchInput aria-label="search" className={className} clearButtonAriaLabel='Clear'/>)
+        await mountAndWait(
+          <SearchInput aria-label="search" className={className} clearButtonAriaLabel="Clear" />
+        )
       )
         .find(SearchInput)
         .getDOMNode();
@@ -143,7 +159,9 @@ describe('<SearchInput />', () => {
 
       const id = 'example-id-2';
 
-      const element = (await mountAndWait(<SearchInput aria-label="search" id={id} clearButtonAriaLabel='Clear'/>))
+      const element = (
+        await mountAndWait(<SearchInput aria-label="search" id={id} clearButtonAriaLabel="Clear" />)
+      )
         .find(SearchInput)
         .getDOMNode();
 
@@ -156,7 +174,11 @@ describe('<SearchInput />', () => {
       const style = { color: 'pink' };
       const styleString = 'color: pink;';
 
-      const element = (await mountAndWait(<SearchInput aria-label="search" style={style} clearButtonAriaLabel='Clear'/>))
+      const element = (
+        await mountAndWait(
+          <SearchInput aria-label="search" style={style} clearButtonAriaLabel="Clear" />
+        )
+      )
         .find(SearchInput)
         .getDOMNode();
 
@@ -166,7 +188,11 @@ describe('<SearchInput />', () => {
     it('should have provided height when height is provided', async () => {
       expect.assertions(1);
 
-      const element = (await mountAndWait(<SearchInput aria-label="search" height={28} clearButtonAriaLabel='Clear'/>))
+      const element = (
+        await mountAndWait(
+          <SearchInput aria-label="search" height={28} clearButtonAriaLabel="Clear" />
+        )
+      )
         .find(SearchInput)
         .getDOMNode();
 
@@ -176,7 +202,9 @@ describe('<SearchInput />', () => {
     it('should have default height when height is not provided', async () => {
       expect.assertions(1);
 
-      const element = (await mountAndWait(<SearchInput aria-label="search" clearButtonAriaLabel='Clear' />))
+      const element = (
+        await mountAndWait(<SearchInput aria-label="search" clearButtonAriaLabel="Clear" />)
+      )
         .find(SearchInput)
         .getDOMNode();
 
@@ -186,17 +214,49 @@ describe('<SearchInput />', () => {
     it('should pass the aria label to the input', async () => {
       expect.assertions(1);
 
-      const element = (await mountAndWait(<SearchInput aria-label="search" searching={true} clearButtonAriaLabel='Clear'/>))
+      const element = (
+        await mountAndWait(
+          <SearchInput aria-label="search" searching={true} clearButtonAriaLabel="Clear" />
+        )
+      )
         .find('input')
         .getDOMNode();
 
       expect(element.getAttribute('aria-label')).toBe('search');
     });
+    it('should have the aria controls attribute when provided', async () => {
+      expect.assertions(1);
+
+      const element = (
+        await mountAndWait(
+          <SearchInput aria-controls="list-element" searching={true} clearButtonAriaLabel="Clear" />
+        )
+      )
+        .find(SearchInput)
+        .getDOMNode();
+
+      expect(element.getAttribute('aria-controls')).toBe('list-element');
+    });
+    it('should have the aria expanded attribute when provided', async () => {
+      expect.assertions(1);
+
+      const element = (
+        await mountAndWait(
+          <SearchInput aria-expanded={false} searching={true} clearButtonAriaLabel="Clear" />
+        )
+      )
+        .find(SearchInput)
+        .getDOMNode();
+
+      expect(element.getAttribute('aria-expanded')).toBeFalsy();
+    });
 
     it('should pass label to the label', async () => {
       expect.assertions(2);
 
-      const wrapper = await mountAndWait(<SearchInput aria-label="search" label="a label" clearButtonAriaLabel='Clear'/>);
+      const wrapper = await mountAndWait(
+        <SearchInput aria-label="search" label="a label" clearButtonAriaLabel="Clear" />
+      );
       const label = wrapper.find('label');
       const realInputId = wrapper.find('input').getDOMNode().getAttribute('id');
 
@@ -207,7 +267,9 @@ describe('<SearchInput />', () => {
     it('should forward a ref if provided', async () => {
       const ref = React.createRef<HTMLInputElement>();
 
-      await mountAndWait(<SearchInput ref={ref} aria-label="search" value="test" clearButtonAriaLabel='Clear'/>);
+      await mountAndWait(
+        <SearchInput ref={ref} aria-label="search" value="test" clearButtonAriaLabel="Clear" />
+      );
 
       expect(ref.current).toBeInstanceOf(HTMLInputElement);
       expect(ref.current.value).toEqual('test');
@@ -215,23 +277,46 @@ describe('<SearchInput />', () => {
 
     it('should work with autofocus', async () => {
       // eslint-disable-next-line jsx-a11y/no-autofocus
-      await mountAndWait(<SearchInput autoFocus aria-label="search" value="test" clearButtonAriaLabel='Clear' />);
+      await mountAndWait(
+        <SearchInput autoFocus aria-label="search" value="test" clearButtonAriaLabel="Clear" />
+      );
     });
 
     it('should not render ButtonSimple if there is no value', async () => {
-      const container = await mountAndWait(<SearchInput aria-label="search" value="" isDisabled={false} clearButtonAriaLabel="clear search"/>);
+      const container = await mountAndWait(
+        <SearchInput
+          aria-label="search"
+          value=""
+          isDisabled={false}
+          clearButtonAriaLabel="clear search"
+        />
+      );
 
       expect(container.find(ButtonSimple).exists()).toBe(false);
     });
 
     it('should not render ButtonSimple if isDisabled is false', async () => {
-      const container = await mountAndWait(<SearchInput aria-label="search" value="test" isDisabled={true} clearButtonAriaLabel="clear search"/>);
+      const container = await mountAndWait(
+        <SearchInput
+          aria-label="search"
+          value="test"
+          isDisabled={true}
+          clearButtonAriaLabel="clear search"
+        />
+      );
 
       expect(container.find(ButtonSimple).exists()).toBe(false);
     });
 
     it('should render ButtonSimple if there is a value and isDisabled is false', async () => {
-      const container = await mountAndWait(<SearchInput aria-label="search" value="test" isDisabled={false} clearButtonAriaLabel="clear search" />);
+      const container = await mountAndWait(
+        <SearchInput
+          aria-label="search"
+          value="test"
+          isDisabled={false}
+          clearButtonAriaLabel="clear search"
+        />
+      );
 
       expect(container.find(ButtonSimple).exists()).toBe(true);
 
@@ -251,7 +336,9 @@ describe('<SearchInput />', () => {
     it('clicking on another part of the component gives focus to the input', async () => {
       expect.assertions(1);
 
-      const wrapper = await mountAndWait(<SearchInput aria-label="search" clearButtonAriaLabel='Clear'/>);
+      const wrapper = await mountAndWait(
+        <SearchInput aria-label="search" clearButtonAriaLabel="Clear" />
+      );
 
       const inputElement = wrapper.find('input');
       const icon = wrapper.find(Icon);

--- a/src/components/SearchInput/SearchInput.unit.test.tsx.snap
+++ b/src/components/SearchInput/SearchInput.unit.test.tsx.snap
@@ -11,6 +11,7 @@ exports[`<SearchInput /> snapshot should match snapshot 1`] = `
       data-focus={false}
       data-height={32}
       onClick={[Function]}
+      role="searchbox"
     >
       <div>
         <Icon
@@ -119,6 +120,7 @@ exports[`<SearchInput /> snapshot should match snapshot when filters are set 1`]
       data-focus={false}
       data-height={32}
       onClick={[Function]}
+      role="searchbox"
     >
       <div>
         <Icon
@@ -261,6 +263,7 @@ exports[`<SearchInput /> snapshot should match snapshot when searching 1`] = `
       data-focus={false}
       data-height={32}
       onClick={[Function]}
+      role="searchbox"
     >
       <div>
         <LoadingSpinner
@@ -376,6 +379,7 @@ exports[`<SearchInput /> snapshot should match snapshot with a label 1`] = `
       data-focus={false}
       data-height={32}
       onClick={[Function]}
+      role="searchbox"
     >
       <label
         htmlFor="test-ID"
@@ -465,6 +469,7 @@ exports[`<SearchInput /> snapshot should match snapshot with className 1`] = `
       data-focus={false}
       data-height={32}
       onClick={[Function]}
+      role="searchbox"
     >
       <div>
         <Icon
@@ -547,6 +552,7 @@ exports[`<SearchInput /> snapshot should match snapshot with height 1`] = `
       data-focus={false}
       data-height={28}
       onClick={[Function]}
+      role="searchbox"
     >
       <div>
         <Icon
@@ -630,6 +636,7 @@ exports[`<SearchInput /> snapshot should match snapshot with id 1`] = `
       data-height={32}
       id="example-id"
       onClick={[Function]}
+      role="searchbox"
     >
       <div>
         <Icon
@@ -716,6 +723,7 @@ exports[`<SearchInput /> snapshot should match snapshot with style 1`] = `
       data-focus={false}
       data-height={32}
       onClick={[Function]}
+      role="searchbox"
       style={
         Object {
           "color": "pink",

--- a/src/components/SearchInput/SearchInput.unit.test.tsx.snap
+++ b/src/components/SearchInput/SearchInput.unit.test.tsx.snap
@@ -251,7 +251,7 @@ exports[`<SearchInput /> snapshot should match snapshot when filters are set 1`]
 </SSRProvider>
 `;
 
-exports[`<SearchInput /> snapshot should match snapshot when iscombobox is true 1`] = `
+exports[`<SearchInput /> snapshot should match snapshot when isCombobox is true 1`] = `
 <SSRProvider>
   <SearchInput
     clearButtonAriaLabel="Clear"

--- a/src/components/SearchInput/SearchInput.unit.test.tsx.snap
+++ b/src/components/SearchInput/SearchInput.unit.test.tsx.snap
@@ -251,6 +251,89 @@ exports[`<SearchInput /> snapshot should match snapshot when filters are set 1`]
 </SSRProvider>
 `;
 
+exports[`<SearchInput /> snapshot should match snapshot when iscombobox is true 1`] = `
+<SSRProvider>
+  <SearchInput
+    clearButtonAriaLabel="Clear"
+    isCombobox={true}
+    isExpanded={false}
+  >
+    <div
+      className="md-search-input-wrapper"
+      data-focus={false}
+      data-height={32}
+      onClick={[Function]}
+    >
+      <div>
+        <Icon
+          className="md-search-input-search"
+          name="search"
+          scale={16}
+          weight="bold"
+        >
+          <div
+            aria-hidden="true"
+            className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-search-input-search md-icon-no-shrink"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              className=""
+              data-autoscale={false}
+              data-scale={16}
+              data-test="search"
+              fill="currentColor"
+              height="100%"
+              style={Object {}}
+              viewBox="0, 0, 32, 32"
+              width="100%"
+            />
+          </div>
+        </Icon>
+      </div>
+      <div
+        className="md-search-input-container"
+      >
+        <input
+          aria-expanded={false}
+          disabled={false}
+          id="test-ID"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          readOnly={false}
+          role="combobox"
+          type="search"
+          value=""
+        />
+      </div>
+      <InputMessage>
+        <div
+          className="md-input-message-wrapper"
+        >
+          <div
+            className="md-input-message-message"
+            message-level="none"
+            role="alert"
+          >
+            <Text
+              className="md-input-message--text"
+              type="body-secondary"
+            >
+              <small
+                className="md-text-wrapper md-input-message--text"
+                data-type="body-secondary"
+              />
+            </Text>
+          </div>
+        </div>
+      </InputMessage>
+    </div>
+  </SearchInput>
+</SSRProvider>
+`;
+
 exports[`<SearchInput /> snapshot should match snapshot when searching 1`] = `
 <SSRProvider>
   <SearchInput

--- a/src/components/SearchInput/SearchInput.unit.test.tsx.snap
+++ b/src/components/SearchInput/SearchInput.unit.test.tsx.snap
@@ -11,7 +11,6 @@ exports[`<SearchInput /> snapshot should match snapshot 1`] = `
       data-focus={false}
       data-height={32}
       onClick={[Function]}
-      role="searchbox"
     >
       <div>
         <Icon
@@ -52,6 +51,7 @@ exports[`<SearchInput /> snapshot should match snapshot 1`] = `
           onFocus={[Function]}
           onKeyDown={[Function]}
           readOnly={false}
+          role="searchbox"
           type="search"
           value=""
         />
@@ -120,7 +120,6 @@ exports[`<SearchInput /> snapshot should match snapshot when filters are set 1`]
       data-focus={false}
       data-height={32}
       onClick={[Function]}
-      role="searchbox"
     >
       <div>
         <Icon
@@ -161,6 +160,7 @@ exports[`<SearchInput /> snapshot should match snapshot when filters are set 1`]
           onFocus={[Function]}
           onKeyDown={[Function]}
           readOnly={false}
+          role="searchbox"
           type="search"
           value="From: someone"
         />
@@ -263,7 +263,6 @@ exports[`<SearchInput /> snapshot should match snapshot when searching 1`] = `
       data-focus={false}
       data-height={32}
       onClick={[Function]}
-      role="searchbox"
     >
       <div>
         <LoadingSpinner
@@ -337,6 +336,7 @@ exports[`<SearchInput /> snapshot should match snapshot when searching 1`] = `
           onFocus={[Function]}
           onKeyDown={[Function]}
           readOnly={false}
+          role="searchbox"
           type="search"
           value=""
         />
@@ -379,7 +379,6 @@ exports[`<SearchInput /> snapshot should match snapshot with a label 1`] = `
       data-focus={false}
       data-height={32}
       onClick={[Function]}
-      role="searchbox"
     >
       <label
         htmlFor="test-ID"
@@ -427,6 +426,7 @@ exports[`<SearchInput /> snapshot should match snapshot with a label 1`] = `
           onFocus={[Function]}
           onKeyDown={[Function]}
           readOnly={false}
+          role="searchbox"
           type="search"
           value=""
         />
@@ -469,7 +469,6 @@ exports[`<SearchInput /> snapshot should match snapshot with className 1`] = `
       data-focus={false}
       data-height={32}
       onClick={[Function]}
-      role="searchbox"
     >
       <div>
         <Icon
@@ -510,6 +509,7 @@ exports[`<SearchInput /> snapshot should match snapshot with className 1`] = `
           onFocus={[Function]}
           onKeyDown={[Function]}
           readOnly={false}
+          role="searchbox"
           type="search"
           value=""
         />
@@ -552,7 +552,6 @@ exports[`<SearchInput /> snapshot should match snapshot with height 1`] = `
       data-focus={false}
       data-height={28}
       onClick={[Function]}
-      role="searchbox"
     >
       <div>
         <Icon
@@ -593,6 +592,7 @@ exports[`<SearchInput /> snapshot should match snapshot with height 1`] = `
           onFocus={[Function]}
           onKeyDown={[Function]}
           readOnly={false}
+          role="searchbox"
           type="search"
           value=""
         />
@@ -636,7 +636,6 @@ exports[`<SearchInput /> snapshot should match snapshot with id 1`] = `
       data-height={32}
       id="example-id"
       onClick={[Function]}
-      role="searchbox"
     >
       <div>
         <Icon
@@ -677,6 +676,7 @@ exports[`<SearchInput /> snapshot should match snapshot with id 1`] = `
           onFocus={[Function]}
           onKeyDown={[Function]}
           readOnly={false}
+          role="searchbox"
           type="search"
           value=""
         />
@@ -723,7 +723,6 @@ exports[`<SearchInput /> snapshot should match snapshot with style 1`] = `
       data-focus={false}
       data-height={32}
       onClick={[Function]}
-      role="searchbox"
       style={
         Object {
           "color": "pink",
@@ -769,6 +768,7 @@ exports[`<SearchInput /> snapshot should match snapshot with style 1`] = `
           onFocus={[Function]}
           onKeyDown={[Function]}
           readOnly={false}
+          role="searchbox"
           type="search"
           value=""
         />

--- a/src/components/SearchInput/SearchInput.unit.test.tsx.snap
+++ b/src/components/SearchInput/SearchInput.unit.test.tsx.snap
@@ -51,7 +51,6 @@ exports[`<SearchInput /> snapshot should match snapshot 1`] = `
           onFocus={[Function]}
           onKeyDown={[Function]}
           readOnly={false}
-          role="searchbox"
           type="search"
           value=""
         />
@@ -160,7 +159,6 @@ exports[`<SearchInput /> snapshot should match snapshot when filters are set 1`]
           onFocus={[Function]}
           onKeyDown={[Function]}
           readOnly={false}
-          role="searchbox"
           type="search"
           value="From: someone"
         />
@@ -419,7 +417,6 @@ exports[`<SearchInput /> snapshot should match snapshot when searching 1`] = `
           onFocus={[Function]}
           onKeyDown={[Function]}
           readOnly={false}
-          role="searchbox"
           type="search"
           value=""
         />
@@ -509,7 +506,6 @@ exports[`<SearchInput /> snapshot should match snapshot with a label 1`] = `
           onFocus={[Function]}
           onKeyDown={[Function]}
           readOnly={false}
-          role="searchbox"
           type="search"
           value=""
         />
@@ -592,7 +588,6 @@ exports[`<SearchInput /> snapshot should match snapshot with className 1`] = `
           onFocus={[Function]}
           onKeyDown={[Function]}
           readOnly={false}
-          role="searchbox"
           type="search"
           value=""
         />
@@ -675,7 +670,6 @@ exports[`<SearchInput /> snapshot should match snapshot with height 1`] = `
           onFocus={[Function]}
           onKeyDown={[Function]}
           readOnly={false}
-          role="searchbox"
           type="search"
           value=""
         />
@@ -759,7 +753,6 @@ exports[`<SearchInput /> snapshot should match snapshot with id 1`] = `
           onFocus={[Function]}
           onKeyDown={[Function]}
           readOnly={false}
-          role="searchbox"
           type="search"
           value=""
         />
@@ -851,7 +844,6 @@ exports[`<SearchInput /> snapshot should match snapshot with style 1`] = `
           onFocus={[Function]}
           onKeyDown={[Function]}
           readOnly={false}
-          role="searchbox"
           type="search"
           value=""
         />

--- a/src/components/SearchInput/SearchInput.unit.test.tsx.snap
+++ b/src/components/SearchInput/SearchInput.unit.test.tsx.snap
@@ -254,7 +254,7 @@ exports[`<SearchInput /> snapshot should match snapshot when isCombobox is true 
   <SearchInput
     clearButtonAriaLabel="Clear"
     isCombobox={true}
-    isExpanded={false}
+    isComboboxExpanded={false}
   >
     <div
       className="md-search-input-wrapper"


### PR DESCRIPTION
# Description

- adds aria-controls, aria-expanded (isExpanded), isCombobox, and 'combobox' role to SearchInput
- three warnings for usage of isCombobox, controls, and isExpanded
- types and unit testing
- updated snapshots accordingly
