### PR TITLE
feat(search-input): accept additional search icon props

### DIFF
--- a/src/components/SearchInput/SearchInput.tsx
+++ b/src/components/SearchInput/SearchInput.tsx
@@ -22,7 +22,6 @@ import Icon from '../Icon';
 import LoadingSpinner from '../LoadingSpinner';
 import { useProvidedRef } from '../../utils/useProvidedRef';
 
-
 type RefOrCallbackRef = RefObject<HTMLInputElement> | ((instance: HTMLInputElement) => void);
 /**
  *  Search input
@@ -40,6 +39,7 @@ const SearchInput = (props: Props, providedRef: RefOrCallbackRef): ReactElement 
     isCombobox = DEFAULTS.ISCOMBOBOX,
     isComboboxExpanded,
     onKeyDown: providedKeydown,
+    searchIconProps,
   } = props;
 
   if (isCombobox && isComboboxExpanded === undefined) {
@@ -125,7 +125,8 @@ const SearchInput = (props: Props, providedRef: RefOrCallbackRef): ReactElement 
             weight="bold"
             scale={ICON_HEIGHT_MAPPING[height]}
             className={STYLE.search}
-            name={'search'}
+            name="search"
+            {...searchIconProps}
           />
         )}
       </div>

--- a/src/components/SearchInput/SearchInput.types.ts
+++ b/src/components/SearchInput/SearchInput.types.ts
@@ -1,6 +1,7 @@
 import { CSSProperties } from 'react';
 import { AriaSearchFieldProps } from '@react-types/searchfield';
 import { HEIGHTS } from './SearchInput.constants';
+import { IconProps } from '../Icon';
 
 export type SearchFieldHeight = typeof HEIGHTS[number];
 
@@ -113,4 +114,9 @@ export interface Props extends AriaSearchFieldProps {
    * @param event - React Keyboard Event
    */
   onKeyDown?: (event: React.KeyboardEvent) => void;
+
+  /**
+   * Props to be passed to the search icon
+   */
+  searchIconProps?: Partial<IconProps>;
 }

--- a/src/components/SearchInput/SearchInput.unit.test.tsx
+++ b/src/components/SearchInput/SearchInput.unit.test.tsx
@@ -401,10 +401,19 @@ describe('<SearchInput />', () => {
 
     it('should forward a callback ref if provided', async () => {
       const callbackRef = jest.fn();
-      const inputElement = (await mountAndWait(
-        <SearchInput ref={callbackRef} aria-label="search" value="test" clearButtonAriaLabel="Clear" />
-      )).find('input').getDOMNode();
-     
+      const inputElement = (
+        await mountAndWait(
+          <SearchInput
+            ref={callbackRef}
+            aria-label="search"
+            value="test"
+            clearButtonAriaLabel="Clear"
+          />
+        )
+      )
+        .find('input')
+        .getDOMNode();
+
       expect(callbackRef).toBeCalledTimes(1);
       expect(callbackRef).toHaveBeenLastCalledWith(inputElement);
     });
@@ -540,7 +549,7 @@ describe('<SearchInput />', () => {
 
     const onKeyDown = jest.fn();
     const wrapper = await mountAndWait(
-      <SearchInput aria-label="search" clearButtonAriaLabel="Clear" onKeyDown={onKeyDown}/>
+      <SearchInput aria-label="search" clearButtonAriaLabel="Clear" onKeyDown={onKeyDown} />
     );
 
     const inputElement = wrapper.find('input');
@@ -552,5 +561,22 @@ describe('<SearchInput />', () => {
     expect(dispatchEventSpy).not.toHaveBeenCalled();
     dispatchEventSpy.mockRestore();
     expect(onKeyDown).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the search icon correctly', async () => {
+    const wrapper = await mountAndWait(
+      <SearchInput
+        clearButtonAriaLabel="Clear"
+        searchIconProps={{ ariaLabel: 'search icon label' }}
+      />
+    );
+
+    expect(wrapper.find(Icon).props()).toStrictEqual({
+      weight: 'bold',
+      scale: 16,
+      className: 'md-search-input-search',
+      name: 'search',
+      ariaLabel: 'search icon label',
+    });
   });
 });


### PR DESCRIPTION
# Description
accept and pass additional props into the search icon
will be used in cantina to specify the aria label of the search icon

# Links
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-505795