### PR TITLE
feat(menu-separator): add hasSeparators prop

### DIFF
--- a/src/components/Menu/Menu.constants.ts
+++ b/src/components/Menu/Menu.constants.ts
@@ -4,12 +4,14 @@ const CLASS_PREFIX = 'md-menu';
 
 const STYLE = {
   wrapper: `${CLASS_PREFIX}-wrapper`,
+  separator: `${CLASS_PREFIX}-separator`,
 };
 
 const DEFAULTS = {
   ITEM_SIZE: 40 as ListItemBaseSize,
   ITEM_SHAPE: 'rectangle' as const,
   IS_TICK_ON_LEFT_SIDE: false,
+  HAS_SEPARATORS: false,
 };
 
 const GROUP = 'group';

--- a/src/components/Menu/Menu.stories.args.ts
+++ b/src/components/Menu/Menu.stories.args.ts
@@ -149,4 +149,17 @@ export default {
       defaultValue: 'multiple',
     },
   },
+  hasSeparators: {
+    description: 'Wheather the menu should display separator lines between menu children',
+    default: false,
+    control: { type: 'boolean' },
+    table: {
+      type: {
+        summary: 'boolean',
+      },
+      defaultValue: {
+        summary: 'false',
+      },
+    },
+  },
 };

--- a/src/components/Menu/Menu.stories.tsx
+++ b/src/components/Menu/Menu.stories.tsx
@@ -12,7 +12,7 @@ import { action } from '@storybook/addon-actions';
 import Flex from '../Flex';
 import Avatar from '../Avatar';
 import { PresenceType } from '../Avatar/Avatar.types';
-import { ListHeader, ListItemBaseSection, Icon } from '..';
+import { Icon, Text } from '..';
 
 export default {
   title: 'Momentum UI/Menu',
@@ -82,39 +82,19 @@ Sections.parameters = {
       isTickOnLeftSide: true,
       onSelectionChange: menuOnSelectionChange,
       onAction: menuOnAction,
+      hasSeparators: true,
       children: [
-        <Section
-          key="0"
-          title={
-            <ListHeader outline={false}>
-              <ListItemBaseSection position="fill">Europe</ListItemBaseSection>
-            </ListHeader>
-          }
-        >
+        <Section key="0" title="Europe">
           <Item key="00">Spain</Item>
           <Item key="01">France</Item>
           <Item key="02">Italy</Item>
         </Section>,
-        <Section
-          key="1"
-          title={
-            <ListHeader outline={true} outlinePosition="top" outlineColor="secondary">
-              <ListItemBaseSection position="fill">Asia</ListItemBaseSection>
-            </ListHeader>
-          }
-        >
+        <Section key="1" title="Asia">
           <Item key="10">India</Item>
           <Item key="11">China</Item>
           <Item key="12">Japan</Item>
         </Section>,
-        <Section
-          key="2"
-          title={
-            <ListHeader outline={true} outlinePosition="top" outlineColor="secondary">
-              <ListItemBaseSection position="fill">America</ListItemBaseSection>
-            </ListHeader>
-          }
-        >
+        <Section key="2" title="America">
           <Item key="13">USA</Item>
           <Item key="14">Mexico</Item>
           <Item key="15">Canada</Item>
@@ -144,6 +124,7 @@ SelectionGroups.parameters = {
       isTickOnLeftSide: true,
       onSelectionChange: menuOnSelectionChange,
       onAction: menuOnAction,
+      hasSeparators: 'true',
       children: [
         <SelectionGroup
           key="0"
@@ -156,14 +137,10 @@ SelectionGroups.parameters = {
             console.log('selectionOnAction1', rest);
           }}
           title={
-            <ListHeader outline={false}>
-              <ListItemBaseSection position="start">
-                <Icon scale={16} name="speaker" strokeColor="none" />
-              </ListItemBaseSection>
-              <ListItemBaseSection position="fill">
-                Speaker (you can choose many)
-              </ListItemBaseSection>
-            </ListHeader>
+            <Flex direction="row" alignItems="center" xgap="0.25rem">
+              <Icon scale={16} name="speaker" strokeColor="none" />
+              <Text>Speaker (you can choose many)</Text>
+            </Flex>
           }
         >
           <Item key="00">System default speaker</Item>
@@ -183,16 +160,10 @@ SelectionGroups.parameters = {
             console.log('selectionOnAction2', rest);
           }}
           title={
-            <>
-              <ListHeader outline={true} outlinePosition="top" outlineColor="secondary">
-                <ListItemBaseSection position="start">
-                  <Icon scale={16} name="microphone" strokeColor="none" />
-                </ListItemBaseSection>
-                <ListItemBaseSection position="fill">
-                  Microphone (you can choose one)
-                </ListItemBaseSection>
-              </ListHeader>
-            </>
+            <Flex direction="row" alignItems="center" xgap="0.25rem">
+              <Icon scale={16} name="microphone" strokeColor="none" />
+              <Text>Microphone (you can choose one)</Text>
+            </Flex>
           }
         >
           <Item key="10">No Microphone</Item>
@@ -218,14 +189,10 @@ SelectionGroups.parameters = {
           }}
           title={
             <>
-              <ListHeader outline={true} outlinePosition="top" outlineColor="secondary">
-                <ListItemBaseSection position="start">
-                  <Icon scale={16} name="adjust-microphone" strokeColor="none" />
-                </ListItemBaseSection>
-                <ListItemBaseSection position="fill">
-                  Webex smart audio (You can choose one)
-                </ListItemBaseSection>
-              </ListHeader>
+              <Flex direction="row" alignItems="center" xgap="0.25rem">
+                <Icon scale={16} name="adjust-microphone" strokeColor="none" />
+                <Text>Webex smart audio (You can choose one)</Text>
+              </Flex>
             </>
           }
         >

--- a/src/components/Menu/Menu.style.scss
+++ b/src/components/Menu/Menu.style.scss
@@ -6,4 +6,12 @@
   > ul {
     margin-left: 0;
   }
+
+  .md-menu-separator {
+    border-bottom: 1px solid var(--mds-color-theme-outline-primary-normal);
+    // the separator is drawn after the list item
+    // so need to move it back up a bit
+    margin-top: 0.25rem;
+    margin-bottom: 0.5rem;
+  }
 }

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -33,6 +33,7 @@ const Menu = <T extends object>(props: Props<T>, providedRef: RefObject<HTMLDivE
     isTickOnLeftSide = DEFAULTS.IS_TICK_ON_LEFT_SIDE,
     itemShape = DEFAULTS.ITEM_SHAPE,
     itemSize = DEFAULTS.ITEM_SIZE,
+    hasSeparators = DEFAULTS.HAS_SEPARATORS,
     ariaLabelledby,
   } = props;
 
@@ -51,21 +52,36 @@ const Menu = <T extends object>(props: Props<T>, providedRef: RefObject<HTMLDivE
 
   const itemArray = Array.from(state.collection.getKeys());
 
+  const lastGroupIndex = itemArray
+    .map((key) => state.collection.getItem(key).hasChildNodes)
+    .lastIndexOf(true);
+
   const renderItem = useCallback(
-    <T extends object>(item: Node<T>, state: TreeState<T>) => {
+    <T extends object>(item: Node<T>, index: number, state: TreeState<T>) => {
+      const isLastGroup = index === lastGroupIndex;
       if (item.type === 'section') {
         if (item.props?.selectionGroup) {
           return (
-            <MenuSelectionGroup
-              item={item}
-              state={state}
-              onAction={_props.onAction}
-              key={item.key}
-              {...item.props}
-            />
+            <>
+              <MenuSelectionGroup
+                item={item}
+                state={state}
+                onAction={_props.onAction}
+                key={item.key}
+                {...item.props}
+              />
+              {hasSeparators && !isLastGroup && (
+                <div role="separator" className={STYLE.separator} />
+              )}
+            </>
           );
         }
-        return <MenuSection key={item.key} item={item} state={state} onAction={_props.onAction} />;
+        return (
+          <>
+            <MenuSection key={item.key} item={item} state={state} onAction={_props.onAction} />
+            {hasSeparators && !isLastGroup && <div role="separator" className={STYLE.separator} />}
+          </>
+        );
       } else {
         // collection.getKeys() return all keys (including sub-keys of child elements)
         // and we don't want to render items twice
@@ -104,9 +120,9 @@ const Menu = <T extends object>(props: Props<T>, providedRef: RefObject<HTMLDivE
         aria-labelledby={ariaLabelledby}
         {...menuProps}
       >
-        {itemArray.map((key) => {
+        {itemArray.map((key, index) => {
           const item = state.collection.getItem(key) as Node<T>;
-          return renderItem(item, state);
+          return renderItem(item, index, state);
         })}
       </div>
     </MenuAppearanceContext.Provider>

--- a/src/components/Menu/Menu.types.ts
+++ b/src/components/Menu/Menu.types.ts
@@ -47,6 +47,11 @@ export interface Props<T> extends AriaMenuProps<T> {
    * aria-labelledby attribute to associate with the menu items
    */
   ariaLabelledby?: string;
+
+  /**
+   * Wheather the menu should display separator lines between menu children
+   */
+  hasSeparators?: boolean;
 }
 
 export interface MenuContextValue extends HTMLAttributes<HTMLElement> {

--- a/src/components/Menu/Menu.unit.test.tsx
+++ b/src/components/Menu/Menu.unit.test.tsx
@@ -180,8 +180,8 @@ describe('<Menu />', () => {
       expect(element.getAttribute('data-shape')).toBe(itemShape);
     });
 
-    it('should have rendered separators between sections when hasSeparators is true', () => {
-      expect.assertions(2);
+    it('should have rendered separators between groups when hasSeparators is true', () => {
+      expect.assertions(3);
 
       const { queryAllByRole } = render(
         <Menu {...defaultProps} hasSeparators>
@@ -189,21 +189,28 @@ describe('<Menu />', () => {
             <Item key="one">One</Item>
             <Item key="two">Two</Item>
           </Section>
-          <Section title="Section 2" key="s2" aria-label="section2">
+          <SelectionGroup title="Selection 2" key="s2" aria-label="section2" selectionMode="single">
             <Item key="three">Three</Item>
-            <Item key="four">Four</Item>
+            <Item key="foud">Four</Item>
+          </SelectionGroup>
+          <Section title="Section 3" key="s3" aria-label="section3">
+            <Item key="five">Five</Item>
+            <Item key="six">Six</Item>
           </Section>
         </Menu>
       );
 
       const separators = queryAllByRole('separator');
-      expect(separators.length).toBe(1);
+      expect(separators.length).toBe(2);
       expect(separators[0].outerHTML).toEqual(
+        '<div role="separator" class="md-menu-separator"></div>'
+      );
+      expect(separators[1].outerHTML).toEqual(
         '<div role="separator" class="md-menu-separator"></div>'
       );
     });
 
-    it('should not have rendered separators between sections when hasSeparators is false', () => {
+    it('should not have rendered separators between groups when hasSeparators is false', () => {
       expect.assertions(1);
 
       const { queryAllByRole } = render(
@@ -212,9 +219,13 @@ describe('<Menu />', () => {
             <Item key="one">One</Item>
             <Item key="two">Two</Item>
           </Section>
-          <Section title="Section 2" key="s2" aria-label="section2">
+          <SelectionGroup title="Selection 2" key="s2" aria-label="section2" selectionMode="single">
             <Item key="three">Three</Item>
-            <Item key="four">Four</Item>
+            <Item key="foud">Four</Item>
+          </SelectionGroup>
+          <Section title="Section 3" key="s3" aria-label="section3">
+            <Item key="five">Five</Item>
+            <Item key="six">Six</Item>
           </Section>
         </Menu>
       );

--- a/src/components/Menu/Menu.unit.test.tsx
+++ b/src/components/Menu/Menu.unit.test.tsx
@@ -74,6 +74,16 @@ describe('<Menu />', () => {
 
       expect(container).toMatchSnapshot();
     });
+
+    it('should match snapshot with hasSeparators', () => {
+      expect.assertions(1);
+
+      const hasSeparators = true;
+
+      const container = mount(<Menu {...defaultProps} hasSeparators={hasSeparators} />);
+
+      expect(container).toMatchSnapshot();
+    });
   });
 
   describe('attributes', () => {
@@ -168,6 +178,49 @@ describe('<Menu />', () => {
         .getDOMNode();
 
       expect(element.getAttribute('data-shape')).toBe(itemShape);
+    });
+
+    it('should have rendered separators between sections when hasSeparators is true', () => {
+      expect.assertions(2);
+
+      const { queryAllByRole } = render(
+        <Menu {...defaultProps} hasSeparators>
+          <Section title="Section 1" key="s1" aria-label="section1">
+            <Item key="one">One</Item>
+            <Item key="two">Two</Item>
+          </Section>
+          <Section title="Section 2" key="s2" aria-label="section2">
+            <Item key="three">Three</Item>
+            <Item key="four">Four</Item>
+          </Section>
+        </Menu>
+      );
+
+      const separators = queryAllByRole('separator');
+      expect(separators.length).toBe(1);
+      expect(separators[0].outerHTML).toEqual(
+        '<div role="separator" class="md-menu-separator"></div>'
+      );
+    });
+
+    it('should not have rendered separators between sections when hasSeparators is false', () => {
+      expect.assertions(1);
+
+      const { queryAllByRole } = render(
+        <Menu {...defaultProps}>
+          <Section title="Section 1" key="s1" aria-label="section1">
+            <Item key="one">One</Item>
+            <Item key="two">Two</Item>
+          </Section>
+          <Section title="Section 2" key="s2" aria-label="section2">
+            <Item key="three">Three</Item>
+            <Item key="four">Four</Item>
+          </Section>
+        </Menu>
+      );
+
+      const separators = queryAllByRole('separator');
+      expect(separators.length).toBe(0);
     });
   });
 

--- a/src/components/Menu/Menu.unit.test.tsx.snap
+++ b/src/components/Menu/Menu.unit.test.tsx.snap
@@ -959,6 +959,486 @@ exports[`<Menu /> snapshot should match snapshot with className 1`] = `
 </_Menu>
 `;
 
+exports[`<Menu /> snapshot should match snapshot with hasSeparators 1`] = `
+<_Menu
+  aria-label="Menu component"
+  hasSeparators={true}
+>
+  <div
+    aria-label="Menu component"
+    className="md-menu-wrapper"
+    onBlur={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onKeyDownCapture={[Function]}
+    onMouseDown={[Function]}
+    role="menu"
+    tabIndex={0}
+  >
+    <MenuItem
+      item={
+        Object {
+          "aria-label": undefined,
+          "childNodes": Object {
+            Symbol(Symbol.iterator): [Function],
+          },
+          "hasChildNodes": false,
+          "index": 0,
+          "key": "one",
+          "level": 0,
+          "nextKey": "two",
+          "parentKey": null,
+          "prevKey": undefined,
+          "props": Object {
+            "children": "One",
+          },
+          "rendered": "One",
+          "shouldInvalidate": undefined,
+          "textValue": "One",
+          "type": "item",
+          "value": undefined,
+          "wrapper": undefined,
+        }
+      }
+      key="one"
+      state={
+        Object {
+          "collection": $f4c7caecb598119f63e2918a55ec91a9$export$TreeCollection {
+            "firstKey": "one",
+            "iterable": Object {
+              Symbol(Symbol.iterator): [Function],
+            },
+            "keyMap": Map {
+              "one" => Object {
+                "aria-label": undefined,
+                "childNodes": Object {
+                  Symbol(Symbol.iterator): [Function],
+                },
+                "hasChildNodes": false,
+                "index": 0,
+                "key": "one",
+                "level": 0,
+                "nextKey": "two",
+                "parentKey": null,
+                "prevKey": undefined,
+                "props": Object {
+                  "children": "One",
+                },
+                "rendered": "One",
+                "shouldInvalidate": undefined,
+                "textValue": "One",
+                "type": "item",
+                "value": undefined,
+                "wrapper": undefined,
+              },
+              "two" => Object {
+                "aria-label": undefined,
+                "childNodes": Object {
+                  Symbol(Symbol.iterator): [Function],
+                },
+                "hasChildNodes": false,
+                "index": 1,
+                "key": "two",
+                "level": 0,
+                "nextKey": undefined,
+                "parentKey": null,
+                "prevKey": "one",
+                "props": Object {
+                  "children": "Two",
+                },
+                "rendered": "Two",
+                "shouldInvalidate": undefined,
+                "textValue": "Two",
+                "type": "item",
+                "value": undefined,
+                "wrapper": undefined,
+              },
+            },
+            "lastKey": "two",
+          },
+          "disabledKeys": Set {},
+          "expandedKeys": Set {},
+          "selectionManager": SelectionManager {
+            "_isSelectAll": null,
+            "allowsCellSelection": false,
+            "collection": $f4c7caecb598119f63e2918a55ec91a9$export$TreeCollection {
+              "firstKey": "one",
+              "iterable": Object {
+                Symbol(Symbol.iterator): [Function],
+              },
+              "keyMap": Map {
+                "one" => Object {
+                  "aria-label": undefined,
+                  "childNodes": Object {
+                    Symbol(Symbol.iterator): [Function],
+                  },
+                  "hasChildNodes": false,
+                  "index": 0,
+                  "key": "one",
+                  "level": 0,
+                  "nextKey": "two",
+                  "parentKey": null,
+                  "prevKey": undefined,
+                  "props": Object {
+                    "children": "One",
+                  },
+                  "rendered": "One",
+                  "shouldInvalidate": undefined,
+                  "textValue": "One",
+                  "type": "item",
+                  "value": undefined,
+                  "wrapper": undefined,
+                },
+                "two" => Object {
+                  "aria-label": undefined,
+                  "childNodes": Object {
+                    Symbol(Symbol.iterator): [Function],
+                  },
+                  "hasChildNodes": false,
+                  "index": 1,
+                  "key": "two",
+                  "level": 0,
+                  "nextKey": undefined,
+                  "parentKey": null,
+                  "prevKey": "one",
+                  "props": Object {
+                    "children": "Two",
+                  },
+                  "rendered": "Two",
+                  "shouldInvalidate": undefined,
+                  "textValue": "Two",
+                  "type": "item",
+                  "value": undefined,
+                  "wrapper": undefined,
+                },
+              },
+              "lastKey": "two",
+            },
+            "state": Object {
+              "childFocusStrategy": null,
+              "disabledKeys": Set {},
+              "disallowEmptySelection": undefined,
+              "focusedKey": null,
+              "isFocused": false,
+              "selectedKeys": Set {},
+              "selectionMode": "none",
+              "setFocused": [Function],
+              "setFocusedKey": [Function],
+              "setSelectedKeys": [Function],
+            },
+          },
+          "toggleKey": [Function],
+        }
+      }
+    >
+      <ListItemBase
+        aria-disabled={false}
+        aria-labelledby={null}
+        className="md-menu-item-wrapper"
+        data-key="one"
+        isDisabled={false}
+        isPadded={true}
+        onClick={[Function]}
+        onDragStart={[Function]}
+        onFocus={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        onTouchCancel={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
+        role="menuitem"
+        shape="rectangle"
+        size={40}
+        tabIndex={-1}
+      >
+        <FocusRing
+          isInset={false}
+        >
+          <FocusRing
+            focusClass="md-focus-ring-wrapper children"
+            focusRingClass="md-focus-ring-wrapper children"
+            isInset={false}
+          >
+            <li
+              aria-disabled={false}
+              aria-labelledby={null}
+              className="md-menu-item-wrapper md-list-item-base-wrapper"
+              data-allow-text-select={false}
+              data-disabled={false}
+              data-interactive={true}
+              data-key="one"
+              data-padded={true}
+              data-shape="rectangle"
+              data-size={40}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onDragStart={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+              onTouchCancel={[Function]}
+              onTouchEnd={[Function]}
+              onTouchMove={[Function]}
+              onTouchStart={[Function]}
+              role="menuitem"
+              tabIndex={-1}
+            >
+              <ListItemBaseSection
+                position="fill"
+                title="One"
+              >
+                <div
+                  data-position="fill"
+                  title="One"
+                >
+                  One
+                </div>
+              </ListItemBaseSection>
+            </li>
+          </FocusRing>
+        </FocusRing>
+      </ListItemBase>
+    </MenuItem>
+    <MenuItem
+      item={
+        Object {
+          "aria-label": undefined,
+          "childNodes": Object {
+            Symbol(Symbol.iterator): [Function],
+          },
+          "hasChildNodes": false,
+          "index": 1,
+          "key": "two",
+          "level": 0,
+          "nextKey": undefined,
+          "parentKey": null,
+          "prevKey": "one",
+          "props": Object {
+            "children": "Two",
+          },
+          "rendered": "Two",
+          "shouldInvalidate": undefined,
+          "textValue": "Two",
+          "type": "item",
+          "value": undefined,
+          "wrapper": undefined,
+        }
+      }
+      key="two"
+      state={
+        Object {
+          "collection": $f4c7caecb598119f63e2918a55ec91a9$export$TreeCollection {
+            "firstKey": "one",
+            "iterable": Object {
+              Symbol(Symbol.iterator): [Function],
+            },
+            "keyMap": Map {
+              "one" => Object {
+                "aria-label": undefined,
+                "childNodes": Object {
+                  Symbol(Symbol.iterator): [Function],
+                },
+                "hasChildNodes": false,
+                "index": 0,
+                "key": "one",
+                "level": 0,
+                "nextKey": "two",
+                "parentKey": null,
+                "prevKey": undefined,
+                "props": Object {
+                  "children": "One",
+                },
+                "rendered": "One",
+                "shouldInvalidate": undefined,
+                "textValue": "One",
+                "type": "item",
+                "value": undefined,
+                "wrapper": undefined,
+              },
+              "two" => Object {
+                "aria-label": undefined,
+                "childNodes": Object {
+                  Symbol(Symbol.iterator): [Function],
+                },
+                "hasChildNodes": false,
+                "index": 1,
+                "key": "two",
+                "level": 0,
+                "nextKey": undefined,
+                "parentKey": null,
+                "prevKey": "one",
+                "props": Object {
+                  "children": "Two",
+                },
+                "rendered": "Two",
+                "shouldInvalidate": undefined,
+                "textValue": "Two",
+                "type": "item",
+                "value": undefined,
+                "wrapper": undefined,
+              },
+            },
+            "lastKey": "two",
+          },
+          "disabledKeys": Set {},
+          "expandedKeys": Set {},
+          "selectionManager": SelectionManager {
+            "_isSelectAll": null,
+            "allowsCellSelection": false,
+            "collection": $f4c7caecb598119f63e2918a55ec91a9$export$TreeCollection {
+              "firstKey": "one",
+              "iterable": Object {
+                Symbol(Symbol.iterator): [Function],
+              },
+              "keyMap": Map {
+                "one" => Object {
+                  "aria-label": undefined,
+                  "childNodes": Object {
+                    Symbol(Symbol.iterator): [Function],
+                  },
+                  "hasChildNodes": false,
+                  "index": 0,
+                  "key": "one",
+                  "level": 0,
+                  "nextKey": "two",
+                  "parentKey": null,
+                  "prevKey": undefined,
+                  "props": Object {
+                    "children": "One",
+                  },
+                  "rendered": "One",
+                  "shouldInvalidate": undefined,
+                  "textValue": "One",
+                  "type": "item",
+                  "value": undefined,
+                  "wrapper": undefined,
+                },
+                "two" => Object {
+                  "aria-label": undefined,
+                  "childNodes": Object {
+                    Symbol(Symbol.iterator): [Function],
+                  },
+                  "hasChildNodes": false,
+                  "index": 1,
+                  "key": "two",
+                  "level": 0,
+                  "nextKey": undefined,
+                  "parentKey": null,
+                  "prevKey": "one",
+                  "props": Object {
+                    "children": "Two",
+                  },
+                  "rendered": "Two",
+                  "shouldInvalidate": undefined,
+                  "textValue": "Two",
+                  "type": "item",
+                  "value": undefined,
+                  "wrapper": undefined,
+                },
+              },
+              "lastKey": "two",
+            },
+            "state": Object {
+              "childFocusStrategy": null,
+              "disabledKeys": Set {},
+              "disallowEmptySelection": undefined,
+              "focusedKey": null,
+              "isFocused": false,
+              "selectedKeys": Set {},
+              "selectionMode": "none",
+              "setFocused": [Function],
+              "setFocusedKey": [Function],
+              "setSelectedKeys": [Function],
+            },
+          },
+          "toggleKey": [Function],
+        }
+      }
+    >
+      <ListItemBase
+        aria-disabled={false}
+        aria-labelledby={null}
+        className="md-menu-item-wrapper"
+        data-key="two"
+        isDisabled={false}
+        isPadded={true}
+        onClick={[Function]}
+        onDragStart={[Function]}
+        onFocus={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        onTouchCancel={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
+        role="menuitem"
+        shape="rectangle"
+        size={40}
+        tabIndex={-1}
+      >
+        <FocusRing
+          isInset={false}
+        >
+          <FocusRing
+            focusClass="md-focus-ring-wrapper children"
+            focusRingClass="md-focus-ring-wrapper children"
+            isInset={false}
+          >
+            <li
+              aria-disabled={false}
+              aria-labelledby={null}
+              className="md-menu-item-wrapper md-list-item-base-wrapper"
+              data-allow-text-select={false}
+              data-disabled={false}
+              data-interactive={true}
+              data-key="two"
+              data-padded={true}
+              data-shape="rectangle"
+              data-size={40}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onDragStart={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+              onTouchCancel={[Function]}
+              onTouchEnd={[Function]}
+              onTouchMove={[Function]}
+              onTouchStart={[Function]}
+              role="menuitem"
+              tabIndex={-1}
+            >
+              <ListItemBaseSection
+                position="fill"
+                title="Two"
+              >
+                <div
+                  data-position="fill"
+                  title="Two"
+                >
+                  Two
+                </div>
+              </ListItemBaseSection>
+            </li>
+          </FocusRing>
+        </FocusRing>
+      </ListItemBase>
+    </MenuItem>
+  </div>
+</_Menu>
+`;
+
 exports[`<Menu /> snapshot should match snapshot with id 1`] = `
 <_Menu
   aria-label="Menu component"


### PR DESCRIPTION
# Description
Before this PR, the way to add separators between Sections or SelectionGroups was to add a ListItemBase with outline, but that created a listitem for the header in a11y tree.

So I added this prop to add separators with the right role between groups (sections/selectiongroups). 