### PR TITLE
feat(tree-node-base): add context menu support

### DIFF
--- a/src/components/AvatarMeetingsListItem/AvatarMeetingsListItem.unit.test.tsx.snap
+++ b/src/components/AvatarMeetingsListItem/AvatarMeetingsListItem.unit.test.tsx.snap
@@ -106,6 +106,58 @@ exports[`<AvatarMeetingsListItem /> snapshot should match snapshot 1`] = `
               data-position="end"
             />
           </ListItemBaseSection>
+          <ContextMenu
+            triggerRef={
+              Object {
+                "current": <li
+                  class="md-avatar-meetings-list-item-wrapper md-list-item-base-wrapper"
+                  data-allow-text-select="false"
+                  data-disabled="false"
+                  data-interactive="true"
+                  data-padded="false"
+                  data-shape="isPilled"
+                  data-size="50"
+                  role="listitem"
+                  tabindex="0"
+                >
+                  <div
+                    data-position="start"
+                  >
+                    <div
+                      aria-hidden="false"
+                      aria-label=""
+                      class="md-avatar-wrapper"
+                      data-color="default"
+                      data-size="32"
+                      role="img"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="md-avatar-wrapper-children"
+                      >
+                        C
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="md-avatar-meetings-list-item-text-wrapper"
+                    data-position="middle"
+                  >
+                    <div>
+                      <p
+                        class="md-text-wrapper"
+                        data-type="body-primary"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    class="md-avatar-meetings-list-item-actions-wrapper"
+                    data-position="end"
+                  />
+                </li>,
+              }
+            }
+          />
         </li>
       </FocusRing>
     </FocusRing>
@@ -269,6 +321,80 @@ exports[`<AvatarMeetingsListItem /> snapshot should match snapshot with avatarPr
               data-position="end"
             />
           </ListItemBaseSection>
+          <ContextMenu
+            triggerRef={
+              Object {
+                "current": <li
+                  class="md-avatar-meetings-list-item-wrapper md-list-item-base-wrapper"
+                  data-allow-text-select="false"
+                  data-disabled="false"
+                  data-interactive="true"
+                  data-padded="false"
+                  data-shape="isPilled"
+                  data-size="50"
+                  role="listitem"
+                  tabindex="0"
+                >
+                  <div
+                    data-position="start"
+                  >
+                    <div
+                      aria-hidden="false"
+                      aria-label=""
+                      class="md-avatar-wrapper"
+                      data-color="default"
+                      data-size="32"
+                      role="img"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="md-avatar-wrapper-children"
+                      >
+                        C
+                      </span>
+                      <div
+                        class="md-avatar-presence-icon-wrapper"
+                        data-shape="true"
+                      >
+                        <div
+                          aria-hidden="true"
+                          class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                          role="img"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class=""
+                            data-autoscale="false"
+                            data-scale="14"
+                            data-test="unread"
+                            height="100%"
+                            style="fill: var(--mds-color-theme-indicator-stable); stroke: none;"
+                            viewBox="0, 0, 32, 32"
+                            width="100%"
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="md-avatar-meetings-list-item-text-wrapper"
+                    data-position="middle"
+                  >
+                    <div>
+                      <p
+                        class="md-text-wrapper"
+                        data-type="body-primary"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    class="md-avatar-meetings-list-item-actions-wrapper"
+                    data-position="end"
+                  />
+                </li>,
+              }
+            }
+          />
         </li>
       </FocusRing>
     </FocusRing>
@@ -384,6 +510,58 @@ exports[`<AvatarMeetingsListItem /> snapshot should match snapshot with classNam
               data-position="end"
             />
           </ListItemBaseSection>
+          <ContextMenu
+            triggerRef={
+              Object {
+                "current": <li
+                  class="example-class md-avatar-meetings-list-item-wrapper md-list-item-base-wrapper"
+                  data-allow-text-select="false"
+                  data-disabled="false"
+                  data-interactive="true"
+                  data-padded="false"
+                  data-shape="isPilled"
+                  data-size="50"
+                  role="listitem"
+                  tabindex="0"
+                >
+                  <div
+                    data-position="start"
+                  >
+                    <div
+                      aria-hidden="false"
+                      aria-label=""
+                      class="md-avatar-wrapper"
+                      data-color="default"
+                      data-size="32"
+                      role="img"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="md-avatar-wrapper-children"
+                      >
+                        C
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="md-avatar-meetings-list-item-text-wrapper"
+                    data-position="middle"
+                  >
+                    <div>
+                      <p
+                        class="md-text-wrapper"
+                        data-type="body-primary"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    class="md-avatar-meetings-list-item-actions-wrapper"
+                    data-position="end"
+                  />
+                </li>,
+              }
+            }
+          />
         </li>
       </FocusRing>
     </FocusRing>
@@ -580,6 +758,90 @@ exports[`<AvatarMeetingsListItem /> snapshot should match snapshot with displayM
               </ButtonCircle>
             </div>
           </ListItemBaseSection>
+          <ContextMenu
+            triggerRef={
+              Object {
+                "current": <li
+                  class="md-avatar-meetings-list-item-wrapper md-list-item-base-wrapper"
+                  data-allow-text-select="false"
+                  data-disabled="false"
+                  data-interactive="true"
+                  data-padded="false"
+                  data-shape="isPilled"
+                  data-size="50"
+                  role="listitem"
+                  tabindex="0"
+                >
+                  <div
+                    data-position="start"
+                  >
+                    <div
+                      aria-hidden="false"
+                      aria-label=""
+                      class="md-avatar-wrapper"
+                      data-color="default"
+                      data-size="32"
+                      role="img"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="md-avatar-wrapper-children"
+                      >
+                        C
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="md-avatar-meetings-list-item-text-wrapper"
+                    data-position="middle"
+                  >
+                    <div>
+                      <p
+                        class="md-text-wrapper"
+                        data-type="body-primary"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    class="md-avatar-meetings-list-item-actions-wrapper"
+                    data-position="end"
+                  >
+                    <button
+                      class="md-button-circle-wrapper md-button-simple-wrapper"
+                      data-color="primary"
+                      data-disabled="false"
+                      data-ghost="true"
+                      data-inverted="false"
+                      data-multiple-children="false"
+                      data-outline="false"
+                      data-shallow-disabled="false"
+                      data-size="28"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <div
+                        aria-hidden="true"
+                        class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                        role="img"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class=""
+                          data-autoscale="false"
+                          data-scale="16"
+                          data-test="more"
+                          fill="currentColor"
+                          height="100%"
+                          viewBox="0, 0, 32, 32"
+                          width="100%"
+                        />
+                      </div>
+                    </button>
+                  </div>
+                </li>,
+              }
+            }
+          />
         </li>
       </FocusRing>
     </FocusRing>
@@ -783,6 +1045,91 @@ exports[`<AvatarMeetingsListItem /> snapshot should match snapshot with displayM
               </ButtonCircle>
             </div>
           </ListItemBaseSection>
+          <ContextMenu
+            triggerRef={
+              Object {
+                "current": <li
+                  class="md-avatar-meetings-list-item-wrapper md-list-item-base-wrapper"
+                  data-allow-text-select="false"
+                  data-disabled="false"
+                  data-interactive="true"
+                  data-padded="false"
+                  data-shape="isPilled"
+                  data-size="50"
+                  role="listitem"
+                  tabindex="0"
+                >
+                  <div
+                    data-position="start"
+                  >
+                    <div
+                      aria-hidden="false"
+                      aria-label=""
+                      class="md-avatar-wrapper"
+                      data-color="default"
+                      data-size="32"
+                      role="img"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="md-avatar-wrapper-children"
+                      >
+                        C
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="md-avatar-meetings-list-item-text-wrapper"
+                    data-position="middle"
+                  >
+                    <div>
+                      <p
+                        class="md-text-wrapper"
+                        data-type="body-primary"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    class="md-avatar-meetings-list-item-actions-wrapper"
+                    data-position="end"
+                  >
+                    <button
+                      class="md-button-circle-wrapper md-button-simple-wrapper"
+                      data-color="primary"
+                      data-disabled="false"
+                      data-ghost="true"
+                      data-inverted="false"
+                      data-multiple-children="false"
+                      data-outline="false"
+                      data-shallow-disabled="false"
+                      data-size="28"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <div
+                        aria-hidden="true"
+                        class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                        role="img"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class=""
+                          data-autoscale="false"
+                          data-scale="16"
+                          data-test="microphone-on"
+                          fill="currentColor"
+                          height="100%"
+                          style="stroke: none;"
+                          viewBox="0, 0, 32, 32"
+                          width="100%"
+                        />
+                      </div>
+                    </button>
+                  </div>
+                </li>,
+              }
+            }
+          />
         </li>
       </FocusRing>
     </FocusRing>
@@ -985,6 +1332,90 @@ exports[`<AvatarMeetingsListItem /> snapshot should match snapshot with displayM
               </ButtonCircle>
             </div>
           </ListItemBaseSection>
+          <ContextMenu
+            triggerRef={
+              Object {
+                "current": <li
+                  class="md-avatar-meetings-list-item-wrapper md-list-item-base-wrapper"
+                  data-allow-text-select="false"
+                  data-disabled="false"
+                  data-interactive="true"
+                  data-padded="false"
+                  data-shape="isPilled"
+                  data-size="50"
+                  role="listitem"
+                  tabindex="0"
+                >
+                  <div
+                    data-position="start"
+                  >
+                    <div
+                      aria-hidden="false"
+                      aria-label=""
+                      class="md-avatar-wrapper"
+                      data-color="default"
+                      data-size="32"
+                      role="img"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="md-avatar-wrapper-children"
+                      >
+                        C
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="md-avatar-meetings-list-item-text-wrapper"
+                    data-position="middle"
+                  >
+                    <div>
+                      <p
+                        class="md-text-wrapper"
+                        data-type="body-primary"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    class="md-avatar-meetings-list-item-actions-wrapper"
+                    data-position="end"
+                  >
+                    <button
+                      class="md-button-circle-wrapper md-button-simple-wrapper"
+                      data-color="primary"
+                      data-disabled="false"
+                      data-ghost="true"
+                      data-inverted="false"
+                      data-multiple-children="false"
+                      data-outline="false"
+                      data-shallow-disabled="false"
+                      data-size="28"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <div
+                        aria-hidden="true"
+                        class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                        role="img"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class=""
+                          data-autoscale="false"
+                          data-scale="16"
+                          data-test="microphone-muted"
+                          height="100%"
+                          style="fill: var(--mds-color-theme-text-error-normal); stroke: none;"
+                          viewBox="0, 0, 32, 32"
+                          width="100%"
+                        />
+                      </div>
+                    </button>
+                  </div>
+                </li>,
+              }
+            }
+          />
         </li>
       </FocusRing>
     </FocusRing>
@@ -1102,6 +1533,60 @@ exports[`<AvatarMeetingsListItem /> snapshot should match snapshot with firstLin
               data-position="end"
             />
           </ListItemBaseSection>
+          <ContextMenu
+            triggerRef={
+              Object {
+                "current": <li
+                  class="md-avatar-meetings-list-item-wrapper md-list-item-base-wrapper"
+                  data-allow-text-select="false"
+                  data-disabled="false"
+                  data-interactive="true"
+                  data-padded="false"
+                  data-shape="isPilled"
+                  data-size="50"
+                  role="listitem"
+                  tabindex="0"
+                >
+                  <div
+                    data-position="start"
+                  >
+                    <div
+                      aria-hidden="false"
+                      aria-label=""
+                      class="md-avatar-wrapper"
+                      data-color="default"
+                      data-size="32"
+                      role="img"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="md-avatar-wrapper-children"
+                      >
+                        C
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="md-avatar-meetings-list-item-text-wrapper"
+                    data-position="middle"
+                  >
+                    <div>
+                      <p
+                        class="md-text-wrapper"
+                        data-type="body-primary"
+                      >
+                        firstLine
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    class="md-avatar-meetings-list-item-actions-wrapper"
+                    data-position="end"
+                  />
+                </li>,
+              }
+            }
+          />
         </li>
       </FocusRing>
     </FocusRing>
@@ -1219,6 +1704,59 @@ exports[`<AvatarMeetingsListItem /> snapshot should match snapshot with id 1`] =
               data-position="end"
             />
           </ListItemBaseSection>
+          <ContextMenu
+            triggerRef={
+              Object {
+                "current": <li
+                  class="md-avatar-meetings-list-item-wrapper md-list-item-base-wrapper"
+                  data-allow-text-select="false"
+                  data-disabled="false"
+                  data-interactive="true"
+                  data-padded="false"
+                  data-shape="isPilled"
+                  data-size="50"
+                  id="example-id"
+                  role="listitem"
+                  tabindex="0"
+                >
+                  <div
+                    data-position="start"
+                  >
+                    <div
+                      aria-hidden="false"
+                      aria-label=""
+                      class="md-avatar-wrapper"
+                      data-color="default"
+                      data-size="32"
+                      role="img"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="md-avatar-wrapper-children"
+                      >
+                        C
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="md-avatar-meetings-list-item-text-wrapper"
+                    data-position="middle"
+                  >
+                    <div>
+                      <p
+                        class="md-text-wrapper"
+                        data-type="body-primary"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    class="md-avatar-meetings-list-item-actions-wrapper"
+                    data-position="end"
+                  />
+                </li>,
+              }
+            }
+          />
         </li>
       </FocusRing>
     </FocusRing>
@@ -1364,6 +1902,75 @@ exports[`<AvatarMeetingsListItem /> snapshot should match snapshot with schedule
               data-position="end"
             />
           </ListItemBaseSection>
+          <ContextMenu
+            triggerRef={
+              Object {
+                "current": <li
+                  class="md-avatar-meetings-list-item-wrapper md-list-item-base-wrapper"
+                  data-allow-text-select="false"
+                  data-disabled="false"
+                  data-interactive="true"
+                  data-padded="false"
+                  data-shape="isPilled"
+                  data-size="50"
+                  role="listitem"
+                  tabindex="0"
+                >
+                  <div
+                    data-position="start"
+                  >
+                    <div
+                      aria-hidden="false"
+                      aria-label=""
+                      class="md-avatar-wrapper"
+                      data-color="default"
+                      data-size="32"
+                      role="img"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="md-avatar-wrapper-children"
+                      >
+                        C
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="md-avatar-meetings-list-item-text-wrapper"
+                    data-position="middle"
+                  >
+                    <div
+                      aria-hidden="true"
+                      class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class=""
+                        data-autoscale="false"
+                        data-scale="16"
+                        data-test="scheduler-available"
+                        height="100%"
+                        style="fill: var(--mds-color-theme-text-success-normal); stroke: none;"
+                        viewBox="0, 0, 32, 32"
+                        width="100%"
+                      />
+                    </div>
+                    <div>
+                      <p
+                        class="md-text-wrapper"
+                        data-type="body-primary"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    class="md-avatar-meetings-list-item-actions-wrapper"
+                    data-position="end"
+                  />
+                </li>,
+              }
+            }
+          />
         </li>
       </FocusRing>
     </FocusRing>
@@ -1509,6 +2116,75 @@ exports[`<AvatarMeetingsListItem /> snapshot should match snapshot with schedule
               data-position="end"
             />
           </ListItemBaseSection>
+          <ContextMenu
+            triggerRef={
+              Object {
+                "current": <li
+                  class="md-avatar-meetings-list-item-wrapper md-list-item-base-wrapper"
+                  data-allow-text-select="false"
+                  data-disabled="false"
+                  data-interactive="true"
+                  data-padded="false"
+                  data-shape="isPilled"
+                  data-size="50"
+                  role="listitem"
+                  tabindex="0"
+                >
+                  <div
+                    data-position="start"
+                  >
+                    <div
+                      aria-hidden="false"
+                      aria-label=""
+                      class="md-avatar-wrapper"
+                      data-color="default"
+                      data-size="32"
+                      role="img"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="md-avatar-wrapper-children"
+                      >
+                        C
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="md-avatar-meetings-list-item-text-wrapper"
+                    data-position="middle"
+                  >
+                    <div
+                      aria-hidden="true"
+                      class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class=""
+                        data-autoscale="false"
+                        data-scale="16"
+                        data-test="scheduler-not-working-hours"
+                        height="100%"
+                        style="fill: var(--mds-color-theme-text-secondary-normal); stroke: none;"
+                        viewBox="0, 0, 32, 32"
+                        width="100%"
+                      />
+                    </div>
+                    <div>
+                      <p
+                        class="md-text-wrapper"
+                        data-type="body-primary"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    class="md-avatar-meetings-list-item-actions-wrapper"
+                    data-position="end"
+                  />
+                </li>,
+              }
+            }
+          />
         </li>
       </FocusRing>
     </FocusRing>
@@ -1654,6 +2330,75 @@ exports[`<AvatarMeetingsListItem /> snapshot should match snapshot with schedule
               data-position="end"
             />
           </ListItemBaseSection>
+          <ContextMenu
+            triggerRef={
+              Object {
+                "current": <li
+                  class="md-avatar-meetings-list-item-wrapper md-list-item-base-wrapper"
+                  data-allow-text-select="false"
+                  data-disabled="false"
+                  data-interactive="true"
+                  data-padded="false"
+                  data-shape="isPilled"
+                  data-size="50"
+                  role="listitem"
+                  tabindex="0"
+                >
+                  <div
+                    data-position="start"
+                  >
+                    <div
+                      aria-hidden="false"
+                      aria-label=""
+                      class="md-avatar-wrapper"
+                      data-color="default"
+                      data-size="32"
+                      role="img"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="md-avatar-wrapper-children"
+                      >
+                        C
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="md-avatar-meetings-list-item-text-wrapper"
+                    data-position="middle"
+                  >
+                    <div
+                      aria-hidden="true"
+                      class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class=""
+                        data-autoscale="false"
+                        data-scale="16"
+                        data-test="scheduler-unavailable"
+                        height="100%"
+                        style="fill: var(--mds-color-theme-text-warning-normal); stroke: none;"
+                        viewBox="0, 0, 32, 32"
+                        width="100%"
+                      />
+                    </div>
+                    <div>
+                      <p
+                        class="md-text-wrapper"
+                        data-type="body-primary"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    class="md-avatar-meetings-list-item-actions-wrapper"
+                    data-position="end"
+                  />
+                </li>,
+              }
+            }
+          />
         </li>
       </FocusRing>
     </FocusRing>
@@ -1799,6 +2544,75 @@ exports[`<AvatarMeetingsListItem /> snapshot should match snapshot with schedule
               data-position="end"
             />
           </ListItemBaseSection>
+          <ContextMenu
+            triggerRef={
+              Object {
+                "current": <li
+                  class="md-avatar-meetings-list-item-wrapper md-list-item-base-wrapper"
+                  data-allow-text-select="false"
+                  data-disabled="false"
+                  data-interactive="true"
+                  data-padded="false"
+                  data-shape="isPilled"
+                  data-size="50"
+                  role="listitem"
+                  tabindex="0"
+                >
+                  <div
+                    data-position="start"
+                  >
+                    <div
+                      aria-hidden="false"
+                      aria-label=""
+                      class="md-avatar-wrapper"
+                      data-color="default"
+                      data-size="32"
+                      role="img"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="md-avatar-wrapper-children"
+                      >
+                        C
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="md-avatar-meetings-list-item-text-wrapper"
+                    data-position="middle"
+                  >
+                    <div
+                      aria-hidden="true"
+                      class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class=""
+                        data-autoscale="false"
+                        data-scale="16"
+                        data-test="scheduler-unknown"
+                        height="100%"
+                        style="fill: var(--mds-color-theme-text-error-normal); stroke: none;"
+                        viewBox="0, 0, 32, 32"
+                        width="100%"
+                      />
+                    </div>
+                    <div>
+                      <p
+                        class="md-text-wrapper"
+                        data-type="body-primary"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    class="md-avatar-meetings-list-item-actions-wrapper"
+                    data-position="end"
+                  />
+                </li>,
+              }
+            }
+          />
         </li>
       </FocusRing>
     </FocusRing>
@@ -1924,6 +2738,64 @@ exports[`<AvatarMeetingsListItem /> snapshot should match snapshot with secondLi
               data-position="end"
             />
           </ListItemBaseSection>
+          <ContextMenu
+            triggerRef={
+              Object {
+                "current": <li
+                  class="md-avatar-meetings-list-item-wrapper md-list-item-base-wrapper"
+                  data-allow-text-select="false"
+                  data-disabled="false"
+                  data-interactive="true"
+                  data-padded="false"
+                  data-shape="isPilled"
+                  data-size="50"
+                  role="listitem"
+                  tabindex="0"
+                >
+                  <div
+                    data-position="start"
+                  >
+                    <div
+                      aria-hidden="false"
+                      aria-label=""
+                      class="md-avatar-wrapper"
+                      data-color="default"
+                      data-size="32"
+                      role="img"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="md-avatar-wrapper-children"
+                      >
+                        C
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="md-avatar-meetings-list-item-text-wrapper"
+                    data-position="middle"
+                  >
+                    <div>
+                      <p
+                        class="md-text-wrapper"
+                        data-type="body-primary"
+                      />
+                      <small
+                        class="md-text-wrapper"
+                        data-type="body-secondary"
+                      >
+                        secondLine
+                      </small>
+                    </div>
+                  </div>
+                  <div
+                    class="md-avatar-meetings-list-item-actions-wrapper"
+                    data-position="end"
+                  />
+                </li>,
+              }
+            }
+          />
         </li>
       </FocusRing>
     </FocusRing>
@@ -2053,6 +2925,59 @@ exports[`<AvatarMeetingsListItem /> snapshot should match snapshot with style 1`
               data-position="end"
             />
           </ListItemBaseSection>
+          <ContextMenu
+            triggerRef={
+              Object {
+                "current": <li
+                  class="md-avatar-meetings-list-item-wrapper md-list-item-base-wrapper"
+                  data-allow-text-select="false"
+                  data-disabled="false"
+                  data-interactive="true"
+                  data-padded="false"
+                  data-shape="isPilled"
+                  data-size="50"
+                  role="listitem"
+                  style="color: pink;"
+                  tabindex="0"
+                >
+                  <div
+                    data-position="start"
+                  >
+                    <div
+                      aria-hidden="false"
+                      aria-label=""
+                      class="md-avatar-wrapper"
+                      data-color="default"
+                      data-size="32"
+                      role="img"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="md-avatar-wrapper-children"
+                      >
+                        C
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="md-avatar-meetings-list-item-text-wrapper"
+                    data-position="middle"
+                  >
+                    <div>
+                      <p
+                        class="md-text-wrapper"
+                        data-type="body-primary"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    class="md-avatar-meetings-list-item-actions-wrapper"
+                    data-position="end"
+                  />
+                </li>,
+              }
+            }
+          />
         </li>
       </FocusRing>
     </FocusRing>

--- a/src/components/ContextMenu/ContextMenu.constants.ts
+++ b/src/components/ContextMenu/ContextMenu.constants.ts
@@ -1,0 +1,9 @@
+const CLASS_PREFIX = 'md-context-menu';
+
+const DEFAULTS = {};
+
+const STYLE = {
+  wrapper: `${CLASS_PREFIX}-wrapper`,
+};
+
+export { CLASS_PREFIX, DEFAULTS, STYLE };

--- a/src/components/ContextMenu/ContextMenu.stories.args.ts
+++ b/src/components/ContextMenu/ContextMenu.stories.args.ts
@@ -1,0 +1,10 @@
+import { commonStyles } from '../../storybook/helper.stories.argtypes';
+
+const contextMenuArgTypes = {};
+
+export { contextMenuArgTypes };
+
+export default {
+  ...commonStyles,
+  ...contextMenuArgTypes,
+};

--- a/src/components/ContextMenu/ContextMenu.stories.docs.mdx
+++ b/src/components/ContextMenu/ContextMenu.stories.docs.mdx
@@ -1,0 +1,1 @@
+The `<ContextMenu />` component.

--- a/src/components/ContextMenu/ContextMenu.stories.tsx
+++ b/src/components/ContextMenu/ContextMenu.stories.tsx
@@ -1,0 +1,44 @@
+import { DocumentationPage } from '../../storybook/helper.stories.docs';
+import StyleDocs from '../../storybook/docs.stories.style.mdx';
+
+import ContextMenu from './';
+import argTypes from './ContextMenu.stories.args';
+import Documentation from './ContextMenu.stories.docs.mdx';
+import React, { useRef } from 'react';
+
+export default {
+  title: 'Momentum UI/ContextMenu',
+  component: ContextMenu,
+  parameters: {
+    expanded: true,
+    docs: {
+      page: DocumentationPage(Documentation, StyleDocs),
+    },
+  },
+};
+
+const Template = (args) => {
+  const triggerRef = useRef(null); // Create a ref for the trigger component
+
+  return (
+    <div>
+      <button ref={triggerRef}>Right click on me</button>
+      <ContextMenu triggerRef={triggerRef} {...args} />
+    </div>
+  );
+};
+
+const Example = Template.bind({});
+
+Example.argTypes = { ...argTypes };
+
+Example.args = {
+  contextMenuActions: [
+    // eslint-disable-next-line no-console
+    { text: 'Action 1', action: () => console.log('Action 1') },
+    // eslint-disable-next-line no-console
+    { text: 'Action 2', action: () => console.log('Action 2') },
+  ],
+};
+
+export { Example };

--- a/src/components/ContextMenu/ContextMenu.style.scss
+++ b/src/components/ContextMenu/ContextMenu.style.scss
@@ -1,0 +1,21 @@
+.md-context-menu-wrapper {
+  max-width: 20rem;
+  border-radius: 0.75rem;
+  z-index: 9999;
+
+  & button {
+    font-size: 0.75rem;
+    padding: 0.25rem 0.5rem;
+    border-radius: 0.5rem;
+    border: var(--md-globals-border-clear);
+    text-align: left;
+    width: 100%;
+    background-color: var(--mds-color-theme-button-secondary-normal);
+    color: var(--mds-color-theme-text-primary-normal);
+
+    &:hover {
+      background-color: var(--mds-color-theme-button-secondary-hover);
+      color: var(--mds-color-theme-text-primary-normal);
+    }
+  }
+}

--- a/src/components/ContextMenu/ContextMenu.tsx
+++ b/src/components/ContextMenu/ContextMenu.tsx
@@ -43,7 +43,11 @@ const ContextMenu: FC<Props> = (props: Props) => {
     }
 
     const { pageX, pageY } = event;
-    setContextMenuState({ x: pageX, y: pageY, isOpen: !contextMenuState.isOpen });
+    setContextMenuState({
+      x: pageX - triggerRef.current.getBoundingClientRect().left,
+      y: pageY - triggerRef.current.getBoundingClientRect().top,
+      isOpen: !contextMenuState.isOpen,
+    });
   };
 
   useEffect(() => {
@@ -68,7 +72,7 @@ const ContextMenu: FC<Props> = (props: Props) => {
       id={id}
       color={'primary' as const}
       style={{
-        position: 'fixed',
+        position: 'absolute',
         left: `${contextMenuState.x}px`,
         top: `${contextMenuState.y}px`,
         ...style,

--- a/src/components/ContextMenu/ContextMenu.tsx
+++ b/src/components/ContextMenu/ContextMenu.tsx
@@ -43,7 +43,6 @@ const ContextMenu: FC<Props> = (props: Props) => {
     }
 
     const { pageX, pageY } = event;
-    console.log(event, pageX);
     setContextMenuState({ x: pageX, y: pageY, isOpen: !contextMenuState.isOpen });
   };
 

--- a/src/components/ContextMenu/ContextMenu.tsx
+++ b/src/components/ContextMenu/ContextMenu.tsx
@@ -4,7 +4,7 @@ import classnames from 'classnames';
 import { STYLE } from './ContextMenu.constants';
 import { ContextMenuState, Props } from './ContextMenu.types';
 import './ContextMenu.style.scss';
-import { useOverlay } from 'react-aria';
+import { useOverlay } from '@react-aria/overlays';
 import ModalContainer from '../ModalContainer';
 import ButtonSimple from '../ButtonSimple';
 

--- a/src/components/ContextMenu/ContextMenu.tsx
+++ b/src/components/ContextMenu/ContextMenu.tsx
@@ -1,0 +1,95 @@
+import React, { FC, useEffect, useRef, useState } from 'react';
+import classnames from 'classnames';
+
+import { STYLE } from './ContextMenu.constants';
+import { ContextMenuState, Props } from './ContextMenu.types';
+import './ContextMenu.style.scss';
+import { useOverlay } from 'react-aria';
+import ModalContainer from '../ModalContainer';
+import ButtonSimple from '../ButtonSimple';
+
+/**
+ * The ContextMenu component.
+ */
+const ContextMenu: FC<Props> = (props: Props) => {
+  const { className, id = 'context-menu', style, contextMenuActions, triggerRef } = props;
+
+  const [contextMenuState, setContextMenuState] = useState<ContextMenuState>({
+    isOpen: false,
+    x: 0,
+    y: 0,
+  });
+
+  const toggleContextMenu = () => {
+    setContextMenuState({ ...contextMenuState, isOpen: !contextMenuState.isOpen });
+  };
+
+  const overlayRef = useRef();
+  const { overlayProps } = useOverlay(
+    {
+      onClose: () => toggleContextMenu(),
+      shouldCloseOnBlur: true,
+      isOpen: contextMenuState.isOpen,
+      isDismissable: true,
+    },
+    overlayRef
+  );
+
+  const handleOnContextMenu = (event: MouseEvent) => {
+    event.preventDefault();
+    // Don't allow to open more context-menus at the same time
+    if (document.getElementById(id)) {
+      return;
+    }
+
+    const { pageX, pageY } = event;
+    console.log(event, pageX);
+    setContextMenuState({ x: pageX, y: pageY, isOpen: !contextMenuState.isOpen });
+  };
+
+  useEffect(() => {
+    if (contextMenuActions) {
+      triggerRef.current.addEventListener('contextmenu', handleOnContextMenu);
+    }
+    return () => {
+      triggerRef.current?.removeEventListener('contextmenu', handleOnContextMenu);
+    };
+  }, []);
+
+  if (!contextMenuActions || !contextMenuState.isOpen) {
+    return null;
+  }
+
+  return (
+    <ModalContainer
+      isPadded
+      round={75}
+      className={classnames(className, STYLE.wrapper)}
+      {...overlayProps}
+      id={id}
+      color={'primary' as const}
+      style={{
+        position: 'fixed',
+        left: `${contextMenuState.x}px`,
+        top: `${contextMenuState.y}px`,
+        ...style,
+      }}
+      ref={overlayRef}
+    >
+      {contextMenuActions.map((item, index) => (
+        <ButtonSimple
+          key={index}
+          aria-label={item?.text}
+          onPress={() => {
+            toggleContextMenu();
+            item?.action();
+          }}
+        >
+          {item?.text}
+        </ButtonSimple>
+      ))}
+    </ModalContainer>
+  );
+};
+
+export default ContextMenu;

--- a/src/components/ContextMenu/ContextMenu.types.ts
+++ b/src/components/ContextMenu/ContextMenu.types.ts
@@ -1,0 +1,43 @@
+import { CSSProperties, ReactNode, RefObject } from 'react';
+
+export interface ContextMenuState {
+  isOpen: boolean;
+  x: number;
+  y: number;
+}
+
+type ContextMenuAction = {
+  text?: string;
+  action?: () => void;
+};
+
+export interface ContextMenuActionsProp {
+  contextMenuActions?: ContextMenuAction[];
+}
+
+export interface Props extends ContextMenuActionsProp {
+  /**
+   * Child components of this ContextMenu.
+   */
+  children?: ReactNode;
+
+  /**
+   * Custom class for overriding this component's CSS.
+   */
+  className?: string;
+
+  /**
+   * Custom id for overriding this component's CSS.
+   */
+  id?: string;
+
+  /**
+   * Custom style for overriding this component's CSS.
+   */
+  style?: CSSProperties;
+
+  /**
+   * Ref object of the context menu trigger.
+   */
+  triggerRef?: RefObject<HTMLElement>;
+}

--- a/src/components/ContextMenu/ContextMenu.unit.test.tsx
+++ b/src/components/ContextMenu/ContextMenu.unit.test.tsx
@@ -126,7 +126,7 @@ describe('<ContextMenu />', () => {
       expect.assertions(1);
 
       const style = { color: 'pink' };
-      const styleString = 'position: fixed; color: pink;';
+      const styleString = 'position: absolute; color: pink;';
 
       const { contextMenu } = renderAndTriggerContextMenu({ ...defaultProps, style });
 

--- a/src/components/ContextMenu/ContextMenu.unit.test.tsx
+++ b/src/components/ContextMenu/ContextMenu.unit.test.tsx
@@ -1,0 +1,153 @@
+import React, { useRef } from 'react';
+import { mount } from 'enzyme';
+
+import ContextMenu, { CONTEXT_MENU_CONSTANTS as CONSTANTS } from './';
+import { act } from 'react-dom/test-utils';
+
+const defaultProps = {
+  contextMenuActions: [
+    { text: 'Action 1', action: () => null },
+    { text: 'Action 2', action: () => null },
+  ],
+};
+
+const TestComponent = (props) => {
+  const triggerRef = useRef(null);
+
+  return (
+    <div>
+      <button ref={triggerRef}>Right click on me</button>
+      <ContextMenu triggerRef={triggerRef} {...props} />
+    </div>
+  );
+};
+
+const rightClickOnElement = (element) => {
+  act(() => {
+    // simulate('contextmenu') won't work when the event listener is added directly to the element instead of using props
+    element.dispatchEvent(new MouseEvent('contextmenu'));
+  });
+};
+
+const renderAndTriggerContextMenu = (props) => {
+  const container = mount(<TestComponent {...props} />, {
+    attachTo: document.getElementById('container'),
+  });
+  rightClickOnElement(container.find('button').getDOMNode());
+  const contextMenu = document.getElementById(props.id || 'context-menu');
+  return { container, contextMenu };
+};
+
+describe('<ContextMenu />', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="container"></div>';
+  });
+
+  afterEach(() => {
+    const div = document.getElementById('container');
+    if (div) {
+      document.body.removeChild(div);
+    }
+  });
+
+  // these snapshots will test both the container and contextMenu
+  describe('snapshot', () => {
+    it('should match snapshot', () => {
+      expect.assertions(1);
+
+      const container = renderAndTriggerContextMenu(defaultProps);
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match snapshot with className', () => {
+      expect.assertions(1);
+
+      const className = 'example-class';
+
+      const container = renderAndTriggerContextMenu({ ...defaultProps, className });
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match snapshot with id', () => {
+      expect.assertions(1);
+
+      const id = 'example-id';
+
+      const container = renderAndTriggerContextMenu({ ...defaultProps, id });
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match snapshot with style', () => {
+      expect.assertions(1);
+
+      const style = { color: 'pink' };
+
+      const container = renderAndTriggerContextMenu({ ...defaultProps, style });
+
+      expect(container).toMatchSnapshot();
+    });
+
+    /* ...additional snapshot tests... */
+  });
+
+  describe('attributes', () => {
+    it('should have its wrapper class', () => {
+      expect.assertions(1);
+
+      const { contextMenu } = renderAndTriggerContextMenu(defaultProps);
+
+      expect(contextMenu.classList.contains(CONSTANTS.STYLE.wrapper)).toBe(true);
+    });
+
+    it('should have provided class when className is provided', () => {
+      expect.assertions(1);
+
+      const className = 'example-class';
+
+      const { contextMenu } = renderAndTriggerContextMenu({ ...defaultProps, className });
+
+      expect(contextMenu.classList.contains(className)).toBe(true);
+    });
+
+    it('should have provided id when id is provided', () => {
+      expect.assertions(1);
+
+      const id = 'example-id';
+
+      const { contextMenu } = renderAndTriggerContextMenu({ ...defaultProps, id });
+
+      expect(contextMenu.id).toBe(id);
+    });
+
+    it('should have provided style when style is provided', () => {
+      expect.assertions(1);
+
+      const style = { color: 'pink' };
+      const styleString = 'position: fixed; color: pink;';
+
+      const { contextMenu } = renderAndTriggerContextMenu({ ...defaultProps, style });
+
+      expect(contextMenu.getAttribute('style')).toBe(styleString);
+    });
+  });
+
+  describe('actions', () => {
+    it('does not show context menu when contextMenuActions is not provided', () => {
+      const { contextMenu } = renderAndTriggerContextMenu({});
+      expect(contextMenu).toBe(null);
+    });
+
+    it('does shows context menu on right click', () => {
+      const { contextMenu } = renderAndTriggerContextMenu(defaultProps);
+      expect(contextMenu).toBeTruthy();
+      expect(contextMenu.children.length).toBe(2);
+      expect(contextMenu.children[0].tagName).toBe('BUTTON');
+      expect(contextMenu.children[0].textContent).toBe('Action 1');
+      expect(contextMenu.children[1].tagName).toBe('BUTTON');
+      expect(contextMenu.children[1].textContent).toBe('Action 2');
+    });
+  });
+});

--- a/src/components/ContextMenu/ContextMenu.unit.test.tsx.snap
+++ b/src/components/ContextMenu/ContextMenu.unit.test.tsx.snap
@@ -52,7 +52,7 @@ Object {
     data-round="75"
     id="context-menu"
     role="dialog"
-    style="position: fixed;"
+    style="position: absolute;"
   >
     <button
       aria-label="Action 1"
@@ -130,7 +130,7 @@ Object {
     data-round="75"
     id="context-menu"
     role="dialog"
-    style="position: fixed;"
+    style="position: absolute;"
   >
     <button
       aria-label="Action 1"
@@ -208,7 +208,7 @@ Object {
     data-round="75"
     id="example-id"
     role="dialog"
-    style="position: fixed;"
+    style="position: absolute;"
   >
     <button
       aria-label="Action 1"
@@ -294,7 +294,7 @@ Object {
     data-round="75"
     id="context-menu"
     role="dialog"
-    style="position: fixed; color: pink;"
+    style="position: absolute; color: pink;"
   >
     <button
       aria-label="Action 1"

--- a/src/components/ContextMenu/ContextMenu.unit.test.tsx.snap
+++ b/src/components/ContextMenu/ContextMenu.unit.test.tsx.snap
@@ -1,0 +1,319 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ContextMenu /> snapshot should match snapshot 1`] = `
+Object {
+  "container": <TestComponent
+    contextMenuActions={
+      Array [
+        Object {
+          "action": [Function],
+          "text": "Action 1",
+        },
+        Object {
+          "action": [Function],
+          "text": "Action 2",
+        },
+      ]
+    }
+  >
+    <div>
+      <button>
+        Right click on me
+      </button>
+      <ContextMenu
+        contextMenuActions={
+          Array [
+            Object {
+              "action": [Function],
+              "text": "Action 1",
+            },
+            Object {
+              "action": [Function],
+              "text": "Action 2",
+            },
+          ]
+        }
+        triggerRef={
+          Object {
+            "current": <button>
+              Right click on me
+            </button>,
+          }
+        }
+      />
+    </div>
+  </TestComponent>,
+  "contextMenu": <div
+    aria-modal="true"
+    class="md-context-menu-wrapper md-modal-container-wrapper"
+    data-color="primary"
+    data-elevation="0"
+    data-padded="true"
+    data-round="75"
+    id="context-menu"
+    role="dialog"
+    style="position: fixed;"
+  >
+    <button
+      aria-label="Action 1"
+      class="md-button-simple-wrapper"
+      type="button"
+    >
+      <span>
+        Action 1
+      </span>
+    </button>
+    <button
+      aria-label="Action 2"
+      class="md-button-simple-wrapper"
+      type="button"
+    >
+      <span>
+        Action 2
+      </span>
+    </button>
+  </div>,
+}
+`;
+
+exports[`<ContextMenu /> snapshot should match snapshot with className 1`] = `
+Object {
+  "container": <TestComponent
+    className="example-class"
+    contextMenuActions={
+      Array [
+        Object {
+          "action": [Function],
+          "text": "Action 1",
+        },
+        Object {
+          "action": [Function],
+          "text": "Action 2",
+        },
+      ]
+    }
+  >
+    <div>
+      <button>
+        Right click on me
+      </button>
+      <ContextMenu
+        className="example-class"
+        contextMenuActions={
+          Array [
+            Object {
+              "action": [Function],
+              "text": "Action 1",
+            },
+            Object {
+              "action": [Function],
+              "text": "Action 2",
+            },
+          ]
+        }
+        triggerRef={
+          Object {
+            "current": <button>
+              Right click on me
+            </button>,
+          }
+        }
+      />
+    </div>
+  </TestComponent>,
+  "contextMenu": <div
+    aria-modal="true"
+    class="example-class md-context-menu-wrapper md-modal-container-wrapper"
+    data-color="primary"
+    data-elevation="0"
+    data-padded="true"
+    data-round="75"
+    id="context-menu"
+    role="dialog"
+    style="position: fixed;"
+  >
+    <button
+      aria-label="Action 1"
+      class="md-button-simple-wrapper"
+      type="button"
+    >
+      <span>
+        Action 1
+      </span>
+    </button>
+    <button
+      aria-label="Action 2"
+      class="md-button-simple-wrapper"
+      type="button"
+    >
+      <span>
+        Action 2
+      </span>
+    </button>
+  </div>,
+}
+`;
+
+exports[`<ContextMenu /> snapshot should match snapshot with id 1`] = `
+Object {
+  "container": <TestComponent
+    contextMenuActions={
+      Array [
+        Object {
+          "action": [Function],
+          "text": "Action 1",
+        },
+        Object {
+          "action": [Function],
+          "text": "Action 2",
+        },
+      ]
+    }
+    id="example-id"
+  >
+    <div>
+      <button>
+        Right click on me
+      </button>
+      <ContextMenu
+        contextMenuActions={
+          Array [
+            Object {
+              "action": [Function],
+              "text": "Action 1",
+            },
+            Object {
+              "action": [Function],
+              "text": "Action 2",
+            },
+          ]
+        }
+        id="example-id"
+        triggerRef={
+          Object {
+            "current": <button>
+              Right click on me
+            </button>,
+          }
+        }
+      />
+    </div>
+  </TestComponent>,
+  "contextMenu": <div
+    aria-modal="true"
+    class="md-context-menu-wrapper md-modal-container-wrapper"
+    data-color="primary"
+    data-elevation="0"
+    data-padded="true"
+    data-round="75"
+    id="example-id"
+    role="dialog"
+    style="position: fixed;"
+  >
+    <button
+      aria-label="Action 1"
+      class="md-button-simple-wrapper"
+      type="button"
+    >
+      <span>
+        Action 1
+      </span>
+    </button>
+    <button
+      aria-label="Action 2"
+      class="md-button-simple-wrapper"
+      type="button"
+    >
+      <span>
+        Action 2
+      </span>
+    </button>
+  </div>,
+}
+`;
+
+exports[`<ContextMenu /> snapshot should match snapshot with style 1`] = `
+Object {
+  "container": <TestComponent
+    contextMenuActions={
+      Array [
+        Object {
+          "action": [Function],
+          "text": "Action 1",
+        },
+        Object {
+          "action": [Function],
+          "text": "Action 2",
+        },
+      ]
+    }
+    style={
+      Object {
+        "color": "pink",
+      }
+    }
+  >
+    <div>
+      <button>
+        Right click on me
+      </button>
+      <ContextMenu
+        contextMenuActions={
+          Array [
+            Object {
+              "action": [Function],
+              "text": "Action 1",
+            },
+            Object {
+              "action": [Function],
+              "text": "Action 2",
+            },
+          ]
+        }
+        style={
+          Object {
+            "color": "pink",
+          }
+        }
+        triggerRef={
+          Object {
+            "current": <button>
+              Right click on me
+            </button>,
+          }
+        }
+      />
+    </div>
+  </TestComponent>,
+  "contextMenu": <div
+    aria-modal="true"
+    class="md-context-menu-wrapper md-modal-container-wrapper"
+    data-color="primary"
+    data-elevation="0"
+    data-padded="true"
+    data-round="75"
+    id="context-menu"
+    role="dialog"
+    style="position: fixed; color: pink;"
+  >
+    <button
+      aria-label="Action 1"
+      class="md-button-simple-wrapper"
+      type="button"
+    >
+      <span>
+        Action 1
+      </span>
+    </button>
+    <button
+      aria-label="Action 2"
+      class="md-button-simple-wrapper"
+      type="button"
+    >
+      <span>
+        Action 2
+      </span>
+    </button>
+  </div>,
+}
+`;

--- a/src/components/ContextMenu/index.ts
+++ b/src/components/ContextMenu/index.ts
@@ -1,0 +1,9 @@
+import { default as ContextMenu } from './ContextMenu';
+import * as CONSTANTS from './ContextMenu.constants';
+import { Props } from './ContextMenu.types';
+
+export { CONSTANTS as CONTEXT_MENU_CONSTANTS };
+
+export type ContextMenuProps = Props;
+
+export default ContextMenu;

--- a/src/components/List/List.unit.test.tsx.snap
+++ b/src/components/List/List.unit.test.tsx.snap
@@ -47,6 +47,25 @@ exports[`<List /> snapshot should match snapshot 1`] = `
             tabIndex={-1}
           >
             ListItemBase 1
+            <ContextMenu
+              triggerRef={
+                Object {
+                  "current": <li
+                    class="md-list-item-base-wrapper"
+                    data-allow-text-select="false"
+                    data-disabled="false"
+                    data-interactive="true"
+                    data-padded="false"
+                    data-shape="rectangle"
+                    data-size="40"
+                    role="listitem"
+                    tabindex="-1"
+                  >
+                    ListItemBase 1
+                  </li>,
+                }
+              }
+            />
           </li>
         </FocusRing>
       </FocusRing>
@@ -88,6 +107,25 @@ exports[`<List /> snapshot should match snapshot 1`] = `
             tabIndex={-1}
           >
             ListItemBase 2
+            <ContextMenu
+              triggerRef={
+                Object {
+                  "current": <li
+                    class="md-list-item-base-wrapper"
+                    data-allow-text-select="false"
+                    data-disabled="false"
+                    data-interactive="true"
+                    data-padded="false"
+                    data-shape="rectangle"
+                    data-size="40"
+                    role="listitem"
+                    tabindex="-1"
+                  >
+                    ListItemBase 2
+                  </li>,
+                }
+              }
+            />
           </li>
         </FocusRing>
       </FocusRing>
@@ -144,6 +182,25 @@ exports[`<List /> snapshot should match snapshot with className 1`] = `
             tabIndex={-1}
           >
             ListItemBase 1
+            <ContextMenu
+              triggerRef={
+                Object {
+                  "current": <li
+                    class="md-list-item-base-wrapper"
+                    data-allow-text-select="false"
+                    data-disabled="false"
+                    data-interactive="true"
+                    data-padded="false"
+                    data-shape="rectangle"
+                    data-size="40"
+                    role="listitem"
+                    tabindex="-1"
+                  >
+                    ListItemBase 1
+                  </li>,
+                }
+              }
+            />
           </li>
         </FocusRing>
       </FocusRing>
@@ -185,6 +242,25 @@ exports[`<List /> snapshot should match snapshot with className 1`] = `
             tabIndex={-1}
           >
             ListItemBase 2
+            <ContextMenu
+              triggerRef={
+                Object {
+                  "current": <li
+                    class="md-list-item-base-wrapper"
+                    data-allow-text-select="false"
+                    data-disabled="false"
+                    data-interactive="true"
+                    data-padded="false"
+                    data-shape="rectangle"
+                    data-size="40"
+                    role="listitem"
+                    tabindex="-1"
+                  >
+                    ListItemBase 2
+                  </li>,
+                }
+              }
+            />
           </li>
         </FocusRing>
       </FocusRing>
@@ -242,6 +318,25 @@ exports[`<List /> snapshot should match snapshot with id 1`] = `
             tabIndex={-1}
           >
             ListItemBase 1
+            <ContextMenu
+              triggerRef={
+                Object {
+                  "current": <li
+                    class="md-list-item-base-wrapper"
+                    data-allow-text-select="false"
+                    data-disabled="false"
+                    data-interactive="true"
+                    data-padded="false"
+                    data-shape="rectangle"
+                    data-size="40"
+                    role="listitem"
+                    tabindex="-1"
+                  >
+                    ListItemBase 1
+                  </li>,
+                }
+              }
+            />
           </li>
         </FocusRing>
       </FocusRing>
@@ -283,6 +378,25 @@ exports[`<List /> snapshot should match snapshot with id 1`] = `
             tabIndex={-1}
           >
             ListItemBase 2
+            <ContextMenu
+              triggerRef={
+                Object {
+                  "current": <li
+                    class="md-list-item-base-wrapper"
+                    data-allow-text-select="false"
+                    data-disabled="false"
+                    data-interactive="true"
+                    data-padded="false"
+                    data-shape="rectangle"
+                    data-size="40"
+                    role="listitem"
+                    tabindex="-1"
+                  >
+                    ListItemBase 2
+                  </li>,
+                }
+              }
+            />
           </li>
         </FocusRing>
       </FocusRing>
@@ -340,6 +454,25 @@ exports[`<List /> snapshot should match snapshot with role 1`] = `
             tabIndex={-1}
           >
             ListItemBase 1
+            <ContextMenu
+              triggerRef={
+                Object {
+                  "current": <li
+                    class="md-list-item-base-wrapper"
+                    data-allow-text-select="false"
+                    data-disabled="false"
+                    data-interactive="true"
+                    data-padded="false"
+                    data-shape="rectangle"
+                    data-size="40"
+                    role="listitem"
+                    tabindex="-1"
+                  >
+                    ListItemBase 1
+                  </li>,
+                }
+              }
+            />
           </li>
         </FocusRing>
       </FocusRing>
@@ -381,6 +514,25 @@ exports[`<List /> snapshot should match snapshot with role 1`] = `
             tabIndex={-1}
           >
             ListItemBase 2
+            <ContextMenu
+              triggerRef={
+                Object {
+                  "current": <li
+                    class="md-list-item-base-wrapper"
+                    data-allow-text-select="false"
+                    data-disabled="false"
+                    data-interactive="true"
+                    data-padded="false"
+                    data-shape="rectangle"
+                    data-size="40"
+                    role="listitem"
+                    tabindex="-1"
+                  >
+                    ListItemBase 2
+                  </li>,
+                }
+              }
+            />
           </li>
         </FocusRing>
       </FocusRing>
@@ -446,6 +598,25 @@ exports[`<List /> snapshot should match snapshot with style 1`] = `
             tabIndex={-1}
           >
             ListItemBase 1
+            <ContextMenu
+              triggerRef={
+                Object {
+                  "current": <li
+                    class="md-list-item-base-wrapper"
+                    data-allow-text-select="false"
+                    data-disabled="false"
+                    data-interactive="true"
+                    data-padded="false"
+                    data-shape="rectangle"
+                    data-size="40"
+                    role="listitem"
+                    tabindex="-1"
+                  >
+                    ListItemBase 1
+                  </li>,
+                }
+              }
+            />
           </li>
         </FocusRing>
       </FocusRing>
@@ -487,6 +658,25 @@ exports[`<List /> snapshot should match snapshot with style 1`] = `
             tabIndex={-1}
           >
             ListItemBase 2
+            <ContextMenu
+              triggerRef={
+                Object {
+                  "current": <li
+                    class="md-list-item-base-wrapper"
+                    data-allow-text-select="false"
+                    data-disabled="false"
+                    data-interactive="true"
+                    data-padded="false"
+                    data-shape="rectangle"
+                    data-size="40"
+                    role="listitem"
+                    tabindex="-1"
+                  >
+                    ListItemBase 2
+                  </li>,
+                }
+              }
+            />
           </li>
         </FocusRing>
       </FocusRing>

--- a/src/components/ListBoxBase/ListBoxBase.unit.test.tsx.snap
+++ b/src/components/ListBoxBase/ListBoxBase.unit.test.tsx.snap
@@ -265,6 +265,33 @@ exports[`ListBoxBase snapshot should match snapshot 1`] = `
                           Item 1
                         </div>
                       </ListItemBaseSection>
+                      <ContextMenu
+                        triggerRef={
+                          Object {
+                            "current": <li
+                              aria-disabled="false"
+                              class="md-list-item-base-wrapper"
+                              data-allow-text-select="false"
+                              data-disabled="false"
+                              data-interactive="true"
+                              data-key="$.0"
+                              data-padded="true"
+                              data-shape="rectangle"
+                              data-size="40"
+                              id="test-ID-option-$.0"
+                              role="option"
+                              tabindex="-1"
+                            >
+                              <div
+                                data-position="fill"
+                                title="Item 1"
+                              >
+                                Item 1
+                              </div>
+                            </li>,
+                          }
+                        }
+                      />
                     </li>
                   </FocusRing>
                 </FocusRing>
@@ -371,6 +398,33 @@ exports[`ListBoxBase snapshot should match snapshot 1`] = `
                           Item 2
                         </div>
                       </ListItemBaseSection>
+                      <ContextMenu
+                        triggerRef={
+                          Object {
+                            "current": <li
+                              aria-disabled="false"
+                              class="md-list-item-base-wrapper"
+                              data-allow-text-select="false"
+                              data-disabled="false"
+                              data-interactive="true"
+                              data-key="$.1"
+                              data-padded="true"
+                              data-shape="rectangle"
+                              data-size="40"
+                              id="test-ID-option-$.1"
+                              role="option"
+                              tabindex="-1"
+                            >
+                              <div
+                                data-position="fill"
+                                title="Item 2"
+                              >
+                                Item 2
+                              </div>
+                            </li>,
+                          }
+                        }
+                      />
                     </li>
                   </FocusRing>
                 </FocusRing>
@@ -651,6 +705,33 @@ exports[`ListBoxBase snapshot should match snapshot when autoFocus provided 1`] 
                           Item 1
                         </div>
                       </ListItemBaseSection>
+                      <ContextMenu
+                        triggerRef={
+                          Object {
+                            "current": <li
+                              aria-disabled="false"
+                              class="md-list-item-base-wrapper"
+                              data-allow-text-select="false"
+                              data-disabled="false"
+                              data-interactive="true"
+                              data-key="$.0"
+                              data-padded="true"
+                              data-shape="rectangle"
+                              data-size="40"
+                              id="test-ID-option-$.0"
+                              role="option"
+                              tabindex="-1"
+                            >
+                              <div
+                                data-position="fill"
+                                title="Item 1"
+                              >
+                                Item 1
+                              </div>
+                            </li>,
+                          }
+                        }
+                      />
                     </li>
                   </FocusRing>
                 </FocusRing>
@@ -757,6 +838,33 @@ exports[`ListBoxBase snapshot should match snapshot when autoFocus provided 1`] 
                           Item 2
                         </div>
                       </ListItemBaseSection>
+                      <ContextMenu
+                        triggerRef={
+                          Object {
+                            "current": <li
+                              aria-disabled="false"
+                              class="md-list-item-base-wrapper"
+                              data-allow-text-select="false"
+                              data-disabled="false"
+                              data-interactive="true"
+                              data-key="$.1"
+                              data-padded="true"
+                              data-shape="rectangle"
+                              data-size="40"
+                              id="test-ID-option-$.1"
+                              role="option"
+                              tabindex="-1"
+                            >
+                              <div
+                                data-position="fill"
+                                title="Item 2"
+                              >
+                                Item 2
+                              </div>
+                            </li>,
+                          }
+                        }
+                      />
                     </li>
                   </FocusRing>
                 </FocusRing>
@@ -1038,6 +1146,33 @@ exports[`ListBoxBase snapshot should match snapshot with className 1`] = `
                           Item 1
                         </div>
                       </ListItemBaseSection>
+                      <ContextMenu
+                        triggerRef={
+                          Object {
+                            "current": <li
+                              aria-disabled="false"
+                              class="md-list-item-base-wrapper"
+                              data-allow-text-select="false"
+                              data-disabled="false"
+                              data-interactive="true"
+                              data-key="$.0"
+                              data-padded="true"
+                              data-shape="rectangle"
+                              data-size="40"
+                              id="test-ID-option-$.0"
+                              role="option"
+                              tabindex="-1"
+                            >
+                              <div
+                                data-position="fill"
+                                title="Item 1"
+                              >
+                                Item 1
+                              </div>
+                            </li>,
+                          }
+                        }
+                      />
                     </li>
                   </FocusRing>
                 </FocusRing>
@@ -1144,6 +1279,33 @@ exports[`ListBoxBase snapshot should match snapshot with className 1`] = `
                           Item 2
                         </div>
                       </ListItemBaseSection>
+                      <ContextMenu
+                        triggerRef={
+                          Object {
+                            "current": <li
+                              aria-disabled="false"
+                              class="md-list-item-base-wrapper"
+                              data-allow-text-select="false"
+                              data-disabled="false"
+                              data-interactive="true"
+                              data-key="$.1"
+                              data-padded="true"
+                              data-shape="rectangle"
+                              data-size="40"
+                              id="test-ID-option-$.1"
+                              role="option"
+                              tabindex="-1"
+                            >
+                              <div
+                                data-position="fill"
+                                title="Item 2"
+                              >
+                                Item 2
+                              </div>
+                            </li>,
+                          }
+                        }
+                      />
                     </li>
                   </FocusRing>
                 </FocusRing>
@@ -1424,6 +1586,33 @@ exports[`ListBoxBase snapshot should match snapshot with id 1`] = `
                           Item 1
                         </div>
                       </ListItemBaseSection>
+                      <ContextMenu
+                        triggerRef={
+                          Object {
+                            "current": <li
+                              aria-disabled="false"
+                              class="md-list-item-base-wrapper"
+                              data-allow-text-select="false"
+                              data-disabled="false"
+                              data-interactive="true"
+                              data-key="$.0"
+                              data-padded="true"
+                              data-shape="rectangle"
+                              data-size="40"
+                              id="test-ID-option-$.0"
+                              role="option"
+                              tabindex="-1"
+                            >
+                              <div
+                                data-position="fill"
+                                title="Item 1"
+                              >
+                                Item 1
+                              </div>
+                            </li>,
+                          }
+                        }
+                      />
                     </li>
                   </FocusRing>
                 </FocusRing>
@@ -1530,6 +1719,33 @@ exports[`ListBoxBase snapshot should match snapshot with id 1`] = `
                           Item 2
                         </div>
                       </ListItemBaseSection>
+                      <ContextMenu
+                        triggerRef={
+                          Object {
+                            "current": <li
+                              aria-disabled="false"
+                              class="md-list-item-base-wrapper"
+                              data-allow-text-select="false"
+                              data-disabled="false"
+                              data-interactive="true"
+                              data-key="$.1"
+                              data-padded="true"
+                              data-shape="rectangle"
+                              data-size="40"
+                              id="test-ID-option-$.1"
+                              role="option"
+                              tabindex="-1"
+                            >
+                              <div
+                                data-position="fill"
+                                title="Item 2"
+                              >
+                                Item 2
+                              </div>
+                            </li>,
+                          }
+                        }
+                      />
                     </li>
                   </FocusRing>
                 </FocusRing>
@@ -1966,6 +2182,33 @@ exports[`ListBoxBase snapshot should match snapshot with sections 1`] = `
                                 Item 1
                               </div>
                             </ListItemBaseSection>
+                            <ContextMenu
+                              triggerRef={
+                                Object {
+                                  "current": <li
+                                    aria-disabled="false"
+                                    class="md-list-item-base-wrapper"
+                                    data-allow-text-select="false"
+                                    data-disabled="false"
+                                    data-interactive="true"
+                                    data-key="$.0.0"
+                                    data-padded="true"
+                                    data-shape="rectangle"
+                                    data-size="40"
+                                    id="test-ID-option-$.0.0"
+                                    role="option"
+                                    tabindex="-1"
+                                  >
+                                    <div
+                                      data-position="fill"
+                                      title="Item 1"
+                                    >
+                                      Item 1
+                                    </div>
+                                  </li>,
+                                }
+                              }
+                            />
                           </li>
                         </FocusRing>
                       </FocusRing>
@@ -2072,6 +2315,33 @@ exports[`ListBoxBase snapshot should match snapshot with sections 1`] = `
                                 Item 2
                               </div>
                             </ListItemBaseSection>
+                            <ContextMenu
+                              triggerRef={
+                                Object {
+                                  "current": <li
+                                    aria-disabled="false"
+                                    class="md-list-item-base-wrapper"
+                                    data-allow-text-select="false"
+                                    data-disabled="false"
+                                    data-interactive="true"
+                                    data-key="$.0.1"
+                                    data-padded="true"
+                                    data-shape="rectangle"
+                                    data-size="40"
+                                    id="test-ID-option-$.0.1"
+                                    role="option"
+                                    tabindex="-1"
+                                  >
+                                    <div
+                                      data-position="fill"
+                                      title="Item 2"
+                                    >
+                                      Item 2
+                                    </div>
+                                  </li>,
+                                }
+                              }
+                            />
                           </li>
                         </FocusRing>
                       </FocusRing>
@@ -2219,6 +2489,33 @@ exports[`ListBoxBase snapshot should match snapshot with sections 1`] = `
                                 Item 3
                               </div>
                             </ListItemBaseSection>
+                            <ContextMenu
+                              triggerRef={
+                                Object {
+                                  "current": <li
+                                    aria-disabled="false"
+                                    class="md-list-item-base-wrapper"
+                                    data-allow-text-select="false"
+                                    data-disabled="false"
+                                    data-interactive="true"
+                                    data-key="$.1.0"
+                                    data-padded="true"
+                                    data-shape="rectangle"
+                                    data-size="40"
+                                    id="test-ID-option-$.1.0"
+                                    role="option"
+                                    tabindex="-1"
+                                  >
+                                    <div
+                                      data-position="fill"
+                                      title="Item 3"
+                                    >
+                                      Item 3
+                                    </div>
+                                  </li>,
+                                }
+                              }
+                            />
                           </li>
                         </FocusRing>
                       </FocusRing>
@@ -2520,6 +2817,33 @@ exports[`ListBoxBase snapshot should match snapshot with style 1`] = `
                           Item 1
                         </div>
                       </ListItemBaseSection>
+                      <ContextMenu
+                        triggerRef={
+                          Object {
+                            "current": <li
+                              aria-disabled="false"
+                              class="md-list-item-base-wrapper"
+                              data-allow-text-select="false"
+                              data-disabled="false"
+                              data-interactive="true"
+                              data-key="$.0"
+                              data-padded="true"
+                              data-shape="rectangle"
+                              data-size="40"
+                              id="test-ID-option-$.0"
+                              role="option"
+                              tabindex="-1"
+                            >
+                              <div
+                                data-position="fill"
+                                title="Item 1"
+                              >
+                                Item 1
+                              </div>
+                            </li>,
+                          }
+                        }
+                      />
                     </li>
                   </FocusRing>
                 </FocusRing>
@@ -2626,6 +2950,33 @@ exports[`ListBoxBase snapshot should match snapshot with style 1`] = `
                           Item 2
                         </div>
                       </ListItemBaseSection>
+                      <ContextMenu
+                        triggerRef={
+                          Object {
+                            "current": <li
+                              aria-disabled="false"
+                              class="md-list-item-base-wrapper"
+                              data-allow-text-select="false"
+                              data-disabled="false"
+                              data-interactive="true"
+                              data-key="$.1"
+                              data-padded="true"
+                              data-shape="rectangle"
+                              data-size="40"
+                              id="test-ID-option-$.1"
+                              role="option"
+                              tabindex="-1"
+                            >
+                              <div
+                                data-position="fill"
+                                title="Item 2"
+                              >
+                                Item 2
+                              </div>
+                            </li>,
+                          }
+                        }
+                      />
                     </li>
                   </FocusRing>
                 </FocusRing>

--- a/src/components/ListBoxItem/ListBoxItem.unit.test.tsx.snap
+++ b/src/components/ListBoxItem/ListBoxItem.unit.test.tsx.snap
@@ -77,6 +77,30 @@ exports[`ListBoxItem snapshot should match snapshot 1`] = `
               Item 1
             </div>
           </ListItemBaseSection>
+          <ContextMenu
+            triggerRef={
+              Object {
+                "current": <li
+                  class="md-list-item-base-wrapper"
+                  data-allow-text-select="false"
+                  data-disabled="false"
+                  data-interactive="true"
+                  data-padded="true"
+                  data-shape="rectangle"
+                  data-size="40"
+                  role="listitem"
+                  tabindex="0"
+                >
+                  <div
+                    data-position="fill"
+                    title="Item 1"
+                  >
+                    Item 1
+                  </div>
+                </li>,
+              }
+            }
+          />
         </li>
       </FocusRing>
     </FocusRing>

--- a/src/components/ListBoxSection/ListBoxSection.unit.test.tsx.snap
+++ b/src/components/ListBoxSection/ListBoxSection.unit.test.tsx.snap
@@ -111,6 +111,30 @@ exports[`ListBoxSection snapshot should match snapshot 1`] = `
                     Item 1
                   </div>
                 </ListItemBaseSection>
+                <ContextMenu
+                  triggerRef={
+                    Object {
+                      "current": <li
+                        class="md-list-item-base-wrapper"
+                        data-allow-text-select="false"
+                        data-disabled="false"
+                        data-interactive="true"
+                        data-padded="true"
+                        data-shape="rectangle"
+                        data-size="40"
+                        role="listitem"
+                        tabindex="0"
+                      >
+                        <div
+                          data-position="fill"
+                          title="Item 1"
+                        >
+                          Item 1
+                        </div>
+                      </li>,
+                    }
+                  }
+                />
               </li>
             </FocusRing>
           </FocusRing>
@@ -193,6 +217,30 @@ exports[`ListBoxSection snapshot should match snapshot 1`] = `
                     Item 2
                   </div>
                 </ListItemBaseSection>
+                <ContextMenu
+                  triggerRef={
+                    Object {
+                      "current": <li
+                        class="md-list-item-base-wrapper"
+                        data-allow-text-select="false"
+                        data-disabled="false"
+                        data-interactive="true"
+                        data-padded="true"
+                        data-shape="rectangle"
+                        data-size="40"
+                        role="listitem"
+                        tabindex="0"
+                      >
+                        <div
+                          data-position="fill"
+                          title="Item 2"
+                        >
+                          Item 2
+                        </div>
+                      </li>,
+                    }
+                  }
+                />
               </li>
             </FocusRing>
           </FocusRing>

--- a/src/components/ListHeader/ListHeader.unit.test.tsx.snap
+++ b/src/components/ListHeader/ListHeader.unit.test.tsx.snap
@@ -48,7 +48,25 @@ exports[`<ListHeader /> snapshot should match snapshot 1`] = `
             onTouchStart={[Function]}
             role="listitem"
             tabIndex={-1}
-          />
+          >
+            <ContextMenu
+              triggerRef={
+                Object {
+                  "current": <li
+                    class="md-list-header-list-item-base md-list-item-base-wrapper"
+                    data-allow-text-select="false"
+                    data-disabled="false"
+                    data-interactive="false"
+                    data-padded="true"
+                    data-shape="rectangle"
+                    data-size="32"
+                    role="listitem"
+                    tabindex="-1"
+                  />,
+                }
+              }
+            />
+          </li>
         </FocusRing>
       </FocusRing>
     </ListItemBase>
@@ -107,7 +125,25 @@ exports[`<ListHeader /> snapshot should match snapshot with bold 1`] = `
             onTouchStart={[Function]}
             role="listitem"
             tabIndex={-1}
-          />
+          >
+            <ContextMenu
+              triggerRef={
+                Object {
+                  "current": <li
+                    class="md-list-header-list-item-base md-list-item-base-wrapper"
+                    data-allow-text-select="false"
+                    data-disabled="false"
+                    data-interactive="false"
+                    data-padded="true"
+                    data-shape="rectangle"
+                    data-size="32"
+                    role="listitem"
+                    tabindex="-1"
+                  />,
+                }
+              }
+            />
+          </li>
         </FocusRing>
       </FocusRing>
     </ListItemBase>
@@ -169,7 +205,25 @@ exports[`<ListHeader /> snapshot should match snapshot with className 1`] = `
             onTouchStart={[Function]}
             role="listitem"
             tabIndex={-1}
-          />
+          >
+            <ContextMenu
+              triggerRef={
+                Object {
+                  "current": <li
+                    class="md-list-header-list-item-base md-list-item-base-wrapper"
+                    data-allow-text-select="false"
+                    data-disabled="false"
+                    data-interactive="false"
+                    data-padded="true"
+                    data-shape="rectangle"
+                    data-size="32"
+                    role="listitem"
+                    tabindex="-1"
+                  />,
+                }
+              }
+            />
+          </li>
         </FocusRing>
       </FocusRing>
     </ListItemBase>
@@ -228,7 +282,25 @@ exports[`<ListHeader /> snapshot should match snapshot with id 1`] = `
             onTouchStart={[Function]}
             role="listitem"
             tabIndex={-1}
-          />
+          >
+            <ContextMenu
+              triggerRef={
+                Object {
+                  "current": <li
+                    class="md-list-header-list-item-base md-list-item-base-wrapper"
+                    data-allow-text-select="false"
+                    data-disabled="false"
+                    data-interactive="false"
+                    data-padded="true"
+                    data-shape="rectangle"
+                    data-size="32"
+                    role="listitem"
+                    tabindex="-1"
+                  />,
+                }
+              }
+            />
+          </li>
         </FocusRing>
       </FocusRing>
     </ListItemBase>
@@ -286,7 +358,25 @@ exports[`<ListHeader /> snapshot should match snapshot with outline 1`] = `
             onTouchStart={[Function]}
             role="listitem"
             tabIndex={-1}
-          />
+          >
+            <ContextMenu
+              triggerRef={
+                Object {
+                  "current": <li
+                    class="md-list-header-list-item-base md-list-item-base-wrapper"
+                    data-allow-text-select="false"
+                    data-disabled="false"
+                    data-interactive="false"
+                    data-padded="true"
+                    data-shape="rectangle"
+                    data-size="32"
+                    role="listitem"
+                    tabindex="-1"
+                  />,
+                }
+              }
+            />
+          </li>
         </FocusRing>
       </FocusRing>
     </ListItemBase>
@@ -349,7 +439,25 @@ exports[`<ListHeader /> snapshot should match snapshot with outlineColor 1`] = `
             onTouchStart={[Function]}
             role="listitem"
             tabIndex={-1}
-          />
+          >
+            <ContextMenu
+              triggerRef={
+                Object {
+                  "current": <li
+                    class="md-list-header-list-item-base md-list-item-base-wrapper"
+                    data-allow-text-select="false"
+                    data-disabled="false"
+                    data-interactive="false"
+                    data-padded="true"
+                    data-shape="rectangle"
+                    data-size="32"
+                    role="listitem"
+                    tabindex="-1"
+                  />,
+                }
+              }
+            />
+          </li>
         </FocusRing>
       </FocusRing>
     </ListItemBase>
@@ -412,7 +520,25 @@ exports[`<ListHeader /> snapshot should match snapshot with outlinePosition 1`] 
             onTouchStart={[Function]}
             role="listitem"
             tabIndex={-1}
-          />
+          >
+            <ContextMenu
+              triggerRef={
+                Object {
+                  "current": <li
+                    class="md-list-header-list-item-base md-list-item-base-wrapper"
+                    data-allow-text-select="false"
+                    data-disabled="false"
+                    data-interactive="false"
+                    data-padded="true"
+                    data-shape="rectangle"
+                    data-size="32"
+                    role="listitem"
+                    tabindex="-1"
+                  />,
+                }
+              }
+            />
+          </li>
         </FocusRing>
       </FocusRing>
     </ListItemBase>
@@ -475,7 +601,25 @@ exports[`<ListHeader /> snapshot should match snapshot with outlinePosition 2`] 
             onTouchStart={[Function]}
             role="listitem"
             tabIndex={-1}
-          />
+          >
+            <ContextMenu
+              triggerRef={
+                Object {
+                  "current": <li
+                    class="md-list-header-list-item-base md-list-item-base-wrapper"
+                    data-allow-text-select="false"
+                    data-disabled="false"
+                    data-interactive="false"
+                    data-padded="true"
+                    data-shape="rectangle"
+                    data-size="32"
+                    role="listitem"
+                    tabindex="-1"
+                  />,
+                }
+              }
+            />
+          </li>
         </FocusRing>
       </FocusRing>
     </ListItemBase>
@@ -546,7 +690,25 @@ exports[`<ListHeader /> snapshot should match snapshot with style 1`] = `
             onTouchStart={[Function]}
             role="listitem"
             tabIndex={-1}
-          />
+          >
+            <ContextMenu
+              triggerRef={
+                Object {
+                  "current": <li
+                    class="md-list-header-list-item-base md-list-item-base-wrapper"
+                    data-allow-text-select="false"
+                    data-disabled="false"
+                    data-interactive="false"
+                    data-padded="true"
+                    data-shape="rectangle"
+                    data-size="32"
+                    role="listitem"
+                    tabindex="-1"
+                  />,
+                }
+              }
+            />
+          </li>
         </FocusRing>
       </FocusRing>
     </ListItemBase>

--- a/src/components/ListItemBase/ListItemBase.stories.tsx
+++ b/src/components/ListItemBase/ListItemBase.stories.tsx
@@ -50,6 +50,7 @@ const Example = Template((args) => (
           </>
         ),
         onPress: action('onPress'),
+        contextMenuActions: [{ text: 'Action 1' }],
       },
       {}
     )}

--- a/src/components/ListItemBase/ListItemBase.style.scss
+++ b/src/components/ListItemBase/ListItemBase.style.scss
@@ -141,25 +141,3 @@
     }
   }
 }
-
-.md-list-item-base-context-menu-wrapper {
-  max-width: 20rem;
-  border-radius: 0.75rem;
-  z-index: 9999;
-
-  & button {
-    font-size: 0.75rem;
-    padding: 0.25rem 0.5rem;
-    border-radius: 0.5rem;
-    border: var(--md-globals-border-clear);
-    text-align: left;
-    width: 100%;
-    background-color: var(--mds-color-theme-button-secondary-normal);
-    color: var(--mds-color-theme-text-primary-normal);
-
-    &:hover {
-      background-color: var(--mds-color-theme-button-secondary-hover);
-      color: var(--mds-color-theme-text-primary-normal);
-    }
-  }
-}

--- a/src/components/ListItemBase/ListItemBase.test.tsx.snap
+++ b/src/components/ListItemBase/ListItemBase.test.tsx.snap
@@ -36,6 +36,25 @@ exports[`ListItemBase snapshot should match snapshot 1`] = `
         tabIndex={-1}
       >
         Test
+        <ContextMenu
+          triggerRef={
+            Object {
+              "current": <li
+                class="md-list-item-base-wrapper"
+                data-allow-text-select="false"
+                data-disabled="false"
+                data-interactive="true"
+                data-padded="false"
+                data-shape="rectangle"
+                data-size="40"
+                role="listitem"
+                tabindex="-1"
+              >
+                Test
+              </li>,
+            }
+          }
+        />
       </li>
     </FocusRing>
   </FocusRing>
@@ -68,6 +87,25 @@ exports[`ListItemBase snapshot should match snapshot with allowTextSelection=tru
         tabIndex={-1}
       >
         Test
+        <ContextMenu
+          triggerRef={
+            Object {
+              "current": <li
+                class="md-list-item-base-wrapper"
+                data-allow-text-select="true"
+                data-disabled="false"
+                data-interactive="true"
+                data-padded="false"
+                data-shape="rectangle"
+                data-size="40"
+                role="listitem"
+                tabindex="-1"
+              >
+                Test
+              </li>,
+            }
+          }
+        />
       </li>
     </FocusRing>
   </FocusRing>
@@ -112,6 +150,25 @@ exports[`ListItemBase snapshot should match snapshot with className 1`] = `
         tabIndex={-1}
       >
         Test
+        <ContextMenu
+          triggerRef={
+            Object {
+              "current": <li
+                class="example-class md-list-item-base-wrapper"
+                data-allow-text-select="false"
+                data-disabled="false"
+                data-interactive="true"
+                data-padded="false"
+                data-shape="rectangle"
+                data-size="40"
+                role="listitem"
+                tabindex="-1"
+              >
+                Test
+              </li>,
+            }
+          }
+        />
       </li>
     </FocusRing>
   </FocusRing>
@@ -157,6 +214,26 @@ exports[`ListItemBase snapshot should match snapshot with id 1`] = `
         tabIndex={-1}
       >
         Test
+        <ContextMenu
+          triggerRef={
+            Object {
+              "current": <li
+                class="md-list-item-base-wrapper"
+                data-allow-text-select="false"
+                data-disabled="false"
+                data-interactive="true"
+                data-padded="false"
+                data-shape="rectangle"
+                data-size="40"
+                id="example-id"
+                role="listitem"
+                tabindex="-1"
+              >
+                Test
+              </li>,
+            }
+          }
+        />
       </li>
     </FocusRing>
   </FocusRing>
@@ -201,6 +278,25 @@ exports[`ListItemBase snapshot should match snapshot with interactive=false 1`] 
         tabIndex={-1}
       >
         Test
+        <ContextMenu
+          triggerRef={
+            Object {
+              "current": <li
+                class="md-list-item-base-wrapper"
+                data-allow-text-select="false"
+                data-disabled="false"
+                data-interactive="false"
+                data-padded="false"
+                data-shape="rectangle"
+                data-size="40"
+                role="listitem"
+                tabindex="-1"
+              >
+                Test
+              </li>,
+            }
+          }
+        />
       </li>
     </FocusRing>
   </FocusRing>
@@ -245,6 +341,25 @@ exports[`ListItemBase snapshot should match snapshot with isDisabled 1`] = `
         tabIndex={-1}
       >
         Test
+        <ContextMenu
+          triggerRef={
+            Object {
+              "current": <li
+                class="md-list-item-base-wrapper"
+                data-allow-text-select="false"
+                data-disabled="true"
+                data-interactive="true"
+                data-padded="false"
+                data-shape="rectangle"
+                data-size="40"
+                role="listitem"
+                tabindex="-1"
+              >
+                Test
+              </li>,
+            }
+          }
+        />
       </li>
     </FocusRing>
   </FocusRing>
@@ -289,6 +404,25 @@ exports[`ListItemBase snapshot should match snapshot with isSelected 1`] = `
         tabIndex={-1}
       >
         Test
+        <ContextMenu
+          triggerRef={
+            Object {
+              "current": <li
+                class="md-list-item-base-wrapper active"
+                data-allow-text-select="false"
+                data-disabled="false"
+                data-interactive="true"
+                data-padded="false"
+                data-shape="rectangle"
+                data-size="40"
+                role="listitem"
+                tabindex="-1"
+              >
+                Test
+              </li>,
+            }
+          }
+        />
       </li>
     </FocusRing>
   </FocusRing>
@@ -334,6 +468,26 @@ exports[`ListItemBase snapshot should match snapshot with lang 1`] = `
         tabIndex={-1}
       >
         Test
+        <ContextMenu
+          triggerRef={
+            Object {
+              "current": <li
+                class="md-list-item-base-wrapper"
+                data-allow-text-select="false"
+                data-disabled="false"
+                data-interactive="true"
+                data-padded="false"
+                data-shape="rectangle"
+                data-size="40"
+                lang="en-US"
+                role="listitem"
+                tabindex="-1"
+              >
+                Test
+              </li>,
+            }
+          }
+        />
       </li>
     </FocusRing>
   </FocusRing>
@@ -378,6 +532,25 @@ exports[`ListItemBase snapshot should match snapshot with role 1`] = `
         tabIndex={-1}
       >
         Test
+        <ContextMenu
+          triggerRef={
+            Object {
+              "current": <li
+                class="md-list-item-base-wrapper"
+                data-allow-text-select="false"
+                data-disabled="false"
+                data-interactive="true"
+                data-padded="false"
+                data-shape="rectangle"
+                data-size="40"
+                role="role"
+                tabindex="-1"
+              >
+                Test
+              </li>,
+            }
+          }
+        />
       </li>
     </FocusRing>
   </FocusRing>
@@ -422,6 +595,25 @@ exports[`ListItemBase snapshot should match snapshot with shape 1`] = `
         tabIndex={-1}
       >
         Test
+        <ContextMenu
+          triggerRef={
+            Object {
+              "current": <li
+                class="md-list-item-base-wrapper"
+                data-allow-text-select="false"
+                data-disabled="false"
+                data-interactive="true"
+                data-padded="false"
+                data-shape="isPilled"
+                data-size="50"
+                role="listitem"
+                tabindex="-1"
+              >
+                Test
+              </li>,
+            }
+          }
+        />
       </li>
     </FocusRing>
   </FocusRing>
@@ -466,6 +658,25 @@ exports[`ListItemBase snapshot should match snapshot with size 1`] = `
         tabIndex={-1}
       >
         Test
+        <ContextMenu
+          triggerRef={
+            Object {
+              "current": <li
+                class="md-list-item-base-wrapper"
+                data-allow-text-select="false"
+                data-disabled="false"
+                data-interactive="true"
+                data-padded="false"
+                data-shape="rectangle"
+                data-size="40"
+                role="listitem"
+                tabindex="-1"
+              >
+                Test
+              </li>,
+            }
+          }
+        />
       </li>
     </FocusRing>
   </FocusRing>
@@ -519,6 +730,26 @@ exports[`ListItemBase snapshot should match snapshot with style 1`] = `
         tabIndex={-1}
       >
         Test
+        <ContextMenu
+          triggerRef={
+            Object {
+              "current": <li
+                class="md-list-item-base-wrapper"
+                data-allow-text-select="false"
+                data-disabled="false"
+                data-interactive="true"
+                data-padded="false"
+                data-shape="rectangle"
+                data-size="40"
+                role="listitem"
+                style="color: pink;"
+                tabindex="-1"
+              >
+                Test
+              </li>,
+            }
+          }
+        />
       </li>
     </FocusRing>
   </FocusRing>

--- a/src/components/ListItemBase/ListItemBase.tsx
+++ b/src/components/ListItemBase/ListItemBase.tsx
@@ -4,29 +4,26 @@ import React, {
   ReactNode,
   useRef,
   useEffect,
-  useState,
   useCallback,
   useLayoutEffect,
 } from 'react';
 import classnames from 'classnames';
 
 import './ListItemBase.style.scss';
-import { ContextMenuState, Props } from './ListItemBase.types';
+import { Props } from './ListItemBase.types';
 import { DEFAULTS, KEYS, SHAPES, SIZES, STYLE } from './ListItemBase.constants';
 import ListItemBaseSection from '../ListItemBaseSection';
 import { verifyTypes } from '../../helpers/verifyTypes';
 import FocusRing from '../FocusRing';
 import { usePress } from '@react-aria/interactions';
-import ModalContainer from '../ModalContainer';
-import { useOverlay } from '@react-aria/overlays';
 import { useListContext } from '../List/List.utils';
-import ButtonSimple from '../ButtonSimple';
 import Text from '../Text';
 import { getListItemBaseTabIndex } from './ListItemBase.utils';
 import { useMutationObservable } from '../../hooks/useMutationObservable';
 import { usePrevious } from '../../hooks/usePrevious';
 import { getKeyboardFocusableElements } from '../../utils/navigation';
 import { useDidUpdateEffect } from '../../hooks/useDidUpdateEffect';
+import ContextMenu from '../ContextMenu';
 
 type RefOrCallbackRef = RefObject<HTMLLIElement> | ((instance: HTMLLIElement) => void);
 
@@ -129,14 +126,16 @@ const ListItemBase = (props: Props, providedRef: RefOrCallbackRef) => {
   });
 
   // Prevent list item update because it can cause state lost in the focused component e.g. Menu
-  const listItemPressProps = allowTextSelection ? {...rest} : {
-    ...pressProps,
-    onKeyDown: (event) => {
-      if (ref.current === document.activeElement || event.key === KEYS.TAB_KEY) {
-        pressProps.onKeyDown(event);
-      }
-    },
-  };
+  const listItemPressProps = allowTextSelection
+    ? { ...rest }
+    : {
+        ...pressProps,
+        onKeyDown: (event) => {
+          if (ref.current === document.activeElement || event.key === KEYS.TAB_KEY) {
+            pressProps.onKeyDown(event);
+          }
+        },
+      };
 
   /**
    * Focus management
@@ -197,81 +196,6 @@ const ListItemBase = (props: Props, providedRef: RefOrCallbackRef) => {
 
   useMutationObservable(ref.current, updateTabIndexes);
 
-  /**
-   * Context menu
-   */
-
-  const [contextMenuState, setContextMenuState] = useState<ContextMenuState>({
-    isOpen: false,
-    x: 0,
-    y: 0,
-  });
-
-  const toggleContextMenu = () => {
-    setContextMenuState({ ...contextMenuState, isOpen: !contextMenuState.isOpen });
-  };
-
-  const overlayRef = useRef();
-  const { overlayProps } = useOverlay(
-    {
-      onClose: () => toggleContextMenu(),
-      shouldCloseOnBlur: true,
-      isOpen: contextMenuState.isOpen,
-      isDismissable: true,
-    },
-    overlayRef
-  );
-
-  const renderContextMenu = () => {
-    const { x, y } = contextMenuState;
-
-    return (
-      <ModalContainer
-        isPadded
-        round={75}
-        className={STYLE.contextMenuWrapper}
-        {...overlayProps}
-        id="list-item-context-menu"
-        color={'primary' as const}
-        style={{ position: 'fixed', left: `${x}px`, top: `${y}px` }}
-        ref={overlayRef}
-      >
-        {contextMenuActions.map((item, index) => (
-          <ButtonSimple
-            key={index}
-            aria-label={item?.text}
-            onPress={() => {
-              toggleContextMenu();
-              item?.action();
-            }}
-          >
-            {item?.text}
-          </ButtonSimple>
-        ))}
-      </ModalContainer>
-    );
-  };
-
-  const handleOnContextMenu = (event: MouseEvent) => {
-    event.preventDefault();
-    // Don't allow to open more context-menus at the same time
-    if (document.getElementById('list-item-context-menu')) {
-      return;
-    }
-
-    const { pageX, pageY } = event;
-    setContextMenuState({ x: pageX, y: pageY, isOpen: !contextMenuState.isOpen });
-  };
-
-  useEffect(() => {
-    if (contextMenuActions) {
-      ref.current.addEventListener('contextmenu', handleOnContextMenu);
-    }
-    return () => {
-      ref.current?.removeEventListener('contextmenu', handleOnContextMenu);
-    };
-  }, []);
-
   return (
     <FocusRing isInset={shouldItemFocusBeInset}>
       <li
@@ -290,7 +214,7 @@ const ListItemBase = (props: Props, providedRef: RefOrCallbackRef) => {
         {...listItemPressProps}
       >
         {content}
-        {contextMenuActions && contextMenuState.isOpen && renderContextMenu()}
+        <ContextMenu contextMenuActions={contextMenuActions} triggerRef={ref} />
       </li>
     </FocusRing>
   );

--- a/src/components/ListItemBase/ListItemBase.types.ts
+++ b/src/components/ListItemBase/ListItemBase.types.ts
@@ -1,24 +1,10 @@
 import { CSSProperties, ReactNode } from 'react';
 import { PressEvents } from '@react-types/shared';
+import { ContextMenuActionsProp } from '../ContextMenu/ContextMenu.types';
 
 export type ListItemBaseSize = 32 | 40 | 50 | 70 | 'auto';
 
-export interface ContextMenuState {
-  isOpen: boolean;
-  x: number;
-  y: number;
-}
-
-type ContextMenuAction = {
-  text?: string;
-  action?: () => void;
-};
-
-export interface ContextMenu {
-  contextMenuActions?: ContextMenuAction[];
-}
-
-export interface Props extends PressEvents, ContextMenu {
+export interface Props extends PressEvents, ContextMenuActionsProp {
   /**
    * className prop description
    * Child components of this ButtonPill.
@@ -95,5 +81,5 @@ export interface Props extends PressEvents, ContextMenu {
   /**
    * Allows text selection of text contents of the ListItemBase. Cannot be used in conjunction with an onPress prop.
    */
-    allowTextSelection?: boolean;
+  allowTextSelection?: boolean;
 }

--- a/src/components/MeetingListItem/MeetingListItem.unit.test.tsx.snap
+++ b/src/components/MeetingListItem/MeetingListItem.unit.test.tsx.snap
@@ -69,6 +69,38 @@ exports[`<MeetingListItem /> snapshot should match snapshot 1`] = `
               />
             </ListItemBaseSection>
           </MeetingRowContent>
+          <ContextMenu
+            triggerRef={
+              Object {
+                "current": <li
+                  class="md-meeting-list-item-wrapper md-list-item-base-wrapper"
+                  data-allow-text-select="false"
+                  data-color="Transparent"
+                  data-disabled="false"
+                  data-interactive="true"
+                  data-padded="true"
+                  data-shape="rectangle"
+                  data-size="50"
+                  role="listitem"
+                  tabindex="0"
+                >
+                  <div
+                    class="md-meeting-row-content-start-section md-meeting-row-content-start-section-no-image"
+                    data-position="start"
+                  >
+                    <div
+                      class="md-meeting-row-content-border"
+                      data-color="Transparent"
+                    />
+                  </div>
+                  <div
+                    class="md-meeting-row-content-middle-section md-meeting-row-content-middle-section-Transparent"
+                    data-position="middle"
+                  />
+                </li>,
+              }
+            }
+          />
         </li>
       </FocusRing>
     </FocusRing>
@@ -168,6 +200,51 @@ exports[`<MeetingListItem /> snapshot should match snapshot with buttonGroup 1`]
               </div>
             </ListItemBaseSection>
           </MeetingRowContent>
+          <ContextMenu
+            triggerRef={
+              Object {
+                "current": <li
+                  class="md-meeting-list-item-wrapper md-list-item-base-wrapper"
+                  data-allow-text-select="false"
+                  data-color="Transparent"
+                  data-disabled="false"
+                  data-interactive="true"
+                  data-padded="true"
+                  data-shape="rectangle"
+                  data-size="50"
+                  role="listitem"
+                  tabindex="0"
+                >
+                  <div
+                    class="md-meeting-row-content-start-section md-meeting-row-content-start-section-no-image"
+                    data-position="start"
+                  >
+                    <div
+                      class="md-meeting-row-content-border"
+                      data-color="Transparent"
+                    />
+                  </div>
+                  <div
+                    class="md-meeting-row-content-middle-section md-meeting-row-content-middle-section-Transparent"
+                    data-position="middle"
+                  />
+                  <div
+                    class="md-meeting-row-content-end-section"
+                    data-position="end"
+                  >
+                    <div
+                      class="md-button-group-wrapper"
+                      data-compressed="false"
+                      data-orientation="horizontal"
+                      data-round="false"
+                      data-separator="false"
+                      data-spaced="false"
+                    />
+                  </div>
+                </li>,
+              }
+            }
+          />
         </li>
       </FocusRing>
     </FocusRing>
@@ -246,6 +323,38 @@ exports[`<MeetingListItem /> snapshot should match snapshot with className 1`] =
               />
             </ListItemBaseSection>
           </MeetingRowContent>
+          <ContextMenu
+            triggerRef={
+              Object {
+                "current": <li
+                  class="example-class md-meeting-list-item-wrapper md-list-item-base-wrapper"
+                  data-allow-text-select="false"
+                  data-color="Transparent"
+                  data-disabled="false"
+                  data-interactive="true"
+                  data-padded="true"
+                  data-shape="rectangle"
+                  data-size="50"
+                  role="listitem"
+                  tabindex="0"
+                >
+                  <div
+                    class="md-meeting-row-content-start-section md-meeting-row-content-start-section-no-image"
+                    data-position="start"
+                  >
+                    <div
+                      class="md-meeting-row-content-border"
+                      data-color="Transparent"
+                    />
+                  </div>
+                  <div
+                    class="md-meeting-row-content-middle-section md-meeting-row-content-middle-section-Transparent"
+                    data-position="middle"
+                  />
+                </li>,
+              }
+            }
+          />
         </li>
       </FocusRing>
     </FocusRing>
@@ -324,6 +433,38 @@ exports[`<MeetingListItem /> snapshot should match snapshot with color 1`] = `
               />
             </ListItemBaseSection>
           </MeetingRowContent>
+          <ContextMenu
+            triggerRef={
+              Object {
+                "current": <li
+                  class="md-meeting-list-item-wrapper md-list-item-base-wrapper"
+                  data-allow-text-select="false"
+                  data-color="AcceptedActive"
+                  data-disabled="false"
+                  data-interactive="true"
+                  data-padded="true"
+                  data-shape="rectangle"
+                  data-size="50"
+                  role="listitem"
+                  tabindex="0"
+                >
+                  <div
+                    class="md-meeting-row-content-start-section md-meeting-row-content-start-section-no-image"
+                    data-position="start"
+                  >
+                    <div
+                      class="md-meeting-row-content-border"
+                      data-color="AcceptedActive"
+                    />
+                  </div>
+                  <div
+                    class="md-meeting-row-content-middle-section md-meeting-row-content-middle-section-AcceptedActive"
+                    data-position="middle"
+                  />
+                </li>,
+              }
+            }
+          />
         </li>
       </FocusRing>
     </FocusRing>
@@ -404,6 +545,39 @@ exports[`<MeetingListItem /> snapshot should match snapshot with id 1`] = `
               />
             </ListItemBaseSection>
           </MeetingRowContent>
+          <ContextMenu
+            triggerRef={
+              Object {
+                "current": <li
+                  class="md-meeting-list-item-wrapper md-list-item-base-wrapper"
+                  data-allow-text-select="false"
+                  data-color="Transparent"
+                  data-disabled="false"
+                  data-interactive="true"
+                  data-padded="true"
+                  data-shape="rectangle"
+                  data-size="50"
+                  id="example-id"
+                  role="listitem"
+                  tabindex="0"
+                >
+                  <div
+                    class="md-meeting-row-content-start-section md-meeting-row-content-start-section-no-image"
+                    data-position="start"
+                  >
+                    <div
+                      class="md-meeting-row-content-border"
+                      data-color="Transparent"
+                    />
+                  </div>
+                  <div
+                    class="md-meeting-row-content-middle-section md-meeting-row-content-middle-section-Transparent"
+                    data-position="middle"
+                  />
+                </li>,
+              }
+            }
+          />
         </li>
       </FocusRing>
     </FocusRing>
@@ -520,6 +694,56 @@ exports[`<MeetingListItem /> snapshot should match snapshot with image 1`] = `
               />
             </ListItemBaseSection>
           </MeetingRowContent>
+          <ContextMenu
+            triggerRef={
+              Object {
+                "current": <li
+                  class="md-meeting-list-item-wrapper md-list-item-base-wrapper"
+                  data-allow-text-select="false"
+                  data-color="Transparent"
+                  data-disabled="false"
+                  data-interactive="true"
+                  data-padded="true"
+                  data-shape="rectangle"
+                  data-size="50"
+                  role="listitem"
+                  tabindex="0"
+                >
+                  <div
+                    class="md-meeting-row-content-start-section"
+                    data-position="start"
+                  >
+                    <div
+                      class="md-meeting-row-content-border"
+                      data-color="Transparent"
+                    />
+                    <div
+                      aria-hidden="true"
+                      class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class=""
+                        data-autoscale="false"
+                        data-scale="12"
+                        data-test="placeholder"
+                        fill="currentColor"
+                        height="100%"
+                        style="stroke: none;"
+                        viewBox="0, 0, 32, 32"
+                        width="100%"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    class="md-meeting-row-content-middle-section md-meeting-row-content-middle-section-Transparent"
+                    data-position="middle"
+                  />
+                </li>,
+              }
+            }
+          />
         </li>
       </FocusRing>
     </FocusRing>
@@ -600,6 +824,38 @@ exports[`<MeetingListItem /> snapshot should match snapshot with isDisabled 1`] 
               />
             </ListItemBaseSection>
           </MeetingRowContent>
+          <ContextMenu
+            triggerRef={
+              Object {
+                "current": <li
+                  class="md-meeting-list-item-wrapper md-list-item-base-wrapper"
+                  data-allow-text-select="false"
+                  data-color="Transparent"
+                  data-disabled="true"
+                  data-interactive="true"
+                  data-padded="true"
+                  data-shape="rectangle"
+                  data-size="50"
+                  role="listitem"
+                  tabindex="0"
+                >
+                  <div
+                    class="md-meeting-row-content-start-section md-meeting-row-content-start-section-no-image"
+                    data-position="start"
+                  >
+                    <div
+                      class="md-meeting-row-content-border"
+                      data-color="Transparent"
+                    />
+                  </div>
+                  <div
+                    class="md-meeting-row-content-middle-section md-meeting-row-content-middle-section-Transparent"
+                    data-position="middle"
+                  />
+                </li>,
+              }
+            }
+          />
         </li>
       </FocusRing>
     </FocusRing>
@@ -692,6 +948,39 @@ exports[`<MeetingListItem /> snapshot should match snapshot with style 1`] = `
               />
             </ListItemBaseSection>
           </MeetingRowContent>
+          <ContextMenu
+            triggerRef={
+              Object {
+                "current": <li
+                  class="md-meeting-list-item-wrapper md-list-item-base-wrapper"
+                  data-allow-text-select="false"
+                  data-color="Transparent"
+                  data-disabled="false"
+                  data-interactive="true"
+                  data-padded="true"
+                  data-shape="rectangle"
+                  data-size="50"
+                  role="listitem"
+                  style="color: pink;"
+                  tabindex="0"
+                >
+                  <div
+                    class="md-meeting-row-content-start-section md-meeting-row-content-start-section-no-image"
+                    data-position="start"
+                  >
+                    <div
+                      class="md-meeting-row-content-border"
+                      data-color="Transparent"
+                    />
+                  </div>
+                  <div
+                    class="md-meeting-row-content-middle-section md-meeting-row-content-middle-section-Transparent"
+                    data-position="middle"
+                  />
+                </li>,
+              }
+            }
+          />
         </li>
       </FocusRing>
     </FocusRing>

--- a/src/components/Menu/Menu.unit.test.tsx.snap
+++ b/src/components/Menu/Menu.unit.test.tsx.snap
@@ -240,6 +240,32 @@ exports[`<Menu /> snapshot should match snapshot 1`] = `
                   One
                 </div>
               </ListItemBaseSection>
+              <ContextMenu
+                triggerRef={
+                  Object {
+                    "current": <li
+                      aria-disabled="false"
+                      class="md-menu-item-wrapper md-list-item-base-wrapper"
+                      data-allow-text-select="false"
+                      data-disabled="false"
+                      data-interactive="true"
+                      data-key="one"
+                      data-padded="true"
+                      data-shape="rectangle"
+                      data-size="40"
+                      role="menuitem"
+                      tabindex="-1"
+                    >
+                      <div
+                        data-position="fill"
+                        title="One"
+                      >
+                        One
+                      </div>
+                    </li>,
+                  }
+                }
+              />
             </li>
           </FocusRing>
         </FocusRing>
@@ -470,6 +496,32 @@ exports[`<Menu /> snapshot should match snapshot 1`] = `
                   Two
                 </div>
               </ListItemBaseSection>
+              <ContextMenu
+                triggerRef={
+                  Object {
+                    "current": <li
+                      aria-disabled="false"
+                      class="md-menu-item-wrapper md-list-item-base-wrapper"
+                      data-allow-text-select="false"
+                      data-disabled="false"
+                      data-interactive="true"
+                      data-key="two"
+                      data-padded="true"
+                      data-shape="rectangle"
+                      data-size="40"
+                      role="menuitem"
+                      tabindex="-1"
+                    >
+                      <div
+                        data-position="fill"
+                        title="Two"
+                      >
+                        Two
+                      </div>
+                    </li>,
+                  }
+                }
+              />
             </li>
           </FocusRing>
         </FocusRing>
@@ -720,6 +772,32 @@ exports[`<Menu /> snapshot should match snapshot with className 1`] = `
                   One
                 </div>
               </ListItemBaseSection>
+              <ContextMenu
+                triggerRef={
+                  Object {
+                    "current": <li
+                      aria-disabled="false"
+                      class="md-menu-item-wrapper md-list-item-base-wrapper"
+                      data-allow-text-select="false"
+                      data-disabled="false"
+                      data-interactive="true"
+                      data-key="one"
+                      data-padded="true"
+                      data-shape="rectangle"
+                      data-size="40"
+                      role="menuitem"
+                      tabindex="-1"
+                    >
+                      <div
+                        data-position="fill"
+                        title="One"
+                      >
+                        One
+                      </div>
+                    </li>,
+                  }
+                }
+              />
             </li>
           </FocusRing>
         </FocusRing>
@@ -950,6 +1028,32 @@ exports[`<Menu /> snapshot should match snapshot with className 1`] = `
                   Two
                 </div>
               </ListItemBaseSection>
+              <ContextMenu
+                triggerRef={
+                  Object {
+                    "current": <li
+                      aria-disabled="false"
+                      class="md-menu-item-wrapper md-list-item-base-wrapper"
+                      data-allow-text-select="false"
+                      data-disabled="false"
+                      data-interactive="true"
+                      data-key="two"
+                      data-padded="true"
+                      data-shape="rectangle"
+                      data-size="40"
+                      role="menuitem"
+                      tabindex="-1"
+                    >
+                      <div
+                        data-position="fill"
+                        title="Two"
+                      >
+                        Two
+                      </div>
+                    </li>,
+                  }
+                }
+              />
             </li>
           </FocusRing>
         </FocusRing>
@@ -1200,6 +1304,32 @@ exports[`<Menu /> snapshot should match snapshot with className 2`] = `
                   One
                 </div>
               </ListItemBaseSection>
+              <ContextMenu
+                triggerRef={
+                  Object {
+                    "current": <li
+                      aria-disabled="false"
+                      class="md-menu-item-wrapper md-list-item-base-wrapper"
+                      data-allow-text-select="false"
+                      data-disabled="false"
+                      data-interactive="true"
+                      data-key="one"
+                      data-padded="true"
+                      data-shape="rectangle"
+                      data-size="40"
+                      role="menuitem"
+                      tabindex="-1"
+                    >
+                      <div
+                        data-position="fill"
+                        title="One"
+                      >
+                        One
+                      </div>
+                    </li>,
+                  }
+                }
+              />
             </li>
           </FocusRing>
         </FocusRing>
@@ -1430,6 +1560,32 @@ exports[`<Menu /> snapshot should match snapshot with className 2`] = `
                   Two
                 </div>
               </ListItemBaseSection>
+              <ContextMenu
+                triggerRef={
+                  Object {
+                    "current": <li
+                      aria-disabled="false"
+                      class="md-menu-item-wrapper md-list-item-base-wrapper"
+                      data-allow-text-select="false"
+                      data-disabled="false"
+                      data-interactive="true"
+                      data-key="two"
+                      data-padded="true"
+                      data-shape="rectangle"
+                      data-size="40"
+                      role="menuitem"
+                      tabindex="-1"
+                    >
+                      <div
+                        data-position="fill"
+                        title="Two"
+                      >
+                        Two
+                      </div>
+                    </li>,
+                  }
+                }
+              />
             </li>
           </FocusRing>
         </FocusRing>
@@ -1681,6 +1837,32 @@ exports[`<Menu /> snapshot should match snapshot with id 1`] = `
                   One
                 </div>
               </ListItemBaseSection>
+              <ContextMenu
+                triggerRef={
+                  Object {
+                    "current": <li
+                      aria-disabled="false"
+                      class="md-menu-item-wrapper md-list-item-base-wrapper"
+                      data-allow-text-select="false"
+                      data-disabled="false"
+                      data-interactive="true"
+                      data-key="one"
+                      data-padded="true"
+                      data-shape="rectangle"
+                      data-size="40"
+                      role="menuitem"
+                      tabindex="-1"
+                    >
+                      <div
+                        data-position="fill"
+                        title="One"
+                      >
+                        One
+                      </div>
+                    </li>,
+                  }
+                }
+              />
             </li>
           </FocusRing>
         </FocusRing>
@@ -1911,6 +2093,32 @@ exports[`<Menu /> snapshot should match snapshot with id 1`] = `
                   Two
                 </div>
               </ListItemBaseSection>
+              <ContextMenu
+                triggerRef={
+                  Object {
+                    "current": <li
+                      aria-disabled="false"
+                      class="md-menu-item-wrapper md-list-item-base-wrapper"
+                      data-allow-text-select="false"
+                      data-disabled="false"
+                      data-interactive="true"
+                      data-key="two"
+                      data-padded="true"
+                      data-shape="rectangle"
+                      data-size="40"
+                      role="menuitem"
+                      tabindex="-1"
+                    >
+                      <div
+                        data-position="fill"
+                        title="Two"
+                      >
+                        Two
+                      </div>
+                    </li>,
+                  }
+                }
+              />
             </li>
           </FocusRing>
         </FocusRing>
@@ -2162,6 +2370,32 @@ exports[`<Menu /> snapshot should match snapshot with itemShape 1`] = `
                   One
                 </div>
               </ListItemBaseSection>
+              <ContextMenu
+                triggerRef={
+                  Object {
+                    "current": <li
+                      aria-disabled="false"
+                      class="md-menu-item-wrapper md-list-item-base-wrapper"
+                      data-allow-text-select="false"
+                      data-disabled="false"
+                      data-interactive="true"
+                      data-key="one"
+                      data-padded="true"
+                      data-shape="isPilled"
+                      data-size="50"
+                      role="menuitem"
+                      tabindex="-1"
+                    >
+                      <div
+                        data-position="fill"
+                        title="One"
+                      >
+                        One
+                      </div>
+                    </li>,
+                  }
+                }
+              />
             </li>
           </FocusRing>
         </FocusRing>
@@ -2392,6 +2626,32 @@ exports[`<Menu /> snapshot should match snapshot with itemShape 1`] = `
                   Two
                 </div>
               </ListItemBaseSection>
+              <ContextMenu
+                triggerRef={
+                  Object {
+                    "current": <li
+                      aria-disabled="false"
+                      class="md-menu-item-wrapper md-list-item-base-wrapper"
+                      data-allow-text-select="false"
+                      data-disabled="false"
+                      data-interactive="true"
+                      data-key="two"
+                      data-padded="true"
+                      data-shape="isPilled"
+                      data-size="50"
+                      role="menuitem"
+                      tabindex="-1"
+                    >
+                      <div
+                        data-position="fill"
+                        title="Two"
+                      >
+                        Two
+                      </div>
+                    </li>,
+                  }
+                }
+              />
             </li>
           </FocusRing>
         </FocusRing>
@@ -2642,6 +2902,32 @@ exports[`<Menu /> snapshot should match snapshot with itemSize 1`] = `
                   One
                 </div>
               </ListItemBaseSection>
+              <ContextMenu
+                triggerRef={
+                  Object {
+                    "current": <li
+                      aria-disabled="false"
+                      class="md-menu-item-wrapper md-list-item-base-wrapper"
+                      data-allow-text-select="false"
+                      data-disabled="false"
+                      data-interactive="true"
+                      data-key="one"
+                      data-padded="true"
+                      data-shape="rectangle"
+                      data-size="50"
+                      role="menuitem"
+                      tabindex="-1"
+                    >
+                      <div
+                        data-position="fill"
+                        title="One"
+                      >
+                        One
+                      </div>
+                    </li>,
+                  }
+                }
+              />
             </li>
           </FocusRing>
         </FocusRing>
@@ -2872,6 +3158,32 @@ exports[`<Menu /> snapshot should match snapshot with itemSize 1`] = `
                   Two
                 </div>
               </ListItemBaseSection>
+              <ContextMenu
+                triggerRef={
+                  Object {
+                    "current": <li
+                      aria-disabled="false"
+                      class="md-menu-item-wrapper md-list-item-base-wrapper"
+                      data-allow-text-select="false"
+                      data-disabled="false"
+                      data-interactive="true"
+                      data-key="two"
+                      data-padded="true"
+                      data-shape="rectangle"
+                      data-size="50"
+                      role="menuitem"
+                      tabindex="-1"
+                    >
+                      <div
+                        data-position="fill"
+                        title="Two"
+                      >
+                        Two
+                      </div>
+                    </li>,
+                  }
+                }
+              />
             </li>
           </FocusRing>
         </FocusRing>
@@ -3167,6 +3479,32 @@ exports[`<Menu /> snapshot should match snapshot with seperator between items 1`
                   One
                 </div>
               </ListItemBaseSection>
+              <ContextMenu
+                triggerRef={
+                  Object {
+                    "current": <li
+                      aria-disabled="false"
+                      class="md-menu-item-wrapper md-list-item-base-wrapper"
+                      data-allow-text-select="false"
+                      data-disabled="false"
+                      data-interactive="true"
+                      data-key="one"
+                      data-padded="true"
+                      data-shape="rectangle"
+                      data-size="40"
+                      role="menuitem"
+                      tabindex="-1"
+                    >
+                      <div
+                        data-position="fill"
+                        title="One"
+                      >
+                        One
+                      </div>
+                    </li>,
+                  }
+                }
+              />
             </li>
           </FocusRing>
         </FocusRing>
@@ -3449,6 +3787,32 @@ exports[`<Menu /> snapshot should match snapshot with seperator between items 1`
                   Two
                 </div>
               </ListItemBaseSection>
+              <ContextMenu
+                triggerRef={
+                  Object {
+                    "current": <li
+                      aria-disabled="false"
+                      class="md-menu-item-wrapper md-list-item-base-wrapper"
+                      data-allow-text-select="false"
+                      data-disabled="false"
+                      data-interactive="true"
+                      data-key="two"
+                      data-padded="true"
+                      data-shape="rectangle"
+                      data-size="40"
+                      role="menuitem"
+                      tabindex="-1"
+                    >
+                      <div
+                        data-position="fill"
+                        title="Two"
+                      >
+                        Two
+                      </div>
+                    </li>,
+                  }
+                }
+              />
             </li>
           </FocusRing>
         </FocusRing>
@@ -4467,6 +4831,32 @@ exports[`<Menu /> snapshot should match snapshot with seperator within section 1
                         One
                       </div>
                     </ListItemBaseSection>
+                    <ContextMenu
+                      triggerRef={
+                        Object {
+                          "current": <li
+                            aria-disabled="false"
+                            class="md-menu-item-wrapper md-list-item-base-wrapper"
+                            data-allow-text-select="false"
+                            data-disabled="false"
+                            data-interactive="true"
+                            data-key="1-one"
+                            data-padded="true"
+                            data-shape="rectangle"
+                            data-size="40"
+                            role="menuitem"
+                            tabindex="-1"
+                          >
+                            <div
+                              data-position="fill"
+                              title="One"
+                            >
+                              One
+                            </div>
+                          </li>,
+                        }
+                      }
+                    />
                   </li>
                 </FocusRing>
               </FocusRing>
@@ -5007,6 +5397,32 @@ exports[`<Menu /> snapshot should match snapshot with seperator within section 1
                         Two
                       </div>
                     </ListItemBaseSection>
+                    <ContextMenu
+                      triggerRef={
+                        Object {
+                          "current": <li
+                            aria-disabled="false"
+                            class="md-menu-item-wrapper md-list-item-base-wrapper"
+                            data-allow-text-select="false"
+                            data-disabled="false"
+                            data-interactive="true"
+                            data-key="1-two"
+                            data-padded="true"
+                            data-shape="rectangle"
+                            data-size="40"
+                            role="menuitem"
+                            tabindex="-1"
+                          >
+                            <div
+                              data-position="fill"
+                              title="Two"
+                            >
+                              Two
+                            </div>
+                          </li>,
+                        }
+                      }
+                    />
                   </li>
                 </FocusRing>
               </FocusRing>
@@ -6015,6 +6431,32 @@ exports[`<Menu /> snapshot should match snapshot with seperator within section 1
                         One
                       </div>
                     </ListItemBaseSection>
+                    <ContextMenu
+                      triggerRef={
+                        Object {
+                          "current": <li
+                            aria-disabled="false"
+                            class="md-menu-item-wrapper md-list-item-base-wrapper"
+                            data-allow-text-select="false"
+                            data-disabled="false"
+                            data-interactive="true"
+                            data-key="2-one"
+                            data-padded="true"
+                            data-shape="rectangle"
+                            data-size="40"
+                            role="menuitem"
+                            tabindex="-1"
+                          >
+                            <div
+                              data-position="fill"
+                              title="One"
+                            >
+                              One
+                            </div>
+                          </li>,
+                        }
+                      }
+                    />
                   </li>
                 </FocusRing>
               </FocusRing>
@@ -6555,6 +6997,32 @@ exports[`<Menu /> snapshot should match snapshot with seperator within section 1
                         Two
                       </div>
                     </ListItemBaseSection>
+                    <ContextMenu
+                      triggerRef={
+                        Object {
+                          "current": <li
+                            aria-disabled="false"
+                            class="md-menu-item-wrapper md-list-item-base-wrapper"
+                            data-allow-text-select="false"
+                            data-disabled="false"
+                            data-interactive="true"
+                            data-key="2-two"
+                            data-padded="true"
+                            data-shape="rectangle"
+                            data-size="40"
+                            role="menuitem"
+                            tabindex="-1"
+                          >
+                            <div
+                              data-position="fill"
+                              title="Two"
+                            >
+                              Two
+                            </div>
+                          </li>,
+                        }
+                      }
+                    />
                   </li>
                 </FocusRing>
               </FocusRing>
@@ -7688,6 +8156,33 @@ exports[`<Menu /> snapshot should match snapshot with seperator within selection
                         One
                       </div>
                     </ListItemBaseSection>
+                    <ContextMenu
+                      triggerRef={
+                        Object {
+                          "current": <li
+                            aria-checked="false"
+                            aria-disabled="false"
+                            class="md-menu-item-wrapper md-list-item-base-wrapper"
+                            data-allow-text-select="false"
+                            data-disabled="false"
+                            data-interactive="true"
+                            data-key="1-one"
+                            data-padded="true"
+                            data-shape="rectangle"
+                            data-size="40"
+                            role="menuitemradio"
+                            tabindex="-1"
+                          >
+                            <div
+                              data-position="fill"
+                              title="One"
+                            >
+                              One
+                            </div>
+                          </li>,
+                        }
+                      }
+                    />
                   </li>
                 </FocusRing>
               </FocusRing>
@@ -8278,6 +8773,33 @@ exports[`<Menu /> snapshot should match snapshot with seperator within selection
                         Two
                       </div>
                     </ListItemBaseSection>
+                    <ContextMenu
+                      triggerRef={
+                        Object {
+                          "current": <li
+                            aria-checked="false"
+                            aria-disabled="false"
+                            class="md-menu-item-wrapper md-list-item-base-wrapper"
+                            data-allow-text-select="false"
+                            data-disabled="false"
+                            data-interactive="true"
+                            data-key="1-two"
+                            data-padded="true"
+                            data-shape="rectangle"
+                            data-size="40"
+                            role="menuitemradio"
+                            tabindex="-1"
+                          >
+                            <div
+                              data-position="fill"
+                              title="Two"
+                            >
+                              Two
+                            </div>
+                          </li>,
+                        }
+                      }
+                    />
                   </li>
                 </FocusRing>
               </FocusRing>
@@ -9398,6 +9920,33 @@ exports[`<Menu /> snapshot should match snapshot with seperator within selection
                         One
                       </div>
                     </ListItemBaseSection>
+                    <ContextMenu
+                      triggerRef={
+                        Object {
+                          "current": <li
+                            aria-checked="false"
+                            aria-disabled="false"
+                            class="md-menu-item-wrapper md-list-item-base-wrapper"
+                            data-allow-text-select="false"
+                            data-disabled="false"
+                            data-interactive="true"
+                            data-key="2-one"
+                            data-padded="true"
+                            data-shape="rectangle"
+                            data-size="40"
+                            role="menuitemcheckbox"
+                            tabindex="-1"
+                          >
+                            <div
+                              data-position="fill"
+                              title="One"
+                            >
+                              One
+                            </div>
+                          </li>,
+                        }
+                      }
+                    />
                   </li>
                 </FocusRing>
               </FocusRing>
@@ -9988,6 +10537,33 @@ exports[`<Menu /> snapshot should match snapshot with seperator within selection
                         Two
                       </div>
                     </ListItemBaseSection>
+                    <ContextMenu
+                      triggerRef={
+                        Object {
+                          "current": <li
+                            aria-checked="false"
+                            aria-disabled="false"
+                            class="md-menu-item-wrapper md-list-item-base-wrapper"
+                            data-allow-text-select="false"
+                            data-disabled="false"
+                            data-interactive="true"
+                            data-key="2-two"
+                            data-padded="true"
+                            data-shape="rectangle"
+                            data-size="40"
+                            role="menuitemcheckbox"
+                            tabindex="-1"
+                          >
+                            <div
+                              data-position="fill"
+                              title="Two"
+                            >
+                              Two
+                            </div>
+                          </li>,
+                        }
+                      }
+                    />
                   </li>
                 </FocusRing>
               </FocusRing>
@@ -10250,6 +10826,32 @@ exports[`<Menu /> snapshot should match snapshot with style 1`] = `
                   One
                 </div>
               </ListItemBaseSection>
+              <ContextMenu
+                triggerRef={
+                  Object {
+                    "current": <li
+                      aria-disabled="false"
+                      class="md-menu-item-wrapper md-list-item-base-wrapper"
+                      data-allow-text-select="false"
+                      data-disabled="false"
+                      data-interactive="true"
+                      data-key="one"
+                      data-padded="true"
+                      data-shape="rectangle"
+                      data-size="40"
+                      role="menuitem"
+                      tabindex="-1"
+                    >
+                      <div
+                        data-position="fill"
+                        title="One"
+                      >
+                        One
+                      </div>
+                    </li>,
+                  }
+                }
+              />
             </li>
           </FocusRing>
         </FocusRing>
@@ -10480,6 +11082,32 @@ exports[`<Menu /> snapshot should match snapshot with style 1`] = `
                   Two
                 </div>
               </ListItemBaseSection>
+              <ContextMenu
+                triggerRef={
+                  Object {
+                    "current": <li
+                      aria-disabled="false"
+                      class="md-menu-item-wrapper md-list-item-base-wrapper"
+                      data-allow-text-select="false"
+                      data-disabled="false"
+                      data-interactive="true"
+                      data-key="two"
+                      data-padded="true"
+                      data-shape="rectangle"
+                      data-size="40"
+                      role="menuitem"
+                      tabindex="-1"
+                    >
+                      <div
+                        data-position="fill"
+                        title="Two"
+                      >
+                        Two
+                      </div>
+                    </li>,
+                  }
+                }
+              />
             </li>
           </FocusRing>
         </FocusRing>
@@ -10742,6 +11370,39 @@ exports[`<Menu /> snapshot should match snapshot with tickPosition 1`] = `
                   One
                 </div>
               </ListItemBaseSection>
+              <ContextMenu
+                triggerRef={
+                  Object {
+                    "current": <li
+                      aria-disabled="false"
+                      class="md-menu-item-wrapper md-list-item-base-wrapper"
+                      data-allow-text-select="false"
+                      data-disabled="false"
+                      data-interactive="true"
+                      data-key="one"
+                      data-padded="true"
+                      data-shape="rectangle"
+                      data-size="50"
+                      role="menuitem"
+                      tabindex="-1"
+                    >
+                      <div
+                        data-position="start"
+                      >
+                        <div
+                          class="md-menu-item-tick-placeholder"
+                        />
+                      </div>
+                      <div
+                        data-position="fill"
+                        title="One"
+                      >
+                        One
+                      </div>
+                    </li>,
+                  }
+                }
+              />
             </li>
           </FocusRing>
         </FocusRing>
@@ -10983,6 +11644,39 @@ exports[`<Menu /> snapshot should match snapshot with tickPosition 1`] = `
                   Two
                 </div>
               </ListItemBaseSection>
+              <ContextMenu
+                triggerRef={
+                  Object {
+                    "current": <li
+                      aria-disabled="false"
+                      class="md-menu-item-wrapper md-list-item-base-wrapper"
+                      data-allow-text-select="false"
+                      data-disabled="false"
+                      data-interactive="true"
+                      data-key="two"
+                      data-padded="true"
+                      data-shape="rectangle"
+                      data-size="50"
+                      role="menuitem"
+                      tabindex="-1"
+                    >
+                      <div
+                        data-position="start"
+                      >
+                        <div
+                          class="md-menu-item-tick-placeholder"
+                        />
+                      </div>
+                      <div
+                        data-position="fill"
+                        title="Two"
+                      >
+                        Two
+                      </div>
+                    </li>,
+                  }
+                }
+              />
             </li>
           </FocusRing>
         </FocusRing>

--- a/src/components/MenuItem/MenuItem.unit.test.tsx.snap
+++ b/src/components/MenuItem/MenuItem.unit.test.tsx.snap
@@ -297,6 +297,36 @@ exports[`<MenuItem /> snapshot should match snapshot 1`] = `
               />
             </div>
           </ListItemBaseSection>
+          <ContextMenu
+            triggerRef={
+              Object {
+                "current": <li
+                  aria-disabled="false"
+                  aria-label="0"
+                  class="md-menu-item-wrapper some-classname md-list-item-base-wrapper"
+                  data-allow-text-select="false"
+                  data-disabled="false"
+                  data-interactive="true"
+                  data-key="$.0"
+                  data-padded="true"
+                  data-shape="rectangle"
+                  data-size="40"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  <div
+                    data-position="fill"
+                    title="Item 1"
+                  >
+                    Item 1
+                  </div>
+                  <div
+                    data-position="end"
+                  />
+                </li>,
+              }
+            }
+          />
         </li>
       </FocusRing>
     </FocusRing>
@@ -601,6 +631,36 @@ exports[`<MenuItem /> snapshot should match snapshot with tickPosition 1`] = `
               Item 1
             </div>
           </ListItemBaseSection>
+          <ContextMenu
+            triggerRef={
+              Object {
+                "current": <li
+                  aria-disabled="false"
+                  aria-label="0"
+                  class="md-menu-item-wrapper md-list-item-base-wrapper"
+                  data-allow-text-select="false"
+                  data-disabled="false"
+                  data-interactive="true"
+                  data-key="$.0"
+                  data-padded="true"
+                  data-shape="rectangle"
+                  data-size="30"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  <div
+                    data-position="start"
+                  />
+                  <div
+                    data-position="fill"
+                    title="Item 1"
+                  >
+                    Item 1
+                  </div>
+                </li>,
+              }
+            }
+          />
         </li>
       </FocusRing>
     </FocusRing>

--- a/src/components/MenuSection/MenuSection.unit.test.tsx.snap
+++ b/src/components/MenuSection/MenuSection.unit.test.tsx.snap
@@ -484,6 +484,33 @@ exports[`<MenuSection /> snapshot should match snapshot 1`] = `
                     Item 1
                   </div>
                 </ListItemBaseSection>
+                <ContextMenu
+                  triggerRef={
+                    Object {
+                      "current": <li
+                        aria-disabled="false"
+                        aria-label="0"
+                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                        data-allow-text-select="false"
+                        data-disabled="false"
+                        data-interactive="true"
+                        data-key="$.0.0"
+                        data-padded="true"
+                        data-shape="rectangle"
+                        data-size="40"
+                        role="menuitem"
+                        tabindex="-1"
+                      >
+                        <div
+                          data-position="fill"
+                          title="Item 1"
+                        >
+                          Item 1
+                        </div>
+                      </li>,
+                    }
+                  }
+                />
               </li>
             </FocusRing>
           </FocusRing>
@@ -759,6 +786,33 @@ exports[`<MenuSection /> snapshot should match snapshot 1`] = `
                     Item 2
                   </div>
                 </ListItemBaseSection>
+                <ContextMenu
+                  triggerRef={
+                    Object {
+                      "current": <li
+                        aria-disabled="false"
+                        aria-label="1"
+                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                        data-allow-text-select="false"
+                        data-disabled="false"
+                        data-interactive="true"
+                        data-key="$.0.1"
+                        data-padded="true"
+                        data-shape="rectangle"
+                        data-size="40"
+                        role="menuitem"
+                        tabindex="-1"
+                      >
+                        <div
+                          data-position="fill"
+                          title="Item 2"
+                        >
+                          Item 2
+                        </div>
+                      </li>,
+                    }
+                  }
+                />
               </li>
             </FocusRing>
           </FocusRing>
@@ -1341,6 +1395,33 @@ exports[`<MenuSection /> snapshot should match snapshot with seperator 1`] = `
                     Item 1
                   </div>
                 </ListItemBaseSection>
+                <ContextMenu
+                  triggerRef={
+                    Object {
+                      "current": <li
+                        aria-disabled="false"
+                        aria-label="0"
+                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                        data-allow-text-select="false"
+                        data-disabled="false"
+                        data-interactive="true"
+                        data-key="$.0.0"
+                        data-padded="true"
+                        data-shape="rectangle"
+                        data-size="40"
+                        role="menuitem"
+                        tabindex="-1"
+                      >
+                        <div
+                          data-position="fill"
+                          title="Item 1"
+                        >
+                          Item 1
+                        </div>
+                      </li>,
+                    }
+                  }
+                />
               </li>
             </FocusRing>
           </FocusRing>
@@ -1666,6 +1747,33 @@ exports[`<MenuSection /> snapshot should match snapshot with seperator 1`] = `
                     Item 2
                   </div>
                 </ListItemBaseSection>
+                <ContextMenu
+                  triggerRef={
+                    Object {
+                      "current": <li
+                        aria-disabled="false"
+                        aria-label="1"
+                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                        data-allow-text-select="false"
+                        data-disabled="false"
+                        data-interactive="true"
+                        data-key="$.0.1"
+                        data-padded="true"
+                        data-shape="rectangle"
+                        data-size="40"
+                        role="menuitem"
+                        tabindex="-1"
+                      >
+                        <div
+                          data-position="fill"
+                          title="Item 2"
+                        >
+                          Item 2
+                        </div>
+                      </li>,
+                    }
+                  }
+                />
               </li>
             </FocusRing>
           </FocusRing>

--- a/src/components/MenuSelectionGroup/MenuSelectionGroup.unit.test.tsx.snap
+++ b/src/components/MenuSelectionGroup/MenuSelectionGroup.unit.test.tsx.snap
@@ -582,6 +582,33 @@ exports[`<MenuSelectionGroup /> snapshot should match snapshot 1`] = `
                     Item 1
                   </div>
                 </ListItemBaseSection>
+                <ContextMenu
+                  triggerRef={
+                    Object {
+                      "current": <li
+                        aria-disabled="false"
+                        aria-label="0"
+                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                        data-allow-text-select="false"
+                        data-disabled="false"
+                        data-interactive="true"
+                        data-key="$.0.0"
+                        data-padded="true"
+                        data-shape="rectangle"
+                        data-size="32"
+                        role="menuitem"
+                        tabindex="-1"
+                      >
+                        <div
+                          data-position="fill"
+                          title="Item 1"
+                        >
+                          Item 1
+                        </div>
+                      </li>,
+                    }
+                  }
+                />
               </li>
             </FocusRing>
           </FocusRing>
@@ -895,6 +922,33 @@ exports[`<MenuSelectionGroup /> snapshot should match snapshot 1`] = `
                     Item 2
                   </div>
                 </ListItemBaseSection>
+                <ContextMenu
+                  triggerRef={
+                    Object {
+                      "current": <li
+                        aria-disabled="false"
+                        aria-label="1"
+                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                        data-allow-text-select="false"
+                        data-disabled="false"
+                        data-interactive="true"
+                        data-key="$.0.1"
+                        data-padded="true"
+                        data-shape="rectangle"
+                        data-size="32"
+                        role="menuitem"
+                        tabindex="-1"
+                      >
+                        <div
+                          data-position="fill"
+                          title="Item 2"
+                        >
+                          Item 2
+                        </div>
+                      </li>,
+                    }
+                  }
+                />
               </li>
             </FocusRing>
           </FocusRing>
@@ -1580,6 +1634,33 @@ exports[`<MenuSelectionGroup /> snapshot should match snapshot with seperator wi
                     Item 1
                   </div>
                 </ListItemBaseSection>
+                <ContextMenu
+                  triggerRef={
+                    Object {
+                      "current": <li
+                        aria-disabled="false"
+                        aria-label="0"
+                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                        data-allow-text-select="false"
+                        data-disabled="false"
+                        data-interactive="true"
+                        data-key="$.0.0"
+                        data-padded="true"
+                        data-shape="rectangle"
+                        data-size="32"
+                        role="menuitem"
+                        tabindex="-1"
+                      >
+                        <div
+                          data-position="fill"
+                          title="Item 1"
+                        >
+                          Item 1
+                        </div>
+                      </li>,
+                    }
+                  }
+                />
               </li>
             </FocusRing>
           </FocusRing>
@@ -1945,6 +2026,33 @@ exports[`<MenuSelectionGroup /> snapshot should match snapshot with seperator wi
                     Item 2
                   </div>
                 </ListItemBaseSection>
+                <ContextMenu
+                  triggerRef={
+                    Object {
+                      "current": <li
+                        aria-disabled="false"
+                        aria-label="1"
+                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                        data-allow-text-select="false"
+                        data-disabled="false"
+                        data-interactive="true"
+                        data-key="$.0.1"
+                        data-padded="true"
+                        data-shape="rectangle"
+                        data-size="32"
+                        role="menuitem"
+                        tabindex="-1"
+                      >
+                        <div
+                          data-position="fill"
+                          title="Item 2"
+                        >
+                          Item 2
+                        </div>
+                      </li>,
+                    }
+                  }
+                />
               </li>
             </FocusRing>
           </FocusRing>

--- a/src/components/MenuTrigger/MenuTrigger.unit.test.tsx.snap
+++ b/src/components/MenuTrigger/MenuTrigger.unit.test.tsx.snap
@@ -773,6 +773,33 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot 1`] = `
                                     One
                                   </div>
                                 </ListItemBaseSection>
+                                <ContextMenu
+                                  triggerRef={
+                                    Object {
+                                      "current": <li
+                                        aria-checked="false"
+                                        aria-disabled="false"
+                                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                                        data-allow-text-select="false"
+                                        data-disabled="false"
+                                        data-interactive="true"
+                                        data-key="one"
+                                        data-padded="true"
+                                        data-shape="rectangle"
+                                        data-size="40"
+                                        role="menuitemradio"
+                                        tabindex="0"
+                                      >
+                                        <div
+                                          data-position="fill"
+                                          title="One"
+                                        >
+                                          One
+                                        </div>
+                                      </li>,
+                                    }
+                                  }
+                                />
                               </li>
                             </FocusRing>
                           </FocusRing>
@@ -1049,6 +1076,33 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot 1`] = `
                                     Two
                                   </div>
                                 </ListItemBaseSection>
+                                <ContextMenu
+                                  triggerRef={
+                                    Object {
+                                      "current": <li
+                                        aria-checked="false"
+                                        aria-disabled="false"
+                                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                                        data-allow-text-select="false"
+                                        data-disabled="false"
+                                        data-interactive="true"
+                                        data-key="two"
+                                        data-padded="true"
+                                        data-shape="rectangle"
+                                        data-size="40"
+                                        role="menuitemradio"
+                                        tabindex="-1"
+                                      >
+                                        <div
+                                          data-position="fill"
+                                          title="Two"
+                                        >
+                                          Two
+                                        </div>
+                                      </li>,
+                                    }
+                                  }
+                                />
                               </li>
                             </FocusRing>
                           </FocusRing>
@@ -1325,6 +1379,33 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot 1`] = `
                                     Three
                                   </div>
                                 </ListItemBaseSection>
+                                <ContextMenu
+                                  triggerRef={
+                                    Object {
+                                      "current": <li
+                                        aria-checked="false"
+                                        aria-disabled="false"
+                                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                                        data-allow-text-select="false"
+                                        data-disabled="false"
+                                        data-interactive="true"
+                                        data-key="three"
+                                        data-padded="true"
+                                        data-shape="rectangle"
+                                        data-size="40"
+                                        role="menuitemradio"
+                                        tabindex="-1"
+                                      >
+                                        <div
+                                          data-position="fill"
+                                          title="Three"
+                                        >
+                                          Three
+                                        </div>
+                                      </li>,
+                                    }
+                                  }
+                                />
                               </li>
                             </FocusRing>
                           </FocusRing>
@@ -1626,6 +1707,33 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot 1`] = `
                                     Four
                                   </div>
                                 </ListItemBaseSection>
+                                <ContextMenu
+                                  triggerRef={
+                                    Object {
+                                      "current": <li
+                                        aria-checked="false"
+                                        aria-disabled="false"
+                                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                                        data-allow-text-select="false"
+                                        data-disabled="false"
+                                        data-interactive="true"
+                                        data-key="asd"
+                                        data-padded="true"
+                                        data-shape="rectangle"
+                                        data-size="40"
+                                        role="menuitemcheckbox"
+                                        tabindex="-1"
+                                      >
+                                        <div
+                                          data-position="fill"
+                                          title="Four"
+                                        >
+                                          Four
+                                        </div>
+                                      </li>,
+                                    }
+                                  }
+                                />
                               </li>
                             </FocusRing>
                           </FocusRing>
@@ -1902,6 +2010,33 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot 1`] = `
                                     Five
                                   </div>
                                 </ListItemBaseSection>
+                                <ContextMenu
+                                  triggerRef={
+                                    Object {
+                                      "current": <li
+                                        aria-checked="false"
+                                        aria-disabled="false"
+                                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                                        data-allow-text-select="false"
+                                        data-disabled="false"
+                                        data-interactive="true"
+                                        data-key="ff"
+                                        data-padded="true"
+                                        data-shape="rectangle"
+                                        data-size="40"
+                                        role="menuitemcheckbox"
+                                        tabindex="-1"
+                                      >
+                                        <div
+                                          data-position="fill"
+                                          title="Five"
+                                        >
+                                          Five
+                                        </div>
+                                      </li>,
+                                    }
+                                  }
+                                />
                               </li>
                             </FocusRing>
                           </FocusRing>
@@ -2178,6 +2313,33 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot 1`] = `
                                     Six
                                   </div>
                                 </ListItemBaseSection>
+                                <ContextMenu
+                                  triggerRef={
+                                    Object {
+                                      "current": <li
+                                        aria-checked="false"
+                                        aria-disabled="false"
+                                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                                        data-allow-text-select="false"
+                                        data-disabled="false"
+                                        data-interactive="true"
+                                        data-key="d"
+                                        data-padded="true"
+                                        data-shape="rectangle"
+                                        data-size="40"
+                                        role="menuitemcheckbox"
+                                        tabindex="-1"
+                                      >
+                                        <div
+                                          data-position="fill"
+                                          title="Six"
+                                        >
+                                          Six
+                                        </div>
+                                      </li>,
+                                    }
+                                  }
+                                />
                               </li>
                             </FocusRing>
                           </FocusRing>
@@ -2974,6 +3136,33 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with className 
                                     One
                                   </div>
                                 </ListItemBaseSection>
+                                <ContextMenu
+                                  triggerRef={
+                                    Object {
+                                      "current": <li
+                                        aria-checked="false"
+                                        aria-disabled="false"
+                                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                                        data-allow-text-select="false"
+                                        data-disabled="false"
+                                        data-interactive="true"
+                                        data-key="one"
+                                        data-padded="true"
+                                        data-shape="rectangle"
+                                        data-size="40"
+                                        role="menuitemradio"
+                                        tabindex="0"
+                                      >
+                                        <div
+                                          data-position="fill"
+                                          title="One"
+                                        >
+                                          One
+                                        </div>
+                                      </li>,
+                                    }
+                                  }
+                                />
                               </li>
                             </FocusRing>
                           </FocusRing>
@@ -3250,6 +3439,33 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with className 
                                     Two
                                   </div>
                                 </ListItemBaseSection>
+                                <ContextMenu
+                                  triggerRef={
+                                    Object {
+                                      "current": <li
+                                        aria-checked="false"
+                                        aria-disabled="false"
+                                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                                        data-allow-text-select="false"
+                                        data-disabled="false"
+                                        data-interactive="true"
+                                        data-key="two"
+                                        data-padded="true"
+                                        data-shape="rectangle"
+                                        data-size="40"
+                                        role="menuitemradio"
+                                        tabindex="-1"
+                                      >
+                                        <div
+                                          data-position="fill"
+                                          title="Two"
+                                        >
+                                          Two
+                                        </div>
+                                      </li>,
+                                    }
+                                  }
+                                />
                               </li>
                             </FocusRing>
                           </FocusRing>
@@ -3526,6 +3742,33 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with className 
                                     Three
                                   </div>
                                 </ListItemBaseSection>
+                                <ContextMenu
+                                  triggerRef={
+                                    Object {
+                                      "current": <li
+                                        aria-checked="false"
+                                        aria-disabled="false"
+                                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                                        data-allow-text-select="false"
+                                        data-disabled="false"
+                                        data-interactive="true"
+                                        data-key="three"
+                                        data-padded="true"
+                                        data-shape="rectangle"
+                                        data-size="40"
+                                        role="menuitemradio"
+                                        tabindex="-1"
+                                      >
+                                        <div
+                                          data-position="fill"
+                                          title="Three"
+                                        >
+                                          Three
+                                        </div>
+                                      </li>,
+                                    }
+                                  }
+                                />
                               </li>
                             </FocusRing>
                           </FocusRing>
@@ -3827,6 +4070,33 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with className 
                                     Four
                                   </div>
                                 </ListItemBaseSection>
+                                <ContextMenu
+                                  triggerRef={
+                                    Object {
+                                      "current": <li
+                                        aria-checked="false"
+                                        aria-disabled="false"
+                                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                                        data-allow-text-select="false"
+                                        data-disabled="false"
+                                        data-interactive="true"
+                                        data-key="asd"
+                                        data-padded="true"
+                                        data-shape="rectangle"
+                                        data-size="40"
+                                        role="menuitemcheckbox"
+                                        tabindex="-1"
+                                      >
+                                        <div
+                                          data-position="fill"
+                                          title="Four"
+                                        >
+                                          Four
+                                        </div>
+                                      </li>,
+                                    }
+                                  }
+                                />
                               </li>
                             </FocusRing>
                           </FocusRing>
@@ -4103,6 +4373,33 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with className 
                                     Five
                                   </div>
                                 </ListItemBaseSection>
+                                <ContextMenu
+                                  triggerRef={
+                                    Object {
+                                      "current": <li
+                                        aria-checked="false"
+                                        aria-disabled="false"
+                                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                                        data-allow-text-select="false"
+                                        data-disabled="false"
+                                        data-interactive="true"
+                                        data-key="ff"
+                                        data-padded="true"
+                                        data-shape="rectangle"
+                                        data-size="40"
+                                        role="menuitemcheckbox"
+                                        tabindex="-1"
+                                      >
+                                        <div
+                                          data-position="fill"
+                                          title="Five"
+                                        >
+                                          Five
+                                        </div>
+                                      </li>,
+                                    }
+                                  }
+                                />
                               </li>
                             </FocusRing>
                           </FocusRing>
@@ -4379,6 +4676,33 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with className 
                                     Six
                                   </div>
                                 </ListItemBaseSection>
+                                <ContextMenu
+                                  triggerRef={
+                                    Object {
+                                      "current": <li
+                                        aria-checked="false"
+                                        aria-disabled="false"
+                                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                                        data-allow-text-select="false"
+                                        data-disabled="false"
+                                        data-interactive="true"
+                                        data-key="d"
+                                        data-padded="true"
+                                        data-shape="rectangle"
+                                        data-size="40"
+                                        role="menuitemcheckbox"
+                                        tabindex="-1"
+                                      >
+                                        <div
+                                          data-position="fill"
+                                          title="Six"
+                                        >
+                                          Six
+                                        </div>
+                                      </li>,
+                                    }
+                                  }
+                                />
                               </li>
                             </FocusRing>
                           </FocusRing>
@@ -5175,6 +5499,33 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with color 1`] 
                                     One
                                   </div>
                                 </ListItemBaseSection>
+                                <ContextMenu
+                                  triggerRef={
+                                    Object {
+                                      "current": <li
+                                        aria-checked="false"
+                                        aria-disabled="false"
+                                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                                        data-allow-text-select="false"
+                                        data-disabled="false"
+                                        data-interactive="true"
+                                        data-key="one"
+                                        data-padded="true"
+                                        data-shape="rectangle"
+                                        data-size="40"
+                                        role="menuitemradio"
+                                        tabindex="0"
+                                      >
+                                        <div
+                                          data-position="fill"
+                                          title="One"
+                                        >
+                                          One
+                                        </div>
+                                      </li>,
+                                    }
+                                  }
+                                />
                               </li>
                             </FocusRing>
                           </FocusRing>
@@ -5451,6 +5802,33 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with color 1`] 
                                     Two
                                   </div>
                                 </ListItemBaseSection>
+                                <ContextMenu
+                                  triggerRef={
+                                    Object {
+                                      "current": <li
+                                        aria-checked="false"
+                                        aria-disabled="false"
+                                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                                        data-allow-text-select="false"
+                                        data-disabled="false"
+                                        data-interactive="true"
+                                        data-key="two"
+                                        data-padded="true"
+                                        data-shape="rectangle"
+                                        data-size="40"
+                                        role="menuitemradio"
+                                        tabindex="-1"
+                                      >
+                                        <div
+                                          data-position="fill"
+                                          title="Two"
+                                        >
+                                          Two
+                                        </div>
+                                      </li>,
+                                    }
+                                  }
+                                />
                               </li>
                             </FocusRing>
                           </FocusRing>
@@ -5727,6 +6105,33 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with color 1`] 
                                     Three
                                   </div>
                                 </ListItemBaseSection>
+                                <ContextMenu
+                                  triggerRef={
+                                    Object {
+                                      "current": <li
+                                        aria-checked="false"
+                                        aria-disabled="false"
+                                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                                        data-allow-text-select="false"
+                                        data-disabled="false"
+                                        data-interactive="true"
+                                        data-key="three"
+                                        data-padded="true"
+                                        data-shape="rectangle"
+                                        data-size="40"
+                                        role="menuitemradio"
+                                        tabindex="-1"
+                                      >
+                                        <div
+                                          data-position="fill"
+                                          title="Three"
+                                        >
+                                          Three
+                                        </div>
+                                      </li>,
+                                    }
+                                  }
+                                />
                               </li>
                             </FocusRing>
                           </FocusRing>
@@ -6028,6 +6433,33 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with color 1`] 
                                     Four
                                   </div>
                                 </ListItemBaseSection>
+                                <ContextMenu
+                                  triggerRef={
+                                    Object {
+                                      "current": <li
+                                        aria-checked="false"
+                                        aria-disabled="false"
+                                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                                        data-allow-text-select="false"
+                                        data-disabled="false"
+                                        data-interactive="true"
+                                        data-key="asd"
+                                        data-padded="true"
+                                        data-shape="rectangle"
+                                        data-size="40"
+                                        role="menuitemcheckbox"
+                                        tabindex="-1"
+                                      >
+                                        <div
+                                          data-position="fill"
+                                          title="Four"
+                                        >
+                                          Four
+                                        </div>
+                                      </li>,
+                                    }
+                                  }
+                                />
                               </li>
                             </FocusRing>
                           </FocusRing>
@@ -6304,6 +6736,33 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with color 1`] 
                                     Five
                                   </div>
                                 </ListItemBaseSection>
+                                <ContextMenu
+                                  triggerRef={
+                                    Object {
+                                      "current": <li
+                                        aria-checked="false"
+                                        aria-disabled="false"
+                                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                                        data-allow-text-select="false"
+                                        data-disabled="false"
+                                        data-interactive="true"
+                                        data-key="ff"
+                                        data-padded="true"
+                                        data-shape="rectangle"
+                                        data-size="40"
+                                        role="menuitemcheckbox"
+                                        tabindex="-1"
+                                      >
+                                        <div
+                                          data-position="fill"
+                                          title="Five"
+                                        >
+                                          Five
+                                        </div>
+                                      </li>,
+                                    }
+                                  }
+                                />
                               </li>
                             </FocusRing>
                           </FocusRing>
@@ -6580,6 +7039,33 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with color 1`] 
                                     Six
                                   </div>
                                 </ListItemBaseSection>
+                                <ContextMenu
+                                  triggerRef={
+                                    Object {
+                                      "current": <li
+                                        aria-checked="false"
+                                        aria-disabled="false"
+                                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                                        data-allow-text-select="false"
+                                        data-disabled="false"
+                                        data-interactive="true"
+                                        data-key="d"
+                                        data-padded="true"
+                                        data-shape="rectangle"
+                                        data-size="40"
+                                        role="menuitemcheckbox"
+                                        tabindex="-1"
+                                      >
+                                        <div
+                                          data-position="fill"
+                                          title="Six"
+                                        >
+                                          Six
+                                        </div>
+                                      </li>,
+                                    }
+                                  }
+                                />
                               </li>
                             </FocusRing>
                           </FocusRing>
@@ -7380,6 +7866,33 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with id 1`] = `
                                     One
                                   </div>
                                 </ListItemBaseSection>
+                                <ContextMenu
+                                  triggerRef={
+                                    Object {
+                                      "current": <li
+                                        aria-checked="false"
+                                        aria-disabled="false"
+                                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                                        data-allow-text-select="false"
+                                        data-disabled="false"
+                                        data-interactive="true"
+                                        data-key="one"
+                                        data-padded="true"
+                                        data-shape="rectangle"
+                                        data-size="40"
+                                        role="menuitemradio"
+                                        tabindex="0"
+                                      >
+                                        <div
+                                          data-position="fill"
+                                          title="One"
+                                        >
+                                          One
+                                        </div>
+                                      </li>,
+                                    }
+                                  }
+                                />
                               </li>
                             </FocusRing>
                           </FocusRing>
@@ -7656,6 +8169,33 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with id 1`] = `
                                     Two
                                   </div>
                                 </ListItemBaseSection>
+                                <ContextMenu
+                                  triggerRef={
+                                    Object {
+                                      "current": <li
+                                        aria-checked="false"
+                                        aria-disabled="false"
+                                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                                        data-allow-text-select="false"
+                                        data-disabled="false"
+                                        data-interactive="true"
+                                        data-key="two"
+                                        data-padded="true"
+                                        data-shape="rectangle"
+                                        data-size="40"
+                                        role="menuitemradio"
+                                        tabindex="-1"
+                                      >
+                                        <div
+                                          data-position="fill"
+                                          title="Two"
+                                        >
+                                          Two
+                                        </div>
+                                      </li>,
+                                    }
+                                  }
+                                />
                               </li>
                             </FocusRing>
                           </FocusRing>
@@ -7932,6 +8472,33 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with id 1`] = `
                                     Three
                                   </div>
                                 </ListItemBaseSection>
+                                <ContextMenu
+                                  triggerRef={
+                                    Object {
+                                      "current": <li
+                                        aria-checked="false"
+                                        aria-disabled="false"
+                                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                                        data-allow-text-select="false"
+                                        data-disabled="false"
+                                        data-interactive="true"
+                                        data-key="three"
+                                        data-padded="true"
+                                        data-shape="rectangle"
+                                        data-size="40"
+                                        role="menuitemradio"
+                                        tabindex="-1"
+                                      >
+                                        <div
+                                          data-position="fill"
+                                          title="Three"
+                                        >
+                                          Three
+                                        </div>
+                                      </li>,
+                                    }
+                                  }
+                                />
                               </li>
                             </FocusRing>
                           </FocusRing>
@@ -8233,6 +8800,33 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with id 1`] = `
                                     Four
                                   </div>
                                 </ListItemBaseSection>
+                                <ContextMenu
+                                  triggerRef={
+                                    Object {
+                                      "current": <li
+                                        aria-checked="false"
+                                        aria-disabled="false"
+                                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                                        data-allow-text-select="false"
+                                        data-disabled="false"
+                                        data-interactive="true"
+                                        data-key="asd"
+                                        data-padded="true"
+                                        data-shape="rectangle"
+                                        data-size="40"
+                                        role="menuitemcheckbox"
+                                        tabindex="-1"
+                                      >
+                                        <div
+                                          data-position="fill"
+                                          title="Four"
+                                        >
+                                          Four
+                                        </div>
+                                      </li>,
+                                    }
+                                  }
+                                />
                               </li>
                             </FocusRing>
                           </FocusRing>
@@ -8509,6 +9103,33 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with id 1`] = `
                                     Five
                                   </div>
                                 </ListItemBaseSection>
+                                <ContextMenu
+                                  triggerRef={
+                                    Object {
+                                      "current": <li
+                                        aria-checked="false"
+                                        aria-disabled="false"
+                                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                                        data-allow-text-select="false"
+                                        data-disabled="false"
+                                        data-interactive="true"
+                                        data-key="ff"
+                                        data-padded="true"
+                                        data-shape="rectangle"
+                                        data-size="40"
+                                        role="menuitemcheckbox"
+                                        tabindex="-1"
+                                      >
+                                        <div
+                                          data-position="fill"
+                                          title="Five"
+                                        >
+                                          Five
+                                        </div>
+                                      </li>,
+                                    }
+                                  }
+                                />
                               </li>
                             </FocusRing>
                           </FocusRing>
@@ -8785,6 +9406,33 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with id 1`] = `
                                     Six
                                   </div>
                                 </ListItemBaseSection>
+                                <ContextMenu
+                                  triggerRef={
+                                    Object {
+                                      "current": <li
+                                        aria-checked="false"
+                                        aria-disabled="false"
+                                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                                        data-allow-text-select="false"
+                                        data-disabled="false"
+                                        data-interactive="true"
+                                        data-key="d"
+                                        data-padded="true"
+                                        data-shape="rectangle"
+                                        data-size="40"
+                                        role="menuitemcheckbox"
+                                        tabindex="-1"
+                                      >
+                                        <div
+                                          data-position="fill"
+                                          title="Six"
+                                        >
+                                          Six
+                                        </div>
+                                      </li>,
+                                    }
+                                  }
+                                />
                               </li>
                             </FocusRing>
                           </FocusRing>
@@ -9581,6 +10229,33 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with placement 
                                     One
                                   </div>
                                 </ListItemBaseSection>
+                                <ContextMenu
+                                  triggerRef={
+                                    Object {
+                                      "current": <li
+                                        aria-checked="false"
+                                        aria-disabled="false"
+                                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                                        data-allow-text-select="false"
+                                        data-disabled="false"
+                                        data-interactive="true"
+                                        data-key="one"
+                                        data-padded="true"
+                                        data-shape="rectangle"
+                                        data-size="40"
+                                        role="menuitemradio"
+                                        tabindex="0"
+                                      >
+                                        <div
+                                          data-position="fill"
+                                          title="One"
+                                        >
+                                          One
+                                        </div>
+                                      </li>,
+                                    }
+                                  }
+                                />
                               </li>
                             </FocusRing>
                           </FocusRing>
@@ -9857,6 +10532,33 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with placement 
                                     Two
                                   </div>
                                 </ListItemBaseSection>
+                                <ContextMenu
+                                  triggerRef={
+                                    Object {
+                                      "current": <li
+                                        aria-checked="false"
+                                        aria-disabled="false"
+                                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                                        data-allow-text-select="false"
+                                        data-disabled="false"
+                                        data-interactive="true"
+                                        data-key="two"
+                                        data-padded="true"
+                                        data-shape="rectangle"
+                                        data-size="40"
+                                        role="menuitemradio"
+                                        tabindex="-1"
+                                      >
+                                        <div
+                                          data-position="fill"
+                                          title="Two"
+                                        >
+                                          Two
+                                        </div>
+                                      </li>,
+                                    }
+                                  }
+                                />
                               </li>
                             </FocusRing>
                           </FocusRing>
@@ -10133,6 +10835,33 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with placement 
                                     Three
                                   </div>
                                 </ListItemBaseSection>
+                                <ContextMenu
+                                  triggerRef={
+                                    Object {
+                                      "current": <li
+                                        aria-checked="false"
+                                        aria-disabled="false"
+                                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                                        data-allow-text-select="false"
+                                        data-disabled="false"
+                                        data-interactive="true"
+                                        data-key="three"
+                                        data-padded="true"
+                                        data-shape="rectangle"
+                                        data-size="40"
+                                        role="menuitemradio"
+                                        tabindex="-1"
+                                      >
+                                        <div
+                                          data-position="fill"
+                                          title="Three"
+                                        >
+                                          Three
+                                        </div>
+                                      </li>,
+                                    }
+                                  }
+                                />
                               </li>
                             </FocusRing>
                           </FocusRing>
@@ -10434,6 +11163,33 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with placement 
                                     Four
                                   </div>
                                 </ListItemBaseSection>
+                                <ContextMenu
+                                  triggerRef={
+                                    Object {
+                                      "current": <li
+                                        aria-checked="false"
+                                        aria-disabled="false"
+                                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                                        data-allow-text-select="false"
+                                        data-disabled="false"
+                                        data-interactive="true"
+                                        data-key="asd"
+                                        data-padded="true"
+                                        data-shape="rectangle"
+                                        data-size="40"
+                                        role="menuitemcheckbox"
+                                        tabindex="-1"
+                                      >
+                                        <div
+                                          data-position="fill"
+                                          title="Four"
+                                        >
+                                          Four
+                                        </div>
+                                      </li>,
+                                    }
+                                  }
+                                />
                               </li>
                             </FocusRing>
                           </FocusRing>
@@ -10710,6 +11466,33 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with placement 
                                     Five
                                   </div>
                                 </ListItemBaseSection>
+                                <ContextMenu
+                                  triggerRef={
+                                    Object {
+                                      "current": <li
+                                        aria-checked="false"
+                                        aria-disabled="false"
+                                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                                        data-allow-text-select="false"
+                                        data-disabled="false"
+                                        data-interactive="true"
+                                        data-key="ff"
+                                        data-padded="true"
+                                        data-shape="rectangle"
+                                        data-size="40"
+                                        role="menuitemcheckbox"
+                                        tabindex="-1"
+                                      >
+                                        <div
+                                          data-position="fill"
+                                          title="Five"
+                                        >
+                                          Five
+                                        </div>
+                                      </li>,
+                                    }
+                                  }
+                                />
                               </li>
                             </FocusRing>
                           </FocusRing>
@@ -10986,6 +11769,33 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with placement 
                                     Six
                                   </div>
                                 </ListItemBaseSection>
+                                <ContextMenu
+                                  triggerRef={
+                                    Object {
+                                      "current": <li
+                                        aria-checked="false"
+                                        aria-disabled="false"
+                                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                                        data-allow-text-select="false"
+                                        data-disabled="false"
+                                        data-interactive="true"
+                                        data-key="d"
+                                        data-padded="true"
+                                        data-shape="rectangle"
+                                        data-size="40"
+                                        role="menuitemcheckbox"
+                                        tabindex="-1"
+                                      >
+                                        <div
+                                          data-position="fill"
+                                          title="Six"
+                                        >
+                                          Six
+                                        </div>
+                                      </li>,
+                                    }
+                                  }
+                                />
                               </li>
                             </FocusRing>
                           </FocusRing>
@@ -11813,6 +12623,33 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with showArrow 
                                     One
                                   </div>
                                 </ListItemBaseSection>
+                                <ContextMenu
+                                  triggerRef={
+                                    Object {
+                                      "current": <li
+                                        aria-checked="false"
+                                        aria-disabled="false"
+                                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                                        data-allow-text-select="false"
+                                        data-disabled="false"
+                                        data-interactive="true"
+                                        data-key="one"
+                                        data-padded="true"
+                                        data-shape="rectangle"
+                                        data-size="40"
+                                        role="menuitemradio"
+                                        tabindex="0"
+                                      >
+                                        <div
+                                          data-position="fill"
+                                          title="One"
+                                        >
+                                          One
+                                        </div>
+                                      </li>,
+                                    }
+                                  }
+                                />
                               </li>
                             </FocusRing>
                           </FocusRing>
@@ -12089,6 +12926,33 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with showArrow 
                                     Two
                                   </div>
                                 </ListItemBaseSection>
+                                <ContextMenu
+                                  triggerRef={
+                                    Object {
+                                      "current": <li
+                                        aria-checked="false"
+                                        aria-disabled="false"
+                                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                                        data-allow-text-select="false"
+                                        data-disabled="false"
+                                        data-interactive="true"
+                                        data-key="two"
+                                        data-padded="true"
+                                        data-shape="rectangle"
+                                        data-size="40"
+                                        role="menuitemradio"
+                                        tabindex="-1"
+                                      >
+                                        <div
+                                          data-position="fill"
+                                          title="Two"
+                                        >
+                                          Two
+                                        </div>
+                                      </li>,
+                                    }
+                                  }
+                                />
                               </li>
                             </FocusRing>
                           </FocusRing>
@@ -12365,6 +13229,33 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with showArrow 
                                     Three
                                   </div>
                                 </ListItemBaseSection>
+                                <ContextMenu
+                                  triggerRef={
+                                    Object {
+                                      "current": <li
+                                        aria-checked="false"
+                                        aria-disabled="false"
+                                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                                        data-allow-text-select="false"
+                                        data-disabled="false"
+                                        data-interactive="true"
+                                        data-key="three"
+                                        data-padded="true"
+                                        data-shape="rectangle"
+                                        data-size="40"
+                                        role="menuitemradio"
+                                        tabindex="-1"
+                                      >
+                                        <div
+                                          data-position="fill"
+                                          title="Three"
+                                        >
+                                          Three
+                                        </div>
+                                      </li>,
+                                    }
+                                  }
+                                />
                               </li>
                             </FocusRing>
                           </FocusRing>
@@ -12666,6 +13557,33 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with showArrow 
                                     Four
                                   </div>
                                 </ListItemBaseSection>
+                                <ContextMenu
+                                  triggerRef={
+                                    Object {
+                                      "current": <li
+                                        aria-checked="false"
+                                        aria-disabled="false"
+                                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                                        data-allow-text-select="false"
+                                        data-disabled="false"
+                                        data-interactive="true"
+                                        data-key="asd"
+                                        data-padded="true"
+                                        data-shape="rectangle"
+                                        data-size="40"
+                                        role="menuitemcheckbox"
+                                        tabindex="-1"
+                                      >
+                                        <div
+                                          data-position="fill"
+                                          title="Four"
+                                        >
+                                          Four
+                                        </div>
+                                      </li>,
+                                    }
+                                  }
+                                />
                               </li>
                             </FocusRing>
                           </FocusRing>
@@ -12942,6 +13860,33 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with showArrow 
                                     Five
                                   </div>
                                 </ListItemBaseSection>
+                                <ContextMenu
+                                  triggerRef={
+                                    Object {
+                                      "current": <li
+                                        aria-checked="false"
+                                        aria-disabled="false"
+                                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                                        data-allow-text-select="false"
+                                        data-disabled="false"
+                                        data-interactive="true"
+                                        data-key="ff"
+                                        data-padded="true"
+                                        data-shape="rectangle"
+                                        data-size="40"
+                                        role="menuitemcheckbox"
+                                        tabindex="-1"
+                                      >
+                                        <div
+                                          data-position="fill"
+                                          title="Five"
+                                        >
+                                          Five
+                                        </div>
+                                      </li>,
+                                    }
+                                  }
+                                />
                               </li>
                             </FocusRing>
                           </FocusRing>
@@ -13218,6 +14163,33 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with showArrow 
                                     Six
                                   </div>
                                 </ListItemBaseSection>
+                                <ContextMenu
+                                  triggerRef={
+                                    Object {
+                                      "current": <li
+                                        aria-checked="false"
+                                        aria-disabled="false"
+                                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                                        data-allow-text-select="false"
+                                        data-disabled="false"
+                                        data-interactive="true"
+                                        data-key="d"
+                                        data-padded="true"
+                                        data-shape="rectangle"
+                                        data-size="40"
+                                        role="menuitemcheckbox"
+                                        tabindex="-1"
+                                      >
+                                        <div
+                                          data-position="fill"
+                                          title="Six"
+                                        >
+                                          Six
+                                        </div>
+                                      </li>,
+                                    }
+                                  }
+                                />
                               </li>
                             </FocusRing>
                           </FocusRing>
@@ -14069,6 +15041,33 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with style 1`] 
                                     One
                                   </div>
                                 </ListItemBaseSection>
+                                <ContextMenu
+                                  triggerRef={
+                                    Object {
+                                      "current": <li
+                                        aria-checked="false"
+                                        aria-disabled="false"
+                                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                                        data-allow-text-select="false"
+                                        data-disabled="false"
+                                        data-interactive="true"
+                                        data-key="one"
+                                        data-padded="true"
+                                        data-shape="rectangle"
+                                        data-size="40"
+                                        role="menuitemradio"
+                                        tabindex="0"
+                                      >
+                                        <div
+                                          data-position="fill"
+                                          title="One"
+                                        >
+                                          One
+                                        </div>
+                                      </li>,
+                                    }
+                                  }
+                                />
                               </li>
                             </FocusRing>
                           </FocusRing>
@@ -14345,6 +15344,33 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with style 1`] 
                                     Two
                                   </div>
                                 </ListItemBaseSection>
+                                <ContextMenu
+                                  triggerRef={
+                                    Object {
+                                      "current": <li
+                                        aria-checked="false"
+                                        aria-disabled="false"
+                                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                                        data-allow-text-select="false"
+                                        data-disabled="false"
+                                        data-interactive="true"
+                                        data-key="two"
+                                        data-padded="true"
+                                        data-shape="rectangle"
+                                        data-size="40"
+                                        role="menuitemradio"
+                                        tabindex="-1"
+                                      >
+                                        <div
+                                          data-position="fill"
+                                          title="Two"
+                                        >
+                                          Two
+                                        </div>
+                                      </li>,
+                                    }
+                                  }
+                                />
                               </li>
                             </FocusRing>
                           </FocusRing>
@@ -14621,6 +15647,33 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with style 1`] 
                                     Three
                                   </div>
                                 </ListItemBaseSection>
+                                <ContextMenu
+                                  triggerRef={
+                                    Object {
+                                      "current": <li
+                                        aria-checked="false"
+                                        aria-disabled="false"
+                                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                                        data-allow-text-select="false"
+                                        data-disabled="false"
+                                        data-interactive="true"
+                                        data-key="three"
+                                        data-padded="true"
+                                        data-shape="rectangle"
+                                        data-size="40"
+                                        role="menuitemradio"
+                                        tabindex="-1"
+                                      >
+                                        <div
+                                          data-position="fill"
+                                          title="Three"
+                                        >
+                                          Three
+                                        </div>
+                                      </li>,
+                                    }
+                                  }
+                                />
                               </li>
                             </FocusRing>
                           </FocusRing>
@@ -14922,6 +15975,33 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with style 1`] 
                                     Four
                                   </div>
                                 </ListItemBaseSection>
+                                <ContextMenu
+                                  triggerRef={
+                                    Object {
+                                      "current": <li
+                                        aria-checked="false"
+                                        aria-disabled="false"
+                                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                                        data-allow-text-select="false"
+                                        data-disabled="false"
+                                        data-interactive="true"
+                                        data-key="asd"
+                                        data-padded="true"
+                                        data-shape="rectangle"
+                                        data-size="40"
+                                        role="menuitemcheckbox"
+                                        tabindex="-1"
+                                      >
+                                        <div
+                                          data-position="fill"
+                                          title="Four"
+                                        >
+                                          Four
+                                        </div>
+                                      </li>,
+                                    }
+                                  }
+                                />
                               </li>
                             </FocusRing>
                           </FocusRing>
@@ -15198,6 +16278,33 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with style 1`] 
                                     Five
                                   </div>
                                 </ListItemBaseSection>
+                                <ContextMenu
+                                  triggerRef={
+                                    Object {
+                                      "current": <li
+                                        aria-checked="false"
+                                        aria-disabled="false"
+                                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                                        data-allow-text-select="false"
+                                        data-disabled="false"
+                                        data-interactive="true"
+                                        data-key="ff"
+                                        data-padded="true"
+                                        data-shape="rectangle"
+                                        data-size="40"
+                                        role="menuitemcheckbox"
+                                        tabindex="-1"
+                                      >
+                                        <div
+                                          data-position="fill"
+                                          title="Five"
+                                        >
+                                          Five
+                                        </div>
+                                      </li>,
+                                    }
+                                  }
+                                />
                               </li>
                             </FocusRing>
                           </FocusRing>
@@ -15474,6 +16581,33 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with style 1`] 
                                     Six
                                   </div>
                                 </ListItemBaseSection>
+                                <ContextMenu
+                                  triggerRef={
+                                    Object {
+                                      "current": <li
+                                        aria-checked="false"
+                                        aria-disabled="false"
+                                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                                        data-allow-text-select="false"
+                                        data-disabled="false"
+                                        data-interactive="true"
+                                        data-key="d"
+                                        data-padded="true"
+                                        data-shape="rectangle"
+                                        data-size="40"
+                                        role="menuitemcheckbox"
+                                        tabindex="-1"
+                                      >
+                                        <div
+                                          data-position="fill"
+                                          title="Six"
+                                        >
+                                          Six
+                                        </div>
+                                      </li>,
+                                    }
+                                  }
+                                />
                               </li>
                             </FocusRing>
                           </FocusRing>
@@ -16270,6 +17404,33 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with variant 1`
                                     One
                                   </div>
                                 </ListItemBaseSection>
+                                <ContextMenu
+                                  triggerRef={
+                                    Object {
+                                      "current": <li
+                                        aria-checked="false"
+                                        aria-disabled="false"
+                                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                                        data-allow-text-select="false"
+                                        data-disabled="false"
+                                        data-interactive="true"
+                                        data-key="one"
+                                        data-padded="true"
+                                        data-shape="rectangle"
+                                        data-size="40"
+                                        role="menuitemradio"
+                                        tabindex="0"
+                                      >
+                                        <div
+                                          data-position="fill"
+                                          title="One"
+                                        >
+                                          One
+                                        </div>
+                                      </li>,
+                                    }
+                                  }
+                                />
                               </li>
                             </FocusRing>
                           </FocusRing>
@@ -16546,6 +17707,33 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with variant 1`
                                     Two
                                   </div>
                                 </ListItemBaseSection>
+                                <ContextMenu
+                                  triggerRef={
+                                    Object {
+                                      "current": <li
+                                        aria-checked="false"
+                                        aria-disabled="false"
+                                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                                        data-allow-text-select="false"
+                                        data-disabled="false"
+                                        data-interactive="true"
+                                        data-key="two"
+                                        data-padded="true"
+                                        data-shape="rectangle"
+                                        data-size="40"
+                                        role="menuitemradio"
+                                        tabindex="-1"
+                                      >
+                                        <div
+                                          data-position="fill"
+                                          title="Two"
+                                        >
+                                          Two
+                                        </div>
+                                      </li>,
+                                    }
+                                  }
+                                />
                               </li>
                             </FocusRing>
                           </FocusRing>
@@ -16822,6 +18010,33 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with variant 1`
                                     Three
                                   </div>
                                 </ListItemBaseSection>
+                                <ContextMenu
+                                  triggerRef={
+                                    Object {
+                                      "current": <li
+                                        aria-checked="false"
+                                        aria-disabled="false"
+                                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                                        data-allow-text-select="false"
+                                        data-disabled="false"
+                                        data-interactive="true"
+                                        data-key="three"
+                                        data-padded="true"
+                                        data-shape="rectangle"
+                                        data-size="40"
+                                        role="menuitemradio"
+                                        tabindex="-1"
+                                      >
+                                        <div
+                                          data-position="fill"
+                                          title="Three"
+                                        >
+                                          Three
+                                        </div>
+                                      </li>,
+                                    }
+                                  }
+                                />
                               </li>
                             </FocusRing>
                           </FocusRing>
@@ -17123,6 +18338,33 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with variant 1`
                                     Four
                                   </div>
                                 </ListItemBaseSection>
+                                <ContextMenu
+                                  triggerRef={
+                                    Object {
+                                      "current": <li
+                                        aria-checked="false"
+                                        aria-disabled="false"
+                                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                                        data-allow-text-select="false"
+                                        data-disabled="false"
+                                        data-interactive="true"
+                                        data-key="asd"
+                                        data-padded="true"
+                                        data-shape="rectangle"
+                                        data-size="40"
+                                        role="menuitemcheckbox"
+                                        tabindex="-1"
+                                      >
+                                        <div
+                                          data-position="fill"
+                                          title="Four"
+                                        >
+                                          Four
+                                        </div>
+                                      </li>,
+                                    }
+                                  }
+                                />
                               </li>
                             </FocusRing>
                           </FocusRing>
@@ -17399,6 +18641,33 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with variant 1`
                                     Five
                                   </div>
                                 </ListItemBaseSection>
+                                <ContextMenu
+                                  triggerRef={
+                                    Object {
+                                      "current": <li
+                                        aria-checked="false"
+                                        aria-disabled="false"
+                                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                                        data-allow-text-select="false"
+                                        data-disabled="false"
+                                        data-interactive="true"
+                                        data-key="ff"
+                                        data-padded="true"
+                                        data-shape="rectangle"
+                                        data-size="40"
+                                        role="menuitemcheckbox"
+                                        tabindex="-1"
+                                      >
+                                        <div
+                                          data-position="fill"
+                                          title="Five"
+                                        >
+                                          Five
+                                        </div>
+                                      </li>,
+                                    }
+                                  }
+                                />
                               </li>
                             </FocusRing>
                           </FocusRing>
@@ -17675,6 +18944,33 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with variant 1`
                                     Six
                                   </div>
                                 </ListItemBaseSection>
+                                <ContextMenu
+                                  triggerRef={
+                                    Object {
+                                      "current": <li
+                                        aria-checked="false"
+                                        aria-disabled="false"
+                                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                                        data-allow-text-select="false"
+                                        data-disabled="false"
+                                        data-interactive="true"
+                                        data-key="d"
+                                        data-padded="true"
+                                        data-shape="rectangle"
+                                        data-size="40"
+                                        role="menuitemcheckbox"
+                                        tabindex="-1"
+                                      >
+                                        <div
+                                          data-position="fill"
+                                          title="Six"
+                                        >
+                                          Six
+                                        </div>
+                                      </li>,
+                                    }
+                                  }
+                                />
                               </li>
                             </FocusRing>
                           </FocusRing>
@@ -18475,6 +19771,33 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with zIndex 1`]
                                     One
                                   </div>
                                 </ListItemBaseSection>
+                                <ContextMenu
+                                  triggerRef={
+                                    Object {
+                                      "current": <li
+                                        aria-checked="false"
+                                        aria-disabled="false"
+                                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                                        data-allow-text-select="false"
+                                        data-disabled="false"
+                                        data-interactive="true"
+                                        data-key="one"
+                                        data-padded="true"
+                                        data-shape="rectangle"
+                                        data-size="40"
+                                        role="menuitemradio"
+                                        tabindex="0"
+                                      >
+                                        <div
+                                          data-position="fill"
+                                          title="One"
+                                        >
+                                          One
+                                        </div>
+                                      </li>,
+                                    }
+                                  }
+                                />
                               </li>
                             </FocusRing>
                           </FocusRing>
@@ -18751,6 +20074,33 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with zIndex 1`]
                                     Two
                                   </div>
                                 </ListItemBaseSection>
+                                <ContextMenu
+                                  triggerRef={
+                                    Object {
+                                      "current": <li
+                                        aria-checked="false"
+                                        aria-disabled="false"
+                                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                                        data-allow-text-select="false"
+                                        data-disabled="false"
+                                        data-interactive="true"
+                                        data-key="two"
+                                        data-padded="true"
+                                        data-shape="rectangle"
+                                        data-size="40"
+                                        role="menuitemradio"
+                                        tabindex="-1"
+                                      >
+                                        <div
+                                          data-position="fill"
+                                          title="Two"
+                                        >
+                                          Two
+                                        </div>
+                                      </li>,
+                                    }
+                                  }
+                                />
                               </li>
                             </FocusRing>
                           </FocusRing>
@@ -19027,6 +20377,33 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with zIndex 1`]
                                     Three
                                   </div>
                                 </ListItemBaseSection>
+                                <ContextMenu
+                                  triggerRef={
+                                    Object {
+                                      "current": <li
+                                        aria-checked="false"
+                                        aria-disabled="false"
+                                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                                        data-allow-text-select="false"
+                                        data-disabled="false"
+                                        data-interactive="true"
+                                        data-key="three"
+                                        data-padded="true"
+                                        data-shape="rectangle"
+                                        data-size="40"
+                                        role="menuitemradio"
+                                        tabindex="-1"
+                                      >
+                                        <div
+                                          data-position="fill"
+                                          title="Three"
+                                        >
+                                          Three
+                                        </div>
+                                      </li>,
+                                    }
+                                  }
+                                />
                               </li>
                             </FocusRing>
                           </FocusRing>
@@ -19328,6 +20705,33 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with zIndex 1`]
                                     Four
                                   </div>
                                 </ListItemBaseSection>
+                                <ContextMenu
+                                  triggerRef={
+                                    Object {
+                                      "current": <li
+                                        aria-checked="false"
+                                        aria-disabled="false"
+                                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                                        data-allow-text-select="false"
+                                        data-disabled="false"
+                                        data-interactive="true"
+                                        data-key="asd"
+                                        data-padded="true"
+                                        data-shape="rectangle"
+                                        data-size="40"
+                                        role="menuitemcheckbox"
+                                        tabindex="-1"
+                                      >
+                                        <div
+                                          data-position="fill"
+                                          title="Four"
+                                        >
+                                          Four
+                                        </div>
+                                      </li>,
+                                    }
+                                  }
+                                />
                               </li>
                             </FocusRing>
                           </FocusRing>
@@ -19604,6 +21008,33 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with zIndex 1`]
                                     Five
                                   </div>
                                 </ListItemBaseSection>
+                                <ContextMenu
+                                  triggerRef={
+                                    Object {
+                                      "current": <li
+                                        aria-checked="false"
+                                        aria-disabled="false"
+                                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                                        data-allow-text-select="false"
+                                        data-disabled="false"
+                                        data-interactive="true"
+                                        data-key="ff"
+                                        data-padded="true"
+                                        data-shape="rectangle"
+                                        data-size="40"
+                                        role="menuitemcheckbox"
+                                        tabindex="-1"
+                                      >
+                                        <div
+                                          data-position="fill"
+                                          title="Five"
+                                        >
+                                          Five
+                                        </div>
+                                      </li>,
+                                    }
+                                  }
+                                />
                               </li>
                             </FocusRing>
                           </FocusRing>
@@ -19880,6 +21311,33 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with zIndex 1`]
                                     Six
                                   </div>
                                 </ListItemBaseSection>
+                                <ContextMenu
+                                  triggerRef={
+                                    Object {
+                                      "current": <li
+                                        aria-checked="false"
+                                        aria-disabled="false"
+                                        class="md-menu-item-wrapper md-list-item-base-wrapper"
+                                        data-allow-text-select="false"
+                                        data-disabled="false"
+                                        data-interactive="true"
+                                        data-key="d"
+                                        data-padded="true"
+                                        data-shape="rectangle"
+                                        data-size="40"
+                                        role="menuitemcheckbox"
+                                        tabindex="-1"
+                                      >
+                                        <div
+                                          data-position="fill"
+                                          title="Six"
+                                        >
+                                          Six
+                                        </div>
+                                      </li>,
+                                    }
+                                  }
+                                />
                               </li>
                             </FocusRing>
                           </FocusRing>

--- a/src/components/Select/Select.unit.test.tsx.snap
+++ b/src/components/Select/Select.unit.test.tsx.snap
@@ -2093,6 +2093,34 @@ exports[`Select snapshot should match snapshot before and after opening select d
                                             Item 1
                                           </div>
                                         </ListItemBaseSection>
+                                        <ContextMenu
+                                          triggerRef={
+                                            Object {
+                                              "current": <li
+                                                aria-disabled="false"
+                                                aria-selected="false"
+                                                class="md-list-item-base-wrapper"
+                                                data-allow-text-select="false"
+                                                data-disabled="false"
+                                                data-interactive="true"
+                                                data-key="$.0"
+                                                data-padded="true"
+                                                data-shape="rectangle"
+                                                data-size="40"
+                                                id="test-ID-option-$.0"
+                                                role="option"
+                                                tabindex="0"
+                                              >
+                                                <div
+                                                  data-position="fill"
+                                                  title="Item 1"
+                                                >
+                                                  Item 1
+                                                </div>
+                                              </li>,
+                                            }
+                                          }
+                                        />
                                       </li>
                                     </FocusRing>
                                   </FocusRing>
@@ -2201,6 +2229,34 @@ exports[`Select snapshot should match snapshot before and after opening select d
                                             Item 2
                                           </div>
                                         </ListItemBaseSection>
+                                        <ContextMenu
+                                          triggerRef={
+                                            Object {
+                                              "current": <li
+                                                aria-disabled="false"
+                                                aria-selected="false"
+                                                class="md-list-item-base-wrapper"
+                                                data-allow-text-select="false"
+                                                data-disabled="false"
+                                                data-interactive="true"
+                                                data-key="$.1"
+                                                data-padded="true"
+                                                data-shape="rectangle"
+                                                data-size="40"
+                                                id="test-ID-option-$.1"
+                                                role="option"
+                                                tabindex="-1"
+                                              >
+                                                <div
+                                                  data-position="fill"
+                                                  title="Item 2"
+                                                >
+                                                  Item 2
+                                                </div>
+                                              </li>,
+                                            }
+                                          }
+                                        />
                                       </li>
                                     </FocusRing>
                                   </FocusRing>
@@ -4902,6 +4958,34 @@ exports[`Select snapshot should match snapshot with disabled option 1`] = `
                                             Item 1
                                           </div>
                                         </ListItemBaseSection>
+                                        <ContextMenu
+                                          triggerRef={
+                                            Object {
+                                              "current": <li
+                                                aria-disabled="true"
+                                                aria-selected="false"
+                                                class="md-list-item-base-wrapper"
+                                                data-allow-text-select="false"
+                                                data-disabled="true"
+                                                data-interactive="true"
+                                                data-key="$.0"
+                                                data-padded="true"
+                                                data-shape="rectangle"
+                                                data-size="40"
+                                                id="test-ID-option-$.0"
+                                                role="option"
+                                                tabindex="-1"
+                                              >
+                                                <div
+                                                  data-position="fill"
+                                                  title="Item 1"
+                                                >
+                                                  Item 1
+                                                </div>
+                                              </li>,
+                                            }
+                                          }
+                                        />
                                       </li>
                                     </FocusRing>
                                   </FocusRing>
@@ -5010,6 +5094,34 @@ exports[`Select snapshot should match snapshot with disabled option 1`] = `
                                             Item 2
                                           </div>
                                         </ListItemBaseSection>
+                                        <ContextMenu
+                                          triggerRef={
+                                            Object {
+                                              "current": <li
+                                                aria-disabled="false"
+                                                aria-selected="false"
+                                                class="md-list-item-base-wrapper"
+                                                data-allow-text-select="false"
+                                                data-disabled="false"
+                                                data-interactive="true"
+                                                data-key="$.1"
+                                                data-padded="true"
+                                                data-shape="rectangle"
+                                                data-size="40"
+                                                id="test-ID-option-$.1"
+                                                role="option"
+                                                tabindex="0"
+                                              >
+                                                <div
+                                                  data-position="fill"
+                                                  title="Item 2"
+                                                >
+                                                  Item 2
+                                                </div>
+                                              </li>,
+                                            }
+                                          }
+                                        />
                                       </li>
                                     </FocusRing>
                                   </FocusRing>
@@ -6894,6 +7006,34 @@ exports[`Select snapshot should match snapshot with listbox opened 1`] = `
                                             Item 1
                                           </div>
                                         </ListItemBaseSection>
+                                        <ContextMenu
+                                          triggerRef={
+                                            Object {
+                                              "current": <li
+                                                aria-disabled="false"
+                                                aria-selected="false"
+                                                class="md-list-item-base-wrapper"
+                                                data-allow-text-select="false"
+                                                data-disabled="false"
+                                                data-interactive="true"
+                                                data-key="$.0"
+                                                data-padded="true"
+                                                data-shape="rectangle"
+                                                data-size="40"
+                                                id="test-ID-option-$.0"
+                                                role="option"
+                                                tabindex="0"
+                                              >
+                                                <div
+                                                  data-position="fill"
+                                                  title="Item 1"
+                                                >
+                                                  Item 1
+                                                </div>
+                                              </li>,
+                                            }
+                                          }
+                                        />
                                       </li>
                                     </FocusRing>
                                   </FocusRing>
@@ -7002,6 +7142,34 @@ exports[`Select snapshot should match snapshot with listbox opened 1`] = `
                                             Item 2
                                           </div>
                                         </ListItemBaseSection>
+                                        <ContextMenu
+                                          triggerRef={
+                                            Object {
+                                              "current": <li
+                                                aria-disabled="false"
+                                                aria-selected="false"
+                                                class="md-list-item-base-wrapper"
+                                                data-allow-text-select="false"
+                                                data-disabled="false"
+                                                data-interactive="true"
+                                                data-key="$.1"
+                                                data-padded="true"
+                                                data-shape="rectangle"
+                                                data-size="40"
+                                                id="test-ID-option-$.1"
+                                                role="option"
+                                                tabindex="-1"
+                                              >
+                                                <div
+                                                  data-position="fill"
+                                                  title="Item 2"
+                                                >
+                                                  Item 2
+                                                </div>
+                                              </li>,
+                                            }
+                                          }
+                                        />
                                       </li>
                                     </FocusRing>
                                   </FocusRing>
@@ -7988,6 +8156,34 @@ exports[`Select snapshot should match snapshot with listboxMaxHeight 1`] = `
                                             Item 1
                                           </div>
                                         </ListItemBaseSection>
+                                        <ContextMenu
+                                          triggerRef={
+                                            Object {
+                                              "current": <li
+                                                aria-disabled="false"
+                                                aria-selected="false"
+                                                class="md-list-item-base-wrapper"
+                                                data-allow-text-select="false"
+                                                data-disabled="false"
+                                                data-interactive="true"
+                                                data-key="$.0"
+                                                data-padded="true"
+                                                data-shape="rectangle"
+                                                data-size="40"
+                                                id="test-ID-option-$.0"
+                                                role="option"
+                                                tabindex="0"
+                                              >
+                                                <div
+                                                  data-position="fill"
+                                                  title="Item 1"
+                                                >
+                                                  Item 1
+                                                </div>
+                                              </li>,
+                                            }
+                                          }
+                                        />
                                       </li>
                                     </FocusRing>
                                   </FocusRing>
@@ -8096,6 +8292,34 @@ exports[`Select snapshot should match snapshot with listboxMaxHeight 1`] = `
                                             Item 2
                                           </div>
                                         </ListItemBaseSection>
+                                        <ContextMenu
+                                          triggerRef={
+                                            Object {
+                                              "current": <li
+                                                aria-disabled="false"
+                                                aria-selected="false"
+                                                class="md-list-item-base-wrapper"
+                                                data-allow-text-select="false"
+                                                data-disabled="false"
+                                                data-interactive="true"
+                                                data-key="$.1"
+                                                data-padded="true"
+                                                data-shape="rectangle"
+                                                data-size="40"
+                                                id="test-ID-option-$.1"
+                                                role="option"
+                                                tabindex="-1"
+                                              >
+                                                <div
+                                                  data-position="fill"
+                                                  title="Item 2"
+                                                >
+                                                  Item 2
+                                                </div>
+                                              </li>,
+                                            }
+                                          }
+                                        />
                                       </li>
                                     </FocusRing>
                                   </FocusRing>
@@ -9082,6 +9306,34 @@ exports[`Select snapshot should match snapshot with listboxWidth 1`] = `
                                             Item 1
                                           </div>
                                         </ListItemBaseSection>
+                                        <ContextMenu
+                                          triggerRef={
+                                            Object {
+                                              "current": <li
+                                                aria-disabled="false"
+                                                aria-selected="false"
+                                                class="md-list-item-base-wrapper"
+                                                data-allow-text-select="false"
+                                                data-disabled="false"
+                                                data-interactive="true"
+                                                data-key="$.0"
+                                                data-padded="true"
+                                                data-shape="rectangle"
+                                                data-size="40"
+                                                id="test-ID-option-$.0"
+                                                role="option"
+                                                tabindex="0"
+                                              >
+                                                <div
+                                                  data-position="fill"
+                                                  title="Item 1"
+                                                >
+                                                  Item 1
+                                                </div>
+                                              </li>,
+                                            }
+                                          }
+                                        />
                                       </li>
                                     </FocusRing>
                                   </FocusRing>
@@ -9190,6 +9442,34 @@ exports[`Select snapshot should match snapshot with listboxWidth 1`] = `
                                             Item 2
                                           </div>
                                         </ListItemBaseSection>
+                                        <ContextMenu
+                                          triggerRef={
+                                            Object {
+                                              "current": <li
+                                                aria-disabled="false"
+                                                aria-selected="false"
+                                                class="md-list-item-base-wrapper"
+                                                data-allow-text-select="false"
+                                                data-disabled="false"
+                                                data-interactive="true"
+                                                data-key="$.1"
+                                                data-padded="true"
+                                                data-shape="rectangle"
+                                                data-size="40"
+                                                id="test-ID-option-$.1"
+                                                role="option"
+                                                tabindex="-1"
+                                              >
+                                                <div
+                                                  data-position="fill"
+                                                  title="Item 2"
+                                                >
+                                                  Item 2
+                                                </div>
+                                              </li>,
+                                            }
+                                          }
+                                        />
                                       </li>
                                     </FocusRing>
                                   </FocusRing>
@@ -11466,6 +11746,56 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
                                             </Icon>
                                           </div>
                                         </ListItemBaseSection>
+                                        <ContextMenu
+                                          triggerRef={
+                                            Object {
+                                              "current": <li
+                                                aria-disabled="false"
+                                                aria-selected="true"
+                                                class="md-list-item-base-wrapper"
+                                                data-allow-text-select="false"
+                                                data-disabled="false"
+                                                data-interactive="true"
+                                                data-key="$.0"
+                                                data-padded="true"
+                                                data-shape="rectangle"
+                                                data-size="40"
+                                                id="test-ID-option-$.0"
+                                                role="option"
+                                                tabindex="0"
+                                              >
+                                                <div
+                                                  data-position="fill"
+                                                  title="Item 1"
+                                                >
+                                                  Item 1
+                                                </div>
+                                                <div
+                                                  data-position="end"
+                                                >
+                                                  <div
+                                                    aria-hidden="true"
+                                                    class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-list-box-item-tick-icon md-icon-no-shrink"
+                                                    role="img"
+                                                  >
+                                                    <svg
+                                                      aria-hidden="true"
+                                                      class=""
+                                                      data-autoscale="false"
+                                                      data-scale="16"
+                                                      data-test="check"
+                                                      fill="currentColor"
+                                                      height="100%"
+                                                      style="stroke: none;"
+                                                      viewBox="0, 0, 32, 32"
+                                                      width="100%"
+                                                    />
+                                                  </div>
+                                                </div>
+                                              </li>,
+                                            }
+                                          }
+                                        />
                                       </li>
                                     </FocusRing>
                                   </FocusRing>
@@ -11574,6 +11904,34 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
                                             Item 2
                                           </div>
                                         </ListItemBaseSection>
+                                        <ContextMenu
+                                          triggerRef={
+                                            Object {
+                                              "current": <li
+                                                aria-disabled="false"
+                                                aria-selected="false"
+                                                class="md-list-item-base-wrapper"
+                                                data-allow-text-select="false"
+                                                data-disabled="false"
+                                                data-interactive="true"
+                                                data-key="$.1"
+                                                data-padded="true"
+                                                data-shape="rectangle"
+                                                data-size="40"
+                                                id="test-ID-option-$.1"
+                                                role="option"
+                                                tabindex="-1"
+                                              >
+                                                <div
+                                                  data-position="fill"
+                                                  title="Item 2"
+                                                >
+                                                  Item 2
+                                                </div>
+                                              </li>,
+                                            }
+                                          }
+                                        />
                                       </li>
                                     </FocusRing>
                                   </FocusRing>

--- a/src/components/SpaceListItem/SpaceListItem.types.ts
+++ b/src/components/SpaceListItem/SpaceListItem.types.ts
@@ -1,9 +1,9 @@
 import { PressEvents } from '@react-types/shared';
 import { CSSProperties } from 'react';
-import { ContextMenu } from '../ListItemBase/ListItemBase.types';
 import { SpaceRowContentProps } from '../SpaceRowContent';
+import { ContextMenuActionsProp } from '../ContextMenu/ContextMenu.types';
 
-export interface Props extends PressEvents, ContextMenu, SpaceRowContentProps {
+export interface Props extends PressEvents, ContextMenuActionsProp, SpaceRowContentProps {
   /**
    * Custom class for overriding this component's CSS.
    */

--- a/src/components/SpaceListItem/SpaceListItem.unit.test.tsx.snap
+++ b/src/components/SpaceListItem/SpaceListItem.unit.test.tsx.snap
@@ -126,6 +126,54 @@ exports[`<SpaceListItem /> snapshot checks divider dot position in compact mode 
               />
             </ListItemBaseSection>
           </SpaceRowContent>
+          <ContextMenu
+            triggerRef={
+              Object {
+                "current": <li
+                  class="md-space-list-item-wrapper md-list-item-base-wrapper"
+                  data-allow-text-select="false"
+                  data-disabled="false"
+                  data-interactive="true"
+                  data-padded="false"
+                  data-shape="isPilled"
+                  data-size="32"
+                  role="listitem"
+                  tabindex="-1"
+                >
+                  <div
+                    data-position="start"
+                  />
+                  <div
+                    class="md-space-row-content-text-wrapper text-row"
+                    data-position="middle"
+                  >
+                    <p
+                      class="md-text-wrapper"
+                      data-disabled="false"
+                      data-test="list-item-first-line"
+                      data-type="body-primary"
+                    >
+                      firstLine
+                    </p>
+                    <div
+                      class="md-divider-dot-wrapper"
+                    />
+                    <small
+                      aria-label="testteam"
+                      class="md-text-wrapper"
+                      data-test="list-item-second-line"
+                      data-type="body-secondary"
+                    >
+                      testteam
+                    </small>
+                  </div>
+                  <div
+                    data-position="end"
+                  />
+                </li>,
+              }
+            }
+          />
         </li>
       </FocusRing>
     </FocusRing>
@@ -215,6 +263,41 @@ exports[`<SpaceListItem /> snapshot should match snapshot 1`] = `
               />
             </ListItemBaseSection>
           </SpaceRowContent>
+          <ContextMenu
+            triggerRef={
+              Object {
+                "current": <li
+                  class="md-space-list-item-wrapper md-list-item-base-wrapper"
+                  data-allow-text-select="false"
+                  data-disabled="false"
+                  data-interactive="true"
+                  data-padded="false"
+                  data-shape="isPilled"
+                  data-size="50"
+                  role="listitem"
+                  tabindex="-1"
+                >
+                  <div
+                    data-position="start"
+                  />
+                  <div
+                    class="md-space-row-content-text-wrapper text-column"
+                    data-position="middle"
+                  >
+                    <p
+                      class="md-text-wrapper"
+                      data-disabled="false"
+                      data-test="list-item-first-line"
+                      data-type="body-primary"
+                    />
+                  </div>
+                  <div
+                    data-position="end"
+                  />
+                </li>,
+              }
+            }
+          />
         </li>
       </FocusRing>
     </FocusRing>
@@ -319,6 +402,45 @@ exports[`<SpaceListItem /> snapshot should match snapshot with action 1`] = `
               </div>
             </ListItemBaseSection>
           </SpaceRowContent>
+          <ContextMenu
+            triggerRef={
+              Object {
+                "current": <li
+                  class="md-space-list-item-wrapper md-list-item-base-wrapper"
+                  data-allow-text-select="false"
+                  data-disabled="false"
+                  data-interactive="true"
+                  data-padded="false"
+                  data-shape="isPilled"
+                  data-size="50"
+                  role="listitem"
+                  tabindex="-1"
+                >
+                  <div
+                    data-position="start"
+                  />
+                  <div
+                    class="md-space-row-content-text-wrapper text-column"
+                    data-position="middle"
+                  >
+                    <p
+                      class="md-text-wrapper"
+                      data-disabled="false"
+                      data-test="list-item-first-line"
+                      data-type="body-primary"
+                    />
+                  </div>
+                  <div
+                    data-position="end"
+                  >
+                    <p>
+                      action
+                    </p>
+                  </div>
+                </li>,
+              }
+            }
+          />
         </li>
       </FocusRing>
     </FocusRing>
@@ -410,6 +532,41 @@ exports[`<SpaceListItem /> snapshot should match snapshot with className 1`] = `
               />
             </ListItemBaseSection>
           </SpaceRowContent>
+          <ContextMenu
+            triggerRef={
+              Object {
+                "current": <li
+                  class="example-class md-space-list-item-wrapper md-list-item-base-wrapper"
+                  data-allow-text-select="false"
+                  data-disabled="false"
+                  data-interactive="true"
+                  data-padded="false"
+                  data-shape="isPilled"
+                  data-size="50"
+                  role="listitem"
+                  tabindex="-1"
+                >
+                  <div
+                    data-position="start"
+                  />
+                  <div
+                    class="md-space-row-content-text-wrapper text-column"
+                    data-position="middle"
+                  >
+                    <p
+                      class="md-text-wrapper"
+                      data-disabled="false"
+                      data-test="list-item-first-line"
+                      data-type="body-primary"
+                    />
+                  </div>
+                  <div
+                    data-position="end"
+                  />
+                </li>,
+              }
+            }
+          />
         </li>
       </FocusRing>
     </FocusRing>
@@ -504,6 +661,43 @@ exports[`<SpaceListItem /> snapshot should match snapshot with firstLine 1`] = `
               />
             </ListItemBaseSection>
           </SpaceRowContent>
+          <ContextMenu
+            triggerRef={
+              Object {
+                "current": <li
+                  class="md-space-list-item-wrapper md-list-item-base-wrapper"
+                  data-allow-text-select="false"
+                  data-disabled="false"
+                  data-interactive="true"
+                  data-padded="false"
+                  data-shape="isPilled"
+                  data-size="50"
+                  role="listitem"
+                  tabindex="-1"
+                >
+                  <div
+                    data-position="start"
+                  />
+                  <div
+                    class="md-space-row-content-text-wrapper text-column"
+                    data-position="middle"
+                  >
+                    <p
+                      class="md-text-wrapper"
+                      data-disabled="false"
+                      data-test="list-item-first-line"
+                      data-type="body-primary"
+                    >
+                      firstLine
+                    </p>
+                  </div>
+                  <div
+                    data-position="end"
+                  />
+                </li>,
+              }
+            }
+          />
         </li>
       </FocusRing>
     </FocusRing>
@@ -597,6 +791,42 @@ exports[`<SpaceListItem /> snapshot should match snapshot with id 1`] = `
               />
             </ListItemBaseSection>
           </SpaceRowContent>
+          <ContextMenu
+            triggerRef={
+              Object {
+                "current": <li
+                  class="md-space-list-item-wrapper md-list-item-base-wrapper"
+                  data-allow-text-select="false"
+                  data-disabled="false"
+                  data-interactive="true"
+                  data-padded="false"
+                  data-shape="isPilled"
+                  data-size="50"
+                  id="example-id"
+                  role="listitem"
+                  tabindex="-1"
+                >
+                  <div
+                    data-position="start"
+                  />
+                  <div
+                    class="md-space-row-content-text-wrapper text-column"
+                    data-position="middle"
+                  >
+                    <p
+                      class="md-text-wrapper"
+                      data-disabled="false"
+                      data-test="list-item-first-line"
+                      data-type="body-primary"
+                    />
+                  </div>
+                  <div
+                    data-position="end"
+                  />
+                </li>,
+              }
+            }
+          />
         </li>
       </FocusRing>
     </FocusRing>
@@ -720,6 +950,59 @@ exports[`<SpaceListItem /> snapshot should match snapshot with isAlert 1`] = `
               </div>
             </ListItemBaseSection>
           </SpaceRowContent>
+          <ContextMenu
+            triggerRef={
+              Object {
+                "current": <li
+                  class="md-space-list-item-wrapper md-list-item-base-wrapper"
+                  data-allow-text-select="false"
+                  data-disabled="false"
+                  data-interactive="true"
+                  data-padded="false"
+                  data-shape="isPilled"
+                  data-size="50"
+                  role="listitem"
+                  tabindex="-1"
+                >
+                  <div
+                    data-position="start"
+                  />
+                  <div
+                    class="md-space-row-content-text-wrapper text-column"
+                    data-position="middle"
+                  >
+                    <p
+                      class="md-text-wrapper"
+                      data-disabled="false"
+                      data-test="list-item-first-line"
+                      data-type="body-primary"
+                    />
+                  </div>
+                  <div
+                    data-position="end"
+                  >
+                    <div
+                      aria-hidden="true"
+                      class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class=""
+                        data-autoscale="false"
+                        data-scale="14"
+                        data-test="alert"
+                        height="100%"
+                        style="fill: var(--mds-color-theme-text-primary-normal); stroke: none;"
+                        viewBox="0, 0, 32, 32"
+                        width="100%"
+                      />
+                    </div>
+                  </div>
+                </li>,
+              }
+            }
+          />
         </li>
       </FocusRing>
     </FocusRing>
@@ -843,6 +1126,59 @@ exports[`<SpaceListItem /> snapshot should match snapshot with isAlertMuted 1`] 
               </div>
             </ListItemBaseSection>
           </SpaceRowContent>
+          <ContextMenu
+            triggerRef={
+              Object {
+                "current": <li
+                  class="md-space-list-item-wrapper md-list-item-base-wrapper"
+                  data-allow-text-select="false"
+                  data-disabled="false"
+                  data-interactive="true"
+                  data-padded="false"
+                  data-shape="isPilled"
+                  data-size="50"
+                  role="listitem"
+                  tabindex="-1"
+                >
+                  <div
+                    data-position="start"
+                  />
+                  <div
+                    class="md-space-row-content-text-wrapper text-column"
+                    data-position="middle"
+                  >
+                    <p
+                      class="md-text-wrapper"
+                      data-disabled="false"
+                      data-test="list-item-first-line"
+                      data-type="body-primary"
+                    />
+                  </div>
+                  <div
+                    data-position="end"
+                  >
+                    <div
+                      aria-hidden="true"
+                      class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class=""
+                        data-autoscale="false"
+                        data-scale="14"
+                        data-test="alert-muted"
+                        height="100%"
+                        style="fill: var(--mds-color-theme-text-primary-normal); stroke: none;"
+                        viewBox="0, 0, 32, 32"
+                        width="100%"
+                      />
+                    </div>
+                  </div>
+                </li>,
+              }
+            }
+          />
         </li>
       </FocusRing>
     </FocusRing>
@@ -934,6 +1270,41 @@ exports[`<SpaceListItem /> snapshot should match snapshot with isDisabled 1`] = 
               />
             </ListItemBaseSection>
           </SpaceRowContent>
+          <ContextMenu
+            triggerRef={
+              Object {
+                "current": <li
+                  class="md-space-list-item-wrapper md-list-item-base-wrapper"
+                  data-allow-text-select="false"
+                  data-disabled="true"
+                  data-interactive="true"
+                  data-padded="false"
+                  data-shape="isPilled"
+                  data-size="50"
+                  role="listitem"
+                  tabindex="-1"
+                >
+                  <div
+                    data-position="start"
+                  />
+                  <div
+                    class="md-space-row-content-text-wrapper text-column"
+                    data-position="middle"
+                  >
+                    <p
+                      class="md-text-wrapper"
+                      data-disabled="true"
+                      data-test="list-item-first-line"
+                      data-type="body-primary"
+                    />
+                  </div>
+                  <div
+                    data-position="end"
+                  />
+                </li>,
+              }
+            }
+          />
         </li>
       </FocusRing>
     </FocusRing>
@@ -1057,6 +1428,59 @@ exports[`<SpaceListItem /> snapshot should match snapshot with isEnterRoom 1`] =
               </div>
             </ListItemBaseSection>
           </SpaceRowContent>
+          <ContextMenu
+            triggerRef={
+              Object {
+                "current": <li
+                  class="md-space-list-item-wrapper md-list-item-base-wrapper"
+                  data-allow-text-select="false"
+                  data-disabled="false"
+                  data-interactive="true"
+                  data-padded="false"
+                  data-shape="isPilled"
+                  data-size="50"
+                  role="listitem"
+                  tabindex="-1"
+                >
+                  <div
+                    data-position="start"
+                  />
+                  <div
+                    class="md-space-row-content-text-wrapper text-column md-space-row-content-is-new-activity"
+                    data-position="middle"
+                  >
+                    <p
+                      class="md-text-wrapper"
+                      data-disabled="false"
+                      data-test="list-item-first-line"
+                      data-type="body-primary"
+                    />
+                  </div>
+                  <div
+                    data-position="end"
+                  >
+                    <div
+                      aria-hidden="true"
+                      class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class=""
+                        data-autoscale="false"
+                        data-scale="14"
+                        data-test="enter-room"
+                        height="100%"
+                        style="fill: var(--mds-color-theme-control-active-normal); stroke: none;"
+                        viewBox="0, 0, 32, 32"
+                        width="100%"
+                      />
+                    </div>
+                  </div>
+                </li>,
+              }
+            }
+          />
         </li>
       </FocusRing>
     </FocusRing>
@@ -1180,6 +1604,59 @@ exports[`<SpaceListItem /> snapshot should match snapshot with isError 1`] = `
               </div>
             </ListItemBaseSection>
           </SpaceRowContent>
+          <ContextMenu
+            triggerRef={
+              Object {
+                "current": <li
+                  class="md-space-list-item-wrapper md-list-item-base-wrapper"
+                  data-allow-text-select="false"
+                  data-disabled="false"
+                  data-interactive="true"
+                  data-padded="false"
+                  data-shape="isPilled"
+                  data-size="50"
+                  role="listitem"
+                  tabindex="-1"
+                >
+                  <div
+                    data-position="start"
+                  />
+                  <div
+                    class="md-space-row-content-text-wrapper text-column"
+                    data-position="middle"
+                  >
+                    <p
+                      class="md-text-wrapper"
+                      data-disabled="false"
+                      data-test="list-item-first-line"
+                      data-type="body-primary"
+                    />
+                  </div>
+                  <div
+                    data-position="end"
+                  >
+                    <div
+                      aria-hidden="true"
+                      class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class=""
+                        data-autoscale="false"
+                        data-scale="14"
+                        data-test="priority-circle"
+                        height="100%"
+                        style="fill: var(--mds-color-theme-text-error-normal); stroke: none;"
+                        viewBox="0, 0, 32, 32"
+                        width="100%"
+                      />
+                    </div>
+                  </div>
+                </li>,
+              }
+            }
+          />
         </li>
       </FocusRing>
     </FocusRing>
@@ -1303,6 +1780,59 @@ exports[`<SpaceListItem /> snapshot should match snapshot with isMention 1`] = `
               </div>
             </ListItemBaseSection>
           </SpaceRowContent>
+          <ContextMenu
+            triggerRef={
+              Object {
+                "current": <li
+                  class="md-space-list-item-wrapper md-list-item-base-wrapper"
+                  data-allow-text-select="false"
+                  data-disabled="false"
+                  data-interactive="true"
+                  data-padded="false"
+                  data-shape="isPilled"
+                  data-size="50"
+                  role="listitem"
+                  tabindex="-1"
+                >
+                  <div
+                    data-position="start"
+                  />
+                  <div
+                    class="md-space-row-content-text-wrapper text-column md-space-row-content-is-new-activity"
+                    data-position="middle"
+                  >
+                    <p
+                      class="md-text-wrapper"
+                      data-disabled="false"
+                      data-test="list-item-first-line"
+                      data-type="body-primary"
+                    />
+                  </div>
+                  <div
+                    data-position="end"
+                  >
+                    <div
+                      aria-hidden="true"
+                      class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class=""
+                        data-autoscale="false"
+                        data-scale="14"
+                        data-test="mention"
+                        height="100%"
+                        style="fill: var(--mds-color-theme-control-active-normal); stroke: none;"
+                        viewBox="0, 0, 32, 32"
+                        width="100%"
+                      />
+                    </div>
+                  </div>
+                </li>,
+              }
+            }
+          />
         </li>
       </FocusRing>
     </FocusRing>
@@ -1395,6 +1925,41 @@ exports[`<SpaceListItem /> snapshot should match snapshot with isNewActivity 1`]
               />
             </ListItemBaseSection>
           </SpaceRowContent>
+          <ContextMenu
+            triggerRef={
+              Object {
+                "current": <li
+                  class="md-space-list-item-wrapper md-list-item-base-wrapper"
+                  data-allow-text-select="false"
+                  data-disabled="false"
+                  data-interactive="true"
+                  data-padded="false"
+                  data-shape="isPilled"
+                  data-size="50"
+                  role="listitem"
+                  tabindex="-1"
+                >
+                  <div
+                    data-position="start"
+                  />
+                  <div
+                    class="md-space-row-content-text-wrapper text-column md-space-row-content-is-new-activity"
+                    data-position="middle"
+                  >
+                    <p
+                      class="md-text-wrapper"
+                      data-disabled="false"
+                      data-test="list-item-first-line"
+                      data-type="body-primary"
+                    />
+                  </div>
+                  <div
+                    data-position="end"
+                  />
+                </li>,
+              }
+            }
+          />
         </li>
       </FocusRing>
     </FocusRing>
@@ -1488,6 +2053,41 @@ exports[`<SpaceListItem /> snapshot should match snapshot with isSelected 1`] = 
               />
             </ListItemBaseSection>
           </SpaceRowContent>
+          <ContextMenu
+            triggerRef={
+              Object {
+                "current": <li
+                  class="md-space-list-item-wrapper md-list-item-base-wrapper active"
+                  data-allow-text-select="false"
+                  data-disabled="false"
+                  data-interactive="true"
+                  data-padded="false"
+                  data-shape="isPilled"
+                  data-size="50"
+                  role="listitem"
+                  tabindex="-1"
+                >
+                  <div
+                    data-position="start"
+                  />
+                  <div
+                    class="md-space-row-content-text-wrapper text-column"
+                    data-position="middle"
+                  >
+                    <p
+                      class="md-text-wrapper"
+                      data-disabled="false"
+                      data-test="list-item-first-line"
+                      data-type="body-primary"
+                    />
+                  </div>
+                  <div
+                    data-position="end"
+                  />
+                </li>,
+              }
+            }
+          />
         </li>
       </FocusRing>
     </FocusRing>
@@ -1614,6 +2214,59 @@ exports[`<SpaceListItem /> snapshot should match snapshot with isSelected and dr
               </div>
             </ListItemBaseSection>
           </SpaceRowContent>
+          <ContextMenu
+            triggerRef={
+              Object {
+                "current": <li
+                  class="md-space-list-item-wrapper md-list-item-base-wrapper"
+                  data-allow-text-select="false"
+                  data-disabled="false"
+                  data-interactive="true"
+                  data-padded="false"
+                  data-shape="isPilled"
+                  data-size="50"
+                  role="listitem"
+                  tabindex="-1"
+                >
+                  <div
+                    data-position="start"
+                  />
+                  <div
+                    class="md-space-row-content-text-wrapper text-column"
+                    data-position="middle"
+                  >
+                    <p
+                      class="md-text-wrapper"
+                      data-disabled="false"
+                      data-test="list-item-first-line"
+                      data-type="body-primary"
+                    />
+                  </div>
+                  <div
+                    data-position="end"
+                  >
+                    <div
+                      aria-hidden="true"
+                      class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class=""
+                        data-autoscale="false"
+                        data-scale="14"
+                        data-test="draft-indicator"
+                        height="100%"
+                        style="fill: var(--mds-color-theme-text-primary-normal); stroke: none;"
+                        viewBox="0, 0, 32, 32"
+                        width="100%"
+                      />
+                    </div>
+                  </div>
+                </li>,
+              }
+            }
+          />
         </li>
       </FocusRing>
     </FocusRing>
@@ -1737,6 +2390,59 @@ exports[`<SpaceListItem /> snapshot should match snapshot with isUnread 1`] = `
               </div>
             </ListItemBaseSection>
           </SpaceRowContent>
+          <ContextMenu
+            triggerRef={
+              Object {
+                "current": <li
+                  class="md-space-list-item-wrapper md-list-item-base-wrapper"
+                  data-allow-text-select="false"
+                  data-disabled="false"
+                  data-interactive="true"
+                  data-padded="false"
+                  data-shape="isPilled"
+                  data-size="50"
+                  role="listitem"
+                  tabindex="-1"
+                >
+                  <div
+                    data-position="start"
+                  />
+                  <div
+                    class="md-space-row-content-text-wrapper text-column md-space-row-content-is-new-activity"
+                    data-position="middle"
+                  >
+                    <p
+                      class="md-text-wrapper"
+                      data-disabled="false"
+                      data-test="list-item-first-line"
+                      data-type="body-primary"
+                    />
+                  </div>
+                  <div
+                    data-position="end"
+                  >
+                    <div
+                      aria-hidden="true"
+                      class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class=""
+                        data-autoscale="false"
+                        data-scale="14"
+                        data-test="unread"
+                        height="100%"
+                        style="fill: var(--mds-color-theme-control-active-normal); stroke: none;"
+                        viewBox="0, 0, 32, 32"
+                        width="100%"
+                      />
+                    </div>
+                  </div>
+                </li>,
+              }
+            }
+          />
         </li>
       </FocusRing>
     </FocusRing>
@@ -1896,6 +2602,57 @@ exports[`<SpaceListItem /> snapshot should match snapshot with multiple string s
               />
             </ListItemBaseSection>
           </SpaceRowContent>
+          <ContextMenu
+            triggerRef={
+              Object {
+                "current": <li
+                  class="md-space-list-item-wrapper md-list-item-base-wrapper"
+                  data-allow-text-select="false"
+                  data-disabled="false"
+                  data-interactive="true"
+                  data-padded="false"
+                  data-shape="isPilled"
+                  data-size="50"
+                  role="listitem"
+                  tabindex="-1"
+                >
+                  <div
+                    data-position="start"
+                  />
+                  <div
+                    class="md-space-row-content-text-wrapper text-column"
+                    data-position="middle"
+                  >
+                    <p
+                      class="md-text-wrapper"
+                      data-disabled="false"
+                      data-test="list-item-first-line"
+                      data-type="body-primary"
+                    />
+                    <small
+                      aria-label="one, two, three"
+                      class="md-text-wrapper"
+                      data-test="list-item-second-line"
+                      data-type="body-secondary"
+                    >
+                      one
+                      <div
+                        class="md-divider-dot-wrapper"
+                      />
+                      two
+                      <div
+                        class="md-divider-dot-wrapper"
+                      />
+                      three
+                    </small>
+                  </div>
+                  <div
+                    data-position="end"
+                  />
+                </li>,
+              }
+            }
+          />
         </li>
       </FocusRing>
     </FocusRing>
@@ -2017,6 +2774,49 @@ exports[`<SpaceListItem /> snapshot should match snapshot with secondLine 1`] = 
               />
             </ListItemBaseSection>
           </SpaceRowContent>
+          <ContextMenu
+            triggerRef={
+              Object {
+                "current": <li
+                  class="md-space-list-item-wrapper md-list-item-base-wrapper"
+                  data-allow-text-select="false"
+                  data-disabled="false"
+                  data-interactive="true"
+                  data-padded="false"
+                  data-shape="isPilled"
+                  data-size="50"
+                  role="listitem"
+                  tabindex="-1"
+                >
+                  <div
+                    data-position="start"
+                  />
+                  <div
+                    class="md-space-row-content-text-wrapper text-column"
+                    data-position="middle"
+                  >
+                    <p
+                      class="md-text-wrapper"
+                      data-disabled="false"
+                      data-test="list-item-first-line"
+                      data-type="body-primary"
+                    />
+                    <small
+                      aria-label="secondLine"
+                      class="md-text-wrapper"
+                      data-test="list-item-second-line"
+                      data-type="body-secondary"
+                    >
+                      secondLine
+                    </small>
+                  </div>
+                  <div
+                    data-position="end"
+                  />
+                </li>,
+              }
+            }
+          />
         </li>
       </FocusRing>
     </FocusRing>
@@ -2122,6 +2922,42 @@ exports[`<SpaceListItem /> snapshot should match snapshot with style 1`] = `
               />
             </ListItemBaseSection>
           </SpaceRowContent>
+          <ContextMenu
+            triggerRef={
+              Object {
+                "current": <li
+                  class="md-space-list-item-wrapper md-list-item-base-wrapper"
+                  data-allow-text-select="false"
+                  data-disabled="false"
+                  data-interactive="true"
+                  data-padded="false"
+                  data-shape="isPilled"
+                  data-size="50"
+                  role="listitem"
+                  style="color: pink;"
+                  tabindex="-1"
+                >
+                  <div
+                    data-position="start"
+                  />
+                  <div
+                    class="md-space-row-content-text-wrapper text-column"
+                    data-position="middle"
+                  >
+                    <p
+                      class="md-text-wrapper"
+                      data-disabled="false"
+                      data-test="list-item-first-line"
+                      data-type="body-primary"
+                    />
+                  </div>
+                  <div
+                    data-position="end"
+                  />
+                </li>,
+              }
+            }
+          />
         </li>
       </FocusRing>
     </FocusRing>
@@ -2214,6 +3050,41 @@ exports[`<SpaceListItem /> snapshot should match snapshot with teamColor 1`] = `
               />
             </ListItemBaseSection>
           </SpaceRowContent>
+          <ContextMenu
+            triggerRef={
+              Object {
+                "current": <li
+                  class="md-space-list-item-wrapper md-list-item-base-wrapper"
+                  data-allow-text-select="false"
+                  data-disabled="false"
+                  data-interactive="true"
+                  data-padded="false"
+                  data-shape="isPilled"
+                  data-size="50"
+                  role="listitem"
+                  tabindex="-1"
+                >
+                  <div
+                    data-position="start"
+                  />
+                  <div
+                    class="md-space-row-content-text-wrapper text-column"
+                    data-position="middle"
+                  >
+                    <p
+                      class="md-text-wrapper"
+                      data-disabled="false"
+                      data-test="list-item-first-line"
+                      data-type="body-primary"
+                    />
+                  </div>
+                  <div
+                    data-position="end"
+                  />
+                </li>,
+              }
+            }
+          />
         </li>
       </FocusRing>
     </FocusRing>

--- a/src/components/SpaceTreeNode/SpaceTreeNode.types.ts
+++ b/src/components/SpaceTreeNode/SpaceTreeNode.types.ts
@@ -1,7 +1,11 @@
+import { ContextMenuActionsProp } from '../ContextMenu/ContextMenu.types';
 import { SpaceRowContentProps } from '../SpaceRowContent';
 import { TreeNodeBaseProps } from '../TreeNodeBase';
 
-export interface Props extends Omit<TreeNodeBaseProps, 'children'>, SpaceRowContentProps {
+export interface Props
+  extends Omit<TreeNodeBaseProps, 'children'>,
+    SpaceRowContentProps,
+    ContextMenuActionsProp {
   /**
    * Custom class for overriding this component's CSS.
    */

--- a/src/components/SpaceTreeNode/SpaceTreeNode.unit.test.tsx.snap
+++ b/src/components/SpaceTreeNode/SpaceTreeNode.unit.test.tsx.snap
@@ -143,6 +143,56 @@ exports[`<SpaceTreeNode /> snapshot checks divider dot position in compact mode 
                   />
                 </ListItemBaseSection>
               </SpaceRowContent>
+              <ContextMenu
+                triggerRef={
+                  Object {
+                    "current": <div
+                      aria-level="1"
+                      aria-posinset="1"
+                      aria-setsize="1"
+                      class="md-space-tree-node-wrapper md-tree-node-base-wrapper active-node"
+                      data-nodeid="root"
+                      data-padded="false"
+                      data-shape="isPilled"
+                      data-size="32"
+                      id="md-tree-node-root"
+                      role="treeitem"
+                      tabindex="0"
+                    >
+                      <div
+                        data-position="start"
+                      />
+                      <div
+                        class="md-space-row-content-text-wrapper text-row"
+                        data-position="middle"
+                      >
+                        <p
+                          class="md-text-wrapper"
+                          data-disabled="false"
+                          data-test="list-item-first-line"
+                          data-type="body-primary"
+                        >
+                          firstLine
+                        </p>
+                        <div
+                          class="md-divider-dot-wrapper"
+                        />
+                        <small
+                          aria-label="testteam"
+                          class="md-text-wrapper"
+                          data-test="list-item-second-line"
+                          data-type="body-secondary"
+                        >
+                          testteam
+                        </small>
+                      </div>
+                      <div
+                        data-position="end"
+                      />
+                    </div>,
+                  }
+                }
+              />
             </div>
           </FocusRing>
         </FocusRing>
@@ -252,6 +302,43 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot 1`] = `
                   />
                 </ListItemBaseSection>
               </SpaceRowContent>
+              <ContextMenu
+                triggerRef={
+                  Object {
+                    "current": <div
+                      aria-level="1"
+                      aria-posinset="1"
+                      aria-setsize="1"
+                      class="md-space-tree-node-wrapper md-tree-node-base-wrapper active-node"
+                      data-nodeid="root"
+                      data-padded="false"
+                      data-shape="isPilled"
+                      data-size="50"
+                      id="md-tree-node-root"
+                      role="treeitem"
+                      tabindex="0"
+                    >
+                      <div
+                        data-position="start"
+                      />
+                      <div
+                        class="md-space-row-content-text-wrapper text-column"
+                        data-position="middle"
+                      >
+                        <p
+                          class="md-text-wrapper"
+                          data-disabled="false"
+                          data-test="list-item-first-line"
+                          data-type="body-primary"
+                        />
+                      </div>
+                      <div
+                        data-position="end"
+                      />
+                    </div>,
+                  }
+                }
+              />
             </div>
           </FocusRing>
         </FocusRing>
@@ -375,6 +462,47 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with action 1`] = `
                   </div>
                 </ListItemBaseSection>
               </SpaceRowContent>
+              <ContextMenu
+                triggerRef={
+                  Object {
+                    "current": <div
+                      aria-level="1"
+                      aria-posinset="1"
+                      aria-setsize="1"
+                      class="md-space-tree-node-wrapper md-tree-node-base-wrapper active-node"
+                      data-nodeid="root"
+                      data-padded="false"
+                      data-shape="isPilled"
+                      data-size="50"
+                      id="md-tree-node-root"
+                      role="treeitem"
+                      tabindex="0"
+                    >
+                      <div
+                        data-position="start"
+                      />
+                      <div
+                        class="md-space-row-content-text-wrapper text-column"
+                        data-position="middle"
+                      >
+                        <p
+                          class="md-text-wrapper"
+                          data-disabled="false"
+                          data-test="list-item-first-line"
+                          data-type="body-primary"
+                        />
+                      </div>
+                      <div
+                        data-position="end"
+                      >
+                        <p>
+                          action
+                        </p>
+                      </div>
+                    </div>,
+                  }
+                }
+              />
             </div>
           </FocusRing>
         </FocusRing>
@@ -485,6 +613,43 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with className 1`] = `
                   />
                 </ListItemBaseSection>
               </SpaceRowContent>
+              <ContextMenu
+                triggerRef={
+                  Object {
+                    "current": <div
+                      aria-level="1"
+                      aria-posinset="1"
+                      aria-setsize="1"
+                      class="example-class md-space-tree-node-wrapper md-tree-node-base-wrapper active-node"
+                      data-nodeid="root"
+                      data-padded="false"
+                      data-shape="isPilled"
+                      data-size="50"
+                      id="md-tree-node-root"
+                      role="treeitem"
+                      tabindex="0"
+                    >
+                      <div
+                        data-position="start"
+                      />
+                      <div
+                        class="md-space-row-content-text-wrapper text-column"
+                        data-position="middle"
+                      >
+                        <p
+                          class="md-text-wrapper"
+                          data-disabled="false"
+                          data-test="list-item-first-line"
+                          data-type="body-primary"
+                        />
+                      </div>
+                      <div
+                        data-position="end"
+                      />
+                    </div>,
+                  }
+                }
+              />
             </div>
           </FocusRing>
         </FocusRing>
@@ -598,6 +763,45 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with firstLine 1`] = `
                   />
                 </ListItemBaseSection>
               </SpaceRowContent>
+              <ContextMenu
+                triggerRef={
+                  Object {
+                    "current": <div
+                      aria-level="1"
+                      aria-posinset="1"
+                      aria-setsize="1"
+                      class="md-space-tree-node-wrapper md-tree-node-base-wrapper active-node"
+                      data-nodeid="root"
+                      data-padded="false"
+                      data-shape="isPilled"
+                      data-size="50"
+                      id="md-tree-node-root"
+                      role="treeitem"
+                      tabindex="0"
+                    >
+                      <div
+                        data-position="start"
+                      />
+                      <div
+                        class="md-space-row-content-text-wrapper text-column"
+                        data-position="middle"
+                      >
+                        <p
+                          class="md-text-wrapper"
+                          data-disabled="false"
+                          data-test="list-item-first-line"
+                          data-type="body-primary"
+                        >
+                          firstLine
+                        </p>
+                      </div>
+                      <div
+                        data-position="end"
+                      />
+                    </div>,
+                  }
+                }
+              />
             </div>
           </FocusRing>
         </FocusRing>
@@ -709,6 +913,43 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with id 1`] = `
                   />
                 </ListItemBaseSection>
               </SpaceRowContent>
+              <ContextMenu
+                triggerRef={
+                  Object {
+                    "current": <div
+                      aria-level="1"
+                      aria-posinset="1"
+                      aria-setsize="1"
+                      class="md-space-tree-node-wrapper md-tree-node-base-wrapper active-node"
+                      data-nodeid="root"
+                      data-padded="false"
+                      data-shape="isPilled"
+                      data-size="50"
+                      id="md-tree-node-root"
+                      role="treeitem"
+                      tabindex="0"
+                    >
+                      <div
+                        data-position="start"
+                      />
+                      <div
+                        class="md-space-row-content-text-wrapper text-column"
+                        data-position="middle"
+                      >
+                        <p
+                          class="md-text-wrapper"
+                          data-disabled="false"
+                          data-test="list-item-first-line"
+                          data-type="body-primary"
+                        />
+                      </div>
+                      <div
+                        data-position="end"
+                      />
+                    </div>,
+                  }
+                }
+              />
             </div>
           </FocusRing>
         </FocusRing>
@@ -851,6 +1092,61 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isAlert 1`] = `
                   </div>
                 </ListItemBaseSection>
               </SpaceRowContent>
+              <ContextMenu
+                triggerRef={
+                  Object {
+                    "current": <div
+                      aria-level="1"
+                      aria-posinset="1"
+                      aria-setsize="1"
+                      class="md-space-tree-node-wrapper md-tree-node-base-wrapper active-node"
+                      data-nodeid="root"
+                      data-padded="false"
+                      data-shape="isPilled"
+                      data-size="50"
+                      id="md-tree-node-root"
+                      role="treeitem"
+                      tabindex="0"
+                    >
+                      <div
+                        data-position="start"
+                      />
+                      <div
+                        class="md-space-row-content-text-wrapper text-column"
+                        data-position="middle"
+                      >
+                        <p
+                          class="md-text-wrapper"
+                          data-disabled="false"
+                          data-test="list-item-first-line"
+                          data-type="body-primary"
+                        />
+                      </div>
+                      <div
+                        data-position="end"
+                      >
+                        <div
+                          aria-hidden="true"
+                          class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                          role="img"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class=""
+                            data-autoscale="false"
+                            data-scale="14"
+                            data-test="alert"
+                            height="100%"
+                            style="fill: var(--mds-color-theme-text-primary-normal); stroke: none;"
+                            viewBox="0, 0, 32, 32"
+                            width="100%"
+                          />
+                        </div>
+                      </div>
+                    </div>,
+                  }
+                }
+              />
             </div>
           </FocusRing>
         </FocusRing>
@@ -993,6 +1289,61 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isAlertMuted 1`] 
                   </div>
                 </ListItemBaseSection>
               </SpaceRowContent>
+              <ContextMenu
+                triggerRef={
+                  Object {
+                    "current": <div
+                      aria-level="1"
+                      aria-posinset="1"
+                      aria-setsize="1"
+                      class="md-space-tree-node-wrapper md-tree-node-base-wrapper active-node"
+                      data-nodeid="root"
+                      data-padded="false"
+                      data-shape="isPilled"
+                      data-size="50"
+                      id="md-tree-node-root"
+                      role="treeitem"
+                      tabindex="0"
+                    >
+                      <div
+                        data-position="start"
+                      />
+                      <div
+                        class="md-space-row-content-text-wrapper text-column"
+                        data-position="middle"
+                      >
+                        <p
+                          class="md-text-wrapper"
+                          data-disabled="false"
+                          data-test="list-item-first-line"
+                          data-type="body-primary"
+                        />
+                      </div>
+                      <div
+                        data-position="end"
+                      >
+                        <div
+                          aria-hidden="true"
+                          class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                          role="img"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class=""
+                            data-autoscale="false"
+                            data-scale="14"
+                            data-test="alert-muted"
+                            height="100%"
+                            style="fill: var(--mds-color-theme-text-primary-normal); stroke: none;"
+                            viewBox="0, 0, 32, 32"
+                            width="100%"
+                          />
+                        </div>
+                      </div>
+                    </div>,
+                  }
+                }
+              />
             </div>
           </FocusRing>
         </FocusRing>
@@ -1103,6 +1454,43 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isDisabled 1`] = 
                   />
                 </ListItemBaseSection>
               </SpaceRowContent>
+              <ContextMenu
+                triggerRef={
+                  Object {
+                    "current": <div
+                      aria-level="1"
+                      aria-posinset="1"
+                      aria-setsize="1"
+                      class="md-space-tree-node-wrapper md-tree-node-base-wrapper active-node"
+                      data-nodeid="root"
+                      data-padded="false"
+                      data-shape="isPilled"
+                      data-size="50"
+                      id="md-tree-node-root"
+                      role="treeitem"
+                      tabindex="0"
+                    >
+                      <div
+                        data-position="start"
+                      />
+                      <div
+                        class="md-space-row-content-text-wrapper text-column"
+                        data-position="middle"
+                      >
+                        <p
+                          class="md-text-wrapper"
+                          data-disabled="true"
+                          data-test="list-item-first-line"
+                          data-type="body-primary"
+                        />
+                      </div>
+                      <div
+                        data-position="end"
+                      />
+                    </div>,
+                  }
+                }
+              />
             </div>
           </FocusRing>
         </FocusRing>
@@ -1245,6 +1633,61 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isEnterRoom 1`] =
                   </div>
                 </ListItemBaseSection>
               </SpaceRowContent>
+              <ContextMenu
+                triggerRef={
+                  Object {
+                    "current": <div
+                      aria-level="1"
+                      aria-posinset="1"
+                      aria-setsize="1"
+                      class="md-space-tree-node-wrapper md-tree-node-base-wrapper active-node"
+                      data-nodeid="root"
+                      data-padded="false"
+                      data-shape="isPilled"
+                      data-size="50"
+                      id="md-tree-node-root"
+                      role="treeitem"
+                      tabindex="0"
+                    >
+                      <div
+                        data-position="start"
+                      />
+                      <div
+                        class="md-space-row-content-text-wrapper text-column md-space-row-content-is-new-activity"
+                        data-position="middle"
+                      >
+                        <p
+                          class="md-text-wrapper"
+                          data-disabled="false"
+                          data-test="list-item-first-line"
+                          data-type="body-primary"
+                        />
+                      </div>
+                      <div
+                        data-position="end"
+                      >
+                        <div
+                          aria-hidden="true"
+                          class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                          role="img"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class=""
+                            data-autoscale="false"
+                            data-scale="14"
+                            data-test="enter-room"
+                            height="100%"
+                            style="fill: var(--mds-color-theme-control-active-normal); stroke: none;"
+                            viewBox="0, 0, 32, 32"
+                            width="100%"
+                          />
+                        </div>
+                      </div>
+                    </div>,
+                  }
+                }
+              />
             </div>
           </FocusRing>
         </FocusRing>
@@ -1387,6 +1830,61 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isError 1`] = `
                   </div>
                 </ListItemBaseSection>
               </SpaceRowContent>
+              <ContextMenu
+                triggerRef={
+                  Object {
+                    "current": <div
+                      aria-level="1"
+                      aria-posinset="1"
+                      aria-setsize="1"
+                      class="md-space-tree-node-wrapper md-tree-node-base-wrapper active-node"
+                      data-nodeid="root"
+                      data-padded="false"
+                      data-shape="isPilled"
+                      data-size="50"
+                      id="md-tree-node-root"
+                      role="treeitem"
+                      tabindex="0"
+                    >
+                      <div
+                        data-position="start"
+                      />
+                      <div
+                        class="md-space-row-content-text-wrapper text-column"
+                        data-position="middle"
+                      >
+                        <p
+                          class="md-text-wrapper"
+                          data-disabled="false"
+                          data-test="list-item-first-line"
+                          data-type="body-primary"
+                        />
+                      </div>
+                      <div
+                        data-position="end"
+                      >
+                        <div
+                          aria-hidden="true"
+                          class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                          role="img"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class=""
+                            data-autoscale="false"
+                            data-scale="14"
+                            data-test="priority-circle"
+                            height="100%"
+                            style="fill: var(--mds-color-theme-text-error-normal); stroke: none;"
+                            viewBox="0, 0, 32, 32"
+                            width="100%"
+                          />
+                        </div>
+                      </div>
+                    </div>,
+                  }
+                }
+              />
             </div>
           </FocusRing>
         </FocusRing>
@@ -1529,6 +2027,61 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isMention 1`] = `
                   </div>
                 </ListItemBaseSection>
               </SpaceRowContent>
+              <ContextMenu
+                triggerRef={
+                  Object {
+                    "current": <div
+                      aria-level="1"
+                      aria-posinset="1"
+                      aria-setsize="1"
+                      class="md-space-tree-node-wrapper md-tree-node-base-wrapper active-node"
+                      data-nodeid="root"
+                      data-padded="false"
+                      data-shape="isPilled"
+                      data-size="50"
+                      id="md-tree-node-root"
+                      role="treeitem"
+                      tabindex="0"
+                    >
+                      <div
+                        data-position="start"
+                      />
+                      <div
+                        class="md-space-row-content-text-wrapper text-column md-space-row-content-is-new-activity"
+                        data-position="middle"
+                      >
+                        <p
+                          class="md-text-wrapper"
+                          data-disabled="false"
+                          data-test="list-item-first-line"
+                          data-type="body-primary"
+                        />
+                      </div>
+                      <div
+                        data-position="end"
+                      >
+                        <div
+                          aria-hidden="true"
+                          class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                          role="img"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class=""
+                            data-autoscale="false"
+                            data-scale="14"
+                            data-test="mention"
+                            height="100%"
+                            style="fill: var(--mds-color-theme-control-active-normal); stroke: none;"
+                            viewBox="0, 0, 32, 32"
+                            width="100%"
+                          />
+                        </div>
+                      </div>
+                    </div>,
+                  }
+                }
+              />
             </div>
           </FocusRing>
         </FocusRing>
@@ -1640,6 +2193,43 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isNewActivity 1`]
                   />
                 </ListItemBaseSection>
               </SpaceRowContent>
+              <ContextMenu
+                triggerRef={
+                  Object {
+                    "current": <div
+                      aria-level="1"
+                      aria-posinset="1"
+                      aria-setsize="1"
+                      class="md-space-tree-node-wrapper md-tree-node-base-wrapper active-node"
+                      data-nodeid="root"
+                      data-padded="false"
+                      data-shape="isPilled"
+                      data-size="50"
+                      id="md-tree-node-root"
+                      role="treeitem"
+                      tabindex="0"
+                    >
+                      <div
+                        data-position="start"
+                      />
+                      <div
+                        class="md-space-row-content-text-wrapper text-column md-space-row-content-is-new-activity"
+                        data-position="middle"
+                      >
+                        <p
+                          class="md-text-wrapper"
+                          data-disabled="false"
+                          data-test="list-item-first-line"
+                          data-type="body-primary"
+                        />
+                      </div>
+                      <div
+                        data-position="end"
+                      />
+                    </div>,
+                  }
+                }
+              />
             </div>
           </FocusRing>
         </FocusRing>
@@ -1751,6 +2341,43 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isSelected 1`] = 
                   />
                 </ListItemBaseSection>
               </SpaceRowContent>
+              <ContextMenu
+                triggerRef={
+                  Object {
+                    "current": <div
+                      aria-level="1"
+                      aria-posinset="1"
+                      aria-setsize="1"
+                      class="md-space-tree-node-wrapper md-tree-node-base-wrapper active-node"
+                      data-nodeid="root"
+                      data-padded="false"
+                      data-shape="isPilled"
+                      data-size="50"
+                      id="md-tree-node-root"
+                      role="treeitem"
+                      tabindex="0"
+                    >
+                      <div
+                        data-position="start"
+                      />
+                      <div
+                        class="md-space-row-content-text-wrapper text-column"
+                        data-position="middle"
+                      >
+                        <p
+                          class="md-text-wrapper"
+                          data-disabled="false"
+                          data-test="list-item-first-line"
+                          data-type="body-primary"
+                        />
+                      </div>
+                      <div
+                        data-position="end"
+                      />
+                    </div>,
+                  }
+                }
+              />
             </div>
           </FocusRing>
         </FocusRing>
@@ -1895,6 +2522,61 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isSelected and dr
                   </div>
                 </ListItemBaseSection>
               </SpaceRowContent>
+              <ContextMenu
+                triggerRef={
+                  Object {
+                    "current": <div
+                      aria-level="1"
+                      aria-posinset="1"
+                      aria-setsize="1"
+                      class="md-space-tree-node-wrapper md-tree-node-base-wrapper active-node"
+                      data-nodeid="root"
+                      data-padded="false"
+                      data-shape="isPilled"
+                      data-size="50"
+                      id="md-tree-node-root"
+                      role="treeitem"
+                      tabindex="0"
+                    >
+                      <div
+                        data-position="start"
+                      />
+                      <div
+                        class="md-space-row-content-text-wrapper text-column"
+                        data-position="middle"
+                      >
+                        <p
+                          class="md-text-wrapper"
+                          data-disabled="false"
+                          data-test="list-item-first-line"
+                          data-type="body-primary"
+                        />
+                      </div>
+                      <div
+                        data-position="end"
+                      >
+                        <div
+                          aria-hidden="true"
+                          class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                          role="img"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class=""
+                            data-autoscale="false"
+                            data-scale="14"
+                            data-test="draft-indicator"
+                            height="100%"
+                            style="fill: var(--mds-color-theme-text-primary-normal); stroke: none;"
+                            viewBox="0, 0, 32, 32"
+                            width="100%"
+                          />
+                        </div>
+                      </div>
+                    </div>,
+                  }
+                }
+              />
             </div>
           </FocusRing>
         </FocusRing>
@@ -2037,6 +2719,61 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isUnread 1`] = `
                   </div>
                 </ListItemBaseSection>
               </SpaceRowContent>
+              <ContextMenu
+                triggerRef={
+                  Object {
+                    "current": <div
+                      aria-level="1"
+                      aria-posinset="1"
+                      aria-setsize="1"
+                      class="md-space-tree-node-wrapper md-tree-node-base-wrapper active-node"
+                      data-nodeid="root"
+                      data-padded="false"
+                      data-shape="isPilled"
+                      data-size="50"
+                      id="md-tree-node-root"
+                      role="treeitem"
+                      tabindex="0"
+                    >
+                      <div
+                        data-position="start"
+                      />
+                      <div
+                        class="md-space-row-content-text-wrapper text-column md-space-row-content-is-new-activity"
+                        data-position="middle"
+                      >
+                        <p
+                          class="md-text-wrapper"
+                          data-disabled="false"
+                          data-test="list-item-first-line"
+                          data-type="body-primary"
+                        />
+                      </div>
+                      <div
+                        data-position="end"
+                      >
+                        <div
+                          aria-hidden="true"
+                          class="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+                          role="img"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class=""
+                            data-autoscale="false"
+                            data-scale="14"
+                            data-test="unread"
+                            height="100%"
+                            style="fill: var(--mds-color-theme-control-active-normal); stroke: none;"
+                            viewBox="0, 0, 32, 32"
+                            width="100%"
+                          />
+                        </div>
+                      </div>
+                    </div>,
+                  }
+                }
+              />
             </div>
           </FocusRing>
         </FocusRing>
@@ -2215,6 +2952,59 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with multiple string s
                   />
                 </ListItemBaseSection>
               </SpaceRowContent>
+              <ContextMenu
+                triggerRef={
+                  Object {
+                    "current": <div
+                      aria-level="1"
+                      aria-posinset="1"
+                      aria-setsize="1"
+                      class="md-space-tree-node-wrapper md-tree-node-base-wrapper active-node"
+                      data-nodeid="root"
+                      data-padded="false"
+                      data-shape="isPilled"
+                      data-size="50"
+                      id="md-tree-node-root"
+                      role="treeitem"
+                      tabindex="0"
+                    >
+                      <div
+                        data-position="start"
+                      />
+                      <div
+                        class="md-space-row-content-text-wrapper text-column"
+                        data-position="middle"
+                      >
+                        <p
+                          class="md-text-wrapper"
+                          data-disabled="false"
+                          data-test="list-item-first-line"
+                          data-type="body-primary"
+                        />
+                        <small
+                          aria-label="one, two, three"
+                          class="md-text-wrapper"
+                          data-test="list-item-second-line"
+                          data-type="body-secondary"
+                        >
+                          one
+                          <div
+                            class="md-divider-dot-wrapper"
+                          />
+                          two
+                          <div
+                            class="md-divider-dot-wrapper"
+                          />
+                          three
+                        </small>
+                      </div>
+                      <div
+                        data-position="end"
+                      />
+                    </div>,
+                  }
+                }
+              />
             </div>
           </FocusRing>
         </FocusRing>
@@ -2355,6 +3145,51 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with secondLine 1`] = 
                   />
                 </ListItemBaseSection>
               </SpaceRowContent>
+              <ContextMenu
+                triggerRef={
+                  Object {
+                    "current": <div
+                      aria-level="1"
+                      aria-posinset="1"
+                      aria-setsize="1"
+                      class="md-space-tree-node-wrapper md-tree-node-base-wrapper active-node"
+                      data-nodeid="root"
+                      data-padded="false"
+                      data-shape="isPilled"
+                      data-size="50"
+                      id="md-tree-node-root"
+                      role="treeitem"
+                      tabindex="0"
+                    >
+                      <div
+                        data-position="start"
+                      />
+                      <div
+                        class="md-space-row-content-text-wrapper text-column"
+                        data-position="middle"
+                      >
+                        <p
+                          class="md-text-wrapper"
+                          data-disabled="false"
+                          data-test="list-item-first-line"
+                          data-type="body-primary"
+                        />
+                        <small
+                          aria-label="secondLine"
+                          class="md-text-wrapper"
+                          data-test="list-item-second-line"
+                          data-type="body-secondary"
+                        >
+                          secondLine
+                        </small>
+                      </div>
+                      <div
+                        data-position="end"
+                      />
+                    </div>,
+                  }
+                }
+              />
             </div>
           </FocusRing>
         </FocusRing>
@@ -2479,6 +3314,44 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with style 1`] = `
                   />
                 </ListItemBaseSection>
               </SpaceRowContent>
+              <ContextMenu
+                triggerRef={
+                  Object {
+                    "current": <div
+                      aria-level="1"
+                      aria-posinset="1"
+                      aria-setsize="1"
+                      class="md-space-tree-node-wrapper md-tree-node-base-wrapper active-node"
+                      data-nodeid="root"
+                      data-padded="false"
+                      data-shape="isPilled"
+                      data-size="50"
+                      id="md-tree-node-root"
+                      role="treeitem"
+                      style="color: pink;"
+                      tabindex="0"
+                    >
+                      <div
+                        data-position="start"
+                      />
+                      <div
+                        class="md-space-row-content-text-wrapper text-column"
+                        data-position="middle"
+                      >
+                        <p
+                          class="md-text-wrapper"
+                          data-disabled="false"
+                          data-test="list-item-first-line"
+                          data-type="body-primary"
+                        />
+                      </div>
+                      <div
+                        data-position="end"
+                      />
+                    </div>,
+                  }
+                }
+              />
             </div>
           </FocusRing>
         </FocusRing>
@@ -2590,6 +3463,43 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with teamColor 1`] = `
                   />
                 </ListItemBaseSection>
               </SpaceRowContent>
+              <ContextMenu
+                triggerRef={
+                  Object {
+                    "current": <div
+                      aria-level="1"
+                      aria-posinset="1"
+                      aria-setsize="1"
+                      class="md-space-tree-node-wrapper md-tree-node-base-wrapper active-node"
+                      data-nodeid="root"
+                      data-padded="false"
+                      data-shape="isPilled"
+                      data-size="50"
+                      id="md-tree-node-root"
+                      role="treeitem"
+                      tabindex="0"
+                    >
+                      <div
+                        data-position="start"
+                      />
+                      <div
+                        class="md-space-row-content-text-wrapper text-column"
+                        data-position="middle"
+                      >
+                        <p
+                          class="md-text-wrapper"
+                          data-disabled="false"
+                          data-test="list-item-first-line"
+                          data-type="body-primary"
+                        />
+                      </div>
+                      <div
+                        data-position="end"
+                      />
+                    </div>,
+                  }
+                }
+              />
             </div>
           </FocusRing>
         </FocusRing>

--- a/src/components/Tree/Tree.stories.docs.mdx
+++ b/src/components/Tree/Tree.stories.docs.mdx
@@ -1,12 +1,13 @@
 The `<Tree />` component implements the basic tree navigation based on the WAI-ARIA specification,
 see [WCAG Tree Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/treeview/) for more details.
 
-`<Tree />` does not render the tree nodes automatically. It makes it more flexible to customize the tree nodes and
-make it possible to use it with Virtualized trees.
+`<Tree />` does not render the tree nodes automatically. It makes it more flexible to customize the
+tree nodes and make it possible to use it with Virtualized trees.
 
-Tree nodes must be wrapped in a `<TreeNodeBase />` component to ensure proper keyboard navigation and focus management.
+Tree nodes must be wrapped in a `<TreeNodeBase />` component to ensure proper keyboard navigation
+and focus management.
 
-Any node inside the `<Tree />` can access to the tree context using the `useTreeContext` hook.#
+Any node inside the `<Tree />` can access the tree context using the `useTreeContext` hook.
 
 ## Nested VS Flat tree
 
@@ -14,128 +15,122 @@ There is 2 ways to represent the tree structure in the DOM:
 
 ### 1) Nested elements
 
-Simple static trees usually represented as nested elements. It's easy to understand and implement and
-most of the semantics are implicitly set. But hard to render it automatically especially in virtualized trees.
+Simple static trees usually represented as nested elements. It's easy to understand and implement
+and most of the semantics are implicitly set. But hard to render it automatically especially in
+virtualized trees.
 
 ```html
 <ul role="tree" aria-labelledby="tree_label">
-    <li role="treeitem" aria-expanded="false" aria-selected="false">
-        <span> Level 1 </span>
+  <li role="treeitem" aria-expanded="false" aria-selected="false">
+    <span> Level 1 </span>
+    <ul role="group">
+      <li role="treeitem" aria-selected="false">Level 2.1</li>
+      <li role="treeitem" aria-selected="false">Level 2.2</li>
+      <li role="treeitem" aria-selected="false">Level 2.3</li>
+      <li role="treeitem" aria-expanded="false" aria-selected="false">
+        <span> Level 2.4 </span>
         <ul role="group">
-            <li role="treeitem" aria-selected="false">Level 2.1</li>
-            <li role="treeitem" aria-selected="false">Level 2.2</li>
-            <li role="treeitem" aria-selected="false">Level 2.3</li>
-            <li role="treeitem" aria-expanded="false" aria-selected="false">
-                <span> Level 2.4 </span>
-                <ul role="group">
-                    <li role="treeitem" aria-selected="false">Level 3.1</li>
-                    <li role="treeitem" aria-selected="false">Level 3.2</li>
-                </ul>
-            </li>
-            <li role="treeitem" aria-selected="false">Level 2.5</li>
+          <li role="treeitem" aria-selected="false">Level 3.1</li>
+          <li role="treeitem" aria-selected="false">Level 3.2</li>
         </ul>
-    </li>
+      </li>
+      <li role="treeitem" aria-selected="false">Level 2.5</li>
+    </ul>
+  </li>
 </ul>
-
 ```
 
 ### 2) Flat elements
 
-Flat tree structure is more flexible and can be used with virtualized trees. It requires more explicit semantics.
+Flat tree structure is more flexible and can be used with virtualized trees. It requires more
+explicit semantics.
 
 ```html
 <h3 id="tree_label_2">Tree with flat DOM</h3>
 <ul role="tree" aria-labelledby="tree_label_2">
-    <li
-            role="treeitem"
-            aria-level="1"
-            aria-expanded="true"
-            aria-selected="false"
-            class="level-1"
-    >
-        <span> Level 1 </span>
-        <div role="group" aria-owns="level-2.1 level-2.2 level-2.3 level-2.4 level-2.5"></div>
-    </li>
-    <li
-            id="level-2.1"
-            aria-setsize="5"
-            aria-posinset="1"
-            role="treeitem"
-            aria-level="2"
-            class="level-2"
-    >
-        <span>  Level 2.1</span>
-    </li>
-    <li
-            id="level-2.2"
-            aria-setsize="5"
-            aria-posinset="2"
-            role="treeitem"
-            aria-level="2"
-            class="level-2"
-    >
-        <span>  Level 2.2</span>
-    </li>
-    <li
-            id="level-2.3"
-            aria-setsize="5"
-            aria-posinset="3"
-            role="treeitem"
-            aria-level="2"
-            class="level-2"
-    >
-        <span>  Level 2.3</span>
-    </li>
-    <li
-            id="level-2.4"
-            aria-setsize="5"
-            aria-posinset="4"
-            role="treeitem"
-            aria-level="2"
-            class="level-2"
-            aria-expanded="true"
-
-    >
-        Level 2.4
-        <div role="group" aria-owns="level-3.1 level-3.2"></div>
-    </li>
-    <li
-            id="level-3.1"
-            aria-setsize="2"
-            aria-posinset="1"
-            role="treeitem"
-            aria-level="3"
-            class="level-3"
-    >
-        <span>  Level 3.1</span>
-    </li>
-    <li
-            id="level-3.2"
-            aria-setsize="2"
-            aria-posinset="2"
-            role="treeitem"
-            aria-level="3"
-            class="level-3"
-    >
-        <span>  Level 3.2</span>
-    </li>
-    <li
-            id="level-2.5"
-            aria-setsize="5"
-            aria-posinset="5"
-            role="treeitem"
-            aria-level="2"
-            class="level-2"
-    >
-        <span>  Level 2.5</span>
-    </li>
+  <li role="treeitem" aria-level="1" aria-expanded="true" aria-selected="false" class="level-1">
+    <span> Level 1 </span>
+    <div role="group" aria-owns="level-2.1 level-2.2 level-2.3 level-2.4 level-2.5"></div>
+  </li>
+  <li
+    id="level-2.1"
+    aria-setsize="5"
+    aria-posinset="1"
+    role="treeitem"
+    aria-level="2"
+    class="level-2"
+  >
+    <span> Level 2.1</span>
+  </li>
+  <li
+    id="level-2.2"
+    aria-setsize="5"
+    aria-posinset="2"
+    role="treeitem"
+    aria-level="2"
+    class="level-2"
+  >
+    <span> Level 2.2</span>
+  </li>
+  <li
+    id="level-2.3"
+    aria-setsize="5"
+    aria-posinset="3"
+    role="treeitem"
+    aria-level="2"
+    class="level-2"
+  >
+    <span> Level 2.3</span>
+  </li>
+  <li
+    id="level-2.4"
+    aria-setsize="5"
+    aria-posinset="4"
+    role="treeitem"
+    aria-level="2"
+    class="level-2"
+    aria-expanded="true"
+  >
+    Level 2.4
+    <div role="group" aria-owns="level-3.1 level-3.2"></div>
+  </li>
+  <li
+    id="level-3.1"
+    aria-setsize="2"
+    aria-posinset="1"
+    role="treeitem"
+    aria-level="3"
+    class="level-3"
+  >
+    <span> Level 3.1</span>
+  </li>
+  <li
+    id="level-3.2"
+    aria-setsize="2"
+    aria-posinset="2"
+    role="treeitem"
+    aria-level="3"
+    class="level-3"
+  >
+    <span> Level 3.2</span>
+  </li>
+  <li
+    id="level-2.5"
+    aria-setsize="5"
+    aria-posinset="5"
+    role="treeitem"
+    aria-level="2"
+    class="level-2"
+  >
+    <span> Level 2.5</span>
+  </li>
 </ul>
 ```
 
 ## Virtual tree usage
 
-This component provide a generic API to connect with virtual tree implementations.
-But work with best with [react-vtree](https://github.com/Lodin/react-vtree/tree/version/2) v2 and v3.
+This component provide a generic API to connect with virtual tree implementations. But work with
+best with [react-vtree](https://github.com/Lodin/react-vtree/tree/version/2) v2 and v3.
 
 ```jsx
 const getTreeStructure = () => {

--- a/src/components/TreeNodeBase/TreeNodeBase.stories.tsx
+++ b/src/components/TreeNodeBase/TreeNodeBase.stories.tsx
@@ -57,6 +57,7 @@ const Example = Template((args) => (
             </>
           ),
         onPress: action('onPress'),
+        contextMenuActions: [{ text: 'Action 1' }],
       },
       {},
       TreeWrapper

--- a/src/components/TreeNodeBase/TreeNodeBase.test.tsx.snap
+++ b/src/components/TreeNodeBase/TreeNodeBase.test.tsx.snap
@@ -32,6 +32,22 @@ exports[`TreeNodeBase snapshot should match snapshot 1`] = `
         tabIndex={0}
       >
         Test
+        <ContextMenu
+          triggerRef={
+            Object {
+              "current": <div
+                class="md-tree-node-base-wrapper active-node"
+                data-nodeid="42"
+                data-padded="false"
+                data-shape="rectangle"
+                data-size="40"
+                tabindex="0"
+              >
+                Test
+              </div>,
+            }
+          }
+        />
       </div>
     </FocusRing>
   </FocusRing>
@@ -71,6 +87,22 @@ exports[`TreeNodeBase snapshot should match snapshot with className 1`] = `
         tabIndex={0}
       >
         Test
+        <ContextMenu
+          triggerRef={
+            Object {
+              "current": <div
+                class="example-class md-tree-node-base-wrapper active-node"
+                data-nodeid="42"
+                data-padded="false"
+                data-shape="rectangle"
+                data-size="40"
+                tabindex="0"
+              >
+                Test
+              </div>,
+            }
+          }
+        />
       </div>
     </FocusRing>
   </FocusRing>
@@ -111,6 +143,23 @@ exports[`TreeNodeBase snapshot should match snapshot with id 1`] = `
         tabIndex={0}
       >
         Test
+        <ContextMenu
+          triggerRef={
+            Object {
+              "current": <div
+                class="md-tree-node-base-wrapper active-node"
+                data-nodeid="42"
+                data-padded="false"
+                data-shape="rectangle"
+                data-size="40"
+                id="example-id"
+                tabindex="0"
+              >
+                Test
+              </div>,
+            }
+          }
+        />
       </div>
     </FocusRing>
   </FocusRing>
@@ -150,6 +199,23 @@ exports[`TreeNodeBase snapshot should match snapshot with isSelected 1`] = `
         tabIndex={0}
       >
         Test
+        <ContextMenu
+          triggerRef={
+            Object {
+              "current": <div
+                aria-selected="true"
+                class="md-tree-node-base-wrapper selected active-node"
+                data-nodeid="42"
+                data-padded="false"
+                data-shape="rectangle"
+                data-size="40"
+                tabindex="0"
+              >
+                Test
+              </div>,
+            }
+          }
+        />
       </div>
     </FocusRing>
   </FocusRing>
@@ -190,6 +256,23 @@ exports[`TreeNodeBase snapshot should match snapshot with lang 1`] = `
         tabIndex={0}
       >
         Test
+        <ContextMenu
+          triggerRef={
+            Object {
+              "current": <div
+                class="md-tree-node-base-wrapper active-node"
+                data-nodeid="42"
+                data-padded="false"
+                data-shape="rectangle"
+                data-size="40"
+                lang="en-US"
+                tabindex="0"
+              >
+                Test
+              </div>,
+            }
+          }
+        />
       </div>
     </FocusRing>
   </FocusRing>
@@ -229,6 +312,22 @@ exports[`TreeNodeBase snapshot should match snapshot with shape 1`] = `
         tabIndex={0}
       >
         Test
+        <ContextMenu
+          triggerRef={
+            Object {
+              "current": <div
+                class="md-tree-node-base-wrapper active-node"
+                data-nodeid="42"
+                data-padded="false"
+                data-shape="isPilled"
+                data-size="50"
+                tabindex="0"
+              >
+                Test
+              </div>,
+            }
+          }
+        />
       </div>
     </FocusRing>
   </FocusRing>
@@ -268,6 +367,22 @@ exports[`TreeNodeBase snapshot should match snapshot with size 1`] = `
         tabIndex={0}
       >
         Test
+        <ContextMenu
+          triggerRef={
+            Object {
+              "current": <div
+                class="md-tree-node-base-wrapper active-node"
+                data-nodeid="42"
+                data-padded="false"
+                data-shape="rectangle"
+                data-size="40"
+                tabindex="0"
+              >
+                Test
+              </div>,
+            }
+          }
+        />
       </div>
     </FocusRing>
   </FocusRing>
@@ -316,6 +431,23 @@ exports[`TreeNodeBase snapshot should match snapshot with style 1`] = `
         tabIndex={0}
       >
         Test
+        <ContextMenu
+          triggerRef={
+            Object {
+              "current": <div
+                class="md-tree-node-base-wrapper active-node"
+                data-nodeid="42"
+                data-padded="false"
+                data-shape="rectangle"
+                data-size="40"
+                style="color: pink;"
+                tabindex="0"
+              >
+                Test
+              </div>,
+            }
+          }
+        />
       </div>
     </FocusRing>
   </FocusRing>
@@ -407,6 +539,39 @@ exports[`TreeNodeBase snapshot should not render the content of the hidden nodes
               aria-owns="md-tree-node-1 md-tree-node-2"
               className="md-tree-node-base-group"
               role="group"
+            />
+            <ContextMenu
+              triggerRef={
+                Object {
+                  "current": <div
+                    aria-expanded="false"
+                    aria-level="1"
+                    aria-posinset="1"
+                    aria-setsize="1"
+                    class="md-tree-node-base-wrapper active-node"
+                    data-nodeid="root"
+                    data-padded="false"
+                    data-shape="rectangle"
+                    data-size="40"
+                    data-testid="node-root"
+                    id="md-tree-node-root"
+                    role="treeitem"
+                    tabindex="0"
+                  >
+                    <div
+                      class="node-content"
+                    >
+                      root
+                    </div>
+                    <div
+                      aria-labelledby="md-tree-node-root"
+                      aria-owns="md-tree-node-1 md-tree-node-2"
+                      class="md-tree-node-base-group"
+                      role="group"
+                    />
+                  </div>,
+                }
+              }
             />
           </div>
         </FocusRing>
@@ -551,6 +716,35 @@ exports[`TreeNodeBase snapshot should render grouping element when the tree is f
               className="md-tree-node-base-group"
               role="group"
             />
+            <ContextMenu
+              triggerRef={
+                Object {
+                  "current": <div
+                    aria-expanded="true"
+                    aria-level="1"
+                    aria-posinset="1"
+                    aria-setsize="1"
+                    class="md-tree-node-base-wrapper active-node"
+                    data-nodeid="root"
+                    data-padded="false"
+                    data-shape="rectangle"
+                    data-size="40"
+                    data-testid="node-root"
+                    id="md-tree-node-root"
+                    role="treeitem"
+                    tabindex="0"
+                  >
+                    root
+                    <div
+                      aria-labelledby="md-tree-node-root"
+                      aria-owns="md-tree-node-1 md-tree-node-2"
+                      class="md-tree-node-base-group"
+                      role="group"
+                    />
+                  </div>,
+                }
+              }
+            />
           </div>
         </FocusRing>
       </FocusRing>
@@ -594,6 +788,28 @@ exports[`TreeNodeBase snapshot should render grouping element when the tree is f
             tabIndex={-1}
           >
             1
+            <ContextMenu
+              triggerRef={
+                Object {
+                  "current": <div
+                    aria-level="1"
+                    aria-posinset="1"
+                    aria-setsize="2"
+                    class="md-tree-node-base-wrapper"
+                    data-nodeid="1"
+                    data-padded="false"
+                    data-shape="rectangle"
+                    data-size="40"
+                    data-testid="node-1"
+                    id="md-tree-node-1"
+                    role="treeitem"
+                    tabindex="-1"
+                  >
+                    1
+                  </div>,
+                }
+              }
+            />
           </div>
         </FocusRing>
       </FocusRing>
@@ -637,6 +853,28 @@ exports[`TreeNodeBase snapshot should render grouping element when the tree is f
             tabIndex={-1}
           >
             2
+            <ContextMenu
+              triggerRef={
+                Object {
+                  "current": <div
+                    aria-level="1"
+                    aria-posinset="2"
+                    aria-setsize="2"
+                    class="md-tree-node-base-wrapper"
+                    data-nodeid="2"
+                    data-padded="false"
+                    data-shape="rectangle"
+                    data-size="40"
+                    data-testid="node-2"
+                    id="md-tree-node-2"
+                    role="treeitem"
+                    tabindex="-1"
+                  >
+                    2
+                  </div>,
+                }
+              }
+            />
           </div>
         </FocusRing>
       </FocusRing>

--- a/src/components/TreeNodeBase/TreeNodeBase.tsx
+++ b/src/components/TreeNodeBase/TreeNodeBase.tsx
@@ -31,6 +31,7 @@ import './TreeNodeBase.style.scss';
 import { getKeyboardFocusableElements } from '../../utils/navigation';
 import { usePrevious } from '../../hooks/usePrevious';
 import { useDidUpdateEffect } from '../../hooks/useDidUpdateEffect';
+import ContextMenu from '../ContextMenu';
 
 const TreeNodeBase = (props: Props, providedRef: TreeNodeBaseRefOrCallbackRef): ReactElement => {
   const {
@@ -44,6 +45,7 @@ const TreeNodeBase = (props: Props, providedRef: TreeNodeBaseRefOrCallbackRef): 
     style,
     onPress,
     lang,
+    contextMenuActions,
     ...rest
   } = props;
   if (!nodeId) {
@@ -221,6 +223,7 @@ const TreeNodeBase = (props: Props, providedRef: TreeNodeBaseRefOrCallbackRef): 
         {treeContext?.isRenderedFlat && !nodeDetails.isLeaf && (
           <div className={STYLE.group} {...groupProps} />
         )}
+        <ContextMenu contextMenuActions={contextMenuActions} triggerRef={ref} />
       </div>
     </FocusRing>
   );

--- a/src/components/TreeNodeBase/TreeNodeBase.types.ts
+++ b/src/components/TreeNodeBase/TreeNodeBase.types.ts
@@ -2,6 +2,7 @@ import { CSSProperties, DetailedHTMLProps, HTMLAttributes, ReactNode, RefObject 
 import { PressEvents } from '@react-types/shared';
 import { TreeNodeId } from '../Tree';
 import { TreeNodeRecord } from '../Tree/Tree.types';
+import { ContextMenuActionsProp } from '../ContextMenu/ContextMenu.types';
 
 /**
  * TreeNodeBase size options
@@ -20,6 +21,7 @@ export type TreeNodeBaseRefOrCallbackRef =
  */
 export interface Props
   extends PressEvents,
+    ContextMenuActionsProp,
     DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> {
   /**
    * Unique identifier for the tree node


### PR DESCRIPTION
# Description
the space list had custom context menus via list item base
tree node base does not
this PR extracts the context menu into a separate component and adds it to tree node base
also changed the positioning of the context menu to be relative to the item in question instead of fixed to the page

# Links
as part of the work for https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-503138
