### PR TITLE
fix(popover): remove event listener onDestroy, not onHidden

### DIFF
--- a/src/components/Popover/tippy-plugins/hideOnBlurPlugin.test.ts
+++ b/src/components/Popover/tippy-plugins/hideOnBlurPlugin.test.ts
@@ -21,7 +21,7 @@ describe('hideOnBlurPlugin', () => {
     });
   });
 
-  it('should add focusout event listener on create', async () => {
+  it('should add focusout event listener onCreate', async () => {
     const { hideOnBlurPlugin } = await import('./hideOnBlurPlugin');
     const popoverInstance = createPopoverInstance();
     const addEventListenerSpy = jest.spyOn(popoverInstance.popper, 'addEventListener');
@@ -32,13 +32,13 @@ describe('hideOnBlurPlugin', () => {
     expect(addEventListenerSpy).toHaveBeenCalledWith('focusout', expect.any(Function));
   });
 
-  it('should remove focusout event listener on hidden', async () => {
+  it('should remove focusout event listener onDestroy', async () => {
     const { hideOnBlurPlugin } = await import('./hideOnBlurPlugin');
     const popoverInstance = createPopoverInstance();
     const removeEventListenerSpy = jest.spyOn(popoverInstance.popper, 'removeEventListener');
 
     const plugin = hideOnBlurPlugin.fn(popoverInstance);
-    plugin.onHidden(popoverInstance);
+    plugin.onDestroy(popoverInstance);
 
     expect(removeEventListenerSpy).toHaveBeenCalledWith('focusout', expect.any(Function));
   });

--- a/src/components/Popover/tippy-plugins/hideOnBlurPlugin.ts
+++ b/src/components/Popover/tippy-plugins/hideOnBlurPlugin.ts
@@ -23,7 +23,7 @@ export const hideOnBlurPlugin: Plugin = {
       onCreate() {
         instance.popper.addEventListener('focusout', focusOutHandler);
       },
-      onHidden() {
+      onDestroy() {
         instance.popper.removeEventListener('focusout', focusOutHandler);
       },
     };


### PR DESCRIPTION
# Description
* the focusOut event listener should be removed when the tippy instance is destroyed, not hidden. if done onHidden, blur handling only works once since the event listener gets removed onHidden.

# Links
* https://atomiks.github.io/tippyjs/v6/all-props/#ondestroy
