### PR TITLE
fix: tree component migrate open/close state

### DIFF
--- a/src/components/SpaceTreeNode/SpaceTreeNode.unit.test.tsx.snap
+++ b/src/components/SpaceTreeNode/SpaceTreeNode.unit.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<SpaceTreeNode /> snapshot checks divider dot position in compact mode 1`] = `
-<ForwardRef
+<Tree
   excludeTreeRoot={false}
   treeStructure={
     Object {
@@ -147,11 +147,11 @@ exports[`<SpaceTreeNode /> snapshot checks divider dot position in compact mode 
       </TreeNodeBase>
     </SpaceTreeNode>
   </div>
-</ForwardRef>
+</Tree>
 `;
 
 exports[`<SpaceTreeNode /> snapshot should match snapshot 1`] = `
-<ForwardRef
+<Tree
   excludeTreeRoot={false}
   treeStructure={
     Object {
@@ -254,11 +254,11 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot 1`] = `
       </TreeNodeBase>
     </SpaceTreeNode>
   </div>
-</ForwardRef>
+</Tree>
 `;
 
 exports[`<SpaceTreeNode /> snapshot should match snapshot with action 1`] = `
-<ForwardRef
+<Tree
   excludeTreeRoot={false}
   treeStructure={
     Object {
@@ -375,11 +375,11 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with action 1`] = `
       </TreeNodeBase>
     </SpaceTreeNode>
   </div>
-</ForwardRef>
+</Tree>
 `;
 
 exports[`<SpaceTreeNode /> snapshot should match snapshot with className 1`] = `
-<ForwardRef
+<Tree
   excludeTreeRoot={false}
   treeStructure={
     Object {
@@ -483,11 +483,11 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with className 1`] = `
       </TreeNodeBase>
     </SpaceTreeNode>
   </div>
-</ForwardRef>
+</Tree>
 `;
 
 exports[`<SpaceTreeNode /> snapshot should match snapshot with firstLine 1`] = `
-<ForwardRef
+<Tree
   excludeTreeRoot={false}
   treeStructure={
     Object {
@@ -594,11 +594,11 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with firstLine 1`] = `
       </TreeNodeBase>
     </SpaceTreeNode>
   </div>
-</ForwardRef>
+</Tree>
 `;
 
 exports[`<SpaceTreeNode /> snapshot should match snapshot with id 1`] = `
-<ForwardRef
+<Tree
   excludeTreeRoot={false}
   treeStructure={
     Object {
@@ -703,11 +703,11 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with id 1`] = `
       </TreeNodeBase>
     </SpaceTreeNode>
   </div>
-</ForwardRef>
+</Tree>
 `;
 
 exports[`<SpaceTreeNode /> snapshot should match snapshot with isAlert 1`] = `
-<ForwardRef
+<Tree
   excludeTreeRoot={false}
   treeStructure={
     Object {
@@ -843,11 +843,11 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isAlert 1`] = `
       </TreeNodeBase>
     </SpaceTreeNode>
   </div>
-</ForwardRef>
+</Tree>
 `;
 
 exports[`<SpaceTreeNode /> snapshot should match snapshot with isAlertMuted 1`] = `
-<ForwardRef
+<Tree
   excludeTreeRoot={false}
   treeStructure={
     Object {
@@ -983,11 +983,11 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isAlertMuted 1`] 
       </TreeNodeBase>
     </SpaceTreeNode>
   </div>
-</ForwardRef>
+</Tree>
 `;
 
 exports[`<SpaceTreeNode /> snapshot should match snapshot with isDisabled 1`] = `
-<ForwardRef
+<Tree
   excludeTreeRoot={false}
   treeStructure={
     Object {
@@ -1091,11 +1091,11 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isDisabled 1`] = 
       </TreeNodeBase>
     </SpaceTreeNode>
   </div>
-</ForwardRef>
+</Tree>
 `;
 
 exports[`<SpaceTreeNode /> snapshot should match snapshot with isEnterRoom 1`] = `
-<ForwardRef
+<Tree
   excludeTreeRoot={false}
   treeStructure={
     Object {
@@ -1231,11 +1231,11 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isEnterRoom 1`] =
       </TreeNodeBase>
     </SpaceTreeNode>
   </div>
-</ForwardRef>
+</Tree>
 `;
 
 exports[`<SpaceTreeNode /> snapshot should match snapshot with isError 1`] = `
-<ForwardRef
+<Tree
   excludeTreeRoot={false}
   treeStructure={
     Object {
@@ -1371,11 +1371,11 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isError 1`] = `
       </TreeNodeBase>
     </SpaceTreeNode>
   </div>
-</ForwardRef>
+</Tree>
 `;
 
 exports[`<SpaceTreeNode /> snapshot should match snapshot with isMention 1`] = `
-<ForwardRef
+<Tree
   excludeTreeRoot={false}
   treeStructure={
     Object {
@@ -1511,11 +1511,11 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isMention 1`] = `
       </TreeNodeBase>
     </SpaceTreeNode>
   </div>
-</ForwardRef>
+</Tree>
 `;
 
 exports[`<SpaceTreeNode /> snapshot should match snapshot with isNewActivity 1`] = `
-<ForwardRef
+<Tree
   excludeTreeRoot={false}
   treeStructure={
     Object {
@@ -1620,11 +1620,11 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isNewActivity 1`]
       </TreeNodeBase>
     </SpaceTreeNode>
   </div>
-</ForwardRef>
+</Tree>
 `;
 
 exports[`<SpaceTreeNode /> snapshot should match snapshot with isSelected 1`] = `
-<ForwardRef
+<Tree
   excludeTreeRoot={false}
   treeStructure={
     Object {
@@ -1729,11 +1729,11 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isSelected 1`] = 
       </TreeNodeBase>
     </SpaceTreeNode>
   </div>
-</ForwardRef>
+</Tree>
 `;
 
 exports[`<SpaceTreeNode /> snapshot should match snapshot with isSelected and draft 1`] = `
-<ForwardRef
+<Tree
   excludeTreeRoot={false}
   treeStructure={
     Object {
@@ -1871,11 +1871,11 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isSelected and dr
       </TreeNodeBase>
     </SpaceTreeNode>
   </div>
-</ForwardRef>
+</Tree>
 `;
 
 exports[`<SpaceTreeNode /> snapshot should match snapshot with isUnread 1`] = `
-<ForwardRef
+<Tree
   excludeTreeRoot={false}
   treeStructure={
     Object {
@@ -2011,11 +2011,11 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isUnread 1`] = `
       </TreeNodeBase>
     </SpaceTreeNode>
   </div>
-</ForwardRef>
+</Tree>
 `;
 
 exports[`<SpaceTreeNode /> snapshot should match snapshot with multiple string secondLine 1`] = `
-<ForwardRef
+<Tree
   excludeTreeRoot={false}
   treeStructure={
     Object {
@@ -2187,11 +2187,11 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with multiple string s
       </TreeNodeBase>
     </SpaceTreeNode>
   </div>
-</ForwardRef>
+</Tree>
 `;
 
 exports[`<SpaceTreeNode /> snapshot should match snapshot with secondLine 1`] = `
-<ForwardRef
+<Tree
   excludeTreeRoot={false}
   treeStructure={
     Object {
@@ -2325,11 +2325,11 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with secondLine 1`] = 
       </TreeNodeBase>
     </SpaceTreeNode>
   </div>
-</ForwardRef>
+</Tree>
 `;
 
 exports[`<SpaceTreeNode /> snapshot should match snapshot with style 1`] = `
-<ForwardRef
+<Tree
   excludeTreeRoot={false}
   treeStructure={
     Object {
@@ -2447,11 +2447,11 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with style 1`] = `
       </TreeNodeBase>
     </SpaceTreeNode>
   </div>
-</ForwardRef>
+</Tree>
 `;
 
 exports[`<SpaceTreeNode /> snapshot should match snapshot with teamColor 1`] = `
-<ForwardRef
+<Tree
   excludeTreeRoot={false}
   treeStructure={
     Object {
@@ -2556,5 +2556,5 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with teamColor 1`] = `
       </TreeNodeBase>
     </SpaceTreeNode>
   </div>
-</ForwardRef>
+</Tree>
 `;

--- a/src/components/Tree/Tree.test.tsx.snap
+++ b/src/components/Tree/Tree.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Tree /> snapshot should match snapshot 1`] = `
-<ForwardRef
+<Tree
   treeStructure={
     Object {
       "children": Array [
@@ -26,11 +26,11 @@ exports[`<Tree /> snapshot should match snapshot 1`] = `
     onKeyDown={[Function]}
     role="tree"
   />
-</ForwardRef>
+</Tree>
 `;
 
 exports[`<Tree /> snapshot should match snapshot with className 1`] = `
-<ForwardRef
+<Tree
   className="example-class"
   treeStructure={
     Object {
@@ -56,11 +56,11 @@ exports[`<Tree /> snapshot should match snapshot with className 1`] = `
     onKeyDown={[Function]}
     role="tree"
   />
-</ForwardRef>
+</Tree>
 `;
 
 exports[`<Tree /> snapshot should match snapshot with id 1`] = `
-<ForwardRef
+<Tree
   id="example-id"
   treeStructure={
     Object {
@@ -87,11 +87,11 @@ exports[`<Tree /> snapshot should match snapshot with id 1`] = `
     onKeyDown={[Function]}
     role="tree"
   />
-</ForwardRef>
+</Tree>
 `;
 
 exports[`<Tree /> snapshot should match snapshot with style 1`] = `
-<ForwardRef
+<Tree
   style={
     Object {
       "color": "pink",
@@ -126,11 +126,11 @@ exports[`<Tree /> snapshot should match snapshot with style 1`] = `
       }
     }
   />
-</ForwardRef>
+</Tree>
 `;
 
 exports[`<Tree /> snapshot should match snapshot with style 2`] = `
-<ForwardRef
+<Tree
   style={
     Object {
       "color": "pink",
@@ -165,11 +165,11 @@ exports[`<Tree /> snapshot should match snapshot with style 2`] = `
       }
     }
   />
-</ForwardRef>
+</Tree>
 `;
 
 exports[`<Tree /> snapshot should match snapshot with style 3`] = `
-<ForwardRef
+<Tree
   style={
     Object {
       "color": "pink",
@@ -204,5 +204,5 @@ exports[`<Tree /> snapshot should match snapshot with style 3`] = `
       }
     }
   />
-</ForwardRef>
+</Tree>
 `;

--- a/src/components/Tree/Tree.types.ts
+++ b/src/components/Tree/Tree.types.ts
@@ -131,6 +131,10 @@ export interface Props
    * The initial tree structure
    *
    * It is used to build an internal tree for navigation and follow open/close states.
+   *
+   * The tree can be updated dynamically via `treeStructure`, but `isOpen` will be migrated from the old tree:
+   * If the node exists the both old and new tree then the value used from the old tree otherwise
+   * falls back to the `isOpenByDefault ?? true`
    */
   treeStructure: TreeRoot;
 

--- a/src/components/Tree/Tree.utils.test.tsx
+++ b/src/components/Tree/Tree.utils.test.tsx
@@ -7,6 +7,7 @@ import {
   isActiveNodeInDOM,
   isEmptyTree,
   mapTree,
+  migrateTreeState,
   toggleTreeNodeRecord,
   TreeContext,
   useTreeContext,
@@ -20,6 +21,7 @@ import {
 } from './Tree.types';
 import { createTreeNode as tNode } from './test.utils';
 import { renderHook } from '@testing-library/react-hooks';
+import tree from './Tree';
 
 const createSingleLevelTree = () =>
   // prettier-ignore
@@ -737,5 +739,41 @@ describe('Tree utils', () => {
         expect(result).toEqual(expected);
       }
     );
+  });
+
+  describe('migrateTreeState', () => {
+    it('should handle empty old tree', () => {
+      const tree = convertNestedTree2MappedTree(sampleTree);
+      migrateTreeState(new Map(), tree);
+      expect(tree).toEqual(convertNestedTree2MappedTree(sampleTree));
+    });
+
+    it('should handle empty new tree', () => {
+      const tree = new Map();
+      migrateTreeState(convertNestedTree2MappedTree(sampleTree), tree);
+      expect(tree).toEqual(tree);
+    });
+
+    it('should migrate isOpen state', () => {
+      const oldTree = new Map([['1', { isOpen: true }]]) as TreeIdNodeMap;
+      const newTree = convertNestedTree2MappedTree(sampleTree);
+
+      expect(oldTree.get('1').isOpen).not.toEqual(newTree.get('1').isOpen);
+
+      migrateTreeState(oldTree, newTree);
+
+      expect(newTree.get('1').isOpen).toEqual(newTree.get('1').isOpen);
+    });
+
+    it('should update isHidden correctly', () => {
+      const oldTree = new Map([['1', { isOpen: true }]]) as TreeIdNodeMap;
+      const newTree = convertNestedTree2MappedTree(sampleTree);
+
+      expect(newTree.get('1.1').isHidden).toEqual(true);
+
+      migrateTreeState(oldTree, newTree);
+
+      expect(newTree.get('1.1').isHidden).toEqual(false);
+    });
   });
 });

--- a/src/components/TreeNodeBase/TreeNodeBase.test.tsx.snap
+++ b/src/components/TreeNodeBase/TreeNodeBase.test.tsx.snap
@@ -323,7 +323,7 @@ exports[`TreeNodeBase snapshot should match snapshot with style 1`] = `
 `;
 
 exports[`TreeNodeBase snapshot should not render the content of the hidden nodes 1`] = `
-<ForwardRef
+<Tree
   excludeTreeRoot={false}
   isRenderedFlat={true}
   treeStructure={
@@ -414,11 +414,11 @@ exports[`TreeNodeBase snapshot should not render the content of the hidden nodes
       nodeId="2"
     />
   </div>
-</ForwardRef>
+</Tree>
 `;
 
 exports[`TreeNodeBase snapshot should not render the content when the node details are not available 1`] = `
-<ForwardRef
+<Tree
   excludeTreeRoot={false}
   isRenderedFlat={true}
   treeStructure={
@@ -461,11 +461,11 @@ exports[`TreeNodeBase snapshot should not render the content when the node detai
       nodeId="wrong-id-2"
     />
   </div>
-</ForwardRef>
+</Tree>
 `;
 
 exports[`TreeNodeBase snapshot should render grouping element when the tree is flat 1`] = `
-<ForwardRef
+<Tree
   excludeTreeRoot={false}
   isRenderedFlat={true}
   treeStructure={
@@ -628,5 +628,5 @@ exports[`TreeNodeBase snapshot should render grouping element when the tree is f
       </FocusRing>
     </TreeNodeBase>
   </div>
-</ForwardRef>
+</Tree>
 `;

--- a/src/components/TreeNodeBase/TreeNodeBase.tsx
+++ b/src/components/TreeNodeBase/TreeNodeBase.tsx
@@ -166,6 +166,7 @@ const TreeNodeBase = (props: Props, providedRef: TreeNodeBaseRefOrCallbackRef): 
   const lastActiveNode = usePrevious(treeContext?.activeNodeId);
   useDidUpdateEffect(() => {
     if (
+      ref.current &&
       lastActiveNode !== undefined &&
       lastActiveNode !== treeContext?.activeNodeId &&
       treeContext?.activeNodeId === nodeId


### PR DESCRIPTION
# Description

When the tree structure updated Tree will migrate the state of the nodes which are remain in the new structure.

It fixes the use case, when a node moves from an open node under a closed one.
