### PR TITLE
feat(icon): use icon type names

### DIFF
--- a/config/typescript/tsconfig.base.json
+++ b/config/typescript/tsconfig.base.json
@@ -6,6 +6,7 @@
     "declaration": true,
     "esModuleInterop": true,
     "isolatedModules": true,
+    "resolveJsonModule": true,
     "jsx": "react",
     "moduleResolution": "node",
     "paths": {

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "@momentum-design/animations": "^0.0.4",
-    "@momentum-design/icons": "0.0.163",
+    "@momentum-design/icons": "0.0.164",
     "@momentum-design/tokens": "0.0.77",
     "@momentum-ui/design-tokens": "^0.0.63",
     "@momentum-ui/icons": "8.28.4",

--- a/src/components/Avatar/Avatar.types.ts
+++ b/src/components/Avatar/Avatar.types.ts
@@ -1,6 +1,7 @@
 import { TeamColor } from '../ThemeProvider/ThemeProvider.types';
 import { AriaButtonProps } from '@react-types/button';
 import { SIZES } from './Avatar.constants';
+import { InferredIconName } from '../Icon/Icon.types';
 
 export enum PresenceType {
   Default = 'default',
@@ -70,12 +71,12 @@ export interface Props extends Omit<AriaButtonProps, 'type'> {
   /**
    * The icon name to display instead of initials or image
    */
-  icon?: string;
+  icon?: InferredIconName;
 
   /**
    * The icon to display when Avatar is hovered or focused
    */
-  iconOnHover?: string;
+  iconOnHover?: InferredIconName;
 
   /**
    * The main description of the Avatar, which will be the first part of its aria-label.

--- a/src/components/Avatar/Avatar.unit.test.tsx
+++ b/src/components/Avatar/Avatar.unit.test.tsx
@@ -4,6 +4,7 @@ import React, { createRef } from 'react';
 import { MAX_INITIALS_SPACE, SIZES, STYLE, AVATAR_COLORS } from './Avatar.constants';
 import { AvatarColor, AvatarSize, PresenceType } from './Avatar.types';
 import { mountAndWait } from '../../../test/utils';
+import { InferredIconName } from '../Icon/Icon.types';
 
 describe('Avatar', () => {
   const sampleProps = {
@@ -13,7 +14,7 @@ describe('Avatar', () => {
     presenceLabel: 'Active',
     presence: PresenceType.Active,
     src: 'src',
-    icon: 'Accessibility',
+    icon: 'accessibility' as InferredIconName,
     typingLabel: 'is typing',
   };
 
@@ -38,7 +39,7 @@ describe('Avatar', () => {
         type={isPerson ? 'person' : 'space'}
         title={sampleProps.title}
         onPress={onPress}
-        icon={avatarType === 'icon' ? sampleProps.icon : ''}
+        icon={avatarType === 'icon' ? sampleProps.icon : undefined}
         src={avatarType === 'src' ? sampleProps.src : ''}
         presence={withPresence ? sampleProps.presence : null}
         presenceLabel={withPresence ? sampleProps.presenceLabel : ''}

--- a/src/components/Avatar/Presence.tsx
+++ b/src/components/Avatar/Presence.tsx
@@ -3,10 +3,11 @@ import Icon from '../Icon';
 
 import { AvatarSize } from './Avatar.types';
 import { STYLE, AVATAR_PRESENCE_ICON_SIZE_MAPPING } from './Avatar.constants';
+import { InferredIconName } from '../Icon/Icon.types';
 
 interface PresenceProps {
   presenceColor: string;
-  presenceIcon: string;
+  presenceIcon: InferredIconName;
   isCircularWrapper: boolean;
   size: AvatarSize;
 }

--- a/src/components/Avatar/Presence.utils.ts
+++ b/src/components/Avatar/Presence.utils.ts
@@ -1,7 +1,8 @@
+import { InferredIconName } from '../Icon/Icon.types';
 import { PresenceType } from './Avatar.types';
 
 type ReturnType = {
-  presenceIcon?: string;
+  presenceIcon?: InferredIconName;
   presenceColor?: string;
   isCircularWrapper?: boolean;
 };
@@ -9,7 +10,7 @@ export const getPresenceIconColor = (
   presenceType: PresenceType,
   failureBadge: boolean
 ): ReturnType => {
-  let presenceIcon: string;
+  let presenceIcon: InferredIconName;
   let presenceColor: string;
   let isCircularWrapper = true;
 

--- a/src/components/AvatarMeetingsListItem/AvatarMeetingsListItem.tsx
+++ b/src/components/AvatarMeetingsListItem/AvatarMeetingsListItem.tsx
@@ -116,7 +116,7 @@ const AvatarMeetingsListItem: FC<Props> = (props: Props) => {
         {displayMuteAction && (
           <ButtonCircle onPress={onPressMuteAction} ghost size={28}>
             <Icon
-              name={isMuted ? 'microphone-muted' : 'audio-microphone-on-green-colored'}
+              name={isMuted ? 'microphone-muted' : 'microphone-on'}
               weight="bold"
               scale={16}
               fillColor={isMuted && 'var(--mds-color-theme-text-error-normal)'}

--- a/src/components/AvatarMeetingsListItem/AvatarMeetingsListItem.unit.test.tsx
+++ b/src/components/AvatarMeetingsListItem/AvatarMeetingsListItem.unit.test.tsx
@@ -323,7 +323,7 @@ describe('<AvatarMeetingsListItem />', () => {
           <AvatarMeetingsListItem displayActions={displayActions} isMuted={isMuted} />
         )
       )
-        .find('Icon[name="audio-microphone-on-green-colored"]')
+        .find('Icon[name="microphone-on"]')
         .getDOMNode();
 
       expect(element).toBeDefined();

--- a/src/components/AvatarMeetingsListItem/AvatarMeetingsListItem.unit.test.tsx.snap
+++ b/src/components/AvatarMeetingsListItem/AvatarMeetingsListItem.unit.test.tsx.snap
@@ -748,7 +748,7 @@ exports[`<AvatarMeetingsListItem /> snapshot should match snapshot with displayM
                       >
                         <Icon
                           fillColor={false}
-                          name="audio-microphone-on-green-colored"
+                          name="microphone-on"
                           scale={16}
                           strokeColor="none"
                           weight="bold"
@@ -763,7 +763,7 @@ exports[`<AvatarMeetingsListItem /> snapshot should match snapshot with displayM
                               className=""
                               data-autoscale={false}
                               data-scale={16}
-                              data-test="audio-microphone-on-green-colored"
+                              data-test="microphone-on"
                               fill="currentColor"
                               height="100%"
                               style={

--- a/src/components/ButtonControl/ButtonControl.tsx
+++ b/src/components/ButtonControl/ButtonControl.tsx
@@ -7,6 +7,7 @@ import Icon, { ICON_CONSTANTS, IconProps } from '../Icon';
 import { ICONS, STYLE } from './ButtonControl.constants';
 import { Props } from './ButtonControl.types';
 import './ButtonControl.style.scss';
+import { InferredIconName } from '../Icon/Icon.types';
 
 /**
  * `<ControlButtons />` are used to control [close, maximize, minimize, etc] components [usually panels] they are assigned to.
@@ -14,7 +15,7 @@ import './ButtonControl.style.scss';
 const ButtonControl = forwardRef((props: Props, providedRef: RefObject<HTMLButtonElement>) => {
   const { className, control, isCircular, ...otherProps } = props;
 
-  const iconName = ICONS[control] || 'not-found';
+  const iconName = (ICONS[control] || 'not-found') as InferredIconName;
   const iconProps: IconProps = {
     autoScale: true,
     name: iconName,

--- a/src/components/Coachmark/Coachmark.types.ts
+++ b/src/components/Coachmark/Coachmark.types.ts
@@ -2,6 +2,7 @@ import type { ReactElement, ReactNode } from 'react';
 
 import { ButtonSimpleProps } from '../ButtonSimple';
 import { PopoverProps } from '../Popover';
+import { InferredIconName } from '../Icon/Icon.types';
 
 export interface CoachmarkWithoutHeaderProps {
   /**
@@ -24,7 +25,7 @@ export interface CoachmarkWithHeaderProps extends CoachmarkWithoutHeaderProps {
   /**
    * Icon to display to the left of the title.
    */
-  icon?: string;
+  icon?: InferredIconName;
 
   /**
    * Image associated with this Coachmark.

--- a/src/components/Icon/Icon.constants.ts
+++ b/src/components/Icon/Icon.constants.ts
@@ -1,5 +1,5 @@
 import { IconScale } from '.';
-import type { IconWeight } from './Icon.types';
+import type { IconWeight, InferredIconName } from './Icon.types';
 
 const CLASS_PREFIX = 'md-icon';
 const COLOR_INHERIT = 'currentColor';
@@ -60,7 +60,7 @@ const DEFAULTS = {
   WEIGHTLESS: false,
 };
 
-const EXCEPTION_ICONS_LIST = [
+const EXCEPTION_ICONS_LIST: Array<InferredIconName> = [
   'check-circle-badge',
   'error-legacy-badge',
   'info-badge',

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -36,7 +36,7 @@ const Icon: React.FC<Props> = (props: Props) => {
   const resolvedSVGName = getResolvedSVGName(name, weight, weightless);
   const { SvgIcon, error } = useDynamicSVGImport(resolvedSVGName);
 
-  const isColoredIcon = name.indexOf('coloured') > 0;
+  const isColoredIcon = /-colou?red$/.test(name as string);
 
   if (error) {
     console.warn('Icon load failed:', error);

--- a/src/components/Icon/Icon.types.ts
+++ b/src/components/Icon/Icon.types.ts
@@ -1,4 +1,11 @@
 import { CSSProperties } from 'react';
+import IconKeys from '@momentum-design/icons/dist/types/types';
+
+export type IconWeight = 'light' | 'regular' | 'bold' | 'filled';
+
+type RemoveWeight<T> = T extends `${infer Base}-${IconWeight}` ? Base : T;
+
+export type InferredIconName = RemoveWeight<IconKeys>;
 
 export type IconScale =
   | 8
@@ -21,8 +28,6 @@ export type IconScale =
   | 124
   | 'auto'
   | 'inherit';
-
-export type IconWeight = 'light' | 'regular' | 'bold' | 'filled';
 
 export interface Props {
   /**
@@ -58,7 +63,7 @@ export interface Props {
    * Name of the icon. Should be lowercase. See Icon docs for
    * available icons.
    */
-  name: string;
+  name: InferredIconName;
 
   /**
    * Scale represents the size/scale of te icon.

--- a/src/components/Icon/Icon.unit.test.tsx
+++ b/src/components/Icon/Icon.unit.test.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from 'react';
 import { STYLE, EXCEPTION_ICONS_LIST, VIEW_BOX_SPECS } from './Icon.constants';
 
 import { mountAndWait } from '../../../test/utils';
+import { InferredIconName } from './Icon.types';
 
 describe('<Icon />', () => {
   let container;
@@ -51,7 +52,7 @@ describe('<Icon />', () => {
 
       const title = 'You have a draft message';
 
-      container = await mountAndWait(<Icon name="draft-indicator-bold" title={title} />);
+      container = await mountAndWait(<Icon name="draft-indicator" weight="bold" title={title} />);
 
       expect(container).toMatchSnapshot();
     });
@@ -61,7 +62,7 @@ describe('<Icon />', () => {
 
       const ariaLabel = 'This participant is muted';
 
-      container = await mountAndWait(<Icon name="draft-indicator-bold" ariaLabel={ariaLabel} />);
+      container = await mountAndWait(<Icon name="draft-indicator" weight="bold" ariaLabel={ariaLabel} />);
 
       expect(container).toMatchSnapshot();
     });
@@ -71,7 +72,7 @@ describe('<Icon />', () => {
 
       const ariaLabel = 'This participant is muted';
 
-      container = await mountAndWait(<Icon name="draft-indicator-bold" aria-label={ariaLabel} />);
+      container = await mountAndWait(<Icon name="draft-indicator" weight="bold" aria-label={ariaLabel} />);
 
       expect(container).toMatchSnapshot();
     });
@@ -142,7 +143,7 @@ describe('<Icon />', () => {
         { virtual: true }
       );
 
-      container = await mountAndWait(<Icon name="invalid_icon_name" />);
+      container = await mountAndWait(<Icon name={`invalid_icon_name` as InferredIconName} />);
 
       expect(container).toMatchSnapshot();
       jest.dontMock('@momentum-design/icons/dist/svg/invalid_icon_name.svg?svgr');
@@ -204,7 +205,7 @@ describe('<Icon />', () => {
 
       const title = 'You have a draft message';
 
-      const wrapper = await mountAndWait(<Icon name="draft-indicator-bold" title={title} />);
+      const wrapper = await mountAndWait(<Icon name="draft-indicator" weight="bold" title={title} />);
       const element = wrapper.find(Icon).getDOMNode();
 
       expect(element.getAttribute('title')).toBe(title);
@@ -216,7 +217,7 @@ describe('<Icon />', () => {
       const ariaLabel = 'This participant is muted';
 
       const wrapper = await mountAndWait(
-        <Icon name="draft-indicator-bold" ariaLabel={ariaLabel} />
+        <Icon name="draft-indicator" weight="bold" ariaLabel={ariaLabel} />
       );
       const element = wrapper.find(Icon).getDOMNode();
 
@@ -230,7 +231,7 @@ describe('<Icon />', () => {
       const ariaLabel = 'This participant is muted';
 
       const wrapper = await mountAndWait(
-        <Icon name="draft-indicator-bold" aria-label={ariaLabel} />
+        <Icon name="draft-indicator" weight="bold" aria-label={ariaLabel} />
       );
       const element = wrapper.find(Icon).getDOMNode();
 
@@ -360,13 +361,6 @@ describe('<Icon />', () => {
       expect(icon.getAttribute('data-scale')).toBe('false');
     });
 
-    it('should pass md-icon-coloured class if name of icon contains coloured', async () => {
-      const wrapper = await mountAndWait(<Icon name={'accessibility-coloured'} />);
-      const icon = wrapper.find('svg').getDOMNode();
-
-      expect(icon.classList.contains('md-icon-coloured')).toBe(true);
-    });
-
     it('should pass color prop', async () => {
       const color = 'blue';
 
@@ -417,7 +411,7 @@ describe('<Icon />', () => {
       const fillColor = 'blue';
 
       const wrapper = await mountAndWait(
-        <Icon name={'accessibility-coloured'} fillColor={fillColor} />
+        <Icon name={'apple-business-chat-colored'} fillColor={fillColor} />
       );
       const icon = wrapper.find('svg').getDOMNode();
 

--- a/src/components/Icon/Icon.unit.test.tsx.snap
+++ b/src/components/Icon/Icon.unit.test.tsx.snap
@@ -28,7 +28,8 @@ exports[`<Icon /> snapshot should match snapshot 1`] = `
 exports[`<Icon /> snapshot should match snapshot with aria-label 1`] = `
 <Icon
   aria-label="This participant is muted"
-  name="draft-indicator-bold"
+  name="draft-indicator"
+  weight="bold"
 >
   <div
     aria-hidden="false"
@@ -41,7 +42,7 @@ exports[`<Icon /> snapshot should match snapshot with aria-label 1`] = `
       className=""
       data-autoscale={false}
       data-scale={32}
-      data-test="draft-indicator-bold"
+      data-test="draft-indicator"
       fill="currentColor"
       height="100%"
       style={Object {}}
@@ -55,7 +56,8 @@ exports[`<Icon /> snapshot should match snapshot with aria-label 1`] = `
 exports[`<Icon /> snapshot should match snapshot with ariaLabel 1`] = `
 <Icon
   ariaLabel="This participant is muted"
-  name="draft-indicator-bold"
+  name="draft-indicator"
+  weight="bold"
 >
   <div
     aria-hidden="false"
@@ -68,7 +70,7 @@ exports[`<Icon /> snapshot should match snapshot with ariaLabel 1`] = `
       className=""
       data-autoscale={false}
       data-scale={32}
-      data-test="draft-indicator-bold"
+      data-test="draft-indicator"
       fill="currentColor"
       height="100%"
       style={Object {}}
@@ -380,8 +382,9 @@ exports[`<Icon /> snapshot should match snapshot with style 1`] = `
 
 exports[`<Icon /> snapshot should match snapshot with title 1`] = `
 <Icon
-  name="draft-indicator-bold"
+  name="draft-indicator"
   title="You have a draft message"
+  weight="bold"
 >
   <div
     aria-hidden="false"
@@ -395,7 +398,7 @@ exports[`<Icon /> snapshot should match snapshot with title 1`] = `
       className=""
       data-autoscale={false}
       data-scale={32}
-      data-test="draft-indicator-bold"
+      data-test="draft-indicator"
       fill="currentColor"
       height="100%"
       style={Object {}}

--- a/src/components/Icon/Icon.utils.test.ts
+++ b/src/components/Icon/Icon.utils.test.ts
@@ -1,4 +1,5 @@
 import type { IconWeight } from '.';
+import { InferredIconName } from './Icon.types';
 import { getResolvedSVGName } from './Icon.utils';
 
 describe('getResolvedSVGName', () => {
@@ -14,6 +15,6 @@ describe('getResolvedSVGName', () => {
     ['icon-name', 'thin', true, 'icon-name'],
     ['icon-name', 'filled', true, 'icon-name'],
   ])('returns the correct name for %s, %s, %s', (name, weight, weightless, expected) => {
-    expect(getResolvedSVGName(name, weight as IconWeight, weightless)).toEqual(expected);
+    expect(getResolvedSVGName(name as InferredIconName, weight as IconWeight, weightless)).toEqual(expected);
   });
 });

--- a/src/components/Icon/Icon.utils.ts
+++ b/src/components/Icon/Icon.utils.ts
@@ -1,4 +1,4 @@
-import type { IconWeight } from './Icon.types';
+import type { IconWeight, InferredIconName } from './Icon.types';
 import { DEFAULTS } from './Icon.constants';
 /**
  * Creates the resolved name for SVG icons lookup.
@@ -8,5 +8,5 @@ import { DEFAULTS } from './Icon.constants';
  * @param weightless - marks that this icon doesn't have a weight
  * @returns - resolved name of the icon
  */
-export const getResolvedSVGName = (name: string, weight: IconWeight, weightless: boolean): string =>
-  weightless ? name : `${name}-${weight || DEFAULTS.WEIGHT}`;
+export const getResolvedSVGName = (name: InferredIconName, weight: IconWeight, weightless: boolean): string =>
+  weightless ? `${String(name)}` : `${String(name)}-${weight || DEFAULTS.WEIGHT}`;

--- a/src/components/LoadingSpinner/LoadingSpinner.tsx
+++ b/src/components/LoadingSpinner/LoadingSpinner.tsx
@@ -12,7 +12,7 @@ const LoadingSpinner: FC<Props> = (props: Props) => {
   return (
     <div className={classnames(className, STYLE.wrapper)} id={id} style={style} {...rest}>
       <Icon scale={scale} name="spinner" weight="regular" />
-      <Icon scale={scale} className={STYLE.arch} name="spinner-partial" weight="regular" />
+      <Icon scale={scale} className={STYLE.arch} name="spinner-in-progress" weight="regular" />
     </div>
   );
 };

--- a/src/components/LoadingSpinner/LoadingSpinner.unit.test.tsx.snap
+++ b/src/components/LoadingSpinner/LoadingSpinner.unit.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`<LoadingSpinner /> snapshot should match snapshot 1`] = `
     </Icon>
     <Icon
       className="md-loading-spinner-arch"
-      name="spinner-partial"
+      name="spinner-in-progress"
       scale={24}
       weight="regular"
     >
@@ -45,7 +45,7 @@ exports[`<LoadingSpinner /> snapshot should match snapshot 1`] = `
           className=""
           data-autoscale={false}
           data-scale={24}
-          data-test="spinner-partial"
+          data-test="spinner-in-progress"
           fill="currentColor"
           height="100%"
           style={Object {}}
@@ -91,7 +91,7 @@ exports[`<LoadingSpinner /> snapshot should match snapshot with className 1`] = 
     </Icon>
     <Icon
       className="md-loading-spinner-arch"
-      name="spinner-partial"
+      name="spinner-in-progress"
       scale={24}
       weight="regular"
     >
@@ -105,7 +105,7 @@ exports[`<LoadingSpinner /> snapshot should match snapshot with className 1`] = 
           className=""
           data-autoscale={false}
           data-scale={24}
-          data-test="spinner-partial"
+          data-test="spinner-in-progress"
           fill="currentColor"
           height="100%"
           style={Object {}}
@@ -152,7 +152,7 @@ exports[`<LoadingSpinner /> snapshot should match snapshot with id 1`] = `
     </Icon>
     <Icon
       className="md-loading-spinner-arch"
-      name="spinner-partial"
+      name="spinner-in-progress"
       scale={24}
       weight="regular"
     >
@@ -166,7 +166,7 @@ exports[`<LoadingSpinner /> snapshot should match snapshot with id 1`] = `
           className=""
           data-autoscale={false}
           data-scale={24}
-          data-test="spinner-partial"
+          data-test="spinner-in-progress"
           fill="currentColor"
           height="100%"
           style={Object {}}
@@ -212,7 +212,7 @@ exports[`<LoadingSpinner /> snapshot should match snapshot with scale 1`] = `
     </Icon>
     <Icon
       className="md-loading-spinner-arch"
-      name="spinner-partial"
+      name="spinner-in-progress"
       scale={32}
       weight="regular"
     >
@@ -226,7 +226,7 @@ exports[`<LoadingSpinner /> snapshot should match snapshot with scale 1`] = `
           className=""
           data-autoscale={false}
           data-scale={32}
-          data-test="spinner-partial"
+          data-test="spinner-in-progress"
           fill="currentColor"
           height="100%"
           style={Object {}}
@@ -281,7 +281,7 @@ exports[`<LoadingSpinner /> snapshot should match snapshot with style 1`] = `
     </Icon>
     <Icon
       className="md-loading-spinner-arch"
-      name="spinner-partial"
+      name="spinner-in-progress"
       scale={24}
       weight="regular"
     >
@@ -295,7 +295,7 @@ exports[`<LoadingSpinner /> snapshot should match snapshot with style 1`] = `
           className=""
           data-autoscale={false}
           data-scale={24}
-          data-test="spinner-partial"
+          data-test="spinner-in-progress"
           fill="currentColor"
           height="100%"
           style={Object {}}

--- a/src/components/NavigationTab/NavigationTab.types.ts
+++ b/src/components/NavigationTab/NavigationTab.types.ts
@@ -1,5 +1,6 @@
 import { CSSProperties } from 'react';
 import { AriaButtonProps } from '@react-types/button';
+import { InferredIconName } from '../Icon/Icon.types';
 
 export interface Props extends AriaButtonProps {
   /**
@@ -30,7 +31,7 @@ export interface Props extends AriaButtonProps {
   /**
    * Size index of this NavTab.
    */
-  icon?: string;
+  icon?: InferredIconName;
 
   /**
    * The amount inside the badge of components of this NavTab. If 0, then it is not shown.

--- a/src/components/Reaction/Reaction.unit.test.tsx.snap
+++ b/src/components/Reaction/Reaction.unit.test.tsx.snap
@@ -487,7 +487,7 @@ exports[`<Reaction/> snapshot should match snapshot with spinner while animation
       </Icon>
       <Icon
         className="md-loading-spinner-arch"
-        name="spinner-partial"
+        name="spinner-in-progress"
         scale={16}
         weight="regular"
       >
@@ -501,7 +501,7 @@ exports[`<Reaction/> snapshot should match snapshot with spinner while animation
             className=""
             data-autoscale={false}
             data-scale={16}
-            data-test="spinner-partial"
+            data-test="spinner-in-progress"
             fill="currentColor"
             height="100%"
             style={Object {}}

--- a/src/components/SearchInput/SearchInput.unit.test.tsx.snap
+++ b/src/components/SearchInput/SearchInput.unit.test.tsx.snap
@@ -379,7 +379,7 @@ exports[`<SearchInput /> snapshot should match snapshot when searching 1`] = `
             </Icon>
             <Icon
               className="md-loading-spinner-arch"
-              name="spinner-partial"
+              name="spinner-in-progress"
               scale={16}
               weight="regular"
             >
@@ -393,7 +393,7 @@ exports[`<SearchInput /> snapshot should match snapshot when searching 1`] = `
                   className=""
                   data-autoscale={false}
                   data-scale={16}
-                  data-test="spinner-partial"
+                  data-test="spinner-in-progress"
                   fill="currentColor"
                   height="100%"
                   style={Object {}}

--- a/src/components/TextToast/TextToast.unit.test.tsx
+++ b/src/components/TextToast/TextToast.unit.test.tsx
@@ -5,11 +5,12 @@ import TextToast, { TEXT_TOAST_CONSTANTS as CONSTANTS } from './';
 import Text from '../Text/Text';
 import { mountAndWait } from '../../../test/utils';
 import Icon from '../Icon';
+import { InferredIconName } from '../Icon/Icon.types';
 
 const textMock =
   'Lorem ipsum dolor site aw aetns ctetuer adipiscing elit nullam amarte adipiscing elit nullam amarte.';
 const iconPropsMock = {
-  name: 'noise-removal',
+  name: 'noise-removal' as InferredIconName,
 };
 
 describe('<TextToast />', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2444,10 +2444,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@momentum-design/icons@npm:0.0.163":
-  version: 0.0.163
-  resolution: "@momentum-design/icons@npm:0.0.163"
-  checksum: 505ae681e4464e8fdd3c2224acaa5f9896ea78f52357f5ef66e3044edda39bf9c6844222a2c7158acb2003938414461183e04359dc5dcd944bc20d1a7d025e44
+"@momentum-design/icons@npm:0.0.164":
+  version: 0.0.164
+  resolution: "@momentum-design/icons@npm:0.0.164"
+  checksum: 35ac73c6c7a70987b6b564e90e48edfe561a2a715e68bd28dc00bcf12a7b7d1c17a5a8781362b653582f34b196faf1a82cbed9458bcb8069e2d882698fa55343
   languageName: node
   linkType: hard
 
@@ -2495,7 +2495,7 @@ __metadata:
     "@commitlint/config-conventional": ^12.0.1
     "@hot-loader/react-dom": ~16.8.0
     "@momentum-design/animations": ^0.0.4
-    "@momentum-design/icons": 0.0.163
+    "@momentum-design/icons": 0.0.164
     "@momentum-design/tokens": 0.0.77
     "@momentum-ui/design-tokens": ^0.0.63
     "@momentum-ui/icons": 8.28.4


### PR DESCRIPTION
# IMPORTANT

**Currently, this project is closed to any external contributions. Any pull request made against this project from external sources will likely be closed. If you would like to make changes to this project, please fork this project.**

# Guide

**This "Help" section can be deleted before submitting this pull request.**

*Update the name of this pull request to reflect the following shape:*

```
{type}/{scope?}/{message}
```

* **type** - A [conventional commit type](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional#type-enum) **REQUIRED**
* **scope** - The kabab-case scope of the changes in this request
* **message** - A short, kebab-case statement describing the changes **REQUIRED**

*Provide a general summary of the scope of the changes in this pull request.*

* [Readme](https://github.com/momentum-design/momentum-react-v2/blob/master/README.md)
* [Getting Started Guide](https://github.com/momentum-design/momentum-react-v2/blob/master/GETTING_STARTED.md)
* [Contributing Guide](https://github.com/momentum-design/momentum-react-v2/blob/master/CONTRIBUTING.md)

# Description

Using icon names as a type from the momentum-design/icons repo for autocomplete, and selection of types

# Links

*Links to relevent resources.*
