### PR TITLE
fix(input-selection): add text selection styles for inputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "@babel/runtime": "^7.0.0",
     "@momentum-design/animations": "^0.0.4",
     "@momentum-design/icons": "0.0.164",
-    "@momentum-design/tokens": "0.0.77",
+    "@momentum-design/tokens": "0.0.95",
     "@momentum-ui/design-tokens": "^0.0.63",
     "@momentum-ui/icons": "8.28.4",
     "@momentum-ui/tokens": "^1.7.1",

--- a/src/components/GlobalSearchInput/GlobalSearchInput.style.scss
+++ b/src/components/GlobalSearchInput/GlobalSearchInput.style.scss
@@ -57,6 +57,11 @@
       color: var(--mds-color-theme-text-secondary-normal);
       opacity: 1;
     }
+
+    &::selection {
+      color: var(--mds-color-theme-inverted-text-primary-normal);
+      background-color: var(--mds-color-theme-background-accent-active);
+    }
   }
 
   .aria-alert {

--- a/src/components/SearchInput/SearchInput.style.scss
+++ b/src/components/SearchInput/SearchInput.style.scss
@@ -66,6 +66,11 @@
       color: var(--mds-color-theme-text-secondary-normal);
       opacity: 1;
     }
+
+    &::selection {
+      color: var(--mds-color-theme-inverted-text-primary-normal);
+      background-color: var(--mds-color-theme-background-accent-active);
+    }
   }
 
   .md-search-input-search,

--- a/src/components/TextInput/TextInput.style.scss
+++ b/src/components/TextInput/TextInput.style.scss
@@ -42,6 +42,11 @@
       opacity: 1;
     }
 
+    &::selection {
+      color: var(--mds-color-theme-inverted-text-primary-normal);
+      background-color: var(--mds-color-theme-background-accent-active);
+    }
+
     &::-webkit-contacts-auto-fill-button {
       background-color: var(--mds-color-theme-text-secondary-normal);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2451,10 +2451,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@momentum-design/tokens@npm:0.0.77":
-  version: 0.0.77
-  resolution: "@momentum-design/tokens@npm:0.0.77"
-  checksum: f95ec9649e4d0f07b4f1e4eed324f5aa1b7e2b71391716a89bbfd7f7fa1a6fa36ad1e77e2adb0553073645641a9c6bb191641a4750729c4f2f08d675e403b076
+"@momentum-design/tokens@npm:0.0.95":
+  version: 0.0.95
+  resolution: "@momentum-design/tokens@npm:0.0.95"
+  checksum: b7b3fceb874fa4b50a9a765e16f143bc09231ffb6e56cccd2a7422d2c67a1b48e777fc329a81377e4b34ca977414f083620ac3678225c5eab1be38cf8b16061a
   languageName: node
   linkType: hard
 
@@ -2496,7 +2496,7 @@ __metadata:
     "@hot-loader/react-dom": ~16.8.0
     "@momentum-design/animations": ^0.0.4
     "@momentum-design/icons": 0.0.164
-    "@momentum-design/tokens": 0.0.77
+    "@momentum-design/tokens": 0.0.95
     "@momentum-ui/design-tokens": ^0.0.63
     "@momentum-ui/icons": 8.28.4
     "@momentum-ui/tokens": ^1.7.1


### PR DESCRIPTION
# Description

This PR updates the `::selection` styles for GlobalSearchInput, SearchInput and TextInput. This requires upgrading `@momentum-design/tokens` to the latest version since the `--mds-color-theme-background-accent-active` token doesn't exist in 0.0.77.

# Links

Jira Ticket: https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-367516 (Issue 1)
Figma Design: https://www.figma.com/design/FmXv8xvun1xAZiOMfztwqg/%F0%9F%A7%A9-Webex-App---Web?m=auto&node-id=68975-21109&t=sK40uXTpBDHnoLie-1