### PR TITLE
style(high-contrast): add focus outline, checkbox styles and tab active styles in high contrast mode

### DIFF
--- a/scss/tools/mixins/focus.scss
+++ b/scss/tools/mixins/focus.scss
@@ -5,12 +5,8 @@
     border-color: $border-color;
   }
 
-  outline: none !important;
+  outline: var(--md-globals-focus-ring-outline) !important;
   box-shadow: var(--md-globals-focus-ring-box-shadow);
-
-  @media (forced-colors: active) {
-    outline: 0.125rem solid var(--mds-color-theme-outline-theme-normal) !important;
-  }
 
   @if $focus-visible-only {
     &:not(:focus-visible) {

--- a/scss/tools/mixins/focus.scss
+++ b/scss/tools/mixins/focus.scss
@@ -9,7 +9,7 @@
   box-shadow: var(--md-globals-focus-ring-box-shadow);
 
   @media (forced-colors: active) {
-    outline: 2px solid var(--mds-color-theme-inverted-outline-theme-normal) !important;
+    outline: 0.125rem solid var(--mds-color-theme-inverted-outline-theme-normal) !important;
   }
 
   @if $focus-visible-only {

--- a/scss/tools/mixins/focus.scss
+++ b/scss/tools/mixins/focus.scss
@@ -9,7 +9,7 @@
   box-shadow: var(--md-globals-focus-ring-box-shadow);
 
   @media (forced-colors: active) {
-    outline: 0.125rem solid var(--mds-color-theme-inverted-outline-theme-normal) !important;
+    outline: 0.125rem solid var(--mds-color-theme-outline-theme-normal) !important;
   }
 
   @if $focus-visible-only {

--- a/scss/tools/mixins/focus.scss
+++ b/scss/tools/mixins/focus.scss
@@ -8,9 +8,17 @@
   outline: none !important;
   box-shadow: var(--md-globals-focus-ring-box-shadow);
 
+  @media (forced-colors: active) {
+    outline: 2px solid var(--mds-color-theme-inverted-outline-theme-normal) !important;
+  }
+
   @if $focus-visible-only {
     &:not(:focus-visible) {
       box-shadow: none;
+
+      @media (forced-colors: active) {
+        outline: none !important;
+      }
     }
   }
 }

--- a/src/components/Checkbox/Checkbox.style.scss
+++ b/src/components/Checkbox/Checkbox.style.scss
@@ -29,6 +29,10 @@
 
     > .md-checkbox-selected {
       background-color: var(--mds-color-theme-control-active-normal);
+
+      @media (forced-colors: active) {
+        background-color: FieldText;
+      }
     }
 
     > .md-checkbox-not-selected {
@@ -44,10 +48,18 @@
 
       > .md-checkbox-selected {
         background-color: var(--mds-color-theme-control-active-hover);
+
+        @media (forced-colors: active) {
+          background-color: SelectedItem;
+        }
       }
 
       > .md-checkbox-not-selected {
         background-color: var(--mds-color-theme-control-inactive-hover);
+
+        @media (forced-colors: active) {
+          border-color: SelectedItem;
+        }
       }
     }
 
@@ -66,11 +78,19 @@
 
     .md-checkbox-focus {
       box-shadow: var(--md-globals-focus-ring-box-shadow-accent);
+
+      @media (forced-colors: active) {
+        outline: var(--md-globals-focus-ring-outline) !important;
+      }
     }
 
     &.focus {
       .checkbox {
         box-shadow: var(--md-globals-focus-ring-box-shadow-accent);
+
+        @media (forced-colors: active) {
+          outline: var(--md-globals-focus-ring-outline) !important;
+        }
       }
     }
   }

--- a/src/components/Checkbox/Checkbox.style.scss
+++ b/src/components/Checkbox/Checkbox.style.scss
@@ -32,6 +32,10 @@
 
       @media (forced-colors: active) {
         background-color: FieldText;
+
+        svg {
+          fill: Field;
+        }
       }
     }
 

--- a/src/components/FocusRing/FocusRing.style.scss
+++ b/src/components/FocusRing/FocusRing.style.scss
@@ -7,9 +7,11 @@
 
   &.md-focus-ring-inset {
     box-shadow: var(--md-globals-focus-ring-box-shadow-inset);
+    outline-offset: -0.125rem;
   }
 }
 
 .md-focus-ring-wrapper-disabled {
   box-shadow: none;
+  outline: none;
 }

--- a/src/components/NavigationTab/NavigationTab.style.scss
+++ b/src/components/NavigationTab/NavigationTab.style.scss
@@ -45,6 +45,11 @@
   &[data-active='true'] {
     background-color: var(--mds-color-theme-button-secondary-pressed);
 
+    @media (forced-colors: active) {
+      background-color: SelectedItem;
+      color: SelectedItemText;
+    }
+
     > .md-navigation-tab-icon > * {
       color: var(--mds-color-theme-text-primary-normal);
     }

--- a/src/components/Tab/Tab.style.scss
+++ b/src/components/Tab/Tab.style.scss
@@ -47,6 +47,11 @@
   &[data-active='true'] {
     background-color: var(--mds-color-theme-button-secondary-active-normal);
 
+    @media (forced-colors: active) {
+      background-color: SelectedItem;
+      color: SelectedItemText;
+    }
+
     .md-text-wrapper,
     .md-icon-wrapper {
       color: var(--mds-color-theme-text-secondary-normal);

--- a/src/components/ThemeProvider/ThemeProvider.style.scss
+++ b/src/components/ThemeProvider/ThemeProvider.style.scss
@@ -53,6 +53,10 @@
   --md-globals-border-style-none: none;
   --md-globals-border-style-solid: solid;
 
+  @media (forced-colors: active) {
+    --md-globals-focus-ring-outline: 0.125rem solid var(--mds-color-theme-outline-theme-normal);
+  }
+
   // Gradient backgrounds
   --md-globals-gradient-primary: var(--mds-color-theme-background-gradient-primary-normal);
   --md-globals-gradient-secondary: var(--mds-color-theme-background-gradient-secondary-normal);


### PR DESCRIPTION
# Description

When Windows High Contrast mode is enabled, certain CSS properties are forced to have certain values. One of these is `box-shadow` which is forced to `none`.

`box-shadow` is used to display the focused element therefore we need a alternative. Since `outline` is already forced to none when using the `focus-styles` mixin, we can use it to display a focus ring.

# Examples
Unfocused:
![image](https://github.com/user-attachments/assets/ab080e9e-902b-4561-989a-e1cd858fc944)

Focused:
![image](https://github.com/user-attachments/assets/abd098d4-466e-4d05-b02e-301548f813c4)

---

Unfocused:
![image](https://github.com/user-attachments/assets/ee49d3b9-7d97-4c8c-b22e-676cf725d782)

Focused:
![image](https://github.com/user-attachments/assets/8796a95f-1ab6-41c7-b2b1-dd2bde7fe7ff)

---

![image](https://github.com/user-attachments/assets/94ea97fe-9feb-49c3-826b-4d9eea712a69)


# Links
https://developer.mozilla.org/en-US/docs/Web/CSS/@media/forced-colors

Should fix a couple of issues raised here:
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-506028
