### PR TITLE
fix(legacy/ListItem): add font-weight when menu item is active for a11y

### DIFF
--- a/scss/components/list-item/mixins.scss
+++ b/scss/components/list-item/mixins.scss
@@ -412,6 +412,10 @@
     background-color: $active-bgrd-color;
     background-color: var($active-bgrd-color-css-var, $active-bgrd-color);
 
+    .md-menu-item__content {
+      font-weight: 700;
+    }
+
     .#{$list-item__class} {
       &__header {
         color: $active-header-color;


### PR DESCRIPTION
# Description

Add font-weight: 700 when a menu item is active as per Figma. This also addresses an a11y color contrast issue.

Before | After
--- | ---
<img height="300" alt="Screenshot 2024-09-19 at 17 17 29" src="https://github.com/user-attachments/assets/05cadbbb-7280-47bb-9f6a-5cdd75db5bad"> | <img height="300" alt="Screenshot 2024-09-19 at 17 17 38" src="https://github.com/user-attachments/assets/370c77a9-a58a-4ad4-b743-303586bca13a">

# Links
Jira Ticket: https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-367582
- Issues 6 & 7

Figma: https://www.figma.com/design/FmXv8xvun1xAZiOMfztwqg/%F0%9F%A7%A9-Webex-App---Web?m=auto&node-id=5431-1707&t=QziLFquo50T9wcRC-1
