### PR TITLE
feat(icon): add brand visuals icons to icon component

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "@momentum-design/animations": "^0.0.4",
+    "@momentum-design/brand-visuals": "^0.0.24",
     "@momentum-design/icons": "0.0.164",
     "@momentum-design/tokens": "0.0.77",
     "@momentum-ui/design-tokens": "^0.0.63",

--- a/src/components/Icon/Icon.constants.ts
+++ b/src/components/Icon/Icon.constants.ts
@@ -58,6 +58,7 @@ const DEFAULTS = {
   AUTO_SCALE: false,
   VIEW_BOX_SPEC: VIEW_BOX_SPECS.NORMAL,
   WEIGHTLESS: false,
+  LIBRARY: 'icons' as const,
 };
 
 const EXCEPTION_ICONS_LIST: Array<InferredIconName> = [

--- a/src/components/Icon/Icon.stories.tsx
+++ b/src/components/Icon/Icon.stories.tsx
@@ -66,6 +66,16 @@ Weights.parameters = {
   ],
 };
 
+const BrandVisuals = Template<IconProps>(Icon).bind({});
+
+BrandVisuals.argTypes = { ...argTypes };
+
+BrandVisuals.args = {
+  name: 'cisco-ai-assistant-color',
+  library: 'brand-visuals',
+  weightless: true,
+};
+
 const Common = MultiTemplate<IconProps>(Icon).bind({});
 
 Common.argTypes = { ...argTypes };
@@ -88,4 +98,4 @@ Common.parameters = {
   ],
 };
 
-export { Example, Sizes, Weights, Common };
+export { Example, Sizes, Weights, BrandVisuals, Common };

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -35,7 +35,7 @@ const Icon: React.FC<Props> = (props: Props) => {
     ...otherProps
   } = props;
   const resolvedSVGName = getResolvedSVGName(name, weight, weightless);
-  const { SvgIcon, error } = useDynamicSVGImport(resolvedSVGName, undefined, library);
+  const { SvgIcon, error } = useDynamicSVGImport(resolvedSVGName, library);
 
   const isColoredIcon = /-colou?red$/.test(name as string);
 

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -31,10 +31,11 @@ const Icon: React.FC<Props> = (props: Props) => {
     weight,
     weightless = DEFAULTS.WEIGHTLESS,
     ariaLabel,
+    library = DEFAULTS.LIBRARY,
     ...otherProps
   } = props;
   const resolvedSVGName = getResolvedSVGName(name, weight, weightless);
-  const { SvgIcon, error } = useDynamicSVGImport(resolvedSVGName);
+  const { SvgIcon, error } = useDynamicSVGImport(resolvedSVGName, undefined, library);
 
   const isColoredIcon = /-colou?red$/.test(name as string);
 

--- a/src/components/Icon/Icon.types.ts
+++ b/src/components/Icon/Icon.types.ts
@@ -1,11 +1,12 @@
 import { CSSProperties } from 'react';
 import IconKeys from '@momentum-design/icons/dist/types/types';
+import BrandVisualsKeys from '@momentum-design/brand-visuals/dist/types/types';
 
 export type IconWeight = 'light' | 'regular' | 'bold' | 'filled';
 
 type RemoveWeight<T> = T extends `${infer Base}-${IconWeight}` ? Base : T;
 
-export type InferredIconName = RemoveWeight<IconKeys>;
+export type InferredIconName = RemoveWeight<IconKeys | BrandVisualsKeys>;
 
 export type IconScale =
   | 8
@@ -28,6 +29,8 @@ export type IconScale =
   | 124
   | 'auto'
   | 'inherit';
+
+export type IconLibrary = 'icons' | 'brand-visuals';
 
 export interface Props {
   /**
@@ -110,4 +113,6 @@ export interface Props {
    * An example would be brand icons.
    */
   weightless?: boolean;
+
+  library?: IconLibrary;
 }

--- a/src/hooks/useDynamicSVGImport.test.ts
+++ b/src/hooks/useDynamicSVGImport.test.ts
@@ -21,14 +21,10 @@ describe('Icon', () => {
       );
 
       const hook = renderHook(() =>
-        useDynamicSVGImport(
-          name,
-          {
-            onCompleted: onCompleteMock,
-            onError: onErrorMock,
-          },
-          library
-        )
+        useDynamicSVGImport(name, library, {
+          onCompleted: onCompleteMock,
+          onError: onErrorMock,
+        })
       );
       expect(hook.result.current.loading).toBe(true);
 
@@ -58,14 +54,10 @@ describe('Icon', () => {
     );
 
     const hook = renderHook(() =>
-      useDynamicSVGImport(
-        name,
-        {
-          onCompleted: onCompleteMock,
-          onError: onErrorMock,
-        },
-        'icons'
-      )
+      useDynamicSVGImport(name, 'icons', {
+        onCompleted: onCompleteMock,
+        onError: onErrorMock,
+      })
     );
     expect(hook.result.current.loading).toBe(true);
 

--- a/src/hooks/useDynamicSVGImport.test.ts
+++ b/src/hooks/useDynamicSVGImport.test.ts
@@ -1,39 +1,47 @@
+import { IconLibrary } from 'src/components/Icon/Icon.types';
 import { useDynamicSVGImport } from './useDynamicSVGImport';
 import { renderHook } from '@testing-library/react-hooks';
 
 describe('Icon', () => {
   beforeEach(() => jest.resetModules());
 
-  it('should successfully return svg component if icon exists', async () => {
-    const name = '3d-object-regular';
-    const onCompleteMock = jest.fn();
-    const onErrorMock = jest.fn();
-    const mockSVG = 'SVG_CONTENT';
-    jest.mock(
-      '@momentum-design/icons/dist/svg/3d-object-regular.svg?svgr',
-      () => {
-        return { ReactComponent: mockSVG };
-      },
-      { virtual: true }
-    );
+  it.each(['icons', 'brand-visuals'] as IconLibrary[])(
+    'should successfully return %s library svg component if icon exists',
+    async (library) => {
+      const name = '3d-object-regular';
+      const onCompleteMock = jest.fn();
+      const onErrorMock = jest.fn();
+      const mockSVG = 'SVG_CONTENT';
+      jest.mock(
+        `@momentum-design/${library}/dist/svg/3d-object-regular.svg?svgr`,
+        () => {
+          return { ReactComponent: mockSVG };
+        },
+        { virtual: true }
+      );
 
-    const hook = renderHook(() =>
-      useDynamicSVGImport(name, {
-        onCompleted: onCompleteMock,
-        onError: onErrorMock,
-      })
-    );
-    expect(hook.result.current.loading).toBe(true);
+      const hook = renderHook(() =>
+        useDynamicSVGImport(
+          name,
+          {
+            onCompleted: onCompleteMock,
+            onError: onErrorMock,
+          },
+          library
+        )
+      );
+      expect(hook.result.current.loading).toBe(true);
 
-    await hook.waitForNextUpdate();
+      await hook.waitForNextUpdate();
 
-    expect(onCompleteMock).toBeCalledTimes(1);
-    expect(onCompleteMock).toBeCalledWith(name, mockSVG);
-    expect(onErrorMock).not.toBeCalled();
-    expect(hook.result.current.SvgIcon).toEqual(mockSVG);
-    expect(hook.result.current.error).toBeUndefined();
-    expect(hook.result.current.loading).toBe(false);
-  });
+      expect(onCompleteMock).toBeCalledTimes(1);
+      expect(onCompleteMock).toBeCalledWith(name, mockSVG);
+      expect(onErrorMock).not.toBeCalled();
+      expect(hook.result.current.SvgIcon).toEqual(mockSVG);
+      expect(hook.result.current.error).toBeUndefined();
+      expect(hook.result.current.loading).toBe(false);
+    }
+  );
 
   it('should return error component does not exist', async () => {
     const name = 'bad_icon';
@@ -50,10 +58,14 @@ describe('Icon', () => {
     );
 
     const hook = renderHook(() =>
-      useDynamicSVGImport(name, {
-        onCompleted: onCompleteMock,
-        onError: onErrorMock,
-      })
+      useDynamicSVGImport(
+        name,
+        {
+          onCompleted: onCompleteMock,
+          onError: onErrorMock,
+        },
+        'icons'
+      )
     );
     expect(hook.result.current.loading).toBe(true);
 

--- a/src/hooks/useDynamicSVGImport.ts
+++ b/src/hooks/useDynamicSVGImport.ts
@@ -1,5 +1,6 @@
 import { useRef, useState, useEffect } from 'react';
 import { useIsMounted } from './useIsMounted';
+import { IconLibrary } from 'src/components/Icon/Icon.types';
 
 interface UseDynamicSVGImportOptions {
   onCompleted?: (
@@ -24,7 +25,8 @@ interface UseDynamicSVGImportReturn {
  */
 function useDynamicSVGImport(
   name: string,
-  options: UseDynamicSVGImportOptions = {}
+  options: UseDynamicSVGImportOptions = {},
+  library: IconLibrary
 ): UseDynamicSVGImportReturn {
   const ImportedIconRef = useRef<React.FC<React.SVGProps<SVGSVGElement>>>();
   const [loading, setLoading] = useState(false);
@@ -38,7 +40,7 @@ function useDynamicSVGImport(
       try {
         setError(undefined);
         ImportedIconRef.current = (
-          await import(`@momentum-design/icons/dist/svg/${name}.svg?svgr`)
+          await import(`@momentum-design/${library}/dist/svg/${name}.svg?svgr`)
         ).ReactComponent;
         if (isMounted()) {
           onCompleted?.(name, ImportedIconRef.current);

--- a/src/hooks/useDynamicSVGImport.ts
+++ b/src/hooks/useDynamicSVGImport.ts
@@ -25,8 +25,8 @@ interface UseDynamicSVGImportReturn {
  */
 function useDynamicSVGImport(
   name: string,
-  options: UseDynamicSVGImportOptions = {},
-  library: IconLibrary
+  library: IconLibrary,
+  options: UseDynamicSVGImportOptions = {}
 ): UseDynamicSVGImportReturn {
   const ImportedIconRef = useRef<React.FC<React.SVGProps<SVGSVGElement>>>();
   const [loading, setLoading] = useState(false);

--- a/src/hooks/useDynamicSVGImport.ts
+++ b/src/hooks/useDynamicSVGImport.ts
@@ -1,6 +1,6 @@
 import { useRef, useState, useEffect } from 'react';
 import { useIsMounted } from './useIsMounted';
-import { IconLibrary } from 'src/components/Icon/Icon.types';
+import { IconLibrary } from '../components/Icon/Icon.types';
 
 interface UseDynamicSVGImportOptions {
   onCompleted?: (

--- a/yarn.lock
+++ b/yarn.lock
@@ -2444,6 +2444,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@momentum-design/brand-visuals@npm:^0.0.24":
+  version: 0.0.24
+  resolution: "@momentum-design/brand-visuals@npm:0.0.24"
+  checksum: c7bf5e078d9157ed8ede29ba882792e05bd75b78a1ffa4c38dcff40156b81475b3aab7e0e33818d0e35b5cd815c7db0cd9e41a7de01cfc6befd16a78b727d0a7
+  languageName: node
+  linkType: hard
+
 "@momentum-design/icons@npm:0.0.164":
   version: 0.0.164
   resolution: "@momentum-design/icons@npm:0.0.164"
@@ -2495,6 +2502,7 @@ __metadata:
     "@commitlint/config-conventional": ^12.0.1
     "@hot-loader/react-dom": ~16.8.0
     "@momentum-design/animations": ^0.0.4
+    "@momentum-design/brand-visuals": ^0.0.24
     "@momentum-design/icons": 0.0.164
     "@momentum-design/tokens": 0.0.77
     "@momentum-ui/design-tokens": ^0.0.63


### PR DESCRIPTION


original PR (https://github.com/momentum-design/momentum-react-v2/pull/649) notes:

# Description
- add brand-visuals library
- add prop to Icon component to load icons from the brand-visuals library

note: the new, larger icons included in the new brand-visuals library will not show correctly with the icons component, but this change should be sufficient for our usage in cantina for now

# Links
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-564427
