### PR TITLE
feat(searchinput): allow searchinput to accept an onkeydown prop

### DIFF
--- a/src/components/SearchInput/SearchInput.tsx
+++ b/src/components/SearchInput/SearchInput.tsx
@@ -39,6 +39,7 @@ const SearchInput = (props: Props, providedRef: RefOrCallbackRef): ReactElement 
     ariaControls,
     isCombobox = DEFAULTS.ISCOMBOBOX,
     isComboboxExpanded,
+    onKeyDown: providedKeydown,
   } = props;
 
   if (isCombobox && isComboboxExpanded === undefined) {
@@ -74,6 +75,7 @@ const SearchInput = (props: Props, providedRef: RefOrCallbackRef): ReactElement 
     }
 
     onKeyDown(e);
+    providedKeydown && providedKeydown(e);
   };
 
   const inputProps = {

--- a/src/components/SearchInput/SearchInput.types.ts
+++ b/src/components/SearchInput/SearchInput.types.ts
@@ -107,4 +107,10 @@ export interface Props extends AriaSearchFieldProps {
    * used for the aria-expanded attribute
    */
   isComboboxExpanded?: boolean;
+
+  /**
+   * Callback function for to be called when keydown events happen in input
+   * @param event - React Keyboard Event
+   */
+  onKeyDown?: (event: React.KeyboardEvent) => void;
 }

--- a/src/components/SearchInput/SearchInput.unit.test.tsx
+++ b/src/components/SearchInput/SearchInput.unit.test.tsx
@@ -534,4 +534,23 @@ describe('<SearchInput />', () => {
 
     dispatchEventSpy.mockRestore();
   });
+
+  it('should call provided onKeyDown prop', async () => {
+    expect.assertions(2);
+
+    const onKeyDown = jest.fn();
+    const wrapper = await mountAndWait(
+      <SearchInput aria-label="search" clearButtonAriaLabel="Clear" onKeyDown={onKeyDown}/>
+    );
+
+    const inputElement = wrapper.find('input');
+    const parentElement = wrapper.getDOMNode();
+    const dispatchEventSpy = jest.spyOn(parentElement, 'dispatchEvent');
+
+    inputElement.simulate('keydown', { key: 'a' });
+
+    expect(dispatchEventSpy).not.toHaveBeenCalled();
+    dispatchEventSpy.mockRestore();
+    expect(onKeyDown).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
# Description
* allow SearchInput to accept an onKeyDown prop. the parent component may want the ability to act on keydown, for example, when pressing "down" from input may need to switch focus to a result


