### PR TITLE
feat(popover): add disable focus lock

### DIFF
--- a/src/components/Popover/Popover.constants.ts
+++ b/src/components/Popover/Popover.constants.ts
@@ -36,6 +36,7 @@ const DEFAULTS = {
   ADD_BACKDROP: true,
   ROLE: MODAL_CONTAINER_CONSTANTS.DEFAULTS.ROLE,
   APPEND_TO: 'parent' as const,
+  DISABLE_FOCUS_LOCK: false,
 };
 
 const STYLE = {

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -46,6 +46,7 @@ const Popover = forwardRef((props: Props, ref: ForwardedRef<HTMLElement>) => {
     addBackdrop = DEFAULTS.ADD_BACKDROP,
     focusBackOnTrigger: focusBackOnTriggerFromProps,
     closeButtonPlacement = DEFAULTS.CLOSE_BUTTON_PLACEMENT,
+    disableFocusLock = DEFAULTS.DISABLE_FOCUS_LOCK,
     closeButtonProps,
     strategy = DEFAULTS.STRATEGY,
     role = DEFAULTS.ROLE,
@@ -88,7 +89,9 @@ const Popover = forwardRef((props: Props, ref: ForwardedRef<HTMLElement>) => {
     ...(interactive && {
       ...((providedAriaLabelledby || !ariaLabel) && { 'aria-labelledby': ariaLabelledby }),
       ...(ariaLabel && { 'aria-label': ariaLabel }),
-      focusLockProps: { restoreFocus: focusBackOnTrigger, autoFocus },
+      focusLockProps: !disableFocusLock
+        ? { restoreFocus: focusBackOnTrigger, autoFocus }
+        : undefined, // if we pass in undefined, the ModalContainer will not use FocusScope
     }),
   };
 

--- a/src/components/Popover/Popover.types.ts
+++ b/src/components/Popover/Popover.types.ts
@@ -219,4 +219,10 @@ export interface Props extends PopoverCommonStyleProps, Partial<LifecycleHooks> 
    * Only required in the unusual circumstance where the popover label cannot match the trigger.
    */
   'aria-label'?: string;
+
+  /**
+   * If true, the focus lock will be disabled for the Popover content.
+   * @default `false`
+   */
+  disableFocusLock?: boolean;
 }

--- a/src/components/Popover/Popover.types.ts
+++ b/src/components/Popover/Popover.types.ts
@@ -222,6 +222,7 @@ export interface Props extends PopoverCommonStyleProps, Partial<LifecycleHooks> 
 
   /**
    * If true, the focus lock will be disabled for the Popover content.
+   * This is useful when you want to handle focus lock mechanism yourself, and to avoid having multiple focus locks.
    * @default `false`
    */
   disableFocusLock?: boolean;

--- a/src/components/Popover/Popover.unit.test.tsx
+++ b/src/components/Popover/Popover.unit.test.tsx
@@ -1450,6 +1450,63 @@ describe('<Popover />', () => {
         });
       });
 
+      it('should not trap focus as expected when interactive and disableFocusLock="true"', async () => {
+        const user = userEvent.setup();
+
+        render(
+          <>
+            <Popover
+              triggerComponent={<button>Click Me!</button>}
+              interactive={true}
+              trigger="click"
+              disableFocusLock={true}
+            >
+              <div>
+                <p>Content</p>
+                <button tabIndex={0}>Button within popover</button>
+              </div>
+            </Popover>
+            <button tabIndex={0}>Button outside the popover</button>
+          </>
+        );
+
+        /**
+         * Click to TriggerButton, Popover should open
+         */
+        const clickMeButton = await screen.findByRole('button', { name: 'Click Me!' });
+        await user.click(clickMeButton);
+
+        await waitFor(() => {
+          expect(screen.getByText('Content')).toBeInTheDocument();
+        });
+        /**
+         * focus is expected to be on the trigger still, because focusLock is disabled (and it also controls auto focus)
+         */
+        expect(await screen.findByRole('button', { name: 'Click Me!' })).toHaveFocus();
+
+        /**
+         * Press Tab, focus should go to the button outside the popover
+         */
+        await user.tab();
+        expect(
+          await screen.findByRole('button', { name: 'Button outside the popover' })
+        ).toHaveFocus();
+
+        /**
+         * Press Tab, focus should go inside the popover
+         */
+        await user.tab();
+        expect(await screen.findByRole('button', { name: 'Button within popover' })).toHaveFocus();
+
+        /**
+         * Press Tab, focus should not be on the button inside the popover (focus lock is disabled)
+         */
+        await user.tab();
+        expect(
+          await screen.findByRole('button', { name: 'Button within popover' })
+        ).not.toHaveFocus();
+      });
+
       it('should behave as expected when interactive and trigger="mouseenter"', async () => {
         /**
          * Expected behavior for this test:


### PR DESCRIPTION
# Description
- add prop to disable react-aria focus scoping inside the popover. We need this because at the moment it doesn't have support for shadow-dom, and some of our 3rd party components are built using web-components.
- this will allow us to add our custom focus lock for web-components without interfering with react-aria's focus scope implementation.

# Links
Issue on react-aria: https://github.com/adobe/react-spectrum/issues/1472
PR with potential future solution: https://github.com/adobe/react-spectrum/pull/6046 (it's recent but not sure how long it will take until this gets released).