### PR TITLE
fix(popover): listen on document to work around other document listeners

### DIFF
--- a/src/components/Popover/tippy-plugins/hideOnEscPlugin.test.ts
+++ b/src/components/Popover/tippy-plugins/hideOnEscPlugin.test.ts
@@ -29,7 +29,7 @@ describe('hideOnEscPlugin', () => {
   it('should add and remove esc key listener correctly', async () => {
     const { hideOnEscPlugin } = await import('./hideOnEscPlugin');
     const { addEventListenerSpy, removeEventListenerSpy, eventHandlers } = sypOnEventListener(
-      window,
+      document,
       ['keydown']
     );
 
@@ -90,7 +90,7 @@ describe('hideOnEscPlugin', () => {
 
   it('should trigger hide when user press esc', async () => {
     const { hideOnEscPlugin } = await import('./hideOnEscPlugin');
-    const { eventHandlers } = sypOnEventListener(window, ['keydown']);
+    const { eventHandlers } = sypOnEventListener(document, ['keydown']);
 
     const tippy = createTippyInstance() as any;
     const plugin = hideOnEscPlugin.fn(tippy);
@@ -105,7 +105,7 @@ describe('hideOnEscPlugin', () => {
     jest.resetModules();
 
     const { hideOnEscPlugin } = await import('./hideOnEscPlugin');
-    const { eventHandlers } = sypOnEventListener(window, ['keydown']);
+    const { eventHandlers } = sypOnEventListener(document, ['keydown']);
 
     const tippy1 = createTippyInstance() as any;
     const plugin1 = hideOnEscPlugin.fn(tippy1);

--- a/src/components/Popover/tippy-plugins/hideOnEscPlugin.ts
+++ b/src/components/Popover/tippy-plugins/hideOnEscPlugin.ts
@@ -24,7 +24,7 @@ const addInstance = (instance: TippyInstance) => {
   }
 
   if (openedTippyInstances.length === 0) {
-    window.addEventListener('keydown', onKeyDown);
+    document.addEventListener('keydown', onKeyDown);
   }
 
   openedTippyInstances.push(instance);
@@ -41,7 +41,7 @@ const removeInstance = (instance: TippyInstance) => {
   openedTippyInstances.splice(openedTippyInstances.indexOf(instance), 1);
 
   if (openedTippyInstances.length === 0) {
-    window.removeEventListener('keydown', onKeyDown);
+    document.removeEventListener('keydown', onKeyDown);
   }
   // Send custom event that tippy instance is no longer shown on screen. This event is listened for in instances of OverlayAlert to allow it to close once there are no tippy instances
   // still shown on screen that were opened after the render of the OverlayAlert.


### PR DESCRIPTION
# Description

Listen to document instead of window. This fixes popover escape when other unrelated listeners on document are stopping propagation.

# Links

*Links to relevent resources.*
