### PR TITLE
fix(ListItem): remove aria-current from legacy ListItem

### DIFF
--- a/src/legacy/ListItem/index.js
+++ b/src/legacy/ListItem/index.js
@@ -10,8 +10,8 @@ import ListContext from '../ListContext';
 import mapContextToProps from '@restart/context/mapContextToProps';
 
 /**
-* @deprecated - Components in the legacy folder (/src/legacy) are deprecated. Please use a component from the components folder (/src/components) instead. Legacy components may not follow accessibility standards.
-**/
+ * @deprecated - Components in the legacy folder (/src/legacy) are deprecated. Please use a component from the components folder (/src/components) instead. Legacy components may not follow accessibility standards.
+ **/
 class ListItem extends React.Component {
   componentDidMount() {
     const { focus, refName, focusOnLoad } = this.props;
@@ -272,9 +272,6 @@ class ListItem extends React.Component {
         tabIndex: !disabled && cxtProps.focus ? 0 : -1,
       }),
       'data-md-event-key': cxtProps.uniqueKey,
-      ...(!cxtProps?.ariaConfig?.disableAriaCurrent && {
-        ...(cxtProps.focus && { 'aria-current': `${cxtProps.focus}` }),
-      }),
       ...(keyboardNavKey && { 'data-md-keyboard-key': keyboardNavKey }),
       ...((title || label) && { title: title || label }),
       ...otherProps,


### PR DESCRIPTION
This PR is simply to change the legacy ListItem to not add the `aria-current` attribute when the item has focus.  Adding `aria-current` causes the screen reader to read each item with "current" added to the label, which is redundant.

Before:
![image](https://github.com/user-attachments/assets/d95a16ce-0f36-42d0-a50a-186e37d7c289)

After:
![image](https://github.com/user-attachments/assets/3caf0724-3faa-4e13-b2ce-09ee9ffbf9b8)

Testing notes:
* yarn start
* go to Legacy > ListItem
* open dev tools on (A Center Button)
* ensure the `aria-current` attr is not present on the anchor