### PR TITLE
fix: handle empty tree structure in tree component

### DIFF
--- a/src/components/Tree/Tree.test.tsx
+++ b/src/components/Tree/Tree.test.tsx
@@ -159,7 +159,19 @@ describe('<Tree />', () => {
     });
   });
 
-  describe('tree focus', () => {
+  describe('tree navigation', () => {
+    it.each(['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'])(
+      'should do nothing when tree structure is empty and user presses %s',
+      (key) => {
+        render(<Tree treeStructure={{}} excludeTreeRoot={false} />);
+        const focusedElement = document.activeElement;
+
+        userEvent.keyboard(`{${key}}`);
+
+        expect(document.activeElement).toBe(focusedElement);
+      }
+    );
+
     it('should handle escape being pressed', async () => {
       const keyDownHandler = jest.fn();
 

--- a/src/components/Tree/Tree.tsx
+++ b/src/components/Tree/Tree.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useRef, useState, useCallback, HTMLAttributes } from 'react';
 import classnames from 'classnames';
 
-import { STYLE, DEFAULTS, TREE_NAVIGATION_KEYS } from './Tree.constants';
+import { STYLE, DEFAULTS } from './Tree.constants';
 import { TreeIdNodeMap, Props, TreeContextValue, TreeNavKeyCodes, TreeNodeId } from './Tree.types';
 import './Tree.style.scss';
 import {
@@ -27,15 +27,11 @@ const Tree: FC<Props> = (props: Props) => {
     ...rest
   } = props;
 
-  if (excludeTreeRoot && !treeStructure.children.length) {
-    throw new Error('Tree must have at least one child when excludeTreeRoot is true');
-  }
-
   const ref = useRef<HTMLDivElement>();
 
   const [tree, setTree] = useState<TreeIdNodeMap>(convertNestedTree2MappedTree(treeStructure));
-  const [activeNodeId, setActiveNodeId] = useState<TreeNodeId>(
-    excludeTreeRoot ? treeStructure.children[0].id : treeStructure.id
+  const [activeNodeId, setActiveNodeId] = useState<TreeNodeId | undefined>(
+    excludeTreeRoot ? treeStructure?.children?.[0]?.id : treeStructure?.id
   );
 
   const isVirtualTree = virtualTreeConnector !== undefined;
@@ -125,14 +121,16 @@ const Tree: FC<Props> = (props: Props) => {
         case 'ArrowRight':
         case 'ArrowLeft': {
           evt.preventDefault();
-          const nextActiveNode = getNextActiveNode(
-            tree,
-            activeNodeId,
-            key,
-            excludeTreeRoot,
-            toggleTreeNode
-          );
-          setActiveNodeId(nextActiveNode);
+          if (activeNodeId) {
+            const nextActiveNode = getNextActiveNode(
+              tree,
+              activeNodeId,
+              key,
+              excludeTreeRoot,
+              toggleTreeNode
+            );
+            setActiveNodeId(nextActiveNode);
+          }
           break;
         }
         default:

--- a/src/components/Tree/Tree.types.ts
+++ b/src/components/Tree/Tree.types.ts
@@ -22,9 +22,14 @@ export type TreeNodeId = string;
 export type ToggleTreeNode = (id: TreeNodeId, isOpen?: boolean) => void;
 
 /**
+ * Empty tree type
+ */
+export type EmptyTree = Record<string, never>;
+
+/**
  * The root node of the tree.
  */
-export type TreeRoot = TreeNode;
+export type TreeRoot = TreeNode | EmptyTree;
 
 /**
  * A node in the tree.

--- a/src/components/Tree/Tree.utils.test.tsx
+++ b/src/components/Tree/Tree.utils.test.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import {
   convertNestedTree2MappedTree,
   getNextActiveNode,
+  getTreeRootId,
+  isEmptyTree,
   mapTree,
   toggleTreeNodeRecord,
   TreeContext,
@@ -71,6 +73,43 @@ describe('Tree utils', () => {
     it('should throw an error when the tree context is not available', () => {
       const { result } = renderHook(() => useTreeContext());
       expect(result.error).toEqual(Error('useTreeContext hook used without TreeContext!'));
+    });
+  });
+
+  describe('getTreeRootId', () => {
+    it('should return with root id for not empty tree', () => {
+      const rootId = getTreeRootId(createTree());
+
+      expect(rootId).toEqual('<root>');
+    });
+
+    it('should return with undefined when the tree is empty', () => {
+      const rootId = getTreeRootId(new Map());
+
+      expect(rootId).toEqual(undefined);
+    });
+
+    it('should return with undefined when there is no root in the tree', () => {
+      const tree = createTree();
+      tree.get('<root>').parent = '1';
+      const rootId = getTreeRootId(tree);
+
+      expect(rootId).toEqual(undefined);
+    });
+  });
+
+  describe('isEmptyTree', () => {
+    it('should return true when the tree is empty', () => {
+      expect(isEmptyTree(null)).toBe(true);
+      expect(isEmptyTree(undefined)).toBe(true);
+      expect(isEmptyTree({})).toBe(true);
+      expect(isEmptyTree({ children: [] })).toBe(true);
+      expect(isEmptyTree(new Map())).toBe(true);
+    });
+
+    it('should return false when the tree is not empty', () => {
+      expect(isEmptyTree({ id: 'root' })).toBe(false);
+      expect(isEmptyTree(new Map([['root', { id: 'root' }]]))).toBe(false);
     });
   });
 

--- a/src/components/Tree/Tree.utils.ts
+++ b/src/components/Tree/Tree.utils.ts
@@ -7,6 +7,7 @@ import {
   TreeNavKeyCodes,
   TreeNode,
   TreeNodeId,
+  TreeRoot,
 } from './Tree.types';
 
 export const TreeContext = React.createContext<TreeContextValue>(null);
@@ -30,6 +31,21 @@ export const useTreeContext = (): TreeContextValue => {
  */
 export const getTreeRootId = (tree: TreeIdNodeMap): TreeNodeId | undefined => {
   return Array.from(tree.values()).find((node) => !node.parent)?.id;
+};
+
+/**
+ * Check if the tree is empty.
+ *
+ * Works with both Map and recursive Object tree representation.
+ *
+ * @param tree
+ */
+export const isEmptyTree = (tree: unknown): boolean => {
+  if (!tree) return true;
+  if (tree instanceof Map && tree.size !== 0) return false;
+  if (tree instanceof Object && tree['id']) return false;
+
+  return true;
 };
 
 /**
@@ -185,8 +201,13 @@ const closeNextNode = (
  *
  * @param tree
  */
-export const convertNestedTree2MappedTree = (tree: TreeNode): TreeIdNodeMap => {
+export const convertNestedTree2MappedTree = (tree: TreeRoot): TreeIdNodeMap => {
   const map: TreeIdNodeMap = new Map();
+
+  if (isEmptyTree(tree)) {
+    return map;
+  }
+
   const idSet = new Set<TreeNodeId>();
   const rootNode = {
     node: tree as TreeNode,


### PR DESCRIPTION
# Description

In some case empty tree structure is a valid input, this fix easy the checks and make sure the navigation works with empty tree as well. 

# Links

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-552764
