### PR TITLE
fix(types): move ItemProps declaration to seperate file and include in index

### DIFF
--- a/src/components/MenuItem/MenuItem.types.ts
+++ b/src/components/MenuItem/MenuItem.types.ts
@@ -1,7 +1,7 @@
 import { Key } from 'react';
 import { Node } from '@react-types/shared';
 import { TreeState } from '@react-stately/tree';
-import { MenuAppearanceContextValue, MenuContextValue } from '../Menu/Menu.types';
+import { MenuAppearanceContextValue } from '../Menu/Menu.types';
 
 export type TickPosition = 'left' | 'right' | 'none';
 export interface Props<T> extends MenuAppearanceContextValue {
@@ -19,9 +19,4 @@ export interface Props<T> extends MenuAppearanceContextValue {
    * Handler to be called when this element is selected
    */
   onAction?: (key: Key) => void;
-}
-
-declare module '@react-types/shared' {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-interface
-  interface ItemProps<T> extends Pick<MenuContextValue, 'closeOnSelect'> {}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -152,17 +152,9 @@ export {
   SpaceListItem as SpaceListItemNext,
   SpaceTreeNode,
   List as ListNext,
-  ListRefObject,
   Popover as PopoverNext,
   Reaction,
-  OnVideoReactionName,
-  OriginalReactionName,
   REACTION_CONSTANTS,
-  ReactionName,
-  ReactionProps,
-  ReactionWithSkinTone,
-  ReactionWithoutSkinTone,
-  SkinTone,
   ReactionBadge,
   ReactionButton,
   ReactionPicker,
@@ -201,4 +193,19 @@ export {
   MeetingRowContent,
 } from './components';
 
+/** V2 Types [TypeScript] */
+export type {
+  ListRefObject,
+  OnVideoReactionName,
+  OriginalReactionName,
+  ReactionName,
+  ReactionProps,
+  ReactionWithSkinTone,
+  ReactionWithoutSkinTone,
+  SkinTone,
+} from './components';
+
 export { PRESERVE_TABINDEX_CLASSNAME } from './utils/navigation';
+
+/** Include updated types for ItemProps from '@react-props/shared' which is used by <Item /> from '@react-stately/collections' */
+import './types/item';

--- a/src/types/item.ts
+++ b/src/types/item.ts
@@ -1,0 +1,6 @@
+import { MenuContextValue } from '../components/Menu/Menu.types';
+
+declare module '@react-types/shared' {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-interface
+  interface ItemProps<T> extends Pick<MenuContextValue, 'closeOnSelect'> {}
+}


### PR DESCRIPTION
# Description

This PR does the following:
- Renames src/index.js to src/index.ts
- Moves updating the type definition of ItemProps (from @react-types/shared) to a seperate file and includes this file in index.

This fixes Typescript in Cantina not understanding that we have updated the type definition. Including src/types/item.ts in index means that when `@momentum-ui/react-collaboration` is imported, the updated definition will be used.

Renaming src/index.js to src/index.ts is required because the import of types/item.ts must be included in index.d.ts when built. If it remains index.js, the import isn't included.
