### PR TITLE
fix(a11y): lightbox remove unnecessary click

### DIFF
--- a/src/legacy/Lightbox/index.js
+++ b/src/legacy/Lightbox/index.js
@@ -581,13 +581,7 @@ class Lightbox extends React.Component {
           </div>
           <div className="md-lightbox__body" ref={(ref) => (this.lightBox = ref)} role="tablist">
             {showColumn && getThumbnails()}
-            <div
-              className="md-lightbox__content"
-              onClick={this.handleClose}
-              onKeyPress={this.handleClose}
-              role="button"
-              tabIndex="0"
-            >
+            <div className="md-lightbox__content">
               <div
                 className={
                   `md-lightbox__viewport` +

--- a/src/legacy/Lightbox/tests/index.spec.js.snap
+++ b/src/legacy/Lightbox/tests/index.spec.js.snap
@@ -121,8 +121,6 @@ exports[`tests for <Lightbox /> should match SnapShot 1`] = `
                   >
                     <div
                       class="md-lightbox__content"
-                      role="button"
-                      tabindex="0"
                     >
                       <div
                         class="md-lightbox__viewport md-lightbox__viewport--decrypting"
@@ -569,10 +567,6 @@ exports[`tests for <Lightbox /> should match SnapShot 1`] = `
                     >
                       <div
                         className="md-lightbox__content"
-                        onClick={[Function]}
-                        onKeyPress={[Function]}
-                        role="button"
-                        tabIndex="0"
                       >
                         <div
                           className="md-lightbox__viewport md-lightbox__viewport--decrypting"


### PR DESCRIPTION

# Description

- Remove the unnecessary click on Lightbox which lets the lightbox close (it is not accessible)
- This will fix existing a11y issues
- Updating snapshot
