### PR TITLE
feat(button-control): add ref forwarding

### DIFF
--- a/src/components/ButtonControl/ButtonControl.tsx
+++ b/src/components/ButtonControl/ButtonControl.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { forwardRef, RefObject } from 'react';
 import classnames from 'classnames';
 
 import ButtonSimple from '../ButtonSimple';
@@ -11,7 +11,7 @@ import './ButtonControl.style.scss';
 /**
  * `<ControlButtons />` are used to control [close, maximize, minimize, etc] components [usually panels] they are assigned to.
  */
-const ButtonControl: FC<Props> = (props: Props) => {
+const ButtonControl = forwardRef((props: Props, providedRef: RefObject<HTMLButtonElement>) => {
   const { className, control, isCircular, ...otherProps } = props;
 
   const iconName = ICONS[control] || 'not-found';
@@ -33,6 +33,7 @@ const ButtonControl: FC<Props> = (props: Props) => {
 
   return (
     <ButtonSimple
+      ref={providedRef}
       className={classnames(STYLE.wrapper, className)}
       data-circular={isCircular}
       data-disabled={props.isDisabled}
@@ -41,6 +42,8 @@ const ButtonControl: FC<Props> = (props: Props) => {
       <Icon {...iconProps} />
     </ButtonSimple>
   );
-};
+});
+
+ButtonControl.displayName = 'ButtonControl';
 
 export default ButtonControl;

--- a/src/components/OverlayAlert/OverlayAlert.style.scss
+++ b/src/components/OverlayAlert/OverlayAlert.style.scss
@@ -10,6 +10,10 @@
         display: flex;
         justify-content: end;
       }
+
+      .md-button-control-wrapper:last-child {
+        border-top-right-radius: 0.75rem;
+      }
     }
 
     > .md-overlay-alert-title {

--- a/src/components/OverlayAlert/OverlayAlert.style.scss
+++ b/src/components/OverlayAlert/OverlayAlert.style.scss
@@ -12,7 +12,7 @@
       }
 
       .md-button-control-wrapper:last-child {
-        border-top-right-radius: 0.75rem;
+        border-top-right-radius: calc(0.75rem - 1px); // 0.75rem: overlay border radius, 1px: overlay border width
       }
     }
 


### PR DESCRIPTION
- add ref forwarding to button control
- also fixing a minor visual bug where the hover bg color of the last button control in an overlay alert exceeds the overlay boundaries

before:
<img width="400" alt="Screenshot 2024-08-23 at 15 23 51" src="https://github.com/user-attachments/assets/1d753b45-9d74-4a57-b10e-c30921bbfb52">

after:
<img width="400" alt="Screenshot 2024-08-23 at 15 28 25" src="https://github.com/user-attachments/assets/5a562c79-6f2e-4fe4-8e5c-8d63769b9567">

