### PR TITLE
fix(searchInput): id should be unique: SPARK-551735

### DIFF
--- a/src/components/SearchInput/SearchInput.tsx
+++ b/src/components/SearchInput/SearchInput.tsx
@@ -2,6 +2,7 @@
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 import React, { ReactElement, useRef, RefObject, forwardRef } from 'react';
 import classnames from 'classnames';
+import { v4 as uuidv4 } from 'uuid';
 
 import ButtonSimple from '../ButtonSimple';
 import {
@@ -56,18 +57,21 @@ const SearchInput = (props: Props, ref: RefObject<HTMLInputElement>): ReactEleme
 
   const containerRef = useRef(null);
 
+  const inputId = `input-id-${uuidv4()}`;
+
   const {
     inputProps: ariaInputProps,
     clearButtonProps,
-    labelProps,
+    labelProps: ariaLabelProps,
   } = useSearchField(props, state, inputRef);
 
   const { onKeyDown, ...otherAriaInputProps } = ariaInputProps;
+  const { htmlFor, ...otherAriaLabelProps} = ariaLabelProps;
 
   const internalOnKeyDown = (e) => {
     // When the input is empty, pressing escape should be
     // propagated to the parent so that popovers can close
-    if ((e.key === 'Escape' && !state.value) || (e.key === 'Enter' && state.value) ) {
+    if ((e.key === 'Escape' && !state.value) || (e.key === 'Enter' && state.value)) {
       containerRef.current.dispatchEvent(new KeyboardEvent('keydown', e));
     }
 
@@ -77,6 +81,12 @@ const SearchInput = (props: Props, ref: RefObject<HTMLInputElement>): ReactEleme
   const inputProps = {
     ...otherAriaInputProps,
     onKeyDown: internalOnKeyDown,
+    id: inputId,
+  };
+
+  const labelProps = {
+    ...otherAriaLabelProps,
+    htmlFor: inputId,
   };
 
   const handleClick = () => {
@@ -110,7 +120,7 @@ const SearchInput = (props: Props, ref: RefObject<HTMLInputElement>): ReactEleme
       ref={containerRef}
     >
       {label && (
-        <label htmlFor={labelProps.htmlFor} {...labelProps}>
+        <label htmlFor={inputId} {...labelProps}>
           {label}
         </label>
       )}

--- a/src/components/SearchInput/SearchInput.tsx
+++ b/src/components/SearchInput/SearchInput.tsx
@@ -2,7 +2,6 @@
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 import React, { ReactElement, useRef, RefObject, forwardRef } from 'react';
 import classnames from 'classnames';
-import { v4 as uuidv4 } from 'uuid';
 
 import ButtonSimple from '../ButtonSimple';
 import {
@@ -28,7 +27,6 @@ import LoadingSpinner from '../LoadingSpinner';
 const SearchInput = (props: Props, ref: RefObject<HTMLInputElement>): ReactElement => {
   const {
     className,
-    id,
     style,
     searching,
     clearButtonAriaLabel,
@@ -57,16 +55,13 @@ const SearchInput = (props: Props, ref: RefObject<HTMLInputElement>): ReactEleme
 
   const containerRef = useRef(null);
 
-  const inputId = `input-id-${uuidv4()}`;
-
   const {
     inputProps: ariaInputProps,
     clearButtonProps,
-    labelProps: ariaLabelProps,
+    labelProps,
   } = useSearchField(props, state, inputRef);
 
   const { onKeyDown, ...otherAriaInputProps } = ariaInputProps;
-  const { htmlFor, ...otherAriaLabelProps} = ariaLabelProps;
 
   const internalOnKeyDown = (e) => {
     // When the input is empty, pressing escape should be
@@ -81,12 +76,6 @@ const SearchInput = (props: Props, ref: RefObject<HTMLInputElement>): ReactEleme
   const inputProps = {
     ...otherAriaInputProps,
     onKeyDown: internalOnKeyDown,
-    id: inputId,
-  };
-
-  const labelProps = {
-    ...otherAriaLabelProps,
-    htmlFor: inputId,
   };
 
   const handleClick = () => {
@@ -111,7 +100,6 @@ const SearchInput = (props: Props, ref: RefObject<HTMLInputElement>): ReactEleme
   return (
     <div
       className={classnames(className, STYLE.wrapper)}
-      id={id}
       onClick={handleClick}
       style={style}
       data-disabled={isDisabled}
@@ -120,7 +108,7 @@ const SearchInput = (props: Props, ref: RefObject<HTMLInputElement>): ReactEleme
       ref={containerRef}
     >
       {label && (
-        <label htmlFor={inputId} {...labelProps}>
+        <label htmlFor={labelProps.htmlFor} {...labelProps}>
           {label}
         </label>
       )}

--- a/src/components/SearchInput/SearchInput.unit.test.tsx
+++ b/src/components/SearchInput/SearchInput.unit.test.tsx
@@ -16,6 +16,13 @@ const testTranslations = {
   text: 'text',
 };
 
+jest.mock('uuid', () => {
+  return {
+    v4: () => 'mock-input-id',
+  };
+});
+
+
 describe('<SearchInput />', () => {
   describe('snapshot', () => {
     const mountComponent = async (component) => {
@@ -522,5 +529,19 @@ describe('<SearchInput />', () => {
     expect(dispatchEventSpy).toHaveBeenCalledTimes(1);
 
     dispatchEventSpy.mockRestore();
+  });
+
+  it('wrapper id should be the same as the input id when id is passed', async () => {
+    expect.assertions(2);
+
+    const wrapper = await mountAndWait(
+      <SearchInput aria-label="search" clearButtonAriaLabel="Clear" id="mock-wrapper-id"/>
+    );
+
+    const inputElement = wrapper.find('input');
+    const parentElement = wrapper.getDOMNode();
+
+    expect(parentElement.id).toBe('mock-wrapper-id');
+    expect(inputElement.getDOMNode().id).toBe('input-id-mock-input-id');
   });
 });

--- a/src/components/SearchInput/SearchInput.unit.test.tsx
+++ b/src/components/SearchInput/SearchInput.unit.test.tsx
@@ -16,13 +16,6 @@ const testTranslations = {
   text: 'text',
 };
 
-jest.mock('uuid', () => {
-  return {
-    v4: () => 'mock-input-id',
-  };
-});
-
-
 describe('<SearchInput />', () => {
   describe('snapshot', () => {
     const mountComponent = async (component) => {
@@ -171,18 +164,19 @@ describe('<SearchInput />', () => {
       expect(element.classList.contains(className)).toBe(true);
     });
 
-    it('should have provided id when id is provided', async () => {
-      expect.assertions(1);
+    it('wrapper id should not be the same as the input id', async () => {
+      expect.assertions(3);
 
-      const id = 'example-id-2';
+      const wrapper = await mountAndWait(
+        <SearchInput aria-label="search" clearButtonAriaLabel="Clear" />
+      );
 
-      const element = (
-        await mountAndWait(<SearchInput aria-label="search" id={id} clearButtonAriaLabel="Clear" />)
-      )
-        .find(SearchInput)
-        .getDOMNode();
+      const inputElement = wrapper.find('input');
+      const parentElement = wrapper.getDOMNode();
 
-      expect(element.id).toBe(id);
+      expect(parentElement.id).toBe('');
+      expect(inputElement.getDOMNode().id).toBe('test-ID');
+      expect(parentElement.id).not.toEqual(inputElement.getDOMNode().id);
     });
 
     it('should have provided style when style is provided', async () => {
@@ -529,19 +523,5 @@ describe('<SearchInput />', () => {
     expect(dispatchEventSpy).toHaveBeenCalledTimes(1);
 
     dispatchEventSpy.mockRestore();
-  });
-
-  it('wrapper id should be the same as the input id when id is passed', async () => {
-    expect.assertions(2);
-
-    const wrapper = await mountAndWait(
-      <SearchInput aria-label="search" clearButtonAriaLabel="Clear" id="mock-wrapper-id"/>
-    );
-
-    const inputElement = wrapper.find('input');
-    const parentElement = wrapper.getDOMNode();
-
-    expect(parentElement.id).toBe('mock-wrapper-id');
-    expect(inputElement.getDOMNode().id).toBe('input-id-mock-input-id');
   });
 });

--- a/src/components/SearchInput/SearchInput.unit.test.tsx.snap
+++ b/src/components/SearchInput/SearchInput.unit.test.tsx.snap
@@ -45,7 +45,7 @@ exports[`<SearchInput /> snapshot should match snapshot 1`] = `
         <input
           aria-label="search"
           disabled={false}
-          id="test-ID"
+          id="input-id-mock-input-id"
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
@@ -153,7 +153,7 @@ exports[`<SearchInput /> snapshot should match snapshot when filters are set 1`]
         <input
           aria-label="search"
           disabled={false}
-          id="test-ID"
+          id="input-id-mock-input-id"
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
@@ -295,7 +295,7 @@ exports[`<SearchInput /> snapshot should match snapshot when isCombobox is true 
         <input
           aria-expanded={false}
           disabled={false}
-          id="test-ID"
+          id="input-id-mock-input-id"
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
@@ -411,7 +411,7 @@ exports[`<SearchInput /> snapshot should match snapshot when searching 1`] = `
         <input
           aria-label="search"
           disabled={false}
-          id="test-ID"
+          id="input-id-mock-input-id"
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
@@ -461,7 +461,7 @@ exports[`<SearchInput /> snapshot should match snapshot with a label 1`] = `
       onClick={[Function]}
     >
       <label
-        htmlFor="test-ID"
+        htmlFor="input-id-mock-input-id"
         id="test-ID"
       >
         search
@@ -500,7 +500,7 @@ exports[`<SearchInput /> snapshot should match snapshot with a label 1`] = `
           aria-label="search"
           aria-labelledby="test-ID"
           disabled={false}
-          id="test-ID"
+          id="input-id-mock-input-id"
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
@@ -582,7 +582,7 @@ exports[`<SearchInput /> snapshot should match snapshot with className 1`] = `
         <input
           aria-label="search"
           disabled={false}
-          id="test-ID"
+          id="input-id-mock-input-id"
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
@@ -664,7 +664,7 @@ exports[`<SearchInput /> snapshot should match snapshot with height 1`] = `
         <input
           aria-label="search"
           disabled={false}
-          id="test-ID"
+          id="input-id-mock-input-id"
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
@@ -747,7 +747,7 @@ exports[`<SearchInput /> snapshot should match snapshot with id 1`] = `
         <input
           aria-label="search"
           disabled={false}
-          id="example-id"
+          id="input-id-mock-input-id"
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
@@ -838,7 +838,7 @@ exports[`<SearchInput /> snapshot should match snapshot with style 1`] = `
         <input
           aria-label="search"
           disabled={false}
-          id="test-ID"
+          id="input-id-mock-input-id"
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}

--- a/src/components/SearchInput/SearchInput.unit.test.tsx.snap
+++ b/src/components/SearchInput/SearchInput.unit.test.tsx.snap
@@ -45,7 +45,7 @@ exports[`<SearchInput /> snapshot should match snapshot 1`] = `
         <input
           aria-label="search"
           disabled={false}
-          id="input-id-mock-input-id"
+          id="test-ID"
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
@@ -153,7 +153,7 @@ exports[`<SearchInput /> snapshot should match snapshot when filters are set 1`]
         <input
           aria-label="search"
           disabled={false}
-          id="input-id-mock-input-id"
+          id="test-ID"
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
@@ -295,7 +295,7 @@ exports[`<SearchInput /> snapshot should match snapshot when isCombobox is true 
         <input
           aria-expanded={false}
           disabled={false}
-          id="input-id-mock-input-id"
+          id="test-ID"
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
@@ -411,7 +411,7 @@ exports[`<SearchInput /> snapshot should match snapshot when searching 1`] = `
         <input
           aria-label="search"
           disabled={false}
-          id="input-id-mock-input-id"
+          id="test-ID"
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
@@ -461,7 +461,7 @@ exports[`<SearchInput /> snapshot should match snapshot with a label 1`] = `
       onClick={[Function]}
     >
       <label
-        htmlFor="input-id-mock-input-id"
+        htmlFor="test-ID"
         id="test-ID"
       >
         search
@@ -500,7 +500,7 @@ exports[`<SearchInput /> snapshot should match snapshot with a label 1`] = `
           aria-label="search"
           aria-labelledby="test-ID"
           disabled={false}
-          id="input-id-mock-input-id"
+          id="test-ID"
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
@@ -582,7 +582,7 @@ exports[`<SearchInput /> snapshot should match snapshot with className 1`] = `
         <input
           aria-label="search"
           disabled={false}
-          id="input-id-mock-input-id"
+          id="test-ID"
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
@@ -664,7 +664,7 @@ exports[`<SearchInput /> snapshot should match snapshot with height 1`] = `
         <input
           aria-label="search"
           disabled={false}
-          id="input-id-mock-input-id"
+          id="test-ID"
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
@@ -711,7 +711,6 @@ exports[`<SearchInput /> snapshot should match snapshot with id 1`] = `
       className="md-search-input-wrapper"
       data-focus={false}
       data-height={32}
-      id="example-id"
       onClick={[Function]}
     >
       <div>
@@ -747,7 +746,7 @@ exports[`<SearchInput /> snapshot should match snapshot with id 1`] = `
         <input
           aria-label="search"
           disabled={false}
-          id="input-id-mock-input-id"
+          id="example-id"
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
@@ -838,7 +837,7 @@ exports[`<SearchInput /> snapshot should match snapshot with style 1`] = `
         <input
           aria-label="search"
           disabled={false}
-          id="input-id-mock-input-id"
+          id="test-ID"
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}


### PR DESCRIPTION
# IMPORTANT

**Currently, this project is closed to any external contributions. Any pull request made against this project from external sources will likely be closed. If you would like to make changes to this project, please fork this project.**

# Guide

**This "Help" section can be deleted before submitting this pull request.**

*Update the name of this pull request to reflect the following shape:*

```
{type}/{scope?}/{message}
```

* **type** - A [conventional commit type](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional#type-enum) **REQUIRED**
* **scope** - The kabab-case scope of the changes in this request
* **message** - A short, kebab-case statement describing the changes **REQUIRED**

*Provide a general summary of the scope of the changes in this pull request.*

* [Readme](https://github.com/momentum-design/momentum-react-v2/blob/master/README.md)
* [Getting Started Guide](https://github.com/momentum-design/momentum-react-v2/blob/master/GETTING_STARTED.md)
* [Contributing Guide](https://github.com/momentum-design/momentum-react-v2/blob/master/CONTRIBUTING.md)

# Description
Generate unique id for ```input``` element.

*The full description of the changes made in this request.*
Id should be unique for each element.
When id is explicit passed from Cantina, id is used for the following div:
```
    <div
      className={classnames(className, STYLE.wrapper)}
      id={id}
      onClick={handleClick}
      style={style}
      data-disabled={isDisabled}
      data-focus={isFocused}
      data-height={height}
      ref={containerRef}
    >
```

Howeve, the ```inputElement``` is using the same ```id```
Cause the following code:
```
  const {
    inputProps: ariaInputProps,
    clearButtonProps,
    labelProps,
  } = useSearchField({ ...props, id: inputId }, state, inputRef);

  const { onKeyDown, ...otherAriaInputProps } = ariaInputProps;

  const inputProps = {
    ...otherAriaInputProps,
    onKeyDown: internalOnKeyDown,
  };
```

# Links
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-551735

*Links to relevent resources.*
