### PR TITLE
fix(overlay-alert): missing gap in the header when there are no controls

### DIFF
--- a/src/components/OverlayAlert/OverlayAlert.style.scss
+++ b/src/components/OverlayAlert/OverlayAlert.style.scss
@@ -5,6 +5,7 @@
     > :first-child {
       width: 100%;
       margin-bottom: -0.5rem;
+      min-height: 2rem;
 
       > :last-child {
         display: flex;


### PR DESCRIPTION
noticed when doing https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-555472

<img width="600" src="https://github.com/user-attachments/assets/b844977f-b7f6-4ede-b5c4-947806ae8011"/>