### PR TITLE
fix(SearchInput): propagate enter key: 

### DIFF
--- a/src/components/SearchInput/SearchInput.tsx
+++ b/src/components/SearchInput/SearchInput.tsx
@@ -50,10 +50,8 @@ const SearchInput = (props: Props, ref: RefObject<HTMLInputElement>): ReactEleme
   }
 
   const state = useSearchFieldState(props);
-
   const componentRef = useRef(null);
   const inputRef = ref || componentRef;
-
   const { focusProps, isFocused } = useFocusState(props);
 
   const containerRef = useRef(null);

--- a/src/components/SearchInput/SearchInput.tsx
+++ b/src/components/SearchInput/SearchInput.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 /* eslint-disable jsx-a11y/click-events-have-key-events */
-import React, { ReactElement, useRef, RefObject, forwardRef, useLayoutEffect } from 'react';
+import React, { ReactElement, useRef, RefObject, forwardRef } from 'react';
 import classnames from 'classnames';
 
 import ButtonSimple from '../ButtonSimple';
@@ -21,12 +21,10 @@ import { useFocusState } from '../../hooks/useFocusState';
 import Icon from '../Icon';
 import LoadingSpinner from '../LoadingSpinner';
 
-
-type RefOrCallbackRef = RefObject<HTMLInputElement> | ((instance: HTMLInputElement) => void);
 /**
  *  Search input
  */
-const SearchInput = (props: Props, providedRef: RefOrCallbackRef): ReactElement => {
+const SearchInput = (props: Props, ref: RefObject<HTMLInputElement>): ReactElement => {
   const {
     className,
     id,
@@ -53,22 +51,9 @@ const SearchInput = (props: Props, providedRef: RefOrCallbackRef): ReactElement 
 
   const state = useSearchFieldState(props);
 
-  const internalRef = useRef<HTMLInputElement>();
+  const componentRef = useRef(null);
+  const inputRef = ref || componentRef;
 
-  let ref = internalRef;
-
-  if (providedRef && typeof providedRef !== 'function') {
-    ref = providedRef;
-  }
-  const inputRef = ref;
-
-  useLayoutEffect(() => {
-    if (providedRef) {
-      if (typeof providedRef === 'function') {
-        providedRef(ref.current);
-      }
-    }
-  });
   const { focusProps, isFocused } = useFocusState(props);
 
   const containerRef = useRef(null);

--- a/src/components/SearchInput/SearchInput.unit.test.tsx
+++ b/src/components/SearchInput/SearchInput.unit.test.tsx
@@ -478,4 +478,49 @@ describe('<SearchInput />', () => {
       expect(focusSpy).toBeCalledWith();
     });
   });
+
+  it('keyDown event should be propagated to the parent when triggered by Enter key', async () => {
+    expect.assertions(3);
+
+    const wrapper = await mountAndWait(
+      <SearchInput aria-label="search" clearButtonAriaLabel="Clear" />
+    );
+
+    const inputElement = wrapper.find('input');
+    const domNode = inputElement.getDOMNode() as HTMLInputElement;
+    const parentElement = wrapper.getDOMNode();
+    const dispatchEventSpy = jest.spyOn(parentElement, 'dispatchEvent');
+
+    inputElement.simulate('keydown', { key: 'Enter' });
+
+    expect(dispatchEventSpy).toHaveBeenCalledTimes(0);
+
+    inputElement.simulate('change', { target: { value: 'test' } });
+
+    expect(domNode.value).toEqual('test');
+
+    inputElement.simulate('keydown', { key: 'Enter' });
+
+    expect(dispatchEventSpy).toHaveBeenCalledTimes(1);
+
+    dispatchEventSpy.mockRestore();
+  });
+
+  it('keyDown event should be propagated to the parent when triggered by Escape key', async () => {
+    expect.assertions(1);
+
+    const wrapper = await mountAndWait(
+      <SearchInput aria-label="search" clearButtonAriaLabel="Clear" />
+    );
+
+    const inputElement = wrapper.find('input');
+    const parentElement = wrapper.getDOMNode();
+    const dispatchEventSpy = jest.spyOn(parentElement, 'dispatchEvent');
+
+    inputElement.simulate('keydown', { key: 'Escape' });
+
+    expect(dispatchEventSpy).toHaveBeenCalledTimes(1);
+
+    dispatchEventSpy.mockRestore();
+  });
 });


### PR DESCRIPTION
# IMPORTANT

**Currently, this project is closed to any external contributions. Any pull request made against this project from external sources will likely be closed. If you would like to make changes to this project, please fork this project.**

# Guide

**This "Help" section can be deleted before submitting this pull request.**

*Update the name of this pull request to reflect the following shape:*

```
{type}/{scope?}/{message}
```

* **type** - A [conventional commit type](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional#type-enum) **REQUIRED**
* **scope** - The kabab-case scope of the changes in this request
* **message** - A short, kebab-case statement describing the changes **REQUIRED**

*Provide a general summary of the scope of the changes in this pull request.*

* [Readme](https://github.com/momentum-design/momentum-react-v2/blob/master/README.md)
* [Getting Started Guide](https://github.com/momentum-design/momentum-react-v2/blob/master/GETTING_STARTED.md)
* [Contributing Guide](https://github.com/momentum-design/momentum-react-v2/blob/master/CONTRIBUTING.md)

# Description

*The full description of the changes made in this request.*
Added ```Enter``` to ```internalOnKeyDown``` to let keyDown event propagated to the parent

# Links
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-551735

*Links to relevent resources.*
