### PR TITLE
fix(Menu): Keyboard navigation fix for menus with multiple sections

### DIFF
--- a/src/components/Menu/Menu.stories.tsx
+++ b/src/components/Menu/Menu.stories.tsx
@@ -3,7 +3,6 @@ import { MultiTemplate, Template } from '../../storybook/helper.stories.template
 import { DocumentationPage } from '../../storybook/helper.stories.docs';
 import StyleDocs from '../../storybook/docs.stories.style.mdx';
 import { Item, Section } from '@react-stately/collections';
-import { Story } from '@storybook/react';
 
 import Menu, { MenuProps } from './';
 import argTypes from './Menu.stories.args';
@@ -39,6 +38,7 @@ Example.args = {
     <Item key="three">Three</Item>,
   ],
 };
+
 const Sections = MultiTemplate<MenuProps<unknown>>(Menu).bind({});
 
 Sections.argTypes = { ...argTypes };
@@ -97,57 +97,6 @@ Sections.parameters = {
       ],
     },
   ],
-};
-
-const MultiMenu: Story = () => {
-  return (
-    <div role="menu">
-      <Menu isGroupRole aria-label="Speaker" onAction={action('onAction')} selectionMode="single">
-        <Section
-          key="0"
-          title={
-            <ListHeader outline={false}>
-              <ListItemBaseSection position="start">
-                <Icon scale={16} name="speaker" strokeColor="none" />
-              </ListItemBaseSection>
-              <ListItemBaseSection position="fill">Speaker</ListItemBaseSection>
-            </ListHeader>
-          }
-        >
-          <Item key="00">Use system setting (internal speakers)</Item>
-          <Item key="01">Internal speaker</Item>
-          <Item key="02">Bose Headset 100</Item>
-        </Section>
-      </Menu>
-      <Menu
-        isGroupRole
-        aria-label="Microphone"
-        onAction={action('onAction')}
-        selectionMode="single"
-      >
-        <Section
-          key="1"
-          title={
-            <ListHeader outline={true} outlinePosition="top" outlineColor="secondary">
-              <ListItemBaseSection position="start">
-                <Icon scale={16} name="microphone" strokeColor="none" />
-              </ListItemBaseSection>
-              <ListItemBaseSection position="fill">Microphone</ListItemBaseSection>
-            </ListHeader>
-          }
-        >
-          <Item key="10">Use system setting (internal microphone)</Item>
-          <Item key="11">Bose Headset 100</Item>
-        </Section>
-      </Menu>
-      <Section title={<ListHeader outline outlineColor="secondary" />} key="2">
-        <Item key="20">No title in the section</Item>
-      </Section>
-      <Section title={<ListHeader outline outlineColor="secondary" />} key="3">
-        <Item key="30">No title in the section</Item>
-      </Section>
-    </div>
-  );
 };
 
 const Common = MultiTemplate<MenuProps<unknown>>(Menu).bind({});
@@ -223,4 +172,4 @@ Common.parameters = {
 delete Common.argTypes.onAction;
 delete Common.argTypes.disabledKeys;
 
-export { Example, Sections, MultiMenu, Common };
+export { Example, Sections, Common };

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -1,10 +1,9 @@
 /* eslint-disable @typescript-eslint/ban-types */
-import { useKeyboard } from '@react-aria/interactions';
 import { Node } from '@react-types/shared';
 import React, { forwardRef, ReactElement, RefObject, useContext, useRef, useCallback } from 'react';
 import classnames from 'classnames';
 
-import { STYLE, DEFAULTS, GROUP } from './Menu.constants';
+import { STYLE, DEFAULTS } from './Menu.constants';
 import { MenuAppearanceContextValue, MenuContextValue, Props } from './Menu.types';
 import './Menu.style.scss';
 import { useMenu } from '@react-aria/menu';
@@ -12,9 +11,6 @@ import { useTreeState, TreeState } from '@react-stately/tree';
 import MenuItem from '../MenuItem';
 import { mergeProps } from '@react-aria/utils';
 import MenuSection from '../MenuSection';
-import { ListContext } from '../List/List.utils';
-import { DEFAULTS as LIST_DEFAULTS } from '../List/List.constants';
-
 
 export const MenuContext = React.createContext<MenuContextValue>({});
 
@@ -28,7 +24,7 @@ export function useMenuAppearanceContext(): MenuAppearanceContextValue {
   return useContext(MenuAppearanceContext);
 }
 
-const Menu = <T extends object>(props: Props<T>, providedRef: RefObject<HTMLUListElement>) => {
+const Menu = <T extends object>(props: Props<T>, providedRef: RefObject<HTMLDivElement>) => {
   const {
     className,
     id,
@@ -36,9 +32,7 @@ const Menu = <T extends object>(props: Props<T>, providedRef: RefObject<HTMLULis
     isTickOnLeftSide = DEFAULTS.IS_TICK_ON_LEFT_SIDE,
     itemShape = DEFAULTS.ITEM_SHAPE,
     itemSize = DEFAULTS.ITEM_SIZE,
-    isGroupRole,
     ariaLabelledby,
-    orientation = LIST_DEFAULTS.ORIENTATION,
     tabIndex,
   } = props;
 
@@ -80,56 +74,30 @@ const Menu = <T extends object>(props: Props<T>, providedRef: RefObject<HTMLULis
     },
     [state]
   );
-  const { keyboardProps } = useKeyboard({
-    onKeyDown: (e) => {
-      switch (e.key) {
-        case 'Escape':
-          e.continuePropagation();
-          break;
-
-        case orientation === 'horizontal' ? 'ArrowLeft' : 'ArrowUp':
-          e.preventDefault();
-          menuProps.onKeyDown({...e, key: 'ArrowUp'});
-          break;
-
-        case orientation === 'horizontal' ? 'ArrowRight' : 'ArrowDown':
-          e.preventDefault();
-          menuProps.onKeyDown({...e, key: 'ArrowDown'});
-          break;
-
-        default:
-          break;
-      }
-    },
-  }); 
 
   // needs to be removed because when used in Menu Trigger, it will
   // label it by the triggerComponent's id, and that doesn't really make
   // sense especially when there are multiple menus inside.
   delete menuProps['aria-labelledby'];
-  
+
   // ListContext is necessary to prevent changes in parent ListContext
   // for example when Menu is inside a list row
   return (
     <MenuAppearanceContext.Provider value={{ itemShape, itemSize, isTickOnLeftSide }}>
-      <ListContext.Provider value={{}}>
-        <ul
-          className={classnames(className, STYLE.wrapper)}
-          id={id}
-          style={style}
-          ref={ref}
-          {...menuProps}
-          role={isGroupRole ? GROUP : menuProps.role}
-          aria-labelledby={ariaLabelledby}
-          {...keyboardProps}
-          tabIndex={tabIndex || menuProps.tabIndex}
-        >
-          {itemArray.map((key) => {
-            const item = state.collection.getItem(key) as Node<T>;
-            return renderItem(item, state);
-          })}
-        </ul>
-      </ListContext.Provider>
+      <div
+        className={classnames(className, STYLE.wrapper)}
+        id={id}
+        style={style}
+        ref={ref}
+        aria-labelledby={ariaLabelledby}
+        {...menuProps}
+        tabIndex={tabIndex || menuProps.tabIndex}
+      >
+        {itemArray.map((key) => {
+          const item = state.collection.getItem(key) as Node<T>;
+          return renderItem(item, state);
+        })}
+      </div>
     </MenuAppearanceContext.Provider>
   );
 };
@@ -141,6 +109,4 @@ const Menu = <T extends object>(props: Props<T>, providedRef: RefObject<HTMLULis
 const _Menu = forwardRef(Menu);
 _Menu.displayName = '_Menu';
 
-export default _Menu as <T>(
-  props: Props<T> & { ref?: RefObject<HTMLUListElement> }
-) => ReactElement;
+export default _Menu as <T>(props: Props<T> & { ref?: RefObject<HTMLDivElement> }) => ReactElement;

--- a/src/components/Menu/Menu.unit.test.tsx
+++ b/src/components/Menu/Menu.unit.test.tsx
@@ -8,6 +8,7 @@ import ListItemBase from '../ListItemBase';
 import userEvent from '@testing-library/user-event';
 import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import ButtonPill from '../ButtonPill';
 
 describe('<Menu />', () => {
   const defaultProps = {
@@ -110,43 +111,12 @@ describe('<Menu />', () => {
       expect(element.id).toBe(id);
     });
 
-    it('should have role of group when isGroupRole is true', () => {
-      expect.assertions(1);
-
-      const element = mount(<Menu {...defaultProps} isGroupRole />)
-        .find(Menu)
-        .getDOMNode();
-
-      expect(element.getAttribute('role')).toBe('group');
-    });
-
-    it('should have role of menu when isGroupRole is false', () => {
-      expect.assertions(1);
-
-      const element = mount(<Menu {...defaultProps} isGroupRole={false} />)
-        .find(Menu)
-        .getDOMNode();
-
-      expect(element.getAttribute('role')).toBe('menu');
-    });
-
-    it('should have role of menu when isGroupRole is undefined', () => {
-      expect.assertions(1);
-
-      const element = mount(<Menu {...defaultProps} isGroupRole={undefined} />)
-        .find(Menu)
-        .getDOMNode();
-
-      expect(element.getAttribute('role')).toBe('menu');
-    });
-
     it('should have aria-labelledby prop when ariaLabelledby is provided', () => {
       expect.assertions(1);
 
       const ariaLabelledby = 'menu-label';
 
-      const element = mount(<Menu {...defaultProps} aria-labelledby={ariaLabelledby}/>)
-        .find(Menu);
+      const element = mount(<Menu {...defaultProps} aria-labelledby={ariaLabelledby} />).find(Menu);
 
       expect(element.prop('aria-labelledby')).toBe(ariaLabelledby);
     });
@@ -156,8 +126,7 @@ describe('<Menu />', () => {
 
       const ariaLabelledby = 'undefined';
 
-      const element = mount(<Menu {...defaultProps} aria-labelledby={ariaLabelledby}/>)
-        .find(Menu);
+      const element = mount(<Menu {...defaultProps} aria-labelledby={ariaLabelledby} />).find(Menu);
 
       expect(element.prop('aria-labelledby')).toBe(ariaLabelledby);
     });
@@ -205,7 +174,7 @@ describe('<Menu />', () => {
       expect.assertions(1);
 
       const element = mount(<Menu {...defaultProps} itemSize={50} tabIndex={-1} />)
-        .find('ul[role="menu"]')
+        .find('div[role="menu"]')
         .at(0)
         .getDOMNode();
 
@@ -233,9 +202,7 @@ describe('<Menu />', () => {
     it('should handle up/down arrow keys correctly - for vertical menus', async () => {
       const user = userEvent.setup();
 
-      const { getAllByRole } = render(
-        <Menu {...defaultProps} />
-      );
+      const { getAllByRole } = render(<Menu {...defaultProps} />);
 
       await user.tab();
 
@@ -255,41 +222,26 @@ describe('<Menu />', () => {
       expect(menuItems[0]).toHaveFocus();
     });
 
-    it('should handle left/right arrow keys correctly - for horizontal menus', async () => {
-      const user = userEvent.setup();
-
-      const { getAllByRole } = render(
-        <Menu {...defaultProps} orientation='horizontal' />
-      );
-
-      await user.tab();
-
-      const menuItems = getAllByRole('menuitem');
-      expect(menuItems[0]).toHaveFocus();
-
-      await user.keyboard('{ArrowRight}');
-
-      expect(menuItems[1]).toHaveFocus();
-
-      await user.keyboard('{ArrowRight}');
-
-      expect(menuItems[0]).toHaveFocus();
-
-      await user.keyboard('{ArrowDown}');
-
-      expect(menuItems[0]).toHaveFocus();
-    });
     it('should handle up/down arrow keys correctly - for vertical menu with section', async () => {
       const user = userEvent.setup();
-      const childrenWithSections = [<Section title="Section Title" key="$.0" aria-label="section"><Item key="one">One</Item><Item key="two">Two</Item></Section>];
 
       const { getAllByRole } = render(
-        <Menu {...defaultProps} children={childrenWithSections} />
+        <Menu {...defaultProps}>
+          <Section title="Section 1" key="s1" aria-label="section1">
+            <Item key="one">One</Item>
+            <Item key="two">Two</Item>
+          </Section>
+          <Section title="Section 2" key="s2" aria-label="section2">
+            <Item key="three">Three</Item>
+            <Item key="four">Four</Item>
+          </Section>
+        </Menu>
       );
 
       await user.tab();
 
       const menuItems = getAllByRole('menuitem');
+
       expect(menuItems[0]).toHaveFocus();
 
       await user.keyboard('{ArrowDown}');
@@ -298,36 +250,31 @@ describe('<Menu />', () => {
 
       await user.keyboard('{ArrowDown}');
 
-      expect(menuItems[0]).toHaveFocus();
+      expect(menuItems[2]).toHaveFocus();
 
-      await user.keyboard('{ArrowRight}');
-
-      expect(menuItems[0]).toHaveFocus();
-    });
-    it('should handle up/down arrow keys correctly - for horizontal menu with section', async () => {
-      const user = userEvent.setup();
-      const childrenWithSections = [<Section title="Section Title" key="$.0" aria-label="section"><Item key="one">One</Item><Item key="two">Two</Item></Section>];
-
-      const { getAllByRole } = render(
-        <Menu {...defaultProps} children={childrenWithSections} orientation='horizontal' />
-      );
-
-      await user.tab();
-
-      const menuItems = getAllByRole('menuitem');
-      expect(menuItems[0]).toHaveFocus();
-
-      await user.keyboard('{ArrowRight}');
+      await user.keyboard('{ArrowUp}');
 
       expect(menuItems[1]).toHaveFocus();
 
-      await user.keyboard('{ArrowRight}');
+      await user.keyboard('{ArrowDown}');
 
-      expect(menuItems[0]).toHaveFocus();
+      expect(menuItems[2]).toHaveFocus();
+
+      await user.keyboard('{ArrowDown}');
+
+      expect(menuItems[3]).toHaveFocus();
 
       await user.keyboard('{ArrowDown}');
 
       expect(menuItems[0]).toHaveFocus();
+
+      await user.keyboard('{ArrowUp}');
+
+      expect(menuItems[3]).toHaveFocus();
+
+      await user.keyboard('{ArrowRight}');
+
+      expect(menuItems[3]).toHaveFocus();
     });
   });
 });

--- a/src/components/Menu/Menu.unit.test.tsx
+++ b/src/components/Menu/Menu.unit.test.tsx
@@ -8,7 +8,6 @@ import ListItemBase from '../ListItemBase';
 import userEvent from '@testing-library/user-event';
 import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import ButtonPill from '../ButtonPill';
 
 describe('<Menu />', () => {
   const defaultProps = {

--- a/src/components/Menu/Menu.unit.test.tsx.snap
+++ b/src/components/Menu/Menu.unit.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`<Menu /> snapshot should match snapshot 1`] = `
 <_Menu
   aria-label="Menu component"
 >
-  <ul
+  <div
     aria-label="Menu component"
     className="md-menu-wrapper"
     onBlur={[Function]}
@@ -475,7 +475,7 @@ exports[`<Menu /> snapshot should match snapshot 1`] = `
         </FocusRing>
       </ListItemBase>
     </MenuItem>
-  </ul>
+  </div>
 </_Menu>
 `;
 
@@ -484,7 +484,7 @@ exports[`<Menu /> snapshot should match snapshot with className 1`] = `
   aria-label="Menu component"
   className="example-class"
 >
-  <ul
+  <div
     aria-label="Menu component"
     className="example-class md-menu-wrapper"
     onBlur={[Function]}
@@ -955,7 +955,7 @@ exports[`<Menu /> snapshot should match snapshot with className 1`] = `
         </FocusRing>
       </ListItemBase>
     </MenuItem>
-  </ul>
+  </div>
 </_Menu>
 `;
 
@@ -964,7 +964,7 @@ exports[`<Menu /> snapshot should match snapshot with id 1`] = `
   aria-label="Menu component"
   id="example-id"
 >
-  <ul
+  <div
     aria-label="Menu component"
     className="md-menu-wrapper"
     id="example-id"
@@ -1436,7 +1436,7 @@ exports[`<Menu /> snapshot should match snapshot with id 1`] = `
         </FocusRing>
       </ListItemBase>
     </MenuItem>
-  </ul>
+  </div>
 </_Menu>
 `;
 
@@ -1446,7 +1446,7 @@ exports[`<Menu /> snapshot should match snapshot with itemShape 1`] = `
   itemShape="isPilled"
   itemSize={50}
 >
-  <ul
+  <div
     aria-label="Menu component"
     className="md-menu-wrapper"
     onBlur={[Function]}
@@ -1917,7 +1917,7 @@ exports[`<Menu /> snapshot should match snapshot with itemShape 1`] = `
         </FocusRing>
       </ListItemBase>
     </MenuItem>
-  </ul>
+  </div>
 </_Menu>
 `;
 
@@ -1926,7 +1926,7 @@ exports[`<Menu /> snapshot should match snapshot with itemSize 1`] = `
   aria-label="Menu component"
   itemSize={50}
 >
-  <ul
+  <div
     aria-label="Menu component"
     className="md-menu-wrapper"
     onBlur={[Function]}
@@ -2397,7 +2397,7 @@ exports[`<Menu /> snapshot should match snapshot with itemSize 1`] = `
         </FocusRing>
       </ListItemBase>
     </MenuItem>
-  </ul>
+  </div>
 </_Menu>
 `;
 
@@ -2410,7 +2410,7 @@ exports[`<Menu /> snapshot should match snapshot with style 1`] = `
     }
   }
 >
-  <ul
+  <div
     aria-label="Menu component"
     className="md-menu-wrapper"
     onBlur={[Function]}
@@ -2886,6 +2886,6 @@ exports[`<Menu /> snapshot should match snapshot with style 1`] = `
         </FocusRing>
       </ListItemBase>
     </MenuItem>
-  </ul>
+  </div>
 </_Menu>
 `;

--- a/src/components/Menu/Menu.unit.test.tsx.snap
+++ b/src/components/Menu/Menu.unit.test.tsx.snap
@@ -40,7 +40,6 @@ exports[`<Menu /> snapshot should match snapshot 1`] = `
           "wrapper": undefined,
         }
       }
-      itemIndex={0}
       key="one"
       state={
         Object {
@@ -179,7 +178,6 @@ exports[`<Menu /> snapshot should match snapshot 1`] = `
         data-key="one"
         isDisabled={false}
         isPadded={true}
-        itemIndex={0}
         onClick={[Function]}
         onDragStart={[Function]}
         onFocus={[Function]}
@@ -272,7 +270,6 @@ exports[`<Menu /> snapshot should match snapshot 1`] = `
           "wrapper": undefined,
         }
       }
-      itemIndex={1}
       key="two"
       state={
         Object {
@@ -411,7 +408,6 @@ exports[`<Menu /> snapshot should match snapshot 1`] = `
         data-key="two"
         isDisabled={false}
         isPadded={true}
-        itemIndex={1}
         onClick={[Function]}
         onDragStart={[Function]}
         onFocus={[Function]}
@@ -524,7 +520,6 @@ exports[`<Menu /> snapshot should match snapshot with className 1`] = `
           "wrapper": undefined,
         }
       }
-      itemIndex={0}
       key="one"
       state={
         Object {
@@ -663,7 +658,6 @@ exports[`<Menu /> snapshot should match snapshot with className 1`] = `
         data-key="one"
         isDisabled={false}
         isPadded={true}
-        itemIndex={0}
         onClick={[Function]}
         onDragStart={[Function]}
         onFocus={[Function]}
@@ -756,7 +750,6 @@ exports[`<Menu /> snapshot should match snapshot with className 1`] = `
           "wrapper": undefined,
         }
       }
-      itemIndex={1}
       key="two"
       state={
         Object {
@@ -895,7 +888,6 @@ exports[`<Menu /> snapshot should match snapshot with className 1`] = `
         data-key="two"
         isDisabled={false}
         isPadded={true}
-        itemIndex={1}
         onClick={[Function]}
         onDragStart={[Function]}
         onFocus={[Function]}
@@ -1009,7 +1001,6 @@ exports[`<Menu /> snapshot should match snapshot with id 1`] = `
           "wrapper": undefined,
         }
       }
-      itemIndex={0}
       key="one"
       state={
         Object {
@@ -1148,7 +1139,6 @@ exports[`<Menu /> snapshot should match snapshot with id 1`] = `
         data-key="one"
         isDisabled={false}
         isPadded={true}
-        itemIndex={0}
         onClick={[Function]}
         onDragStart={[Function]}
         onFocus={[Function]}
@@ -1241,7 +1231,6 @@ exports[`<Menu /> snapshot should match snapshot with id 1`] = `
           "wrapper": undefined,
         }
       }
-      itemIndex={1}
       key="two"
       state={
         Object {
@@ -1380,7 +1369,6 @@ exports[`<Menu /> snapshot should match snapshot with id 1`] = `
         data-key="two"
         isDisabled={false}
         isPadded={true}
-        itemIndex={1}
         onClick={[Function]}
         onDragStart={[Function]}
         onFocus={[Function]}
@@ -1494,7 +1482,6 @@ exports[`<Menu /> snapshot should match snapshot with itemShape 1`] = `
           "wrapper": undefined,
         }
       }
-      itemIndex={0}
       key="one"
       state={
         Object {
@@ -1633,7 +1620,6 @@ exports[`<Menu /> snapshot should match snapshot with itemShape 1`] = `
         data-key="one"
         isDisabled={false}
         isPadded={true}
-        itemIndex={0}
         onClick={[Function]}
         onDragStart={[Function]}
         onFocus={[Function]}
@@ -1726,7 +1712,6 @@ exports[`<Menu /> snapshot should match snapshot with itemShape 1`] = `
           "wrapper": undefined,
         }
       }
-      itemIndex={1}
       key="two"
       state={
         Object {
@@ -1865,7 +1850,6 @@ exports[`<Menu /> snapshot should match snapshot with itemShape 1`] = `
         data-key="two"
         isDisabled={false}
         isPadded={true}
-        itemIndex={1}
         onClick={[Function]}
         onDragStart={[Function]}
         onFocus={[Function]}
@@ -1978,7 +1962,6 @@ exports[`<Menu /> snapshot should match snapshot with itemSize 1`] = `
           "wrapper": undefined,
         }
       }
-      itemIndex={0}
       key="one"
       state={
         Object {
@@ -2117,7 +2100,6 @@ exports[`<Menu /> snapshot should match snapshot with itemSize 1`] = `
         data-key="one"
         isDisabled={false}
         isPadded={true}
-        itemIndex={0}
         onClick={[Function]}
         onDragStart={[Function]}
         onFocus={[Function]}
@@ -2210,7 +2192,6 @@ exports[`<Menu /> snapshot should match snapshot with itemSize 1`] = `
           "wrapper": undefined,
         }
       }
-      itemIndex={1}
       key="two"
       state={
         Object {
@@ -2349,7 +2330,6 @@ exports[`<Menu /> snapshot should match snapshot with itemSize 1`] = `
         data-key="two"
         isDisabled={false}
         isPadded={true}
-        itemIndex={1}
         onClick={[Function]}
         onDragStart={[Function]}
         onFocus={[Function]}
@@ -2471,7 +2451,6 @@ exports[`<Menu /> snapshot should match snapshot with style 1`] = `
           "wrapper": undefined,
         }
       }
-      itemIndex={0}
       key="one"
       state={
         Object {
@@ -2610,7 +2589,6 @@ exports[`<Menu /> snapshot should match snapshot with style 1`] = `
         data-key="one"
         isDisabled={false}
         isPadded={true}
-        itemIndex={0}
         onClick={[Function]}
         onDragStart={[Function]}
         onFocus={[Function]}
@@ -2703,7 +2681,6 @@ exports[`<Menu /> snapshot should match snapshot with style 1`] = `
           "wrapper": undefined,
         }
       }
-      itemIndex={1}
       key="two"
       state={
         Object {
@@ -2842,7 +2819,6 @@ exports[`<Menu /> snapshot should match snapshot with style 1`] = `
         data-key="two"
         isDisabled={false}
         isPadded={true}
-        itemIndex={1}
         onClick={[Function]}
         onDragStart={[Function]}
         onFocus={[Function]}

--- a/src/components/MenuItem/MenuItem.tsx
+++ b/src/components/MenuItem/MenuItem.tsx
@@ -12,7 +12,7 @@ import Icon from '../Icon';
 import { useMenuContext, useMenuAppearanceContext } from '../Menu/Menu';
 
 const MenuItem = <T extends object>(props: Props<T>): ReactElement => {
-  const { item, state, onAction, itemIndex } = props;
+  const { item, state, onAction } = props;
 
   const ref = React.useRef();
   const isDisabled = state.disabledKeys.has(item.key);
@@ -75,7 +75,6 @@ const MenuItem = <T extends object>(props: Props<T>): ReactElement => {
     <ListItemBase
       size={itemSize}
       shape={itemShape}
-      itemIndex={itemIndex}
       className={STYLE.wrapper}
       ref={ref}
       isDisabled={isDisabled}

--- a/src/components/MenuItem/MenuItem.types.ts
+++ b/src/components/MenuItem/MenuItem.types.ts
@@ -17,9 +17,4 @@ export interface Props<T> {
    * Handler to be called when this element is selected
    */
   onAction?: (key: Key) => void;
-  
-  /**
-   * Index for handling keyboard list navigation
-   */
-  itemIndex?: number;
 }

--- a/src/components/MenuSection/MenuSection.tsx
+++ b/src/components/MenuSection/MenuSection.tsx
@@ -7,7 +7,6 @@ import { Props } from './MenuSection.types';
 import './MenuSection.style.scss';
 import MenuItem from '../MenuItem';
 import { useMenuSection } from '@react-aria/menu';
-import { ListContext } from '../List/List.utils';
 
 const MenuSection = <T extends object>(props: Props<T>): ReactElement => {
   const { item, state, onAction } = props;
@@ -24,7 +23,7 @@ const MenuSection = <T extends object>(props: Props<T>): ReactElement => {
   }, [state]);
 
   return (
-    <ul {...itemProps}>
+    <div {...itemProps}>
       {!React.isValidElement(item.rendered) && item.rendered ? (
         <span className={STYLE.header} {...headingProps}>
           {item.rendered}
@@ -32,12 +31,10 @@ const MenuSection = <T extends object>(props: Props<T>): ReactElement => {
       ) : (
         item.rendered && React.cloneElement(item.rendered as ReactElement, { ...headingProps })
       )}
-      <ListContext.Provider value={{}}>
-        <ul {...groupProps} className={STYLE.wrapper}>
-          {renderItems()}
-        </ul>
-      </ListContext.Provider>
-    </ul>
+      <ul {...groupProps} className={STYLE.wrapper}>
+        {renderItems()}
+      </ul>
+    </div>
   );
 };
 

--- a/src/components/MenuSection/MenuSection.tsx
+++ b/src/components/MenuSection/MenuSection.tsx
@@ -8,23 +8,18 @@ import './MenuSection.style.scss';
 import MenuItem from '../MenuItem';
 import { useMenuSection } from '@react-aria/menu';
 import { ListContext } from '../List/List.utils';
-import useOrientationBasedKeyboardNavigation from '../../hooks/useOrientationBasedKeyboardNavigation';
 
 const MenuSection = <T extends object>(props: Props<T>): ReactElement => {
-  const { item, state, onAction, orientation } = props;
+  const { item, state, onAction } = props;
 
   const { itemProps, headingProps, groupProps } = useMenuSection({
     heading: item.rendered,
     'aria-label': item['aria-label'],
   });
-  const childItems = Array.from(item.childNodes);
-  const listSize = childItems.length;
-
-  const {keyboardProps, getContext} = useOrientationBasedKeyboardNavigation({listSize, orientation});
 
   const renderItems = useCallback(() => {
-    return Array.from(item.childNodes).map((node, index) => (
-      <MenuItem itemIndex={index} key={node.key} item={node} state={state} onAction={onAction} />
+    return Array.from(item.childNodes).map((node) => (
+      <MenuItem key={node.key} item={node} state={state} onAction={onAction} />
     ));
   }, [state]);
 
@@ -37,8 +32,8 @@ const MenuSection = <T extends object>(props: Props<T>): ReactElement => {
       ) : (
         item.rendered && React.cloneElement(item.rendered as ReactElement, { ...headingProps })
       )}
-      <ListContext.Provider value={getContext()}>
-        <ul {...groupProps} {...keyboardProps} className={STYLE.wrapper}>
+      <ListContext.Provider value={{}}>
+        <ul {...groupProps} className={STYLE.wrapper}>
           {renderItems()}
         </ul>
       </ListContext.Provider>

--- a/src/components/MenuSection/MenuSection.types.ts
+++ b/src/components/MenuSection/MenuSection.types.ts
@@ -18,16 +18,4 @@ export interface Props<T> {
    * Handler to be called when this element is selected
    */
   onAction?: (key: Key) => void;
-
-  /**
-   * Determines the orientation of the list
-   *
-   * The orientation of the list change the keyboard navigation in the list:
-   *
-   * - vertical: up and down arrow keys
-   * - horizontal: left and right arrow keys
-   *
-   * @default 'vertical'
-   */
-  orientation?: ListOrientation
 }

--- a/src/components/MenuSection/MenuSection.unit.test.tsx.snap
+++ b/src/components/MenuSection/MenuSection.unit.test.tsx.snap
@@ -198,7 +198,7 @@ exports[`<MenuSection /> snapshot should match snapshot 1`] = `
     }
   }
 >
-  <ul
+  <div
     role="presentation"
   >
     <span
@@ -765,6 +765,6 @@ exports[`<MenuSection /> snapshot should match snapshot 1`] = `
         </ListItemBase>
       </MenuItem>
     </ul>
-  </ul>
+  </div>
 </MenuSection>
 `;

--- a/src/components/MenuSection/MenuSection.unit.test.tsx.snap
+++ b/src/components/MenuSection/MenuSection.unit.test.tsx.snap
@@ -212,7 +212,6 @@ exports[`<MenuSection /> snapshot should match snapshot 1`] = `
       aria-label="section"
       aria-labelledby="test-ID"
       className="md-menu-section-wrapper"
-      onKeyDown={[Function]}
       role="group"
     >
       <MenuItem
@@ -241,7 +240,6 @@ exports[`<MenuSection /> snapshot should match snapshot 1`] = `
             "wrapper": undefined,
           }
         }
-        itemIndex={0}
         key="$.0.0"
         state={
           Object {
@@ -425,7 +423,6 @@ exports[`<MenuSection /> snapshot should match snapshot 1`] = `
           data-key="$.0.0"
           isDisabled={false}
           isPadded={true}
-          itemIndex={0}
           onClick={[Function]}
           onDragStart={[Function]}
           onFocus={[Function]}
@@ -518,7 +515,6 @@ exports[`<MenuSection /> snapshot should match snapshot 1`] = `
             "wrapper": undefined,
           }
         }
-        itemIndex={1}
         key="$.0.1"
         state={
           Object {
@@ -702,7 +698,6 @@ exports[`<MenuSection /> snapshot should match snapshot 1`] = `
           data-key="$.0.1"
           isDisabled={false}
           isPadded={true}
-          itemIndex={1}
           onClick={[Function]}
           onDragStart={[Function]}
           onFocus={[Function]}

--- a/src/components/MenuTrigger/MenuTrigger.unit.test.tsx.snap
+++ b/src/components/MenuTrigger/MenuTrigger.unit.test.tsx.snap
@@ -526,7 +526,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot 1`] = `
                             "wrapper": undefined,
                           }
                         }
-                        itemIndex={0}
                         key="one"
                         state={
                           Object {
@@ -710,7 +709,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot 1`] = `
                           data-key="one"
                           isDisabled={false}
                           isPadded={true}
-                          itemIndex={0}
                           onClick={[Function]}
                           onDragStart={[Function]}
                           onFocus={[Function]}
@@ -804,7 +802,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot 1`] = `
                             "wrapper": undefined,
                           }
                         }
-                        itemIndex={1}
                         key="two"
                         state={
                           Object {
@@ -988,7 +985,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot 1`] = `
                           data-key="two"
                           isDisabled={false}
                           isPadded={true}
-                          itemIndex={1}
                           onClick={[Function]}
                           onDragStart={[Function]}
                           onFocus={[Function]}
@@ -1082,7 +1078,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot 1`] = `
                             "wrapper": undefined,
                           }
                         }
-                        itemIndex={2}
                         key="three"
                         state={
                           Object {
@@ -1266,7 +1261,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot 1`] = `
                           data-key="three"
                           isDisabled={false}
                           isPadded={true}
-                          itemIndex={2}
                           onClick={[Function]}
                           onDragStart={[Function]}
                           onFocus={[Function]}
@@ -1385,7 +1379,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot 1`] = `
                             "wrapper": undefined,
                           }
                         }
-                        itemIndex={0}
                         key="asd"
                         state={
                           Object {
@@ -1569,7 +1562,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot 1`] = `
                           data-key="asd"
                           isDisabled={false}
                           isPadded={true}
-                          itemIndex={0}
                           onClick={[Function]}
                           onDragStart={[Function]}
                           onFocus={[Function]}
@@ -1663,7 +1655,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot 1`] = `
                             "wrapper": undefined,
                           }
                         }
-                        itemIndex={1}
                         key="ff"
                         state={
                           Object {
@@ -1847,7 +1838,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot 1`] = `
                           data-key="ff"
                           isDisabled={false}
                           isPadded={true}
-                          itemIndex={1}
                           onClick={[Function]}
                           onDragStart={[Function]}
                           onFocus={[Function]}
@@ -1941,7 +1931,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot 1`] = `
                             "wrapper": undefined,
                           }
                         }
-                        itemIndex={2}
                         key="d"
                         state={
                           Object {
@@ -2125,7 +2114,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot 1`] = `
                           data-key="d"
                           isDisabled={false}
                           isPadded={true}
-                          itemIndex={2}
                           onClick={[Function]}
                           onDragStart={[Function]}
                           onFocus={[Function]}
@@ -2738,7 +2726,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with className 
                             "wrapper": undefined,
                           }
                         }
-                        itemIndex={0}
                         key="one"
                         state={
                           Object {
@@ -2922,7 +2909,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with className 
                           data-key="one"
                           isDisabled={false}
                           isPadded={true}
-                          itemIndex={0}
                           onClick={[Function]}
                           onDragStart={[Function]}
                           onFocus={[Function]}
@@ -3016,7 +3002,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with className 
                             "wrapper": undefined,
                           }
                         }
-                        itemIndex={1}
                         key="two"
                         state={
                           Object {
@@ -3200,7 +3185,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with className 
                           data-key="two"
                           isDisabled={false}
                           isPadded={true}
-                          itemIndex={1}
                           onClick={[Function]}
                           onDragStart={[Function]}
                           onFocus={[Function]}
@@ -3294,7 +3278,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with className 
                             "wrapper": undefined,
                           }
                         }
-                        itemIndex={2}
                         key="three"
                         state={
                           Object {
@@ -3478,7 +3461,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with className 
                           data-key="three"
                           isDisabled={false}
                           isPadded={true}
-                          itemIndex={2}
                           onClick={[Function]}
                           onDragStart={[Function]}
                           onFocus={[Function]}
@@ -3597,7 +3579,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with className 
                             "wrapper": undefined,
                           }
                         }
-                        itemIndex={0}
                         key="asd"
                         state={
                           Object {
@@ -3781,7 +3762,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with className 
                           data-key="asd"
                           isDisabled={false}
                           isPadded={true}
-                          itemIndex={0}
                           onClick={[Function]}
                           onDragStart={[Function]}
                           onFocus={[Function]}
@@ -3875,7 +3855,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with className 
                             "wrapper": undefined,
                           }
                         }
-                        itemIndex={1}
                         key="ff"
                         state={
                           Object {
@@ -4059,7 +4038,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with className 
                           data-key="ff"
                           isDisabled={false}
                           isPadded={true}
-                          itemIndex={1}
                           onClick={[Function]}
                           onDragStart={[Function]}
                           onFocus={[Function]}
@@ -4153,7 +4131,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with className 
                             "wrapper": undefined,
                           }
                         }
-                        itemIndex={2}
                         key="d"
                         state={
                           Object {
@@ -4337,7 +4314,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with className 
                           data-key="d"
                           isDisabled={false}
                           isPadded={true}
-                          itemIndex={2}
                           onClick={[Function]}
                           onDragStart={[Function]}
                           onFocus={[Function]}
@@ -4950,7 +4926,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with color 1`] 
                             "wrapper": undefined,
                           }
                         }
-                        itemIndex={0}
                         key="one"
                         state={
                           Object {
@@ -5134,7 +5109,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with color 1`] 
                           data-key="one"
                           isDisabled={false}
                           isPadded={true}
-                          itemIndex={0}
                           onClick={[Function]}
                           onDragStart={[Function]}
                           onFocus={[Function]}
@@ -5228,7 +5202,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with color 1`] 
                             "wrapper": undefined,
                           }
                         }
-                        itemIndex={1}
                         key="two"
                         state={
                           Object {
@@ -5412,7 +5385,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with color 1`] 
                           data-key="two"
                           isDisabled={false}
                           isPadded={true}
-                          itemIndex={1}
                           onClick={[Function]}
                           onDragStart={[Function]}
                           onFocus={[Function]}
@@ -5506,7 +5478,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with color 1`] 
                             "wrapper": undefined,
                           }
                         }
-                        itemIndex={2}
                         key="three"
                         state={
                           Object {
@@ -5690,7 +5661,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with color 1`] 
                           data-key="three"
                           isDisabled={false}
                           isPadded={true}
-                          itemIndex={2}
                           onClick={[Function]}
                           onDragStart={[Function]}
                           onFocus={[Function]}
@@ -5809,7 +5779,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with color 1`] 
                             "wrapper": undefined,
                           }
                         }
-                        itemIndex={0}
                         key="asd"
                         state={
                           Object {
@@ -5993,7 +5962,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with color 1`] 
                           data-key="asd"
                           isDisabled={false}
                           isPadded={true}
-                          itemIndex={0}
                           onClick={[Function]}
                           onDragStart={[Function]}
                           onFocus={[Function]}
@@ -6087,7 +6055,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with color 1`] 
                             "wrapper": undefined,
                           }
                         }
-                        itemIndex={1}
                         key="ff"
                         state={
                           Object {
@@ -6271,7 +6238,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with color 1`] 
                           data-key="ff"
                           isDisabled={false}
                           isPadded={true}
-                          itemIndex={1}
                           onClick={[Function]}
                           onDragStart={[Function]}
                           onFocus={[Function]}
@@ -6365,7 +6331,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with color 1`] 
                             "wrapper": undefined,
                           }
                         }
-                        itemIndex={2}
                         key="d"
                         state={
                           Object {
@@ -6549,7 +6514,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with color 1`] 
                           data-key="d"
                           isDisabled={false}
                           isPadded={true}
-                          itemIndex={2}
                           onClick={[Function]}
                           onDragStart={[Function]}
                           onFocus={[Function]}
@@ -7166,7 +7130,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with id 1`] = `
                             "wrapper": undefined,
                           }
                         }
-                        itemIndex={0}
                         key="one"
                         state={
                           Object {
@@ -7350,7 +7313,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with id 1`] = `
                           data-key="one"
                           isDisabled={false}
                           isPadded={true}
-                          itemIndex={0}
                           onClick={[Function]}
                           onDragStart={[Function]}
                           onFocus={[Function]}
@@ -7444,7 +7406,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with id 1`] = `
                             "wrapper": undefined,
                           }
                         }
-                        itemIndex={1}
                         key="two"
                         state={
                           Object {
@@ -7628,7 +7589,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with id 1`] = `
                           data-key="two"
                           isDisabled={false}
                           isPadded={true}
-                          itemIndex={1}
                           onClick={[Function]}
                           onDragStart={[Function]}
                           onFocus={[Function]}
@@ -7722,7 +7682,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with id 1`] = `
                             "wrapper": undefined,
                           }
                         }
-                        itemIndex={2}
                         key="three"
                         state={
                           Object {
@@ -7906,7 +7865,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with id 1`] = `
                           data-key="three"
                           isDisabled={false}
                           isPadded={true}
-                          itemIndex={2}
                           onClick={[Function]}
                           onDragStart={[Function]}
                           onFocus={[Function]}
@@ -8025,7 +7983,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with id 1`] = `
                             "wrapper": undefined,
                           }
                         }
-                        itemIndex={0}
                         key="asd"
                         state={
                           Object {
@@ -8209,7 +8166,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with id 1`] = `
                           data-key="asd"
                           isDisabled={false}
                           isPadded={true}
-                          itemIndex={0}
                           onClick={[Function]}
                           onDragStart={[Function]}
                           onFocus={[Function]}
@@ -8303,7 +8259,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with id 1`] = `
                             "wrapper": undefined,
                           }
                         }
-                        itemIndex={1}
                         key="ff"
                         state={
                           Object {
@@ -8487,7 +8442,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with id 1`] = `
                           data-key="ff"
                           isDisabled={false}
                           isPadded={true}
-                          itemIndex={1}
                           onClick={[Function]}
                           onDragStart={[Function]}
                           onFocus={[Function]}
@@ -8581,7 +8535,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with id 1`] = `
                             "wrapper": undefined,
                           }
                         }
-                        itemIndex={2}
                         key="d"
                         state={
                           Object {
@@ -8765,7 +8718,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with id 1`] = `
                           data-key="d"
                           isDisabled={false}
                           isPadded={true}
-                          itemIndex={2}
                           onClick={[Function]}
                           onDragStart={[Function]}
                           onFocus={[Function]}
@@ -9378,7 +9330,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with placement 
                             "wrapper": undefined,
                           }
                         }
-                        itemIndex={0}
                         key="one"
                         state={
                           Object {
@@ -9562,7 +9513,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with placement 
                           data-key="one"
                           isDisabled={false}
                           isPadded={true}
-                          itemIndex={0}
                           onClick={[Function]}
                           onDragStart={[Function]}
                           onFocus={[Function]}
@@ -9656,7 +9606,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with placement 
                             "wrapper": undefined,
                           }
                         }
-                        itemIndex={1}
                         key="two"
                         state={
                           Object {
@@ -9840,7 +9789,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with placement 
                           data-key="two"
                           isDisabled={false}
                           isPadded={true}
-                          itemIndex={1}
                           onClick={[Function]}
                           onDragStart={[Function]}
                           onFocus={[Function]}
@@ -9934,7 +9882,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with placement 
                             "wrapper": undefined,
                           }
                         }
-                        itemIndex={2}
                         key="three"
                         state={
                           Object {
@@ -10118,7 +10065,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with placement 
                           data-key="three"
                           isDisabled={false}
                           isPadded={true}
-                          itemIndex={2}
                           onClick={[Function]}
                           onDragStart={[Function]}
                           onFocus={[Function]}
@@ -10237,7 +10183,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with placement 
                             "wrapper": undefined,
                           }
                         }
-                        itemIndex={0}
                         key="asd"
                         state={
                           Object {
@@ -10421,7 +10366,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with placement 
                           data-key="asd"
                           isDisabled={false}
                           isPadded={true}
-                          itemIndex={0}
                           onClick={[Function]}
                           onDragStart={[Function]}
                           onFocus={[Function]}
@@ -10515,7 +10459,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with placement 
                             "wrapper": undefined,
                           }
                         }
-                        itemIndex={1}
                         key="ff"
                         state={
                           Object {
@@ -10699,7 +10642,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with placement 
                           data-key="ff"
                           isDisabled={false}
                           isPadded={true}
-                          itemIndex={1}
                           onClick={[Function]}
                           onDragStart={[Function]}
                           onFocus={[Function]}
@@ -10793,7 +10735,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with placement 
                             "wrapper": undefined,
                           }
                         }
-                        itemIndex={2}
                         key="d"
                         state={
                           Object {
@@ -10977,7 +10918,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with placement 
                           data-key="d"
                           isDisabled={false}
                           isPadded={true}
-                          itemIndex={2}
                           onClick={[Function]}
                           onDragStart={[Function]}
                           onFocus={[Function]}
@@ -11621,7 +11561,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with showArrow 
                             "wrapper": undefined,
                           }
                         }
-                        itemIndex={0}
                         key="one"
                         state={
                           Object {
@@ -11805,7 +11744,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with showArrow 
                           data-key="one"
                           isDisabled={false}
                           isPadded={true}
-                          itemIndex={0}
                           onClick={[Function]}
                           onDragStart={[Function]}
                           onFocus={[Function]}
@@ -11899,7 +11837,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with showArrow 
                             "wrapper": undefined,
                           }
                         }
-                        itemIndex={1}
                         key="two"
                         state={
                           Object {
@@ -12083,7 +12020,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with showArrow 
                           data-key="two"
                           isDisabled={false}
                           isPadded={true}
-                          itemIndex={1}
                           onClick={[Function]}
                           onDragStart={[Function]}
                           onFocus={[Function]}
@@ -12177,7 +12113,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with showArrow 
                             "wrapper": undefined,
                           }
                         }
-                        itemIndex={2}
                         key="three"
                         state={
                           Object {
@@ -12361,7 +12296,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with showArrow 
                           data-key="three"
                           isDisabled={false}
                           isPadded={true}
-                          itemIndex={2}
                           onClick={[Function]}
                           onDragStart={[Function]}
                           onFocus={[Function]}
@@ -12480,7 +12414,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with showArrow 
                             "wrapper": undefined,
                           }
                         }
-                        itemIndex={0}
                         key="asd"
                         state={
                           Object {
@@ -12664,7 +12597,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with showArrow 
                           data-key="asd"
                           isDisabled={false}
                           isPadded={true}
-                          itemIndex={0}
                           onClick={[Function]}
                           onDragStart={[Function]}
                           onFocus={[Function]}
@@ -12758,7 +12690,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with showArrow 
                             "wrapper": undefined,
                           }
                         }
-                        itemIndex={1}
                         key="ff"
                         state={
                           Object {
@@ -12942,7 +12873,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with showArrow 
                           data-key="ff"
                           isDisabled={false}
                           isPadded={true}
-                          itemIndex={1}
                           onClick={[Function]}
                           onDragStart={[Function]}
                           onFocus={[Function]}
@@ -13036,7 +12966,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with showArrow 
                             "wrapper": undefined,
                           }
                         }
-                        itemIndex={2}
                         key="d"
                         state={
                           Object {
@@ -13220,7 +13149,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with showArrow 
                           data-key="d"
                           isDisabled={false}
                           isPadded={true}
-                          itemIndex={2}
                           onClick={[Function]}
                           onDragStart={[Function]}
                           onFocus={[Function]}
@@ -13888,7 +13816,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with style 1`] 
                             "wrapper": undefined,
                           }
                         }
-                        itemIndex={0}
                         key="one"
                         state={
                           Object {
@@ -14072,7 +13999,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with style 1`] 
                           data-key="one"
                           isDisabled={false}
                           isPadded={true}
-                          itemIndex={0}
                           onClick={[Function]}
                           onDragStart={[Function]}
                           onFocus={[Function]}
@@ -14166,7 +14092,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with style 1`] 
                             "wrapper": undefined,
                           }
                         }
-                        itemIndex={1}
                         key="two"
                         state={
                           Object {
@@ -14350,7 +14275,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with style 1`] 
                           data-key="two"
                           isDisabled={false}
                           isPadded={true}
-                          itemIndex={1}
                           onClick={[Function]}
                           onDragStart={[Function]}
                           onFocus={[Function]}
@@ -14444,7 +14368,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with style 1`] 
                             "wrapper": undefined,
                           }
                         }
-                        itemIndex={2}
                         key="three"
                         state={
                           Object {
@@ -14628,7 +14551,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with style 1`] 
                           data-key="three"
                           isDisabled={false}
                           isPadded={true}
-                          itemIndex={2}
                           onClick={[Function]}
                           onDragStart={[Function]}
                           onFocus={[Function]}
@@ -14747,7 +14669,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with style 1`] 
                             "wrapper": undefined,
                           }
                         }
-                        itemIndex={0}
                         key="asd"
                         state={
                           Object {
@@ -14931,7 +14852,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with style 1`] 
                           data-key="asd"
                           isDisabled={false}
                           isPadded={true}
-                          itemIndex={0}
                           onClick={[Function]}
                           onDragStart={[Function]}
                           onFocus={[Function]}
@@ -15025,7 +14945,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with style 1`] 
                             "wrapper": undefined,
                           }
                         }
-                        itemIndex={1}
                         key="ff"
                         state={
                           Object {
@@ -15209,7 +15128,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with style 1`] 
                           data-key="ff"
                           isDisabled={false}
                           isPadded={true}
-                          itemIndex={1}
                           onClick={[Function]}
                           onDragStart={[Function]}
                           onFocus={[Function]}
@@ -15303,7 +15221,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with style 1`] 
                             "wrapper": undefined,
                           }
                         }
-                        itemIndex={2}
                         key="d"
                         state={
                           Object {
@@ -15487,7 +15404,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with style 1`] 
                           data-key="d"
                           isDisabled={false}
                           isPadded={true}
-                          itemIndex={2}
                           onClick={[Function]}
                           onDragStart={[Function]}
                           onFocus={[Function]}
@@ -16100,7 +16016,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with variant 1`
                             "wrapper": undefined,
                           }
                         }
-                        itemIndex={0}
                         key="one"
                         state={
                           Object {
@@ -16284,7 +16199,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with variant 1`
                           data-key="one"
                           isDisabled={false}
                           isPadded={true}
-                          itemIndex={0}
                           onClick={[Function]}
                           onDragStart={[Function]}
                           onFocus={[Function]}
@@ -16378,7 +16292,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with variant 1`
                             "wrapper": undefined,
                           }
                         }
-                        itemIndex={1}
                         key="two"
                         state={
                           Object {
@@ -16562,7 +16475,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with variant 1`
                           data-key="two"
                           isDisabled={false}
                           isPadded={true}
-                          itemIndex={1}
                           onClick={[Function]}
                           onDragStart={[Function]}
                           onFocus={[Function]}
@@ -16656,7 +16568,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with variant 1`
                             "wrapper": undefined,
                           }
                         }
-                        itemIndex={2}
                         key="three"
                         state={
                           Object {
@@ -16840,7 +16751,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with variant 1`
                           data-key="three"
                           isDisabled={false}
                           isPadded={true}
-                          itemIndex={2}
                           onClick={[Function]}
                           onDragStart={[Function]}
                           onFocus={[Function]}
@@ -16959,7 +16869,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with variant 1`
                             "wrapper": undefined,
                           }
                         }
-                        itemIndex={0}
                         key="asd"
                         state={
                           Object {
@@ -17143,7 +17052,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with variant 1`
                           data-key="asd"
                           isDisabled={false}
                           isPadded={true}
-                          itemIndex={0}
                           onClick={[Function]}
                           onDragStart={[Function]}
                           onFocus={[Function]}
@@ -17237,7 +17145,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with variant 1`
                             "wrapper": undefined,
                           }
                         }
-                        itemIndex={1}
                         key="ff"
                         state={
                           Object {
@@ -17421,7 +17328,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with variant 1`
                           data-key="ff"
                           isDisabled={false}
                           isPadded={true}
-                          itemIndex={1}
                           onClick={[Function]}
                           onDragStart={[Function]}
                           onFocus={[Function]}
@@ -17515,7 +17421,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with variant 1`
                             "wrapper": undefined,
                           }
                         }
-                        itemIndex={2}
                         key="d"
                         state={
                           Object {
@@ -17699,7 +17604,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with variant 1`
                           data-key="d"
                           isDisabled={false}
                           isPadded={true}
-                          itemIndex={2}
                           onClick={[Function]}
                           onDragStart={[Function]}
                           onFocus={[Function]}
@@ -18316,7 +18220,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with zIndex 1`]
                             "wrapper": undefined,
                           }
                         }
-                        itemIndex={0}
                         key="one"
                         state={
                           Object {
@@ -18500,7 +18403,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with zIndex 1`]
                           data-key="one"
                           isDisabled={false}
                           isPadded={true}
-                          itemIndex={0}
                           onClick={[Function]}
                           onDragStart={[Function]}
                           onFocus={[Function]}
@@ -18594,7 +18496,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with zIndex 1`]
                             "wrapper": undefined,
                           }
                         }
-                        itemIndex={1}
                         key="two"
                         state={
                           Object {
@@ -18778,7 +18679,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with zIndex 1`]
                           data-key="two"
                           isDisabled={false}
                           isPadded={true}
-                          itemIndex={1}
                           onClick={[Function]}
                           onDragStart={[Function]}
                           onFocus={[Function]}
@@ -18872,7 +18772,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with zIndex 1`]
                             "wrapper": undefined,
                           }
                         }
-                        itemIndex={2}
                         key="three"
                         state={
                           Object {
@@ -19056,7 +18955,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with zIndex 1`]
                           data-key="three"
                           isDisabled={false}
                           isPadded={true}
-                          itemIndex={2}
                           onClick={[Function]}
                           onDragStart={[Function]}
                           onFocus={[Function]}
@@ -19175,7 +19073,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with zIndex 1`]
                             "wrapper": undefined,
                           }
                         }
-                        itemIndex={0}
                         key="asd"
                         state={
                           Object {
@@ -19359,7 +19256,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with zIndex 1`]
                           data-key="asd"
                           isDisabled={false}
                           isPadded={true}
-                          itemIndex={0}
                           onClick={[Function]}
                           onDragStart={[Function]}
                           onFocus={[Function]}
@@ -19453,7 +19349,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with zIndex 1`]
                             "wrapper": undefined,
                           }
                         }
-                        itemIndex={1}
                         key="ff"
                         state={
                           Object {
@@ -19637,7 +19532,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with zIndex 1`]
                           data-key="ff"
                           isDisabled={false}
                           isPadded={true}
-                          itemIndex={1}
                           onClick={[Function]}
                           onDragStart={[Function]}
                           onFocus={[Function]}
@@ -19731,7 +19625,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with zIndex 1`]
                             "wrapper": undefined,
                           }
                         }
-                        itemIndex={2}
                         key="d"
                         state={
                           Object {
@@ -19915,7 +19808,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with zIndex 1`]
                           data-key="d"
                           isDisabled={false}
                           isPadded={true}
-                          itemIndex={2}
                           onClick={[Function]}
                           onDragStart={[Function]}
                           onFocus={[Function]}

--- a/src/components/MenuTrigger/MenuTrigger.unit.test.tsx.snap
+++ b/src/components/MenuTrigger/MenuTrigger.unit.test.tsx.snap
@@ -292,7 +292,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot 1`] = `
                   data-round="75"
                   role="dialog"
                 >
-                  <ul
+                  <div
                     class="md-menu-wrapper"
                     id="test-ID"
                     role="menu"
@@ -361,12 +361,12 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot 1`] = `
                         Three
                       </div>
                     </li>
-                  </ul>
+                  </div>
                   <li
                     class="md-content-separator-wrapper"
                     role="separator"
                   />
-                  <ul
+                  <div
                     class="md-menu-wrapper"
                     id="test-ID"
                     role="menu"
@@ -435,7 +435,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot 1`] = `
                         Six
                       </div>
                     </li>
-                  </ul>
+                  </div>
                 </div>
                 <span
                   data-focus-scope-end="true"
@@ -490,7 +490,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot 1`] = `
                     key=".$2"
                     selectionMode="single"
                   >
-                    <ul
+                    <div
                       className="md-menu-wrapper"
                       id="test-ID"
                       onBlur={[Function]}
@@ -1329,7 +1329,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot 1`] = `
                           </FocusRing>
                         </ListItemBase>
                       </MenuItem>
-                    </ul>
+                    </div>
                   </_Menu>
                   <ContentSeparator
                     key="separator-0"
@@ -1343,7 +1343,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot 1`] = `
                     key=".$4"
                     selectionMode="multiple"
                   >
-                    <ul
+                    <div
                       className="md-menu-wrapper"
                       id="test-ID"
                       onBlur={[Function]}
@@ -2182,7 +2182,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot 1`] = `
                           </FocusRing>
                         </ListItemBase>
                       </MenuItem>
-                    </ul>
+                    </div>
                   </_Menu>
                 </div>
                 <span
@@ -2492,7 +2492,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with className 
                   data-round="75"
                   role="dialog"
                 >
-                  <ul
+                  <div
                     class="md-menu-wrapper"
                     id="test-ID"
                     role="menu"
@@ -2561,12 +2561,12 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with className 
                         Three
                       </div>
                     </li>
-                  </ul>
+                  </div>
                   <li
                     class="md-content-separator-wrapper"
                     role="separator"
                   />
-                  <ul
+                  <div
                     class="md-menu-wrapper"
                     id="test-ID"
                     role="menu"
@@ -2635,7 +2635,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with className 
                         Six
                       </div>
                     </li>
-                  </ul>
+                  </div>
                 </div>
                 <span
                   data-focus-scope-end="true"
@@ -2690,7 +2690,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with className 
                     key=".$2"
                     selectionMode="single"
                   >
-                    <ul
+                    <div
                       className="md-menu-wrapper"
                       id="test-ID"
                       onBlur={[Function]}
@@ -3529,7 +3529,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with className 
                           </FocusRing>
                         </ListItemBase>
                       </MenuItem>
-                    </ul>
+                    </div>
                   </_Menu>
                   <ContentSeparator
                     key="separator-0"
@@ -3543,7 +3543,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with className 
                     key=".$4"
                     selectionMode="multiple"
                   >
-                    <ul
+                    <div
                       className="md-menu-wrapper"
                       id="test-ID"
                       onBlur={[Function]}
@@ -4382,7 +4382,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with className 
                           </FocusRing>
                         </ListItemBase>
                       </MenuItem>
-                    </ul>
+                    </div>
                   </_Menu>
                 </div>
                 <span
@@ -4692,7 +4692,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with color 1`] 
                   data-round="75"
                   role="dialog"
                 >
-                  <ul
+                  <div
                     class="md-menu-wrapper"
                     id="test-ID"
                     role="menu"
@@ -4761,12 +4761,12 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with color 1`] 
                         Three
                       </div>
                     </li>
-                  </ul>
+                  </div>
                   <li
                     class="md-content-separator-wrapper"
                     role="separator"
                   />
-                  <ul
+                  <div
                     class="md-menu-wrapper"
                     id="test-ID"
                     role="menu"
@@ -4835,7 +4835,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with color 1`] 
                         Six
                       </div>
                     </li>
-                  </ul>
+                  </div>
                 </div>
                 <span
                   data-focus-scope-end="true"
@@ -4890,7 +4890,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with color 1`] 
                     key=".$2"
                     selectionMode="single"
                   >
-                    <ul
+                    <div
                       className="md-menu-wrapper"
                       id="test-ID"
                       onBlur={[Function]}
@@ -5729,7 +5729,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with color 1`] 
                           </FocusRing>
                         </ListItemBase>
                       </MenuItem>
-                    </ul>
+                    </div>
                   </_Menu>
                   <ContentSeparator
                     key="separator-0"
@@ -5743,7 +5743,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with color 1`] 
                     key=".$4"
                     selectionMode="multiple"
                   >
-                    <ul
+                    <div
                       className="md-menu-wrapper"
                       id="test-ID"
                       onBlur={[Function]}
@@ -6582,7 +6582,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with color 1`] 
                           </FocusRing>
                         </ListItemBase>
                       </MenuItem>
-                    </ul>
+                    </div>
                   </_Menu>
                 </div>
                 <span
@@ -6894,7 +6894,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with id 1`] = `
                   id="example-id"
                   role="dialog"
                 >
-                  <ul
+                  <div
                     class="md-menu-wrapper"
                     id="test-ID"
                     role="menu"
@@ -6963,12 +6963,12 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with id 1`] = `
                         Three
                       </div>
                     </li>
-                  </ul>
+                  </div>
                   <li
                     class="md-content-separator-wrapper"
                     role="separator"
                   />
-                  <ul
+                  <div
                     class="md-menu-wrapper"
                     id="test-ID"
                     role="menu"
@@ -7037,7 +7037,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with id 1`] = `
                         Six
                       </div>
                     </li>
-                  </ul>
+                  </div>
                 </div>
                 <span
                   data-focus-scope-end="true"
@@ -7094,7 +7094,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with id 1`] = `
                     key=".$2"
                     selectionMode="single"
                   >
-                    <ul
+                    <div
                       className="md-menu-wrapper"
                       id="test-ID"
                       onBlur={[Function]}
@@ -7933,7 +7933,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with id 1`] = `
                           </FocusRing>
                         </ListItemBase>
                       </MenuItem>
-                    </ul>
+                    </div>
                   </_Menu>
                   <ContentSeparator
                     key="separator-0"
@@ -7947,7 +7947,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with id 1`] = `
                     key=".$4"
                     selectionMode="multiple"
                   >
-                    <ul
+                    <div
                       className="md-menu-wrapper"
                       id="test-ID"
                       onBlur={[Function]}
@@ -8786,7 +8786,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with id 1`] = `
                           </FocusRing>
                         </ListItemBase>
                       </MenuItem>
-                    </ul>
+                    </div>
                   </_Menu>
                 </div>
                 <span
@@ -9096,7 +9096,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with placement 
                   data-round="75"
                   role="dialog"
                 >
-                  <ul
+                  <div
                     class="md-menu-wrapper"
                     id="test-ID"
                     role="menu"
@@ -9165,12 +9165,12 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with placement 
                         Three
                       </div>
                     </li>
-                  </ul>
+                  </div>
                   <li
                     class="md-content-separator-wrapper"
                     role="separator"
                   />
-                  <ul
+                  <div
                     class="md-menu-wrapper"
                     id="test-ID"
                     role="menu"
@@ -9239,7 +9239,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with placement 
                         Six
                       </div>
                     </li>
-                  </ul>
+                  </div>
                 </div>
                 <span
                   data-focus-scope-end="true"
@@ -9294,7 +9294,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with placement 
                     key=".$2"
                     selectionMode="single"
                   >
-                    <ul
+                    <div
                       className="md-menu-wrapper"
                       id="test-ID"
                       onBlur={[Function]}
@@ -10133,7 +10133,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with placement 
                           </FocusRing>
                         </ListItemBase>
                       </MenuItem>
-                    </ul>
+                    </div>
                   </_Menu>
                   <ContentSeparator
                     key="separator-0"
@@ -10147,7 +10147,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with placement 
                     key=".$4"
                     selectionMode="multiple"
                   >
-                    <ul
+                    <div
                       className="md-menu-wrapper"
                       id="test-ID"
                       onBlur={[Function]}
@@ -10986,7 +10986,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with placement 
                           </FocusRing>
                         </ListItemBase>
                       </MenuItem>
-                    </ul>
+                    </div>
                   </_Menu>
                 </div>
                 <span
@@ -11296,7 +11296,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with showArrow 
                   data-round="75"
                   role="dialog"
                 >
-                  <ul
+                  <div
                     class="md-menu-wrapper"
                     id="test-ID"
                     role="menu"
@@ -11365,12 +11365,12 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with showArrow 
                         Three
                       </div>
                     </li>
-                  </ul>
+                  </div>
                   <li
                     class="md-content-separator-wrapper"
                     role="separator"
                   />
-                  <ul
+                  <div
                     class="md-menu-wrapper"
                     id="test-ID"
                     role="menu"
@@ -11439,7 +11439,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with showArrow 
                         Six
                       </div>
                     </li>
-                  </ul>
+                  </div>
                   <div
                     class="md-modal-container-arrow-wrapper"
                     data-popper-arrow="true"
@@ -11525,7 +11525,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with showArrow 
                     key=".$2"
                     selectionMode="single"
                   >
-                    <ul
+                    <div
                       className="md-menu-wrapper"
                       id="test-ID"
                       onBlur={[Function]}
@@ -12364,7 +12364,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with showArrow 
                           </FocusRing>
                         </ListItemBase>
                       </MenuItem>
-                    </ul>
+                    </div>
                   </_Menu>
                   <ContentSeparator
                     key="separator-0"
@@ -12378,7 +12378,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with showArrow 
                     key=".$4"
                     selectionMode="multiple"
                   >
-                    <ul
+                    <div
                       className="md-menu-wrapper"
                       id="test-ID"
                       onBlur={[Function]}
@@ -13217,7 +13217,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with showArrow 
                           </FocusRing>
                         </ListItemBase>
                       </MenuItem>
-                    </ul>
+                    </div>
                   </_Menu>
                   <div
                     className="md-modal-container-arrow-wrapper"
@@ -13572,7 +13572,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with style 1`] 
                   role="dialog"
                   style="color: pink;"
                 >
-                  <ul
+                  <div
                     class="md-menu-wrapper"
                     id="test-ID"
                     role="menu"
@@ -13641,12 +13641,12 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with style 1`] 
                         Three
                       </div>
                     </li>
-                  </ul>
+                  </div>
                   <li
                     class="md-content-separator-wrapper"
                     role="separator"
                   />
-                  <ul
+                  <div
                     class="md-menu-wrapper"
                     id="test-ID"
                     role="menu"
@@ -13715,7 +13715,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with style 1`] 
                         Six
                       </div>
                     </li>
-                  </ul>
+                  </div>
                 </div>
                 <span
                   data-focus-scope-end="true"
@@ -13780,7 +13780,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with style 1`] 
                     key=".$2"
                     selectionMode="single"
                   >
-                    <ul
+                    <div
                       className="md-menu-wrapper"
                       id="test-ID"
                       onBlur={[Function]}
@@ -14619,7 +14619,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with style 1`] 
                           </FocusRing>
                         </ListItemBase>
                       </MenuItem>
-                    </ul>
+                    </div>
                   </_Menu>
                   <ContentSeparator
                     key="separator-0"
@@ -14633,7 +14633,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with style 1`] 
                     key=".$4"
                     selectionMode="multiple"
                   >
-                    <ul
+                    <div
                       className="md-menu-wrapper"
                       id="test-ID"
                       onBlur={[Function]}
@@ -15472,7 +15472,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with style 1`] 
                           </FocusRing>
                         </ListItemBase>
                       </MenuItem>
-                    </ul>
+                    </div>
                   </_Menu>
                 </div>
                 <span
@@ -15782,7 +15782,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with variant 1`
                   data-round="50"
                   role="dialog"
                 >
-                  <ul
+                  <div
                     class="md-menu-wrapper"
                     id="test-ID"
                     role="menu"
@@ -15851,12 +15851,12 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with variant 1`
                         Three
                       </div>
                     </li>
-                  </ul>
+                  </div>
                   <li
                     class="md-content-separator-wrapper"
                     role="separator"
                   />
-                  <ul
+                  <div
                     class="md-menu-wrapper"
                     id="test-ID"
                     role="menu"
@@ -15925,7 +15925,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with variant 1`
                         Six
                       </div>
                     </li>
-                  </ul>
+                  </div>
                 </div>
                 <span
                   data-focus-scope-end="true"
@@ -15980,7 +15980,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with variant 1`
                     key=".$2"
                     selectionMode="single"
                   >
-                    <ul
+                    <div
                       className="md-menu-wrapper"
                       id="test-ID"
                       onBlur={[Function]}
@@ -16819,7 +16819,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with variant 1`
                           </FocusRing>
                         </ListItemBase>
                       </MenuItem>
-                    </ul>
+                    </div>
                   </_Menu>
                   <ContentSeparator
                     key="separator-0"
@@ -16833,7 +16833,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with variant 1`
                     key=".$4"
                     selectionMode="multiple"
                   >
-                    <ul
+                    <div
                       className="md-menu-wrapper"
                       id="test-ID"
                       onBlur={[Function]}
@@ -17672,7 +17672,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with variant 1`
                           </FocusRing>
                         </ListItemBase>
                       </MenuItem>
-                    </ul>
+                    </div>
                   </_Menu>
                 </div>
                 <span
@@ -17986,7 +17986,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with zIndex 1`]
                   data-round="75"
                   role="dialog"
                 >
-                  <ul
+                  <div
                     class="md-menu-wrapper"
                     id="test-ID"
                     role="menu"
@@ -18055,12 +18055,12 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with zIndex 1`]
                         Three
                       </div>
                     </li>
-                  </ul>
+                  </div>
                   <li
                     class="md-content-separator-wrapper"
                     role="separator"
                   />
-                  <ul
+                  <div
                     class="md-menu-wrapper"
                     id="test-ID"
                     role="menu"
@@ -18129,7 +18129,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with zIndex 1`]
                         Six
                       </div>
                     </li>
-                  </ul>
+                  </div>
                 </div>
                 <span
                   data-focus-scope-end="true"
@@ -18184,7 +18184,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with zIndex 1`]
                     key=".$2"
                     selectionMode="single"
                   >
-                    <ul
+                    <div
                       className="md-menu-wrapper"
                       id="test-ID"
                       onBlur={[Function]}
@@ -19023,7 +19023,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with zIndex 1`]
                           </FocusRing>
                         </ListItemBase>
                       </MenuItem>
-                    </ul>
+                    </div>
                   </_Menu>
                   <ContentSeparator
                     key="separator-0"
@@ -19037,7 +19037,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with zIndex 1`]
                     key=".$4"
                     selectionMode="multiple"
                   >
-                    <ul
+                    <div
                       className="md-menu-wrapper"
                       id="test-ID"
                       onBlur={[Function]}
@@ -19876,7 +19876,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with zIndex 1`]
                           </FocusRing>
                         </ListItemBase>
                       </MenuItem>
-                    </ul>
+                    </div>
                   </_Menu>
                 </div>
                 <span

--- a/src/hooks/useOrientationBasedKeyboardNavigation.ts
+++ b/src/hooks/useOrientationBasedKeyboardNavigation.ts
@@ -15,8 +15,8 @@ type IUseOrientationBasedKeyboardNavigationReturn = {
 };
 
 export type IUseOrientationBasedKeyboardNavigationProps = {
-  listSize: number;
-  orientation: ListOrientation;
+  listSize?: number;
+  orientation?: ListOrientation;
   noLoop?: boolean;
   contextProps?: {
     shouldFocusOnPress?: boolean;

--- a/src/hooks/useOrientationBasedKeyboardNavigation.ts
+++ b/src/hooks/useOrientationBasedKeyboardNavigation.ts
@@ -15,8 +15,8 @@ type IUseOrientationBasedKeyboardNavigationReturn = {
 };
 
 export type IUseOrientationBasedKeyboardNavigationProps = {
-  listSize?: number;
-  orientation?: ListOrientation;
+  listSize: number;
+  orientation: ListOrientation;
   noLoop?: boolean;
   contextProps?: {
     shouldFocusOnPress?: boolean;


### PR DESCRIPTION
# Description

1. Removing Multimenu story as we are no longer going to follow the approach of having more than 1 menu on a single popover.
2. For the previous reason, we are no longer needing the isGroupRole prop on Menu.
3. Google Chrome Settings Menu has horizontally displayed items that are navigated using up and down arrow key. For that reason, we are removing the orientation prop from Menu as we no longer need to enforce the kb navigation to left-right if the items are horizontally displayed.
4. We are removing any List/ul traces from Menu. We realized menus with sections had 3 layers of ul's without any purpose. 
5. We are letting menu navigation be dictated by react-aria useMenu hook, and not by list navigation hooks. For that reason, we are also removing itemIndex prop from MenuSection and MenuItem. 

# Links

*Links to relevent resources.*
