### PR TITLE
feat(menu): remove tabIndex, orientation and isGroupRole from types

### DIFF
--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -33,7 +33,6 @@ const Menu = <T extends object>(props: Props<T>, providedRef: RefObject<HTMLDivE
     itemShape = DEFAULTS.ITEM_SHAPE,
     itemSize = DEFAULTS.ITEM_SIZE,
     ariaLabelledby,
-    tabIndex,
   } = props;
 
   const contextProps = useMenuContext();
@@ -91,7 +90,6 @@ const Menu = <T extends object>(props: Props<T>, providedRef: RefObject<HTMLDivE
         ref={ref}
         aria-labelledby={ariaLabelledby}
         {...menuProps}
-        tabIndex={tabIndex || menuProps.tabIndex}
       >
         {itemArray.map((key) => {
           const item = state.collection.getItem(key) as Node<T>;

--- a/src/components/Menu/Menu.types.ts
+++ b/src/components/Menu/Menu.types.ts
@@ -2,7 +2,6 @@ import { CSSProperties, HTMLAttributes, MutableRefObject } from 'react';
 import { AriaMenuProps } from '@react-types/menu';
 import { FocusStrategy } from '@react-types/shared';
 import { ListItemBaseSize } from '../ListItemBase/ListItemBase.types';
-import { ListOrientation } from '../List/List.types';
 
 export interface Props<T> extends AriaMenuProps<T> {
   /**
@@ -39,32 +38,9 @@ export interface Props<T> extends AriaMenuProps<T> {
   isTickOnLeftSide?: boolean;
 
   /**
-   * Wether it is part of nested menu items.
-   * @default false
-   */
-  isGroupRole?: boolean;
-  
-  /**
    * aria-labelledby attribute to associate with the menu items
    */
   ariaLabelledby?: string;
-  
-  /**
-   * Determines the orientation of the list
-   *
-   * The orientation of the list change the keyboard navigation in the list:
-   *
-   * - vertical: up and down arrow keys
-   * - horizontal: left and right arrow keys
-   *
-   * @default 'vertical'
-   */
-  orientation?: ListOrientation
-
-  /**
-   * accepts tabIndex to override default provided by useMenu
-   */
-  tabIndex?: number;
 }
 
 export interface MenuContextValue extends HTMLAttributes<HTMLElement> {

--- a/src/components/Menu/Menu.unit.test.tsx
+++ b/src/components/Menu/Menu.unit.test.tsx
@@ -168,17 +168,6 @@ describe('<Menu />', () => {
 
       expect(element.getAttribute('data-shape')).toBe(itemShape);
     });
-
-    it('should have provided tabindex when tabIndex is provided', () => {
-      expect.assertions(1);
-
-      const element = mount(<Menu {...defaultProps} itemSize={50} tabIndex={-1} />)
-        .find('div[role="menu"]')
-        .at(0)
-        .getDOMNode();
-
-      expect(element.getAttribute('tabindex')).toBe('-1');
-    });
   });
 
   describe('actions', () => {


### PR DESCRIPTION
# Description

As part of https://github.com/momentum-design/momentum-react-v2/pull/624 , we are removing the types from Menu component to rely fully on useMenu keyboard behaviour and role assignment. 

