### PR TITLE
fix(avatar): avatar add buttonclassname prop

### DIFF
--- a/src/components/Avatar/Avatar.stories.args.tsx
+++ b/src/components/Avatar/Avatar.stories.args.tsx
@@ -17,6 +17,20 @@ export default {
       },
     },
   },
+  buttonClassName: {
+    defaultValue: undefined,
+    description:
+      'If present, the class name will be added to the button component (if onPress set). Used to override styles by consumers.',
+    control: { type: 'text' },
+    table: {
+      type: {
+        summary: 'string',
+      },
+      defaultValue: {
+        summary: undefined,
+      },
+    },
+  },
   size: {
     defaultValue: DEFAULTS.SIZE,
     description: 'Size represents the size of the avatar.',

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -16,6 +16,7 @@ import { useAvatarImage } from './Avatar.hooks';
 const Avatar = (props: Props, ref: RefObject<HTMLButtonElement>) => {
   const {
     className,
+    buttonClassName,
     src,
     title,
     initials,
@@ -141,7 +142,7 @@ const Avatar = (props: Props, ref: RefObject<HTMLButtonElement>) => {
         aria-label={containerAriaLabel}
         useNativeKeyDown
         ref={ref}
-        className={STYLE.buttonWrapper}
+        className={classnames(STYLE.buttonWrapper, buttonClassName)}
         onPress={onPress}
         {...rest}
       >

--- a/src/components/Avatar/Avatar.types.ts
+++ b/src/components/Avatar/Avatar.types.ts
@@ -31,6 +31,11 @@ export interface Props extends Omit<AriaButtonProps, 'type'> {
   className?: string;
 
   /**
+   * className prop for the button, in case onPress is passed in
+   */
+  buttonClassName?: string;
+
+  /**
    * Size of the avatar
    * @default 32
    */
@@ -73,7 +78,7 @@ export interface Props extends Omit<AriaButtonProps, 'type'> {
   iconOnHover?: string;
 
   /**
-   * The main description of the Avatar, which will be the first part of its aria-label. 
+   * The main description of the Avatar, which will be the first part of its aria-label.
    * e.g 'Avatar of Bob'
    */
   mainLabel?: string;

--- a/src/components/Avatar/Avatar.unit.test.tsx
+++ b/src/components/Avatar/Avatar.unit.test.tsx
@@ -4,7 +4,6 @@ import React, { createRef } from 'react';
 import { MAX_INITIALS_SPACE, SIZES, STYLE, AVATAR_COLORS } from './Avatar.constants';
 import { AvatarColor, AvatarSize, PresenceType } from './Avatar.types';
 import { mountAndWait } from '../../../test/utils';
-import Icon from '../Icon';
 
 describe('Avatar', () => {
   const sampleProps = {
@@ -187,6 +186,16 @@ describe('Avatar', () => {
       const container = await mountAndWait(
         <Avatar isTyping={isTyping} typingLabel={typingLabel} title="Cisco Webex" />
       );
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match snapshot with buttonClassName', async () => {
+      expect.assertions(1);
+
+      const buttonClassName = 'button classname test';
+
+      const container = await mountAndWait(<Avatar buttonClassName={buttonClassName} />);
 
       expect(container).toMatchSnapshot();
     });

--- a/src/components/Avatar/Avatar.unit.test.tsx.snap
+++ b/src/components/Avatar/Avatar.unit.test.tsx.snap
@@ -43,6 +43,21 @@ exports[`Avatar snapshot should match snapshot with aria-label 1`] = `
 </Avatar>
 `;
 
+exports[`Avatar snapshot should match snapshot with buttonClassName 1`] = `
+<Avatar
+  buttonClassName="button classname test"
+>
+  <div
+    aria-hidden="false"
+    aria-label=""
+    className="md-avatar-wrapper"
+    data-color="default"
+    data-size={24}
+    role="img"
+  />
+</Avatar>
+`;
+
 exports[`Avatar snapshot should match snapshot with failureBadge 1`] = `
 <Avatar
   failureBadge={true}


### PR DESCRIPTION
# Description

- Allow passing in a buttonClassName to override the classname of the button of the avatar
- This is required to fix a a11y issue.

