### PR TITLE
fix: preserve tabindex for specified elements

### DIFF
--- a/src/components/SpaceTreeNode/SpaceTreeNode.unit.test.tsx.snap
+++ b/src/components/SpaceTreeNode/SpaceTreeNode.unit.test.tsx.snap
@@ -13,6 +13,8 @@ exports[`<SpaceTreeNode /> snapshot checks divider dot position in compact mode 
 >
   <div
     className="md-tree-wrapper"
+    onBlur={[Function]}
+    onFocus={[Function]}
     onKeyDown={[Function]}
     role="tree"
   >
@@ -163,6 +165,8 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot 1`] = `
 >
   <div
     className="md-tree-wrapper"
+    onBlur={[Function]}
+    onFocus={[Function]}
     onKeyDown={[Function]}
     role="tree"
   >
@@ -270,6 +274,8 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with action 1`] = `
 >
   <div
     className="md-tree-wrapper"
+    onBlur={[Function]}
+    onFocus={[Function]}
     onKeyDown={[Function]}
     role="tree"
   >
@@ -391,6 +397,8 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with className 1`] = `
 >
   <div
     className="md-tree-wrapper"
+    onBlur={[Function]}
+    onFocus={[Function]}
     onKeyDown={[Function]}
     role="tree"
   >
@@ -499,6 +507,8 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with firstLine 1`] = `
 >
   <div
     className="md-tree-wrapper"
+    onBlur={[Function]}
+    onFocus={[Function]}
     onKeyDown={[Function]}
     role="tree"
   >
@@ -610,6 +620,8 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with id 1`] = `
 >
   <div
     className="md-tree-wrapper"
+    onBlur={[Function]}
+    onFocus={[Function]}
     onKeyDown={[Function]}
     role="tree"
   >
@@ -719,6 +731,8 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isAlert 1`] = `
 >
   <div
     className="md-tree-wrapper"
+    onBlur={[Function]}
+    onFocus={[Function]}
     onKeyDown={[Function]}
     role="tree"
   >
@@ -859,6 +873,8 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isAlertMuted 1`] 
 >
   <div
     className="md-tree-wrapper"
+    onBlur={[Function]}
+    onFocus={[Function]}
     onKeyDown={[Function]}
     role="tree"
   >
@@ -999,6 +1015,8 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isDisabled 1`] = 
 >
   <div
     className="md-tree-wrapper"
+    onBlur={[Function]}
+    onFocus={[Function]}
     onKeyDown={[Function]}
     role="tree"
   >
@@ -1107,6 +1125,8 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isEnterRoom 1`] =
 >
   <div
     className="md-tree-wrapper"
+    onBlur={[Function]}
+    onFocus={[Function]}
     onKeyDown={[Function]}
     role="tree"
   >
@@ -1247,6 +1267,8 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isError 1`] = `
 >
   <div
     className="md-tree-wrapper"
+    onBlur={[Function]}
+    onFocus={[Function]}
     onKeyDown={[Function]}
     role="tree"
   >
@@ -1387,6 +1409,8 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isMention 1`] = `
 >
   <div
     className="md-tree-wrapper"
+    onBlur={[Function]}
+    onFocus={[Function]}
     onKeyDown={[Function]}
     role="tree"
   >
@@ -1527,6 +1551,8 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isNewActivity 1`]
 >
   <div
     className="md-tree-wrapper"
+    onBlur={[Function]}
+    onFocus={[Function]}
     onKeyDown={[Function]}
     role="tree"
   >
@@ -1636,6 +1662,8 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isSelected 1`] = 
 >
   <div
     className="md-tree-wrapper"
+    onBlur={[Function]}
+    onFocus={[Function]}
     onKeyDown={[Function]}
     role="tree"
   >
@@ -1745,6 +1773,8 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isSelected and dr
 >
   <div
     className="md-tree-wrapper"
+    onBlur={[Function]}
+    onFocus={[Function]}
     onKeyDown={[Function]}
     role="tree"
   >
@@ -1887,6 +1917,8 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isUnread 1`] = `
 >
   <div
     className="md-tree-wrapper"
+    onBlur={[Function]}
+    onFocus={[Function]}
     onKeyDown={[Function]}
     role="tree"
   >
@@ -2027,6 +2059,8 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with multiple string s
 >
   <div
     className="md-tree-wrapper"
+    onBlur={[Function]}
+    onFocus={[Function]}
     onKeyDown={[Function]}
     role="tree"
   >
@@ -2203,6 +2237,8 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with secondLine 1`] = 
 >
   <div
     className="md-tree-wrapper"
+    onBlur={[Function]}
+    onFocus={[Function]}
     onKeyDown={[Function]}
     role="tree"
   >
@@ -2341,6 +2377,8 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with style 1`] = `
 >
   <div
     className="md-tree-wrapper"
+    onBlur={[Function]}
+    onFocus={[Function]}
     onKeyDown={[Function]}
     role="tree"
   >
@@ -2463,6 +2501,8 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with teamColor 1`] = `
 >
   <div
     className="md-tree-wrapper"
+    onBlur={[Function]}
+    onFocus={[Function]}
     onKeyDown={[Function]}
     role="tree"
   >

--- a/src/components/Tree/Tree.stories.docs.mdx
+++ b/src/components/Tree/Tree.stories.docs.mdx
@@ -6,7 +6,7 @@ make it possible to use it with Virtualized trees.
 
 Tree nodes must be wrapped in a `<TreeNodeBase />` component to ensure proper keyboard navigation and focus management.
 
-Any node inside the `<Tree />` can access to the tree context using the `useTreeContext` hook.
+Any node inside the `<Tree />` can access to the tree context using the `useTreeContext` hook.#
 
 ## Nested VS Flat tree
 

--- a/src/components/Tree/Tree.stories.tsx
+++ b/src/components/Tree/Tree.stories.tsx
@@ -18,6 +18,7 @@ import { TreeNodeRecord, TreeRefObject } from './Tree.types';
 import ButtonPill from '../ButtonPill';
 import Flex from '../Flex';
 import { v4 as uuidV4 } from 'uuid';
+import { PRESERVE_TABINDEX_CLASSNAME } from '../../utils/navigation';
 
 // prettier-ignore
 const exampleTree =
@@ -89,6 +90,7 @@ const ExampleTreeNode = ({ node }: ExampleTreeNodeProps) => {
           </div>
           {nodeDetails.isLeaf && (
             <MenuTrigger
+              className={PRESERVE_TABINDEX_CLASSNAME}
               triggerComponent={
                 <ButtonCircle size={20} ghost aria-label="More menu">
                   <Icon name="more" weight="bold" autoScale={100} />

--- a/src/components/Tree/Tree.test.tsx.snap
+++ b/src/components/Tree/Tree.test.tsx.snap
@@ -23,6 +23,8 @@ exports[`<Tree /> snapshot should match snapshot 1`] = `
 >
   <div
     className="md-tree-wrapper"
+    onBlur={[Function]}
+    onFocus={[Function]}
     onKeyDown={[Function]}
     role="tree"
   />
@@ -53,6 +55,8 @@ exports[`<Tree /> snapshot should match snapshot with className 1`] = `
 >
   <div
     className="example-class md-tree-wrapper"
+    onBlur={[Function]}
+    onFocus={[Function]}
     onKeyDown={[Function]}
     role="tree"
   />
@@ -84,6 +88,8 @@ exports[`<Tree /> snapshot should match snapshot with id 1`] = `
   <div
     className="md-tree-wrapper"
     id="example-id"
+    onBlur={[Function]}
+    onFocus={[Function]}
     onKeyDown={[Function]}
     role="tree"
   />
@@ -118,6 +124,8 @@ exports[`<Tree /> snapshot should match snapshot with style 1`] = `
 >
   <div
     className="md-tree-wrapper"
+    onBlur={[Function]}
+    onFocus={[Function]}
     onKeyDown={[Function]}
     role="tree"
     style={
@@ -157,6 +165,8 @@ exports[`<Tree /> snapshot should match snapshot with style 2`] = `
 >
   <div
     className="md-tree-wrapper"
+    onBlur={[Function]}
+    onFocus={[Function]}
     onKeyDown={[Function]}
     role="tree"
     style={
@@ -196,6 +206,8 @@ exports[`<Tree /> snapshot should match snapshot with style 3`] = `
 >
   <div
     className="md-tree-wrapper"
+    onBlur={[Function]}
+    onFocus={[Function]}
     onKeyDown={[Function]}
     role="tree"
     style={

--- a/src/components/Tree/Tree.tsx
+++ b/src/components/Tree/Tree.tsx
@@ -23,7 +23,7 @@ import {
   toggleTreeNodeRecord,
   TreeContext,
 } from './Tree.utils';
-import { useKeyboard } from '@react-aria/interactions';
+import { useFocusWithin, useKeyboard } from '@react-aria/interactions';
 import { useVirtualTreeNavigation } from './Tree.hooks';
 import { useDidUpdateEffect } from '../../hooks/useDidUpdateEffect';
 import { usePrevious } from '../../hooks/usePrevious';
@@ -63,6 +63,7 @@ const Tree = forwardRef((props: Props, ref: ForwardedRef<TreeRefObject>) => {
   const [activeNodeId, setActiveNodeId] = useState<TreeNodeId | undefined>(
     getFistActiveNode(tree, excludeTreeRoot)
   );
+  const [isFocusWithin, setIsFocusWithin] = useState(false);
 
   const previousTree = usePrevious(tree);
 
@@ -155,6 +156,7 @@ const Tree = forwardRef((props: Props, ref: ForwardedRef<TreeRefObject>) => {
       toggleTreeNode,
       selectableNodes,
       itemSelection,
+      isFocusWithin: isFocusWithin,
     }),
     [
       activeNodeId,
@@ -165,6 +167,7 @@ const Tree = forwardRef((props: Props, ref: ForwardedRef<TreeRefObject>) => {
       toggleTreeNode,
       itemSelection,
       selectableNodes,
+      isFocusWithin,
     ]
   );
 
@@ -180,6 +183,10 @@ const Tree = forwardRef((props: Props, ref: ForwardedRef<TreeRefObject>) => {
     }),
     [setActiveNodeId, toggleTreeNode, itemSelection]
   );
+
+  const { focusWithinProps } = useFocusWithin({
+    onFocusWithinChange: setIsFocusWithin,
+  });
 
   const { keyboardProps } = useKeyboard({
     onKeyDown: (evt) => {
@@ -238,6 +245,7 @@ const Tree = forwardRef((props: Props, ref: ForwardedRef<TreeRefObject>) => {
         {...ariaProps}
         {...keyboardProps}
         {...rest}
+        {...focusWithinProps}
       >
         {children}
       </div>

--- a/src/components/Tree/Tree.types.ts
+++ b/src/components/Tree/Tree.types.ts
@@ -269,6 +269,11 @@ export interface TreeContextValue
    * The item selection state of the tree nodes.
    */
   itemSelection: ItemSelection<TreeNodeId>;
+  /**
+   * True when the focus is inside the tree component before the tree structure changed,
+   * otherwise false
+   */
+  isFocusWithin: boolean;
 }
 
 /**

--- a/src/components/Tree/Tree.utils.ts
+++ b/src/components/Tree/Tree.utils.ts
@@ -81,7 +81,9 @@ const findNextTreeNode = (tree: TreeIdNodeMap, activeNodeId: TreeNodeId): TreeNo
       // If we are at the end of the parent's children, move up one level
       current = parent;
       if (loopCheck.has(current.id)) {
-        throw new Error('Infinite loop detected in the tree navigation.');
+        // eslint-disable-next-line no-console
+        console.error('Infinite loop detected in the tree navigation.');
+        return current.id;
       } else {
         loopCheck.add(current.id);
       }
@@ -127,7 +129,9 @@ const findPreviousTreeNode = (
     next = tree.get(next.children[next.children.length - 1]);
 
     if (loopCheck.has(next.id)) {
-      throw new Error('Infinite loop detected in the tree navigation.');
+      // eslint-disable-next-line no-console
+      console.error('Infinite loop detected in the tree navigation.');
+      return next.id;
     } else {
       loopCheck.add(next.id);
     }
@@ -224,12 +228,14 @@ export const convertNestedTree2MappedTree = (tree: TreeRoot): TreeIdNodeMap => {
     const { node: parentNode, parentId, level, index, isHidden } = nodeStack.pop();
 
     if (idSet.has(parentNode.id)) {
-      throw new Error(`Duplicate node id found: "${parentNode.id.toString()}".`);
+      // eslint-disable-next-line no-console
+      console.error(`Duplicate node id ("${parentNode.id.toString()}") found and skipped.`);
+      continue;
     } else {
       idSet.add(parentNode.id);
     }
 
-    const children = parentNode.children.map((n) => n.id);
+    const children = Array.from(new Set(parentNode.children.map((n) => n.id)));
     const isOpen = parentNode.isOpenByDefault ?? true;
 
     map.set(parentNode.id, {
@@ -360,7 +366,9 @@ export const mapTree = <T>(
   const rootNodeId = options?.rootNodeId ?? getTreeRootId(tree);
 
   if (!tree.has(rootNodeId)) {
-    throw new Error(`Tree root node is not found for id: "${rootNodeId.toString()}".`);
+    // eslint-disable-next-line no-console
+    console.error(`Tree root node is not found for id: "${rootNodeId.toString()}".`);
+    return [];
   }
 
   const excludeRoot = options?.excludeRootNode ?? true;

--- a/src/components/TreeNodeBase/TreeNodeBase.stories.docs.mdx
+++ b/src/components/TreeNodeBase/TreeNodeBase.stories.docs.mdx
@@ -10,6 +10,10 @@ After the node selected the user can use the `Tab` key to select the first, seco
 When the last interactable element is selected, the next tab will move the focus to the next interactable
 element after the tree.
 
+`<TreeNodeBase />` might contain other components which have their own focus management, and they're updating tabindex
+in the process, for example `<Memu />` component. `<TreeNodeBase />` can preserve these state if the component
+(or any parent of it) has either a  `data-preserve-tabindex` attribute or `md-nav-preserve-tabindex` class name.
+
 Content of the `<TreeNodeBase />` does not rendered if the node details are not available from the tree context.
 
 Below are a few examples on how to use it and what you can achieve.

--- a/src/components/TreeNodeBase/TreeNodeBase.test.tsx
+++ b/src/components/TreeNodeBase/TreeNodeBase.test.tsx
@@ -28,6 +28,7 @@ const getMockedTreeContext = (activeNodeId: string): TreeContextValue => ({
     update: jest.fn(),
     clear: jest.fn(),
   },
+  isFocusWithin: true,
 });
 
 const getSampleTree = () => {

--- a/src/components/TreeNodeBase/TreeNodeBase.test.tsx.snap
+++ b/src/components/TreeNodeBase/TreeNodeBase.test.tsx.snap
@@ -347,6 +347,8 @@ exports[`TreeNodeBase snapshot should not render the content of the hidden nodes
 >
   <div
     className="md-tree-wrapper"
+    onBlur={[Function]}
+    onFocus={[Function]}
     onKeyDown={[Function]}
     role="tree"
   >
@@ -442,6 +444,8 @@ exports[`TreeNodeBase snapshot should not render the content when the node detai
 >
   <div
     className="md-tree-wrapper"
+    onBlur={[Function]}
+    onFocus={[Function]}
     onKeyDown={[Function]}
     role="tree"
   >
@@ -489,6 +493,8 @@ exports[`TreeNodeBase snapshot should render grouping element when the tree is f
 >
   <div
     className="md-tree-wrapper"
+    onBlur={[Function]}
+    onFocus={[Function]}
     onKeyDown={[Function]}
     role="tree"
   >

--- a/src/components/TreeNodeBase/TreeNodeBase.tsx
+++ b/src/components/TreeNodeBase/TreeNodeBase.tsx
@@ -169,7 +169,8 @@ const TreeNodeBase = (props: Props, providedRef: TreeNodeBaseRefOrCallbackRef): 
       ref.current &&
       lastActiveNode !== undefined &&
       lastActiveNode !== treeContext?.activeNodeId &&
-      treeContext?.activeNodeId === nodeId
+      treeContext?.activeNodeId === nodeId &&
+      treeContext.isFocusWithin
     ) {
       ref.current.focus();
     }

--- a/src/hooks/useItemSelected.ts
+++ b/src/hooks/useItemSelected.ts
@@ -83,10 +83,12 @@ const getSelection = <T extends Array<unknown>>(
   mode: SelectionMode,
   selectedByDefault: T = [] as T
 ): T => {
-  if (mode === 'none' || !selectedByDefault) {
-    console.warn(
-      '"None" selection mode does not support any selection, selected items will be ignored'
-    );
+  if (mode === 'none') {
+    if (selectedByDefault && selectedByDefault.length > 0) {
+      console.warn(
+        '"None" selection mode does not support any selection, selected items will be ignored'
+      );
+    }
     return [] as T;
   }
   if (mode === 'single' && selectedByDefault.length > 1) {

--- a/src/index.js
+++ b/src/index.js
@@ -199,3 +199,5 @@ export {
   SelectionGroup,
   TreeNodeBase,
 } from './components';
+
+export { PRESERVE_TABINDEX_CLASSNAME } from './utils/navigation';

--- a/src/utils/navigation.test.ts
+++ b/src/utils/navigation.test.ts
@@ -22,13 +22,17 @@ describe('navigation', () => {
       <textarea id='5'></textarea>
       <select id='6'></select>
       <details id='7'></details>
-      <div tabindex='0' id='8'>
-      <div tabindex='-1' id='9'>
+      <div tabindex='0' id='8'></div>
+      <div tabindex='-1' id='9'></div>
       <div id='10'></div>
+      <button hidden id='11'></button>
+      <button aria-hidden='true' id='12'></button>
+      <button aria-hidden='false' id='13'></button>
+      <button disabled id='14'></button>
     `)
       ).map((n) => n.id);
 
-      expect(ids).toEqual(['2', '3', '4', '5', '6', '7', '8']);
+      expect(ids).toEqual(['2', '3', '4', '5', '6', '7', '8', '13']);
     });
 
     it('should return with focusable tags for any elements which can be focused', () => {
@@ -41,14 +45,18 @@ describe('navigation', () => {
       <textarea id='5'></textarea>
       <select id='6'></select>
       <details id='7'></details>
-      <div tabindex='0' id='8'>
-      <div tabindex='-1' id='9'>
+      <div tabindex='0' id='8'></div>
+      <div tabindex='-1' id='9'></div>
       <div id='10'></div>
+      <button hidden id='11'></button>
+      <button aria-hidden='true' id='12'></button>
+      <button aria-hidden='false' id='13'></button>
+      <button disabled id='14'></button>
     `),
         false
       ).map((n) => n.id);
 
-      expect(ids).toEqual(['2', '3', '4', '5', '6', '7', '8', '9']);
+      expect(ids).toEqual(['2', '3', '4', '5', '6', '7', '8', '9', '13']);
     });
 
     it('should return filter out disabled and aria hidden nodes', () => {
@@ -61,6 +69,69 @@ describe('navigation', () => {
       ).map((n) => n.id);
 
       expect(ids).toEqual(['3']);
+    });
+
+    describe.each`
+      format
+      ${'attribute'}
+      ${'class name'}
+    `('preserve tabindex with $format', (format) => {
+      const getAttributes = () => {
+        return format === 'attribute'
+          ? 'data-preserve-tabindex'
+          : 'class="md-nav-preserve-tabindex"';
+      };
+      it(`should filter out elements flagged with preserved tabindex ${format} nodes`, () => {
+        const ids = getKeyboardFocusableElements(
+          createRootNodeRef(`
+        <button ${getAttributes()} id='1' />
+    `)
+        ).map((n) => n.id);
+
+        expect(ids).toEqual([]);
+      });
+
+      it(`should filter out elements if any parent flagged with preserved ${format} tabindex`, () => {
+        const ids = getKeyboardFocusableElements(
+          createRootNodeRef(`
+          <div>
+            <div ${getAttributes()}>
+              <button id='1' />
+              <div>
+                <input id='2''>
+              </div>
+            </div>
+                    <div ${getAttributes()}>
+              <input id='3' />
+              <div>
+                <button id='4''>
+              </div>
+            </div>
+        </div>
+      `)
+        ).map((n) => n.id);
+
+        expect(ids).toEqual([]);
+      });
+
+      it(`should not check preserved tabindex ${format} for parent of the root node`, () => {
+        const dom = createRootNodeRef(`
+          <div ${getAttributes()}>
+            <div id='root'>
+              <button id='1' />
+              <div ${getAttributes()}>
+                <input id='2''>
+              </div>
+            </div>
+        </div>
+      `);
+
+        const ids = getKeyboardFocusableElements(dom.querySelector('#root') as any).map(
+          (n) => n.id
+        );
+
+        expect(ids).toEqual(['1']);
+      });
     });
 
     it('should exclude tabIndex="" when includeTabbableOnly is true', () => {

--- a/src/utils/navigation.ts
+++ b/src/utils/navigation.ts
@@ -1,38 +1,40 @@
-const FOCUSABLE_ELEMENT_SELECTORS =
-  'a[href], button, input, textarea, select, details, [tabindex]:not([tabindex=""])';
-const FOCUSABLE_AND_TABBABLE_ONLY_ELEMENT_SELECTORS =
-  'a[href], button, input, textarea, select, details, [tabindex]:not([tabindex="-1"])';
+export const PRESERVE_TABINDEX_CLASSNAME = 'md-nav-preserve-tabindex';
+const FOCUSABLE_ELEMENT_SELECTORS = 'a[href], button, input, textarea, select, details, [tabindex]';
+const PRESERVE_TABINDEX_SELECTORS = `[data-preserve-tabindex],.${PRESERVE_TABINDEX_CLASSNAME}`;
 
 /**
  * Returns all focusable child elements as an Element Array
+ *
+ * An element focusable if it:
+ * - it is interactive element (anchor with href, button, input, textarea, select and details)
+ * - it is not disabled
+ * - it is not hidden
+ * - it is not aria hidden
+ * - it or any of its parents do not have `data-preserve-tabindex` attribute or `
+ *   md-nav-preserve-tabindex` class
+ * - it has none empty or not "-1" tabindex, see `includeTabbableOnly` parameter
+ *
+ * @remarks
+ * Element with 0 tabindex can be tabbed to, while elements with any tabindex value can be
+ * manually focused
+ *
  * @param root - root node to search in
  * @param includeTabbableOnly - whether only tabbable children should be returned or all
- * children that can be focused. Element with 0 tabindex can be tabbed to,
- * while elements with any tabindex value can be manually focused
  */
 export function getKeyboardFocusableElements<T extends HTMLElement>(
   root: T,
   includeTabbableOnly = true
 ): Array<HTMLElement> {
-  const focusableNodes = includeTabbableOnly
-    ? FOCUSABLE_AND_TABBABLE_ONLY_ELEMENT_SELECTORS
-    : FOCUSABLE_ELEMENT_SELECTORS;
+  const tabindex = includeTabbableOnly ? '-1' : '';
+  const preserveTabindexContainers = Array.from(root.querySelectorAll(PRESERVE_TABINDEX_SELECTORS));
 
-  return Array.from(root.querySelectorAll(focusableNodes)).filter(
-    (el) => !el.hasAttribute('disabled') && el.getAttribute('aria-hidden') !== 'true'
+  return Array.from(root.querySelectorAll(FOCUSABLE_ELEMENT_SELECTORS)).filter(
+    (el) =>
+      !el.hasAttribute('disabled') &&
+      el.getAttribute('hidden') === null &&
+      el.getAttribute('aria-hidden') !== 'true' &&
+      el.getAttribute('tabindex') !== tabindex &&
+      // note: container.contains(container) is true
+      !preserveTabindexContainers.some((p) => p.contains(el))
   ) as Array<HTMLElement>;
 }
-
-/**
- * Returns all focusable child elements as an Element Array
- *
- * @param element
- * @param includeTabbableOnly
- */
-export const isFocusableNode = (element: HTMLElement, includeTabbableOnly = true): boolean => {
-  return element.matches(
-    includeTabbableOnly
-      ? FOCUSABLE_AND_TABBABLE_ONLY_ELEMENT_SELECTORS
-      : FOCUSABLE_ELEMENT_SELECTORS
-  );
-};


### PR DESCRIPTION
# Description

TreeNodeBase change tabindex of all interactable elements, but this can change elements which are under focus management,
eg. Menu, nested lists, etc.

