### PR TITLE
feat(meeting-row-content): add MeetingRowContent component and consume in MeetingListItem

### DIFF
--- a/src/components/MeetingListItem/MeetingListItem.constants.ts
+++ b/src/components/MeetingListItem/MeetingListItem.constants.ts
@@ -8,11 +8,6 @@ const DEFAULTS = {
 
 const STYLE = {
   wrapper: `${CLASS_PREFIX}-wrapper`,
-  startSection: `${CLASS_PREFIX}-start-section`,
-  border: `${CLASS_PREFIX}-border`,
-  middleSection: `${CLASS_PREFIX}-middle-section`,
-  endSection: `${CLASS_PREFIX}-end-section`,
-  startSectionNoImage: `${CLASS_PREFIX}-start-section-no-image`,
 };
 
 export { CLASS_PREFIX, DEFAULTS, STYLE };

--- a/src/components/MeetingListItem/MeetingListItem.style.scss
+++ b/src/components/MeetingListItem/MeetingListItem.style.scss
@@ -33,103 +33,14 @@
     }
   }
 
-  .md-meeting-list-item-start-section {
-    display: flex;
-    align-items: center;
-
-    &.md-meeting-list-item-start-section-no-image {
-      margin-right: 0;
-    }
-
-    .md-meeting-list-item-border {
-      position: absolute;
-      left: 0;
-      top: 0;
-      height: 100%;
-      width: 0.3rem;
-      border-radius: 0.5rem 0 0 0.5rem;
-      margin-right: 0.5rem;
-
-      &[data-color='AcceptedActive'] {
-        background-color: var(--mds-color-theme-button-join-normal);
-      }
-
-      &[data-color='AcceptedInactive'] {
-        background-color: var(--mds-color-theme-background-secondary-active);
-      }
-
-      &[data-color='TentativeActive'] {
-        background: webkit-repeating-linear-gradient(
-          -45deg,
-          transparent,
-          transparent 7%,
-          var(--mds-color-theme-button-join-normal) 7%,
-          var(--mds-color-theme-button-join-normal) 14%
-        );
-        background: -o-repeating-linear-gradient(
-          -45deg,
-          transparent,
-          transparent 7%,
-          var(--mds-color-theme-button-join-normal) 7%,
-          var(--mds-color-theme-button-join-normal) 14%
-        );
-        background: repeating-linear-gradient(
-          -45deg,
-          transparent,
-          transparent 7%,
-          var(--mds-color-theme-button-join-normal) 7%,
-          var(--mds-color-theme-button-join-normal) 14%
-        );
-      }
-
-      &[data-color='TentativeInactive'] {
-        background: webkit-repeating-linear-gradient(
-          -45deg,
-          transparent,
-          transparent 7%,
-          var(--mds-color-theme-background-secondary-active) 7%,
-          var(--mds-color-theme-background-secondary-active) 14%
-        );
-        background: -o-repeating-linear-gradient(
-          -45deg,
-          transparent,
-          transparent 7%,
-          var(--mds-color-theme-background-secondary-active) 7%,
-          var(--mds-color-theme-background-secondary-active) 14%
-        );
-        background: repeating-linear-gradient(
-          -45deg,
-          transparent,
-          transparent 7%,
-          var(--mds-color-theme-background-secondary-active) 7%,
-          var(--mds-color-theme-background-secondary-active) 14%
-        );
-      }
-    }
-  }
-
-  .md-meeting-list-item-middle-section {
-    .md-text-wrapper:first-of-type {
-      margin-bottom: -0.25rem;
-    }
-  }
-
   &[data-disabled='false'] {
-    .md-meeting-list-item-middle-section {
+    .md-meeting-row-content-middle-section {
       *:first-of-type {
         color: var(--mds-color-theme-text-primary-normal);
       }
 
       *:last-of-type:not(:first-of-type) {
         color: var(--mds-color-theme-text-secondary-normal);
-      }
-    }
-  }
-
-  .md-meeting-list-item-end-section {
-    .md-button-group-wrapper > .md-icon-wrapper > svg {
-      path {
-        fill: var(--mds-color-theme-text-secondary-normal);
       }
     }
   }

--- a/src/components/MeetingListItem/MeetingListItem.tsx
+++ b/src/components/MeetingListItem/MeetingListItem.tsx
@@ -1,8 +1,5 @@
 import React, {
-  Children,
-  cloneElement,
   FC,
-  ReactElement,
   forwardRef,
   useRef,
   RefObject,
@@ -13,12 +10,7 @@ import { STYLE, DEFAULTS } from './MeetingListItem.constants';
 import { Props } from './MeetingListItem.types';
 import './MeetingListItem.style.scss';
 import ListItemBase from '../ListItemBase';
-import ListItemBaseSection from '../ListItemBaseSection';
-import { verifyTypes } from '../../helpers/verifyTypes';
-import ButtonPill from '../ButtonPill';
-import ButtonCircle from '../ButtonCircle';
-import Avatar from '../Avatar';
-import Icon from '../Icon';
+import MeetingRowContent from '../MeetingRowContent';
 
 const MeetingListItem: FC<Props> = forwardRef(
   (props: Props, providedRef: RefObject<HTMLLIElement>) => {
@@ -37,55 +29,6 @@ const MeetingListItem: FC<Props> = forwardRef(
     const internalRef = useRef();
     const ref = providedRef || internalRef;
 
-    const getRestrictedProps = (element: ReactElement) => {
-      const sizeProps = {};
-      if (verifyTypes(element, ButtonPill)) {
-        sizeProps['size'] = 28;
-        sizeProps['disabled'] = isDisabled;
-      } else if (verifyTypes(element, ButtonCircle)) {
-        sizeProps['size'] = 32;
-        sizeProps['disabled'] = isDisabled;
-      } else if (verifyTypes(element, Icon)) {
-        // Because this constraints get applied recursively to the children,
-        // I still want to be able to override some of the props (like scale).
-        if (!element.props.scale) {
-          sizeProps['scale'] = 12;
-          sizeProps['strokeColor'] = 'none';
-          sizeProps['weight'] = 'bold';
-        }
-      } else if (verifyTypes(element, Avatar)) {
-        sizeProps['size'] = 32;
-      }
-      return sizeProps;
-    };
-
-    const getSizedElement = (element) => {
-      if (element && React.isValidElement(element)) {
-        const elementChildren = element.props['children'];
-        let sizedChildren;
-        if (elementChildren) {
-          if (Array.isArray(elementChildren)) {
-            sizedChildren = [];
-            Children.map(elementChildren, (child) => {
-              sizedChildren.push(getSizedElement(child));
-            });
-          } else {
-            sizedChildren = getSizedElement(elementChildren);
-          }
-        }
-        return cloneElement(element, getRestrictedProps(element), sizedChildren);
-      }
-      return element;
-    };
-
-    let buttonSection = buttonGroup;
-
-    if (buttonGroup && React.isValidElement(buttonGroup)) {
-      buttonSection = getSizedElement(buttonGroup);
-    }
-
-    const middleSectionColorClass = color ? ` md-meeting-list-item-middle-section-${color}` : '';
-
     return (
       <ListItemBase
         isPadded
@@ -97,26 +40,9 @@ const MeetingListItem: FC<Props> = forwardRef(
         size={large ? 70 : 50}
         {...rest}
       >
-        <ListItemBaseSection
-          className={classnames(STYLE.startSection, { [STYLE.startSectionNoImage]: !image })}
-          position="start"
-        >
-          <div className={STYLE.border} data-color={color} />
-          {React.isValidElement(image) ? getSizedElement(image) : image}
-        </ListItemBaseSection>
-
-        <ListItemBaseSection
-          className={`${STYLE.middleSection}${middleSectionColorClass}`}
-          position="middle"
-        >
-          {getSizedElement(children)}
-        </ListItemBaseSection>
-
-        {buttonSection && (
-          <ListItemBaseSection className={STYLE.endSection} position="end">
-            {buttonSection}
-          </ListItemBaseSection>
-        )}
+        <MeetingRowContent color={color} isDisabled={isDisabled} buttonGroup={buttonGroup} image={image}>
+          {children}
+        </MeetingRowContent>
       </ListItemBase>
     );
   }

--- a/src/components/MeetingListItem/MeetingListItem.unit.test.tsx.snap
+++ b/src/components/MeetingListItem/MeetingListItem.unit.test.tsx.snap
@@ -42,29 +42,33 @@ exports[`<MeetingListItem /> snapshot should match snapshot 1`] = `
           role="listitem"
           tabIndex={0}
         >
-          <ListItemBaseSection
-            className="md-meeting-list-item-start-section md-meeting-list-item-start-section-no-image"
-            position="start"
+          <MeetingRowContent
+            color="Transparent"
           >
-            <div
-              className="md-meeting-list-item-start-section md-meeting-list-item-start-section-no-image"
-              data-position="start"
+            <ListItemBaseSection
+              className="md-meeting-row-content-start-section md-meeting-row-content-start-section-no-image"
+              position="start"
             >
               <div
-                className="md-meeting-list-item-border"
-                data-color="Transparent"
+                className="md-meeting-row-content-start-section md-meeting-row-content-start-section-no-image"
+                data-position="start"
+              >
+                <div
+                  className="md-meeting-row-content-border"
+                  data-color="Transparent"
+                />
+              </div>
+            </ListItemBaseSection>
+            <ListItemBaseSection
+              className="md-meeting-row-content-middle-section md-meeting-row-content-middle-section-Transparent"
+              position="middle"
+            >
+              <div
+                className="md-meeting-row-content-middle-section md-meeting-row-content-middle-section-Transparent"
+                data-position="middle"
               />
-            </div>
-          </ListItemBaseSection>
-          <ListItemBaseSection
-            className="md-meeting-list-item-middle-section md-meeting-list-item-middle-section-Transparent"
-            position="middle"
-          >
-            <div
-              className="md-meeting-list-item-middle-section md-meeting-list-item-middle-section-Transparent"
-              data-position="middle"
-            />
-          </ListItemBaseSection>
+            </ListItemBaseSection>
+          </MeetingRowContent>
         </li>
       </FocusRing>
     </FocusRing>
@@ -116,49 +120,54 @@ exports[`<MeetingListItem /> snapshot should match snapshot with buttonGroup 1`]
           role="listitem"
           tabIndex={0}
         >
-          <ListItemBaseSection
-            className="md-meeting-list-item-start-section md-meeting-list-item-start-section-no-image"
-            position="start"
+          <MeetingRowContent
+            buttonGroup={<ButtonGroup />}
+            color="Transparent"
           >
-            <div
-              className="md-meeting-list-item-start-section md-meeting-list-item-start-section-no-image"
-              data-position="start"
+            <ListItemBaseSection
+              className="md-meeting-row-content-start-section md-meeting-row-content-start-section-no-image"
+              position="start"
             >
               <div
-                className="md-meeting-list-item-border"
-                data-color="Transparent"
-              />
-            </div>
-          </ListItemBaseSection>
-          <ListItemBaseSection
-            className="md-meeting-list-item-middle-section md-meeting-list-item-middle-section-Transparent"
-            position="middle"
-          >
-            <div
-              className="md-meeting-list-item-middle-section md-meeting-list-item-middle-section-Transparent"
-              data-position="middle"
-            />
-          </ListItemBaseSection>
-          <ListItemBaseSection
-            className="md-meeting-list-item-end-section"
-            position="end"
-          >
-            <div
-              className="md-meeting-list-item-end-section"
-              data-position="end"
-            >
-              <ButtonGroup>
+                className="md-meeting-row-content-start-section md-meeting-row-content-start-section-no-image"
+                data-position="start"
+              >
                 <div
-                  className="md-button-group-wrapper"
-                  data-compressed={false}
-                  data-orientation="horizontal"
-                  data-round={false}
-                  data-separator={false}
-                  data-spaced={false}
+                  className="md-meeting-row-content-border"
+                  data-color="Transparent"
                 />
-              </ButtonGroup>
-            </div>
-          </ListItemBaseSection>
+              </div>
+            </ListItemBaseSection>
+            <ListItemBaseSection
+              className="md-meeting-row-content-middle-section md-meeting-row-content-middle-section-Transparent"
+              position="middle"
+            >
+              <div
+                className="md-meeting-row-content-middle-section md-meeting-row-content-middle-section-Transparent"
+                data-position="middle"
+              />
+            </ListItemBaseSection>
+            <ListItemBaseSection
+              className="md-meeting-row-content-end-section"
+              position="end"
+            >
+              <div
+                className="md-meeting-row-content-end-section"
+                data-position="end"
+              >
+                <ButtonGroup>
+                  <div
+                    className="md-button-group-wrapper"
+                    data-compressed={false}
+                    data-orientation="horizontal"
+                    data-round={false}
+                    data-separator={false}
+                    data-spaced={false}
+                  />
+                </ButtonGroup>
+              </div>
+            </ListItemBaseSection>
+          </MeetingRowContent>
         </li>
       </FocusRing>
     </FocusRing>
@@ -210,29 +219,33 @@ exports[`<MeetingListItem /> snapshot should match snapshot with className 1`] =
           role="listitem"
           tabIndex={0}
         >
-          <ListItemBaseSection
-            className="md-meeting-list-item-start-section md-meeting-list-item-start-section-no-image"
-            position="start"
+          <MeetingRowContent
+            color="Transparent"
           >
-            <div
-              className="md-meeting-list-item-start-section md-meeting-list-item-start-section-no-image"
-              data-position="start"
+            <ListItemBaseSection
+              className="md-meeting-row-content-start-section md-meeting-row-content-start-section-no-image"
+              position="start"
             >
               <div
-                className="md-meeting-list-item-border"
-                data-color="Transparent"
+                className="md-meeting-row-content-start-section md-meeting-row-content-start-section-no-image"
+                data-position="start"
+              >
+                <div
+                  className="md-meeting-row-content-border"
+                  data-color="Transparent"
+                />
+              </div>
+            </ListItemBaseSection>
+            <ListItemBaseSection
+              className="md-meeting-row-content-middle-section md-meeting-row-content-middle-section-Transparent"
+              position="middle"
+            >
+              <div
+                className="md-meeting-row-content-middle-section md-meeting-row-content-middle-section-Transparent"
+                data-position="middle"
               />
-            </div>
-          </ListItemBaseSection>
-          <ListItemBaseSection
-            className="md-meeting-list-item-middle-section md-meeting-list-item-middle-section-Transparent"
-            position="middle"
-          >
-            <div
-              className="md-meeting-list-item-middle-section md-meeting-list-item-middle-section-Transparent"
-              data-position="middle"
-            />
-          </ListItemBaseSection>
+            </ListItemBaseSection>
+          </MeetingRowContent>
         </li>
       </FocusRing>
     </FocusRing>
@@ -284,29 +297,33 @@ exports[`<MeetingListItem /> snapshot should match snapshot with color 1`] = `
           role="listitem"
           tabIndex={0}
         >
-          <ListItemBaseSection
-            className="md-meeting-list-item-start-section md-meeting-list-item-start-section-no-image"
-            position="start"
+          <MeetingRowContent
+            color="AcceptedActive"
           >
-            <div
-              className="md-meeting-list-item-start-section md-meeting-list-item-start-section-no-image"
-              data-position="start"
+            <ListItemBaseSection
+              className="md-meeting-row-content-start-section md-meeting-row-content-start-section-no-image"
+              position="start"
             >
               <div
-                className="md-meeting-list-item-border"
-                data-color="AcceptedActive"
+                className="md-meeting-row-content-start-section md-meeting-row-content-start-section-no-image"
+                data-position="start"
+              >
+                <div
+                  className="md-meeting-row-content-border"
+                  data-color="AcceptedActive"
+                />
+              </div>
+            </ListItemBaseSection>
+            <ListItemBaseSection
+              className="md-meeting-row-content-middle-section md-meeting-row-content-middle-section-AcceptedActive"
+              position="middle"
+            >
+              <div
+                className="md-meeting-row-content-middle-section md-meeting-row-content-middle-section-AcceptedActive"
+                data-position="middle"
               />
-            </div>
-          </ListItemBaseSection>
-          <ListItemBaseSection
-            className="md-meeting-list-item-middle-section md-meeting-list-item-middle-section-AcceptedActive"
-            position="middle"
-          >
-            <div
-              className="md-meeting-list-item-middle-section md-meeting-list-item-middle-section-AcceptedActive"
-              data-position="middle"
-            />
-          </ListItemBaseSection>
+            </ListItemBaseSection>
+          </MeetingRowContent>
         </li>
       </FocusRing>
     </FocusRing>
@@ -360,29 +377,33 @@ exports[`<MeetingListItem /> snapshot should match snapshot with id 1`] = `
           role="listitem"
           tabIndex={0}
         >
-          <ListItemBaseSection
-            className="md-meeting-list-item-start-section md-meeting-list-item-start-section-no-image"
-            position="start"
+          <MeetingRowContent
+            color="Transparent"
           >
-            <div
-              className="md-meeting-list-item-start-section md-meeting-list-item-start-section-no-image"
-              data-position="start"
+            <ListItemBaseSection
+              className="md-meeting-row-content-start-section md-meeting-row-content-start-section-no-image"
+              position="start"
             >
               <div
-                className="md-meeting-list-item-border"
-                data-color="Transparent"
+                className="md-meeting-row-content-start-section md-meeting-row-content-start-section-no-image"
+                data-position="start"
+              >
+                <div
+                  className="md-meeting-row-content-border"
+                  data-color="Transparent"
+                />
+              </div>
+            </ListItemBaseSection>
+            <ListItemBaseSection
+              className="md-meeting-row-content-middle-section md-meeting-row-content-middle-section-Transparent"
+              position="middle"
+            >
+              <div
+                className="md-meeting-row-content-middle-section md-meeting-row-content-middle-section-Transparent"
+                data-position="middle"
               />
-            </div>
-          </ListItemBaseSection>
-          <ListItemBaseSection
-            className="md-meeting-list-item-middle-section md-meeting-list-item-middle-section-Transparent"
-            position="middle"
-          >
-            <div
-              className="md-meeting-list-item-middle-section md-meeting-list-item-middle-section-Transparent"
-              data-position="middle"
-            />
-          </ListItemBaseSection>
+            </ListItemBaseSection>
+          </MeetingRowContent>
         </li>
       </FocusRing>
     </FocusRing>
@@ -438,58 +459,67 @@ exports[`<MeetingListItem /> snapshot should match snapshot with image 1`] = `
           role="listitem"
           tabIndex={0}
         >
-          <ListItemBaseSection
-            className="md-meeting-list-item-start-section"
-            position="start"
-          >
-            <div
-              className="md-meeting-list-item-start-section"
-              data-position="start"
-            >
-              <div
-                className="md-meeting-list-item-border"
-                data-color="Transparent"
-              />
+          <MeetingRowContent
+            color="Transparent"
+            image={
               <Icon
                 name="placeholder"
-                scale={12}
-                strokeColor="none"
-                weight="bold"
+              />
+            }
+          >
+            <ListItemBaseSection
+              className="md-meeting-row-content-start-section"
+              position="start"
+            >
+              <div
+                className="md-meeting-row-content-start-section"
+                data-position="start"
               >
                 <div
-                  aria-hidden="true"
-                  className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
-                  role="img"
+                  className="md-meeting-row-content-border"
+                  data-color="Transparent"
+                />
+                <Icon
+                  name="placeholder"
+                  scale={12}
+                  strokeColor="none"
+                  weight="bold"
                 >
-                  <svg
+                  <div
                     aria-hidden="true"
-                    className=""
-                    data-autoscale={false}
-                    data-scale={12}
-                    data-test="placeholder"
-                    fill="currentColor"
-                    height="100%"
-                    style={
-                      Object {
-                        "stroke": "none",
+                    className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      className=""
+                      data-autoscale={false}
+                      data-scale={12}
+                      data-test="placeholder"
+                      fill="currentColor"
+                      height="100%"
+                      style={
+                        Object {
+                          "stroke": "none",
+                        }
                       }
-                    }
-                    viewBox="0, 0, 32, 32"
-                    width="100%"
-                  />
-                </div>
-              </Icon>
-            </div>
-          </ListItemBaseSection>
-          <ListItemBaseSection
-            className="md-meeting-list-item-middle-section md-meeting-list-item-middle-section-Transparent"
-            position="middle"
-          >
-            <div
-              className="md-meeting-list-item-middle-section md-meeting-list-item-middle-section-Transparent"
-              data-position="middle"
-            />
-          </ListItemBaseSection>
+                      viewBox="0, 0, 32, 32"
+                      width="100%"
+                    />
+                  </div>
+                </Icon>
+              </div>
+            </ListItemBaseSection>
+            <ListItemBaseSection
+              className="md-meeting-row-content-middle-section md-meeting-row-content-middle-section-Transparent"
+              position="middle"
+            >
+              <div
+                className="md-meeting-row-content-middle-section md-meeting-row-content-middle-section-Transparent"
+                data-position="middle"
+              />
+            </ListItemBaseSection>
+          </MeetingRowContent>
         </li>
       </FocusRing>
     </FocusRing>
@@ -542,29 +572,34 @@ exports[`<MeetingListItem /> snapshot should match snapshot with isDisabled 1`] 
           role="listitem"
           tabIndex={0}
         >
-          <ListItemBaseSection
-            className="md-meeting-list-item-start-section md-meeting-list-item-start-section-no-image"
-            position="start"
+          <MeetingRowContent
+            color="Transparent"
+            isDisabled={true}
           >
-            <div
-              className="md-meeting-list-item-start-section md-meeting-list-item-start-section-no-image"
-              data-position="start"
+            <ListItemBaseSection
+              className="md-meeting-row-content-start-section md-meeting-row-content-start-section-no-image"
+              position="start"
             >
               <div
-                className="md-meeting-list-item-border"
-                data-color="Transparent"
+                className="md-meeting-row-content-start-section md-meeting-row-content-start-section-no-image"
+                data-position="start"
+              >
+                <div
+                  className="md-meeting-row-content-border"
+                  data-color="Transparent"
+                />
+              </div>
+            </ListItemBaseSection>
+            <ListItemBaseSection
+              className="md-meeting-row-content-middle-section md-meeting-row-content-middle-section-Transparent"
+              position="middle"
+            >
+              <div
+                className="md-meeting-row-content-middle-section md-meeting-row-content-middle-section-Transparent"
+                data-position="middle"
               />
-            </div>
-          </ListItemBaseSection>
-          <ListItemBaseSection
-            className="md-meeting-list-item-middle-section md-meeting-list-item-middle-section-Transparent"
-            position="middle"
-          >
-            <div
-              className="md-meeting-list-item-middle-section md-meeting-list-item-middle-section-Transparent"
-              data-position="middle"
-            />
-          </ListItemBaseSection>
+            </ListItemBaseSection>
+          </MeetingRowContent>
         </li>
       </FocusRing>
     </FocusRing>
@@ -630,29 +665,33 @@ exports[`<MeetingListItem /> snapshot should match snapshot with style 1`] = `
           }
           tabIndex={0}
         >
-          <ListItemBaseSection
-            className="md-meeting-list-item-start-section md-meeting-list-item-start-section-no-image"
-            position="start"
+          <MeetingRowContent
+            color="Transparent"
           >
-            <div
-              className="md-meeting-list-item-start-section md-meeting-list-item-start-section-no-image"
-              data-position="start"
+            <ListItemBaseSection
+              className="md-meeting-row-content-start-section md-meeting-row-content-start-section-no-image"
+              position="start"
             >
               <div
-                className="md-meeting-list-item-border"
-                data-color="Transparent"
+                className="md-meeting-row-content-start-section md-meeting-row-content-start-section-no-image"
+                data-position="start"
+              >
+                <div
+                  className="md-meeting-row-content-border"
+                  data-color="Transparent"
+                />
+              </div>
+            </ListItemBaseSection>
+            <ListItemBaseSection
+              className="md-meeting-row-content-middle-section md-meeting-row-content-middle-section-Transparent"
+              position="middle"
+            >
+              <div
+                className="md-meeting-row-content-middle-section md-meeting-row-content-middle-section-Transparent"
+                data-position="middle"
               />
-            </div>
-          </ListItemBaseSection>
-          <ListItemBaseSection
-            className="md-meeting-list-item-middle-section md-meeting-list-item-middle-section-Transparent"
-            position="middle"
-          >
-            <div
-              className="md-meeting-list-item-middle-section md-meeting-list-item-middle-section-Transparent"
-              data-position="middle"
-            />
-          </ListItemBaseSection>
+            </ListItemBaseSection>
+          </MeetingRowContent>
         </li>
       </FocusRing>
     </FocusRing>

--- a/src/components/MeetingRowContent/MeetingRowContent.constants.ts
+++ b/src/components/MeetingRowContent/MeetingRowContent.constants.ts
@@ -1,0 +1,13 @@
+const CLASS_PREFIX = 'md-meeting-row-content';
+
+const DEFAULTS = {};
+
+const STYLE = {
+  startSection: `${CLASS_PREFIX}-start-section`,
+  border: `${CLASS_PREFIX}-border`,
+  middleSection: `${CLASS_PREFIX}-middle-section`,
+  endSection: `${CLASS_PREFIX}-end-section`,
+  startSectionNoImage: `${CLASS_PREFIX}-start-section-no-image`,
+};
+
+export { CLASS_PREFIX, DEFAULTS, STYLE };

--- a/src/components/MeetingRowContent/MeetingRowContent.stories.args.ts
+++ b/src/components/MeetingRowContent/MeetingRowContent.stories.args.ts
@@ -1,0 +1,72 @@
+import { commonAriaPressProps, commonStyles } from '../../storybook/helper.stories.argtypes';
+import { MeetingMarker } from '../MeetingListItem/MeetingListItem.types';
+
+export default {
+  ...commonStyles,
+  ...commonAriaPressProps,
+  children: {
+    description: 'Provides the child nodes for this element.', 
+    control: { type: 'none' },
+    table: {
+      type: {
+        summary: 'ReactNode', 
+      },
+      defaultValue: {
+        summary: 'undefined',
+      },
+    },
+  },
+  isDisabled: {
+    defaultValue: false,
+    description: 'Determines if this item is disabled',
+    control: { type: 'boolean' },
+    table: {
+      type: {
+        summary: 'boolean',
+      },
+      defaultValue: {
+        summary: false,
+      },
+    },
+  },
+  buttonGroup: {
+    defaultValue: undefined,
+    description: 'Provides the nodes for the end of the item',
+    control: { type: 'none' },
+    table: {
+      type: {
+        summary: 'ReactNode',
+      },
+      defaultValue: {
+        summary: undefined,
+      },
+    },
+  },
+  color: {
+    defaultValue: undefined,
+    description: 'Provides the color status of this item',
+    control: { type: 'select' },
+    options: [...Object.keys(MeetingMarker)],
+    table: {
+      type: {
+        summary: 'MeetingMarker',
+      },
+      defaultValue: {
+        summary: undefined,
+      },
+    },
+  },
+  image: {
+    defaultValue: undefined,
+    description: 'Provides the nodes for the start of the item',
+    control: { type: 'none' },
+    table: {
+      type: {
+        summary: 'ReactNode',
+      },
+      defaultValue: {
+        summary: undefined,
+      },
+    },
+  },
+};

--- a/src/components/MeetingRowContent/MeetingRowContent.stories.docs.mdx
+++ b/src/components/MeetingRowContent/MeetingRowContent.stories.docs.mdx
@@ -1,0 +1,1 @@
+The `<MeetingRowContent />` component. To be used internally for `<MeetingListItem />`.

--- a/src/components/MeetingRowContent/MeetingRowContent.stories.tsx
+++ b/src/components/MeetingRowContent/MeetingRowContent.stories.tsx
@@ -1,0 +1,342 @@
+import React from 'react';
+import { MultiTemplate, MultiTemplateWithLabel, Template } from '../../storybook/helper.stories.templates';
+import { DocumentationPage } from '../../storybook/helper.stories.docs';
+import StyleDocs from '../../storybook/docs.stories.style.mdx';
+
+import MeetingRowContent, { MeetingRowContentProps } from './';
+import argTypes from './MeetingRowContent.stories.args';
+import Documentation from './MeetingRowContent.stories.docs.mdx';
+import ButtonGroup from '../ButtonGroup';
+import ButtonHyperlink from '../ButtonHyperlink';
+import ButtonPill from '../ButtonPill';
+import Text from '../Text';
+import { MeetingMarker } from '../MeetingListItem';
+import Avatar from '../Avatar';
+import Icon from '../Icon';
+import ButtonCircle from '../ButtonCircle';
+
+export default {
+  title: 'Momentum UI/MeetingRowContent',
+  component: MeetingRowContent,
+  parameters: {
+    expanded: true,
+    docs: {
+      page: DocumentationPage(Documentation, StyleDocs),
+    },
+  },
+};
+
+const Example = Template<MeetingRowContentProps>((args: MeetingRowContentProps) => <div style={{position:'relative'}} ><MeetingRowContent {...args} /></div>
+).bind({});
+
+Example.argTypes = { ...argTypes };
+
+Example.args = {
+  buttonGroup: (
+    <ButtonGroup spaced>
+      <ButtonHyperlink key="link">Link</ButtonHyperlink>
+      <div key="participants-list" style={{ paddingRight: 0 }}>
+        17
+      </div>
+      <Icon key="participants-icon" name="participant-list" scale={16} />
+      <ButtonPill key="join-button" color="join">
+        Join
+      </ButtonPill>
+    </ButtonGroup>
+  ),
+  children: (
+    <>
+      <Text type="body-primary" key="child1">
+        Date
+      </Text>
+      <Text type="body-secondary" key="child2">
+        Normal
+      </Text>
+    </>
+  ),
+  color: MeetingMarker.AcceptedActive,
+  image: <Avatar initials="TU" />,
+};
+
+/**
+ * Common variants story. This renders multiple variants of a single component.
+ */
+const Common = MultiTemplateWithLabel<MeetingRowContentProps>((args: MeetingRowContentProps) => <div style={{position:'relative'}} ><MeetingRowContent {...args} /></div>
+).bind({});
+
+Common.argTypes = { ...argTypes };
+delete Common.argTypes.children;
+
+Common.parameters = {
+  variants: [
+    {
+      label: 'Recording with buttons',
+      buttonGroup: (
+        <ButtonGroup spaced>
+          <ButtonCircle key="btn-info" ghost={true}>
+            <Icon name="info-circle" />
+          </ButtonCircle>
+          <ButtonCircle key="btn-share" ghost={true}>
+            <Icon name="share-c-native-iph" />
+          </ButtonCircle>
+          <ButtonCircle key="btn-chat" ghost={true}>
+            <Icon name="chat" />
+          </ButtonCircle>
+        </ButtonGroup>
+      ),
+      children: (
+        <>
+          <Text type="header-primary" key="first-line">
+            Today
+          </Text>
+          <Text type="body-secondary" key="second-line">
+            11:00 - 12:00
+          </Text>
+        </>
+      ),
+      image: (
+        <ButtonCircle>
+          <Icon key="play-icon" name="play" />
+        </ButtonCircle>
+      ),
+    },
+    {
+      label: 'Recording with buttons and link',
+      buttonGroup: (
+        <ButtonGroup spaced>
+          <ButtonHyperlink key="link">hyperlink</ButtonHyperlink>
+          <ButtonCircle key="btn-info" ghost={true}>
+            <Icon name="info-circle" />
+          </ButtonCircle>
+          <ButtonCircle key="btn-chat" ghost={true}>
+            <Icon name="chat" />
+          </ButtonCircle>
+        </ButtonGroup>
+      ),
+      children: (
+        <>
+          <Text type="header-primary" key="first-line">
+            Today
+          </Text>
+          <Text type="body-secondary" key="second-line">
+            11:00 - 12:00
+          </Text>
+        </>
+      ),
+      image: (
+        <ButtonCircle>
+          <Icon key="play-icon" name="play" />
+        </ButtonCircle>
+      ),
+    },
+    {
+      label: 'Active meeting with participant count',
+      buttonGroup: (
+        <ButtonGroup spaced>
+          <ButtonHyperlink key="link">Link</ButtonHyperlink>
+          <div key="participant-list" style={{ paddingRight: 0, marginRight: 0 }}>
+            17
+          </div>
+          <Icon key="participant-list-icon" name="participant-list" scale={16} />
+          <ButtonPill key="join-button" color="join">
+            Join
+          </ButtonPill>
+        </ButtonGroup>
+      ),
+      children: (
+        <>
+          <Text type="header-primary" key="child1">
+            Date
+          </Text>
+          <Text type="body-secondary" key="child2">
+            Normal
+          </Text>
+        </>
+      ),
+      color: MeetingMarker.AcceptedActive,
+      image: <Avatar initials="TU" />,
+    },
+    {
+      label: 'Inactive meeting',
+      buttonGroup: (
+        <ButtonGroup spaced>
+          <Icon key="recurring-icon" name="recurring" />
+          <Icon key="calendar-icon" name="calendar-empty" />
+        </ButtonGroup>
+      ),
+      children: (
+        <>
+          <Text type="body-primary" key="child1">
+            Date
+          </Text>
+          <Text type="body-secondary" key="child2">
+            Normal
+          </Text>
+        </>
+      ),
+      color: MeetingMarker.AcceptedInactive,
+      image: <Avatar initials="TU" />,
+    },
+    {
+      label: 'Active meeting without join button',
+      buttonGroup: (
+        <ButtonGroup spaced>
+          <Icon key="icon-recurring" name="recurring" />
+          <Icon key="icon-calendar" name="calendar-empty" />
+        </ButtonGroup>
+      ),
+      children: (
+        <>
+          <Text type="body-primary" key="child1">
+            Date
+          </Text>
+          <Text type="body-secondary" key="child2">
+            Normal
+          </Text>
+        </>
+      ),
+      color: MeetingMarker.AcceptedInactive,
+      image: <Avatar initials="TU" />,
+    },
+    {
+      label: 'Scheduled meeting',
+      children: (
+        <div key="child-1" style={{ display: 'flex' }}>
+          <div key="first-line-group" style={{ display: 'flex', flexDirection: 'column' }}>
+            <Text key="first-line" type="body-primary">
+              Date
+            </Text>
+            <Text key="second-line" type="body-secondary">
+              Time - Time
+            </Text>
+          </div>
+          <div
+            key="third-line"
+            style={{ display: 'flex', alignItems: 'center', marginLeft: '10px' }}
+          >
+            <div key="third-line-text" style={{ marginRight: '5px' }}>
+              Normal
+            </div>
+            <Icon key="recurring-icon" name="recurring" />
+          </div>
+        </div>
+      ),
+      buttonGroup: <Avatar initials="TU" />,
+      color: MeetingMarker.Transparent,
+    },
+    {
+      label: 'Three-line item',
+      children: (
+        <>
+          <Text type="body-primary" key="first-line">
+            Primary
+          </Text>
+          <Text type="body-secondary" key="second-line">
+            Name
+          </Text>
+          <Text type="body-secondary" key="third-line">
+            Date
+          </Text>
+        </>
+      ),
+      buttonGroup: (
+        <ButtonGroup spaced>
+          <ButtonHyperlink key="link">hyperlink</ButtonHyperlink>
+          <ButtonCircle key="button-copy" ghost={true}>
+            <Icon name="copy" />
+          </ButtonCircle>
+          <ButtonCircle key="button-chat" ghost={true}>
+            <Icon name="chat" />
+          </ButtonCircle>
+        </ButtonGroup>
+      ),
+      image: <Icon key="placeholder-icon" name="placeholder" />,
+      large: true,
+    },
+  ],
+};
+
+const Colors = MultiTemplate<MeetingRowContentProps>((args: MeetingRowContentProps) => {
+
+  return <div style={{position:'relative'}} ><MeetingRowContent {...args} /></div>;
+}).bind({});
+
+Colors.argTypes = { ...argTypes };
+delete Colors.argTypes.children;
+
+Colors.parameters = {
+  variants: [
+    {
+      buttonGroup: (
+        <ButtonGroup spaced>
+          <ButtonHyperlink>Link</ButtonHyperlink>
+        </ButtonGroup>
+      ),
+      children: <Text type="body-primary">{MeetingMarker.AcceptedActive}</Text>,
+      color: MeetingMarker.AcceptedActive,
+      image: <Avatar initials="TU" />,
+    },
+    {
+      buttonGroup: (
+        <ButtonGroup spaced>
+          <ButtonHyperlink>Link</ButtonHyperlink>
+        </ButtonGroup>
+      ),
+      children: <Text type="body-primary">{MeetingMarker.AcceptedInactive}</Text>,
+      color: MeetingMarker.AcceptedInactive,
+      image: <Avatar initials="TU" />,
+    },
+    {
+      buttonGroup: (
+        <ButtonGroup spaced>
+          <ButtonHyperlink>Link</ButtonHyperlink>
+        </ButtonGroup>
+      ),
+      children: <Text type="body-primary">{MeetingMarker.TentativeActive}</Text>,
+      color: MeetingMarker.TentativeActive,
+      image: <Avatar initials="TU" />,
+    },
+    {
+      buttonGroup: (
+        <ButtonGroup spaced>
+          <ButtonHyperlink>Link</ButtonHyperlink>
+        </ButtonGroup>
+      ),
+      children: <Text type="body-primary">{MeetingMarker.TentativeInactive}</Text>,
+      color: MeetingMarker.TentativeInactive,
+      image: <Avatar initials="TU" />,
+    },
+    {
+      buttonGroup: (
+        <ButtonGroup spaced>
+          <ButtonHyperlink>Link</ButtonHyperlink>
+        </ButtonGroup>
+      ),
+      children: <Text type="body-primary">{MeetingMarker.Transparent}</Text>,
+      color: MeetingMarker.Transparent,
+      image: <Avatar initials="TU" />,
+    },
+    {
+      buttonGroup: (
+        <ButtonGroup spaced>
+          <ButtonHyperlink>Link</ButtonHyperlink>
+        </ButtonGroup>
+      ),
+      children: <Text type="body-primary">{MeetingMarker.Gray}</Text>,
+      color: MeetingMarker.Gray,
+      image: <Avatar initials="TU" />,
+    },
+    {
+      buttonGroup: (
+        <ButtonGroup spaced>
+          <ButtonHyperlink>Link</ButtonHyperlink>
+        </ButtonGroup>
+      ),
+      children: <Text type="body-primary">{MeetingMarker.GrayStatic}</Text>,
+      color: MeetingMarker.GrayStatic,
+      image: <Avatar initials="TU" />,
+    },
+  ],
+};
+
+export { Example, Colors, Common };

--- a/src/components/MeetingRowContent/MeetingRowContent.style.scss
+++ b/src/components/MeetingRowContent/MeetingRowContent.style.scss
@@ -1,0 +1,88 @@
+.md-meeting-row-content-start-section {
+    display: flex;
+    align-items: center;
+
+    &.md-meeting-row-content-start-section-no-image {
+      margin-right: 0 !important;
+    }
+
+    .md-meeting-row-content-border {
+      position: absolute;
+      left: 0;
+      top: 0;
+      height: 100%;
+      width: 0.3rem;
+      border-radius: 0.5rem 0 0 0.5rem;
+      margin-right: 0.5rem;
+
+      &[data-color='AcceptedActive'] {
+        background-color: var(--mds-color-theme-button-join-normal);
+      }
+
+      &[data-color='AcceptedInactive'] {
+        background-color: var(--mds-color-theme-background-secondary-active);
+      }
+
+      &[data-color='TentativeActive'] {
+        background: webkit-repeating-linear-gradient(
+          -45deg,
+          transparent,
+          transparent 7%,
+          var(--mds-color-theme-button-join-normal) 7%,
+          var(--mds-color-theme-button-join-normal) 14%
+        );
+        background: -o-repeating-linear-gradient(
+          -45deg,
+          transparent,
+          transparent 7%,
+          var(--mds-color-theme-button-join-normal) 7%,
+          var(--mds-color-theme-button-join-normal) 14%
+        );
+        background: repeating-linear-gradient(
+          -45deg,
+          transparent,
+          transparent 7%,
+          var(--mds-color-theme-button-join-normal) 7%,
+          var(--mds-color-theme-button-join-normal) 14%
+        );
+      }
+
+      &[data-color='TentativeInactive'] {
+        background: webkit-repeating-linear-gradient(
+          -45deg,
+          transparent,
+          transparent 7%,
+          var(--mds-color-theme-background-secondary-active) 7%,
+          var(--mds-color-theme-background-secondary-active) 14%
+        );
+        background: -o-repeating-linear-gradient(
+          -45deg,
+          transparent,
+          transparent 7%,
+          var(--mds-color-theme-background-secondary-active) 7%,
+          var(--mds-color-theme-background-secondary-active) 14%
+        );
+        background: repeating-linear-gradient(
+          -45deg,
+          transparent,
+          transparent 7%,
+          var(--mds-color-theme-background-secondary-active) 7%,
+          var(--mds-color-theme-background-secondary-active) 14%
+        );
+      }
+    }   
+}
+
+.md-meeting-row-content-middle-section {
+    .md-text-wrapper:first-of-type {
+        margin-bottom: -0.25rem;
+    }
+}
+
+.md-meeting-row-content-end-section {
+    .md-button-group-wrapper > .md-icon-wrapper > svg {
+        path {
+        fill: var(--mds-color-theme-text-secondary-normal);
+        }
+    }
+}

--- a/src/components/MeetingRowContent/MeetingRowContent.tsx
+++ b/src/components/MeetingRowContent/MeetingRowContent.tsx
@@ -1,0 +1,100 @@
+import React, { Children, cloneElement, FC, ReactElement } from 'react';
+import classnames from 'classnames';
+
+import { STYLE } from './MeetingRowContent.constants';
+import { DEFAULTS as MEETING_LIST_ITEM_DEFAULTS } from '../MeetingListItem/MeetingListItem.constants';
+import { Props } from './MeetingRowContent.types';
+import './MeetingRowContent.style.scss';
+import ListItemBaseSection from '../ListItemBaseSection';
+import { verifyTypes } from '../../helpers/verifyTypes';
+import ButtonPill from '../ButtonPill';
+import ButtonCircle from '../ButtonCircle';
+import Avatar from '../Avatar';
+import Icon from '../Icon';
+
+/**
+ * The MeetingRowContent component.
+ */
+const MeetingRowContent: FC<Props> = (props: Props) => {
+  const {
+    children,
+    color = MEETING_LIST_ITEM_DEFAULTS.color,
+    isDisabled,
+    buttonGroup,
+    image,
+  } = props;
+
+  const getRestrictedProps = (element: ReactElement) => {
+    const sizeProps = {};
+    if (verifyTypes(element, ButtonPill)) {
+      sizeProps['size'] = 28;
+      sizeProps['disabled'] = isDisabled;
+    } else if (verifyTypes(element, ButtonCircle)) {
+      sizeProps['size'] = 32;
+      sizeProps['disabled'] = isDisabled;
+    } else if (verifyTypes(element, Icon)) {
+      // Because this constraints get applied recursively to the children,
+      // I still want to be able to override some of the props (like scale).
+      if (!element.props.scale) {
+        sizeProps['scale'] = 12;
+        sizeProps['strokeColor'] = 'none';
+        sizeProps['weight'] = 'bold';
+      }
+    } else if (verifyTypes(element, Avatar)) {
+      sizeProps['size'] = 32;
+    }
+    return sizeProps;
+  };
+
+  const getSizedElement = (element) => {
+    if (element && React.isValidElement(element)) {
+      const elementChildren = element.props['children'];
+      let sizedChildren;
+      if (elementChildren) {
+        if (Array.isArray(elementChildren)) {
+          sizedChildren = [];
+          Children.map(elementChildren, (child) => {
+            sizedChildren.push(getSizedElement(child));
+          });
+        } else {
+          sizedChildren = getSizedElement(elementChildren);
+        }
+      }
+      return cloneElement(element, getRestrictedProps(element), sizedChildren);
+    }
+    return element;
+  };
+
+  let buttonSection = buttonGroup;
+
+  if (buttonGroup && React.isValidElement(buttonGroup)) {
+    buttonSection = getSizedElement(buttonGroup);
+  }
+
+  const middleSectionColorClass = color ? ` md-meeting-row-content-middle-section-${color}` : '';
+
+  return (
+    <>
+      <ListItemBaseSection
+        className={classnames(STYLE.startSection, { [STYLE.startSectionNoImage]: !image })}
+        position="start"
+      >
+        <div className={STYLE.border} data-color={color} />
+        {React.isValidElement(image) ? getSizedElement(image) : image}
+      </ListItemBaseSection>
+      <ListItemBaseSection
+        className={`${STYLE.middleSection}${middleSectionColorClass}`}
+        position="middle"
+      >
+        {getSizedElement(children)}
+      </ListItemBaseSection>
+      {buttonSection && (
+        <ListItemBaseSection className={STYLE.endSection} position="end">
+          {buttonSection}
+        </ListItemBaseSection>
+      )}
+    </>
+  );
+};
+
+export default MeetingRowContent;

--- a/src/components/MeetingRowContent/MeetingRowContent.types.ts
+++ b/src/components/MeetingRowContent/MeetingRowContent.types.ts
@@ -1,0 +1,30 @@
+import { ReactNode } from 'react';
+import { MeetingMarker } from '../MeetingListItem';
+
+export interface Props {
+  /**
+   * Child components of this MeetingRowContent.
+   */
+  children?: ReactNode;
+
+  /**
+   * Buttons or icons for end of item
+   */
+  buttonGroup?: ReactNode;
+
+  /**
+   * Determines if this item is disabled
+   * @default false
+   */
+  isDisabled?: boolean;
+
+  /**
+   * Icon, Avatar, or other content for beginning of item
+   */
+  image?: ReactNode;
+
+  /**
+   * Color status
+   */
+  color?: MeetingMarker;
+}

--- a/src/components/MeetingRowContent/MeetingRowContent.unit.test.tsx
+++ b/src/components/MeetingRowContent/MeetingRowContent.unit.test.tsx
@@ -1,0 +1,144 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import MeetingRowContent from './';
+import ButtonPill from '../ButtonPill';
+import ButtonGroup from '../ButtonGroup';
+import ButtonHyperlink from '../ButtonHyperlink';
+import Icon from '../Icon';
+import { MeetingMarker } from '../MeetingListItem';
+import ButtonCircle from '../ButtonCircle';
+import Avatar from '../Avatar';
+import { mountAndWait } from '../../../test/utils';
+
+describe('<MeetingRowContent />', () => {
+  describe('snapshot', () => {
+    it('should match snapshot', () => {
+      expect.assertions(1);
+
+      const container = mount(<MeetingRowContent />);
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match snapshot with children', () => {
+      expect.assertions(1);
+
+      const children = <ButtonPill>Example children</ButtonPill>;
+
+      const container = mount(<MeetingRowContent>{children}</MeetingRowContent>);
+
+      expect(container).toMatchSnapshot();
+    });
+
+
+    it('should match snapshot with buttonGroup', () => {
+      expect.assertions(1);
+
+      const buttonGroup = (
+        <ButtonGroup spaced>
+          <ButtonHyperlink key="link">Link</ButtonHyperlink>
+            <div key="participants-list" style={{ paddingRight: 0 }}>
+              17
+            </div>
+          <Icon key="participants-icon" name="participant-list" scale={16} />
+          <ButtonPill key="join-button" color="join">
+            Join
+          </ButtonPill>
+        </ButtonGroup>
+      );
+
+      const container = mount(<MeetingRowContent buttonGroup={buttonGroup} />);
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match snapshot with color', () => {
+      expect.assertions(1);
+
+      const color = MeetingMarker.TentativeActive;
+
+      const container = mount(<MeetingRowContent color={color} />);
+
+      expect(container).toMatchSnapshot();
+    });
+  });
+
+  describe('attributes', () => {
+    it('should have border color classname', () => {
+      expect.assertions(1);
+
+      const element = mount(<MeetingRowContent color={MeetingMarker.TentativeActive}/>);
+
+      const borderDiv =  element.find('.md-meeting-row-content-middle-section').at(1).getDOMNode();
+
+      expect(borderDiv.classList.contains('md-meeting-row-content-middle-section-TentativeActive')).toBe(true);
+    });
+
+    it('should render children as expected', () => {
+      expect.assertions(1);
+
+      const container = mount(
+        <MeetingRowContent>
+          Test Children
+        </MeetingRowContent>
+      );
+
+      const middleSection = container.find('.md-meeting-row-content-middle-section').first().getDOMNode();
+
+      expect(middleSection.textContent).toBe('Test Children');
+    });
+
+    it('should have disable buttons inside if isDisabled is provided', () => {
+      expect.assertions(2);
+
+      const isDisabled = true;
+
+      const container = mount(
+        <MeetingRowContent
+          isDisabled={isDisabled}
+          buttonGroup={
+            <ButtonGroup>
+              <ButtonCircle key="1">Test</ButtonCircle>
+              <ButtonPill key="2">Test</ButtonPill>
+            </ButtonGroup>
+          }
+        >
+          Test Children
+        </MeetingRowContent>
+      );
+
+      const buttonCircle = container.find(ButtonCircle).getDOMNode();
+      const buttonPill = container.find(ButtonPill).getDOMNode();
+
+      expect(buttonCircle.getAttribute('data-disabled')).toBe('true');
+      expect(buttonPill.getAttribute('data-disabled')).toBe('true');
+    });
+
+    it('should have appropriate sizes for button group', async () => {
+      expect.assertions(3);
+
+      const container = await mountAndWait(
+        <MeetingRowContent
+          buttonGroup={
+            <ButtonGroup>
+              <ButtonPill key="1" />
+              <ButtonCircle key="2"/>
+              <Avatar key="4" />
+            </ButtonGroup>
+          }
+        />
+      );
+
+      const buttonCircle = container.find(ButtonCircle).getDOMNode();
+      const buttonPill = container.find(ButtonPill).getDOMNode();
+      const avatar = container.find(Avatar).at(0).getDOMNode();
+
+      expect(buttonPill.getAttribute('data-size')).toBe('28');
+      expect(buttonCircle.getAttribute('data-size')).toBe(
+        '32'
+      );
+      expect(avatar.getAttribute('data-size')).toBe('32');
+    });
+  });
+});

--- a/src/components/MeetingRowContent/MeetingRowContent.unit.test.tsx.snap
+++ b/src/components/MeetingRowContent/MeetingRowContent.unit.test.tsx.snap
@@ -1,0 +1,326 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<MeetingRowContent /> snapshot should match snapshot 1`] = `
+<MeetingRowContent>
+  <ListItemBaseSection
+    className="md-meeting-row-content-start-section md-meeting-row-content-start-section-no-image"
+    position="start"
+  >
+    <div
+      className="md-meeting-row-content-start-section md-meeting-row-content-start-section-no-image"
+      data-position="start"
+    >
+      <div
+        className="md-meeting-row-content-border"
+        data-color="Transparent"
+      />
+    </div>
+  </ListItemBaseSection>
+  <ListItemBaseSection
+    className="md-meeting-row-content-middle-section md-meeting-row-content-middle-section-Transparent"
+    position="middle"
+  >
+    <div
+      className="md-meeting-row-content-middle-section md-meeting-row-content-middle-section-Transparent"
+      data-position="middle"
+    />
+  </ListItemBaseSection>
+</MeetingRowContent>
+`;
+
+exports[`<MeetingRowContent /> snapshot should match snapshot with buttonGroup 1`] = `
+<MeetingRowContent
+  buttonGroup={
+    <ButtonGroup
+      spaced={true}
+    >
+      <ButtonHyperlink>
+        Link
+      </ButtonHyperlink>
+      <div
+        style={
+          Object {
+            "paddingRight": 0,
+          }
+        }
+      >
+        17
+      </div>
+      <Icon
+        name="participant-list"
+        scale={16}
+      />
+      <ButtonPill
+        color="join"
+      >
+        Join
+      </ButtonPill>
+    </ButtonGroup>
+  }
+>
+  <ListItemBaseSection
+    className="md-meeting-row-content-start-section md-meeting-row-content-start-section-no-image"
+    position="start"
+  >
+    <div
+      className="md-meeting-row-content-start-section md-meeting-row-content-start-section-no-image"
+      data-position="start"
+    >
+      <div
+        className="md-meeting-row-content-border"
+        data-color="Transparent"
+      />
+    </div>
+  </ListItemBaseSection>
+  <ListItemBaseSection
+    className="md-meeting-row-content-middle-section md-meeting-row-content-middle-section-Transparent"
+    position="middle"
+  >
+    <div
+      className="md-meeting-row-content-middle-section md-meeting-row-content-middle-section-Transparent"
+      data-position="middle"
+    />
+  </ListItemBaseSection>
+  <ListItemBaseSection
+    className="md-meeting-row-content-end-section"
+    position="end"
+  >
+    <div
+      className="md-meeting-row-content-end-section"
+      data-position="end"
+    >
+      <ButtonGroup
+        spaced={true}
+      >
+        <div
+          className="md-button-group-wrapper"
+          data-compressed={false}
+          data-orientation="horizontal"
+          data-round={false}
+          data-separator={false}
+          data-spaced={true}
+        >
+          <ButtonHyperlink
+            key="link"
+          >
+            <FocusRing>
+              <FocusRing
+                focusClass="md-focus-ring-wrapper children"
+                focusRingClass="md-focus-ring-wrapper children"
+              >
+                <a
+                  className="md-button-hyperlink-wrapper"
+                  data-disabled={false}
+                  data-inverted={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onDragStart={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchCancel={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  Link
+                </a>
+              </FocusRing>
+            </FocusRing>
+          </ButtonHyperlink>
+          <div
+            key="participants-list"
+            style={
+              Object {
+                "paddingRight": 0,
+              }
+            }
+          >
+            17
+          </div>
+          <Icon
+            key="participants-icon"
+            name="participant-list"
+            scale={16}
+          />
+          <ButtonPill
+            color="join"
+            key="join-button"
+            size={28}
+          >
+            <ButtonSimple
+              aria-disabled={false}
+              className="md-button-pill-wrapper"
+              data-color="join"
+              data-disabled={false}
+              data-ghost={false}
+              data-grown={false}
+              data-inverted={false}
+              data-outline={false}
+              data-shallow-disabled={false}
+              data-size={28}
+            >
+              <FocusRing>
+                <FocusRing
+                  focusClass="md-focus-ring-wrapper children"
+                  focusRingClass="md-focus-ring-wrapper children"
+                >
+                  <button
+                    className="md-button-pill-wrapper md-button-simple-wrapper"
+                    data-color="join"
+                    data-disabled={false}
+                    data-ghost={false}
+                    data-grown={false}
+                    data-inverted={false}
+                    data-outline={false}
+                    data-shallow-disabled={false}
+                    data-size={28}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onDragStart={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchCancel={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchMove={[Function]}
+                    onTouchStart={[Function]}
+                    type="button"
+                  >
+                    <span>
+                      Join
+                    </span>
+                  </button>
+                </FocusRing>
+              </FocusRing>
+            </ButtonSimple>
+          </ButtonPill>
+        </div>
+      </ButtonGroup>
+    </div>
+  </ListItemBaseSection>
+</MeetingRowContent>
+`;
+
+exports[`<MeetingRowContent /> snapshot should match snapshot with children 1`] = `
+<MeetingRowContent>
+  <ListItemBaseSection
+    className="md-meeting-row-content-start-section md-meeting-row-content-start-section-no-image"
+    position="start"
+  >
+    <div
+      className="md-meeting-row-content-start-section md-meeting-row-content-start-section-no-image"
+      data-position="start"
+    >
+      <div
+        className="md-meeting-row-content-border"
+        data-color="Transparent"
+      />
+    </div>
+  </ListItemBaseSection>
+  <ListItemBaseSection
+    className="md-meeting-row-content-middle-section md-meeting-row-content-middle-section-Transparent"
+    position="middle"
+  >
+    <div
+      className="md-meeting-row-content-middle-section md-meeting-row-content-middle-section-Transparent"
+      data-position="middle"
+    >
+      <ButtonPill
+        size={28}
+      >
+        <ButtonSimple
+          aria-disabled={false}
+          className="md-button-pill-wrapper"
+          data-color="primary"
+          data-disabled={false}
+          data-ghost={false}
+          data-grown={false}
+          data-inverted={false}
+          data-outline={false}
+          data-shallow-disabled={false}
+          data-size={28}
+        >
+          <FocusRing>
+            <FocusRing
+              focusClass="md-focus-ring-wrapper children"
+              focusRingClass="md-focus-ring-wrapper children"
+            >
+              <button
+                className="md-button-pill-wrapper md-button-simple-wrapper"
+                data-color="primary"
+                data-disabled={false}
+                data-ghost={false}
+                data-grown={false}
+                data-inverted={false}
+                data-outline={false}
+                data-shallow-disabled={false}
+                data-size={28}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onDragStart={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchCancel={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                type="button"
+              >
+                <span>
+                  Example children
+                </span>
+              </button>
+            </FocusRing>
+          </FocusRing>
+        </ButtonSimple>
+      </ButtonPill>
+    </div>
+  </ListItemBaseSection>
+</MeetingRowContent>
+`;
+
+exports[`<MeetingRowContent /> snapshot should match snapshot with color 1`] = `
+<MeetingRowContent
+  color="TentativeActive"
+>
+  <ListItemBaseSection
+    className="md-meeting-row-content-start-section md-meeting-row-content-start-section-no-image"
+    position="start"
+  >
+    <div
+      className="md-meeting-row-content-start-section md-meeting-row-content-start-section-no-image"
+      data-position="start"
+    >
+      <div
+        className="md-meeting-row-content-border"
+        data-color="TentativeActive"
+      />
+    </div>
+  </ListItemBaseSection>
+  <ListItemBaseSection
+    className="md-meeting-row-content-middle-section md-meeting-row-content-middle-section-TentativeActive"
+    position="middle"
+  >
+    <div
+      className="md-meeting-row-content-middle-section md-meeting-row-content-middle-section-TentativeActive"
+      data-position="middle"
+    />
+  </ListItemBaseSection>
+</MeetingRowContent>
+`;

--- a/src/components/MeetingRowContent/index.ts
+++ b/src/components/MeetingRowContent/index.ts
@@ -1,0 +1,9 @@
+import { default as MeetingRowContent } from './MeetingRowContent';
+import * as CONSTANTS from './MeetingRowContent.constants';
+import { Props } from './MeetingRowContent.types';
+
+export { CONSTANTS as MEETING_ROW_CONTENT_CONSTANTS };
+
+export type MeetingRowContentProps = Props;
+
+export default MeetingRowContent;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -83,3 +83,4 @@ export { default as ButtonCircleLink } from './ButtonCircleLink';
 export { default as ButtonPillLink } from './ButtonPillLink';
 export { default as Tree, useTreeContext } from './Tree';
 export { default as TreeNodeBase } from './TreeNodeBase';
+export { default as MeetingRowContent } from './MeetingRowContent';

--- a/src/index.js
+++ b/src/index.js
@@ -198,4 +198,5 @@ export {
   useTreeContext,
   SelectionGroup,
   TreeNodeBase,
+  MeetingRowContent,
 } from './components';

--- a/src/storybook/helper.stories.templates.tsx
+++ b/src/storybook/helper.stories.templates.tsx
@@ -120,4 +120,42 @@ function MultiTemplateWithPseudoStates<Props>(Component: FC): Story<Props> {
   return LocalTemplate;
 }
 
-export { MultiTemplate, Template, MultiTemplateWithPseudoStates };
+/**
+ * Generate a Story Template that consists of multiple variants of a single Component with a label. See the [Storybook Documentation]{@link https://storybook.js.org/docs/react/writing-stories/introduction#using-args}.
+ * @param Component - Functional Component to generate multiple templates from.
+ * @returns - A Story Template with multiple variants of the provided Component's states.
+ */
+function MultiTemplateWithLabel<Props>(Component: FC): Story<Props> {
+  const LocalTemplate: Story<Props> = (args: Props, { parameters }) => {
+    const { variants } = parameters;
+
+    const items = variants.map(({ Wrapper, ...variant }, index) => (
+      <div key={index}>
+        <div style={{ padding: '0 1rem' }}>{variant.label}</div>
+        <div
+          style={{
+            minWidth: '18rem',
+            padding: '1rem',
+            gap: '1.5rem',
+            alignItems: 'start',
+            alignContent: 'start',
+          }}
+        >
+          {Wrapper ? (
+            <Wrapper key={index}>
+              <Component {...args} {...variant} />
+            </Wrapper>
+            ) : (
+            <Component key={index} {...args} {...variant} />
+          )}
+        </div>
+      </div>
+    ));
+
+    return <>{items}</>;
+  };
+
+  return LocalTemplate;
+}
+
+export { MultiTemplate, Template, MultiTemplateWithPseudoStates, MultiTemplateWithLabel };


### PR DESCRIPTION
# Description

This is to fix a bug in ActivityList refactor where the MeetingListItem is causing issues as it's not immediately wrapped in a ListNext component. To solve this we will just use MeetingRowContent in Cantina inside ActivityList and style it as if it were a MeetingListItem.
