### PR TITLE
fix(Popover): remove aria-modal from non-dialogs and don't output aria-label on presentational elements

### DIFF
--- a/src/components/MenuTrigger/MenuTrigger.unit.test.tsx.snap
+++ b/src/components/MenuTrigger/MenuTrigger.unit.test.tsx.snap
@@ -282,8 +282,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot 1`] = `
                   hidden=""
                 />
                 <div
-                  aria-labelledby="test-ID"
-                  aria-modal="true"
                   class="md-menu-trigger-wrapper md-modal-container-wrapper"
                   data-arrow-orientation="vertical"
                   data-color="primary"
@@ -446,7 +444,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot 1`] = `
             }
           >
             <ModalContainer
-              aria-labelledby="test-ID"
               ariaModal={true}
               arrowId="arrow1"
               className="md-menu-trigger-wrapper"
@@ -475,8 +472,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot 1`] = `
                   hidden={true}
                 />
                 <div
-                  aria-labelledby="test-ID"
-                  aria-modal={true}
                   className="md-menu-trigger-wrapper md-modal-container-wrapper"
                   data-arrow-orientation="vertical"
                   data-color="primary"
@@ -2489,8 +2484,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with className 
                   hidden=""
                 />
                 <div
-                  aria-labelledby="test-ID"
-                  aria-modal="true"
                   class="example-class md-menu-trigger-wrapper md-modal-container-wrapper"
                   data-arrow-orientation="vertical"
                   data-color="primary"
@@ -2653,7 +2646,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with className 
             }
           >
             <ModalContainer
-              aria-labelledby="test-ID"
               ariaModal={true}
               arrowId="arrow1"
               className="example-class md-menu-trigger-wrapper"
@@ -2682,8 +2674,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with className 
                   hidden={true}
                 />
                 <div
-                  aria-labelledby="test-ID"
-                  aria-modal={true}
                   className="example-class md-menu-trigger-wrapper md-modal-container-wrapper"
                   data-arrow-orientation="vertical"
                   data-color="primary"
@@ -4696,8 +4686,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with color 1`] 
                   hidden=""
                 />
                 <div
-                  aria-labelledby="test-ID"
-                  aria-modal="true"
                   class="md-menu-trigger-wrapper md-modal-container-wrapper"
                   data-arrow-orientation="vertical"
                   data-color="secondary"
@@ -4860,7 +4848,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with color 1`] 
             }
           >
             <ModalContainer
-              aria-labelledby="test-ID"
               ariaModal={true}
               arrowId="arrow1"
               className="md-menu-trigger-wrapper"
@@ -4889,8 +4876,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with color 1`] 
                   hidden={true}
                 />
                 <div
-                  aria-labelledby="test-ID"
-                  aria-modal={true}
                   className="md-menu-trigger-wrapper md-modal-container-wrapper"
                   data-arrow-orientation="vertical"
                   data-color="secondary"
@@ -6904,8 +6889,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with id 1`] = `
                   hidden=""
                 />
                 <div
-                  aria-labelledby="test-ID"
-                  aria-modal="true"
                   class="md-menu-trigger-wrapper md-modal-container-wrapper"
                   data-arrow-orientation="vertical"
                   data-color="primary"
@@ -7069,7 +7052,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with id 1`] = `
             }
           >
             <ModalContainer
-              aria-labelledby="test-ID"
               ariaModal={true}
               arrowId="arrow1"
               className="md-menu-trigger-wrapper"
@@ -7099,8 +7081,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with id 1`] = `
                   hidden={true}
                 />
                 <div
-                  aria-labelledby="test-ID"
-                  aria-modal={true}
                   className="md-menu-trigger-wrapper md-modal-container-wrapper"
                   data-arrow-orientation="vertical"
                   data-color="primary"
@@ -9114,8 +9094,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with placement 
                   hidden=""
                 />
                 <div
-                  aria-labelledby="test-ID"
-                  aria-modal="true"
                   class="md-menu-trigger-wrapper md-modal-container-wrapper"
                   data-arrow-orientation="vertical"
                   data-color="primary"
@@ -9278,7 +9256,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with placement 
             }
           >
             <ModalContainer
-              aria-labelledby="test-ID"
               ariaModal={true}
               arrowId="arrow1"
               className="md-menu-trigger-wrapper"
@@ -9307,8 +9284,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with placement 
                   hidden={true}
                 />
                 <div
-                  aria-labelledby="test-ID"
-                  aria-modal={true}
                   className="md-menu-trigger-wrapper md-modal-container-wrapper"
                   data-arrow-orientation="vertical"
                   data-color="primary"
@@ -11321,8 +11296,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with showArrow 
                   hidden=""
                 />
                 <div
-                  aria-labelledby="test-ID"
-                  aria-modal="true"
                   class="md-menu-trigger-wrapper md-modal-container-wrapper"
                   data-arrow-orientation="vertical"
                   data-color="primary"
@@ -11516,7 +11489,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with showArrow 
             }
           >
             <ModalContainer
-              aria-labelledby="test-ID"
               ariaModal={true}
               arrowId="arrow1"
               className="md-menu-trigger-wrapper"
@@ -11545,8 +11517,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with showArrow 
                   hidden={true}
                 />
                 <div
-                  aria-labelledby="test-ID"
-                  aria-modal={true}
                   className="md-menu-trigger-wrapper md-modal-container-wrapper"
                   data-arrow-orientation="vertical"
                   data-color="primary"
@@ -13603,8 +13573,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with style 1`] 
                   hidden=""
                 />
                 <div
-                  aria-labelledby="test-ID"
-                  aria-modal="true"
                   class="md-menu-trigger-wrapper md-modal-container-wrapper"
                   data-arrow-orientation="vertical"
                   data-color="primary"
@@ -13768,7 +13736,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with style 1`] 
             }
           >
             <ModalContainer
-              aria-labelledby="test-ID"
               ariaModal={true}
               arrowId="arrow1"
               className="md-menu-trigger-wrapper"
@@ -13802,8 +13769,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with style 1`] 
                   hidden={true}
                 />
                 <div
-                  aria-labelledby="test-ID"
-                  aria-modal={true}
                   className="md-menu-trigger-wrapper md-modal-container-wrapper"
                   data-arrow-orientation="vertical"
                   data-color="primary"
@@ -15821,8 +15786,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with variant 1`
                   hidden=""
                 />
                 <div
-                  aria-labelledby="test-ID"
-                  aria-modal="true"
                   class="md-menu-trigger-wrapper md-modal-container-wrapper"
                   data-arrow-orientation="vertical"
                   data-color="primary"
@@ -15985,7 +15948,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with variant 1`
             }
           >
             <ModalContainer
-              aria-labelledby="test-ID"
               ariaModal={true}
               arrowId="arrow1"
               className="md-menu-trigger-wrapper"
@@ -16014,8 +15976,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with variant 1`
                   hidden={true}
                 />
                 <div
-                  aria-labelledby="test-ID"
-                  aria-modal={true}
                   className="md-menu-trigger-wrapper md-modal-container-wrapper"
                   data-arrow-orientation="vertical"
                   data-color="primary"
@@ -18032,8 +17992,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with zIndex 1`]
                   hidden=""
                 />
                 <div
-                  aria-labelledby="test-ID"
-                  aria-modal="true"
                   class="md-menu-trigger-wrapper md-modal-container-wrapper"
                   data-arrow-orientation="vertical"
                   data-color="primary"
@@ -18196,7 +18154,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with zIndex 1`]
             }
           >
             <ModalContainer
-              aria-labelledby="test-ID"
               ariaModal={true}
               arrowId="arrow1"
               className="md-menu-trigger-wrapper"
@@ -18225,8 +18182,6 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with zIndex 1`]
                   hidden={true}
                 />
                 <div
-                  aria-labelledby="test-ID"
-                  aria-modal={true}
                   className="md-menu-trigger-wrapper md-modal-container-wrapper"
                   data-arrow-orientation="vertical"
                   data-color="primary"

--- a/src/components/ModalContainer/ModalContainer.tsx
+++ b/src/components/ModalContainer/ModalContainer.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef, RefObject } from 'react';
 import classnames from 'classnames';
-import {FocusScope} from '@react-aria/focus';
+import { FocusScope } from '@react-aria/focus';
 
 import ModalArrow from '../ModalArrow';
 
@@ -30,38 +30,47 @@ const ModalContainer = (props: Props, ref: RefObject<HTMLDivElement>) => {
 
   const arrowOrientation = getArrowOrientation(placement);
 
-  const content = (<div
-    ref={ref}
-    role={role}
-    aria-modal={ariaModal}
-    className={classnames(className, STYLE.wrapper)}
-    id={id}
-    style={style}
-    data-placement={placement}
-    data-arrow-orientation={arrowOrientation}
-    data-color={color}
-    data-elevation={elevation}
-    data-padded={isPadded}
-    data-round={round}
-    {...otherProps}
-  >
-    {children}
-    {
-      /*arrow has to be wrapped in HTML element to allow Popover to style it*/
-      showArrow && (
-        <div id={arrowId} data-popper-arrow className={classnames(STYLE.arrowWrapper)}>
-          <ModalArrow placement={placement} color={color} />
-        </div>
-      )
-    }
-  </div>);
+  // aria-modal should only be on dialogs (https://w3c.github.io/aria/#aria-modal)
+  const roleProps = ['dialog', 'alertdialog'].includes(role) ? { 'aria-modal': ariaModal } : {};
+
+  const content = (
+    <div
+      ref={ref}
+      role={role}
+      {...roleProps}
+      className={classnames(className, STYLE.wrapper)}
+      id={id}
+      style={style}
+      data-placement={placement}
+      data-arrow-orientation={arrowOrientation}
+      data-color={color}
+      data-elevation={elevation}
+      data-padded={isPadded}
+      data-round={round}
+      {...otherProps}
+    >
+      {children}
+      {
+        /*arrow has to be wrapped in HTML element to allow Popover to style it*/
+        showArrow && (
+          <div id={arrowId} data-popper-arrow className={classnames(STYLE.arrowWrapper)}>
+            <ModalArrow placement={placement} color={color} />
+          </div>
+        )
+      }
+    </div>
+  );
 
   if (!focusLockProps) {
     return content;
   }
 
-  // eslint-disable-next-line jsx-a11y/no-autofocus
-  return <FocusScope contain autoFocus {...focusLockProps}>{content}</FocusScope>;
+  return (
+    // eslint-disable-next-line jsx-a11y/no-autofocus
+    <FocusScope contain autoFocus {...focusLockProps}>
+      {content}
+    </FocusScope>
+  );
 };
 
 const _ModalContainer = forwardRef(ModalContainer);

--- a/src/components/ModalContainer/ModalContainer.types.ts
+++ b/src/components/ModalContainer/ModalContainer.types.ts
@@ -1,4 +1,4 @@
-import { CSSProperties, ReactNode, ComponentProps } from 'react';
+import { CSSProperties, ReactNode, ComponentProps, AriaRole } from 'react';
 import type { PlacementType } from '../ModalArrow/ModalArrow.types';
 import { FocusScope } from '@react-aria/focus';
 
@@ -75,7 +75,7 @@ export interface Props {
   /**
    * Role for this modal.
    */
-  role?: string;
+  role?: AriaRole;
 
   /**
    * Boolean for aria modal.

--- a/src/components/ModalContainer/ModalContainer.unit.test.tsx.snap
+++ b/src/components/ModalContainer/ModalContainer.unit.test.tsx.snap
@@ -251,7 +251,6 @@ exports[`<ModalContainer /> snapshot should match snapshot with role 1`] = `
   role="tooltip"
 >
   <div
-    aria-modal={true}
     className="md-modal-container-wrapper"
     data-color="primary"
     data-elevation={0}

--- a/src/components/NotificationSystem/NotificationSystem.unit.test.tsx.snap
+++ b/src/components/NotificationSystem/NotificationSystem.unit.test.tsx.snap
@@ -30,7 +30,6 @@ exports[`<NotificationSystem /> snapshot should match snapshot 1`] = `
           >
             <div>
               <div
-                aria-modal="false"
                 class="md-toast-notification-wrapper md-modal-container-wrapper"
                 data-color="primary"
                 data-elevation="0"
@@ -151,7 +150,6 @@ exports[`<NotificationSystem /> snapshot should match snapshot if notification c
           >
             <div>
               <div
-                aria-modal="false"
                 class="md-toast-notification-wrapper md-modal-container-wrapper"
                 data-color="primary"
                 data-elevation="0"
@@ -271,7 +269,6 @@ exports[`<NotificationSystem /> snapshot should match snapshot if notification c
           >
             <div>
               <div
-                aria-modal="false"
                 class="md-toast-notification-wrapper md-modal-container-wrapper"
                 data-color="primary"
                 data-elevation="0"
@@ -392,7 +389,6 @@ exports[`<NotificationSystem /> snapshot should match snapshot when limit is set
           >
             <div>
               <div
-                aria-modal="false"
                 class="md-toast-notification-wrapper md-modal-container-wrapper"
                 data-color="primary"
                 data-elevation="0"
@@ -513,7 +509,6 @@ exports[`<NotificationSystem /> snapshot should match snapshot with ariaLabel pr
           >
             <div>
               <div
-                aria-modal="false"
                 class="md-toast-notification-wrapper md-modal-container-wrapper"
                 data-color="primary"
                 data-elevation="0"
@@ -634,7 +629,6 @@ exports[`<NotificationSystem /> snapshot should match snapshot with body class n
           >
             <div>
               <div
-                aria-modal="false"
                 class="md-toast-notification-wrapper md-modal-container-wrapper"
                 data-color="primary"
                 data-elevation="0"
@@ -755,7 +749,6 @@ exports[`<NotificationSystem /> snapshot should match snapshot with className 1`
           >
             <div>
               <div
-                aria-modal="false"
                 class="md-toast-notification-wrapper md-modal-container-wrapper"
                 data-color="primary"
                 data-elevation="0"
@@ -876,7 +869,6 @@ exports[`<NotificationSystem /> snapshot should match snapshot with container cl
           >
             <div>
               <div
-                aria-modal="false"
                 class="md-toast-notification-wrapper md-modal-container-wrapper"
                 data-color="primary"
                 data-elevation="0"
@@ -993,7 +985,6 @@ exports[`<NotificationSystem /> snapshot should match snapshot with different at
           >
             <div>
               <div
-                aria-modal="false"
                 class="md-toast-notification-wrapper md-modal-container-wrapper"
                 data-color="primary"
                 data-elevation="0"
@@ -1107,7 +1098,6 @@ exports[`<NotificationSystem /> snapshot should match snapshot with different po
           >
             <div>
               <div
-                aria-modal="false"
                 class="md-toast-notification-wrapper md-modal-container-wrapper"
                 data-color="primary"
                 data-elevation="0"
@@ -1232,7 +1222,6 @@ exports[`<NotificationSystem /> snapshot should match snapshot with different zI
           >
             <div>
               <div
-                aria-modal="false"
                 class="md-toast-notification-wrapper md-modal-container-wrapper"
                 data-color="primary"
                 data-elevation="0"
@@ -1353,7 +1342,6 @@ exports[`<NotificationSystem /> snapshot should match snapshot with enter animat
           >
             <div>
               <div
-                aria-modal="false"
                 class="md-toast-notification-wrapper md-modal-container-wrapper"
                 data-color="primary"
                 data-elevation="0"
@@ -1474,7 +1462,6 @@ exports[`<NotificationSystem /> snapshot should match snapshot with id 1`] = `
           >
             <div>
               <div
-                aria-modal="false"
                 class="md-toast-notification-wrapper md-modal-container-wrapper"
                 data-color="primary"
                 data-elevation="0"
@@ -1595,7 +1582,6 @@ exports[`<NotificationSystem /> snapshot should match snapshot with newest on to
           >
             <div>
               <div
-                aria-modal="false"
                 class="md-toast-notification-wrapper md-modal-container-wrapper"
                 data-color="primary"
                 data-elevation="0"
@@ -1716,7 +1702,6 @@ exports[`<NotificationSystem /> snapshot should match snapshot with style 1`] = 
           >
             <div>
               <div
-                aria-modal="false"
                 class="md-toast-notification-wrapper md-modal-container-wrapper"
                 data-color="primary"
                 data-elevation="0"
@@ -1837,7 +1822,6 @@ exports[`<NotificationSystem /> snapshot should match snapshot with toast class 
           >
             <div>
               <div
-                aria-modal="false"
                 class="md-toast-notification-wrapper md-modal-container-wrapper"
                 data-color="primary"
                 data-elevation="0"

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -93,10 +93,13 @@ const Popover = forwardRef((props: Props, ref: ForwardedRef<HTMLElement>) => {
 
   const ariaLabelledby = providedAriaLabelledby || triggerComponent.props?.id || generatedTriggerId;
 
+  const isGenericAriaRole = ['generic', 'presentation', 'none'].includes(role);
+
   const modalConditionalProps = {
     ...(interactive && {
-      ...((providedAriaLabelledby || !ariaLabel) && { 'aria-labelledby': ariaLabelledby }),
-      ...(ariaLabel && { 'aria-label': ariaLabel }),
+      ...((providedAriaLabelledby || !ariaLabel) &&
+        !isGenericAriaRole && { 'aria-labelledby': ariaLabelledby }),
+      ...(ariaLabel && !isGenericAriaRole && { 'aria-label': ariaLabel }),
       focusLockProps: !disableFocusLock
         ? { restoreFocus: focusBackOnTrigger, autoFocus }
         : undefined, // if we pass in undefined, the ModalContainer will not use FocusScope

--- a/src/components/Popover/Popover.types.ts
+++ b/src/components/Popover/Popover.types.ts
@@ -1,4 +1,4 @@
-import type { CSSProperties, ReactElement, ReactNode } from 'react';
+import type { AriaRole, CSSProperties, ReactElement, ReactNode } from 'react';
 import type { Instance, LifecycleHooks } from 'tippy.js';
 import type { TippyProps } from '@tippyjs/react';
 import type { Color } from '../ModalContainer/ModalContainer.types';
@@ -214,7 +214,7 @@ export interface Props extends PopoverCommonStyleProps, Partial<LifecycleHooks> 
   /**
    * Role of the popover content
    */
-  role?: string;
+  role?: AriaRole;
 
   /**
    * The element to append the popover to.

--- a/src/components/Select/Select.unit.test.tsx.snap
+++ b/src/components/Select/Select.unit.test.tsx.snap
@@ -1690,7 +1690,6 @@ exports[`Select snapshot should match snapshot before and after opening select d
                   />
                   <div
                     aria-labelledby="test-ID"
-                    aria-modal="true"
                     class="md-select-popover md-modal-container-wrapper"
                     data-arrow-orientation="vertical"
                     data-color="primary"
@@ -1796,7 +1795,6 @@ exports[`Select snapshot should match snapshot before and after opening select d
                   />
                   <div
                     aria-labelledby="test-ID"
-                    aria-modal={true}
                     className="md-select-popover md-modal-container-wrapper"
                     data-arrow-orientation="vertical"
                     data-color="primary"
@@ -4497,7 +4495,6 @@ exports[`Select snapshot should match snapshot with disabled option 1`] = `
                   />
                   <div
                     aria-labelledby="test-ID"
-                    aria-modal="true"
                     class="md-select-popover md-modal-container-wrapper"
                     data-arrow-orientation="vertical"
                     data-color="primary"
@@ -4603,7 +4600,6 @@ exports[`Select snapshot should match snapshot with disabled option 1`] = `
                   />
                   <div
                     aria-labelledby="test-ID"
-                    aria-modal={true}
                     className="md-select-popover md-modal-container-wrapper"
                     data-arrow-orientation="vertical"
                     data-color="primary"
@@ -6495,7 +6491,6 @@ exports[`Select snapshot should match snapshot with listbox opened 1`] = `
                   />
                   <div
                     aria-labelledby="test-ID"
-                    aria-modal="true"
                     class="md-select-popover md-modal-container-wrapper"
                     data-arrow-orientation="vertical"
                     data-color="primary"
@@ -6601,7 +6596,6 @@ exports[`Select snapshot should match snapshot with listbox opened 1`] = `
                   />
                   <div
                     aria-labelledby="test-ID"
-                    aria-modal={true}
                     className="md-select-popover md-modal-container-wrapper"
                     data-arrow-orientation="vertical"
                     data-color="primary"
@@ -7591,7 +7585,6 @@ exports[`Select snapshot should match snapshot with listboxMaxHeight 1`] = `
                   />
                   <div
                     aria-labelledby="test-ID"
-                    aria-modal="true"
                     class="md-select-popover md-modal-container-wrapper"
                     data-arrow-orientation="vertical"
                     data-color="primary"
@@ -7697,7 +7690,6 @@ exports[`Select snapshot should match snapshot with listboxMaxHeight 1`] = `
                   />
                   <div
                     aria-labelledby="test-ID"
-                    aria-modal={true}
                     className="md-select-popover md-modal-container-wrapper"
                     data-arrow-orientation="vertical"
                     data-color="primary"
@@ -8687,7 +8679,6 @@ exports[`Select snapshot should match snapshot with listboxWidth 1`] = `
                   />
                   <div
                     aria-labelledby="test-ID"
-                    aria-modal="true"
                     class="md-select-popover md-modal-container-wrapper"
                     data-arrow-orientation="vertical"
                     data-color="primary"
@@ -8793,7 +8784,6 @@ exports[`Select snapshot should match snapshot with listboxWidth 1`] = `
                   />
                   <div
                     aria-labelledby="test-ID"
-                    aria-modal={true}
                     className="md-select-popover md-modal-container-wrapper"
                     data-arrow-orientation="vertical"
                     data-color="primary"
@@ -10990,7 +10980,6 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
                   />
                   <div
                     aria-labelledby="test-ID"
-                    aria-modal="true"
                     class="md-select-popover md-modal-container-wrapper"
                     data-arrow-orientation="vertical"
                     data-color="primary"
@@ -11118,7 +11107,6 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
                   />
                   <div
                     aria-labelledby="test-ID"
-                    aria-modal={true}
                     className="md-select-popover md-modal-container-wrapper"
                     data-arrow-orientation="vertical"
                     data-color="primary"

--- a/src/components/ToastNotification/ToastNotification.unit.test.tsx.snap
+++ b/src/components/ToastNotification/ToastNotification.unit.test.tsx.snap
@@ -12,7 +12,6 @@ exports[`<ToastNotification /> snapshot should match snapshot 1`] = `
     round={50}
   >
     <div
-      aria-modal={false}
       className="md-toast-notification-wrapper md-modal-container-wrapper"
       data-color="primary"
       data-elevation={0}
@@ -56,7 +55,6 @@ exports[`<ToastNotification /> snapshot should match snapshot with aria-label 1`
   >
     <div
       aria-label="test"
-      aria-modal={false}
       className="example-class md-toast-notification-wrapper md-modal-container-wrapper"
       data-color="primary"
       data-elevation={0}
@@ -111,7 +109,6 @@ exports[`<ToastNotification /> snapshot should match snapshot with button group 
     round={50}
   >
     <div
-      aria-modal={false}
       className="md-toast-notification-wrapper md-modal-container-wrapper"
       data-color="primary"
       data-elevation={0}
@@ -265,7 +262,6 @@ exports[`<ToastNotification /> snapshot should match snapshot with className 1`]
     round={50}
   >
     <div
-      aria-modal={false}
       className="example-class md-toast-notification-wrapper md-modal-container-wrapper"
       data-color="primary"
       data-elevation={0}
@@ -307,7 +303,6 @@ exports[`<ToastNotification /> snapshot should match snapshot with id 1`] = `
     round={50}
   >
     <div
-      aria-modal={false}
       className="md-toast-notification-wrapper md-modal-container-wrapper"
       data-color="primary"
       data-elevation={0}
@@ -355,7 +350,6 @@ exports[`<ToastNotification /> snapshot should match snapshot with leading visua
     round={50}
   >
     <div
-      aria-modal={false}
       className="md-toast-notification-wrapper md-modal-container-wrapper"
       data-color="primary"
       data-elevation={0}
@@ -427,7 +421,6 @@ exports[`<ToastNotification /> snapshot should match snapshot with non string co
     round={50}
   >
     <div
-      aria-modal={false}
       className="md-toast-notification-wrapper md-modal-container-wrapper"
       data-color="primary"
       data-elevation={0}
@@ -465,7 +458,6 @@ exports[`<ToastNotification /> snapshot should match snapshot with onClose and c
     round={50}
   >
     <div
-      aria-modal={false}
       className="md-toast-notification-wrapper md-modal-container-wrapper"
       data-color="primary"
       data-elevation={0}
@@ -590,7 +582,6 @@ exports[`<ToastNotification /> snapshot should match snapshot with string conten
     round={50}
   >
     <div
-      aria-modal={false}
       className="md-toast-notification-wrapper md-modal-container-wrapper"
       data-color="primary"
       data-elevation={0}
@@ -640,7 +631,6 @@ exports[`<ToastNotification /> snapshot should match snapshot with style 1`] = `
     }
   >
     <div
-      aria-modal={false}
       className="md-toast-notification-wrapper md-modal-container-wrapper"
       data-color="primary"
       data-elevation={0}

--- a/src/components/Tooltip/Tooltip.unit.test.tsx.snap
+++ b/src/components/Tooltip/Tooltip.unit.test.tsx.snap
@@ -98,7 +98,6 @@ exports[`<Tooltip type"description /> snapshot should display only one tooltip a
   >
     <div
       aria-hidden="true"
-      aria-modal="false"
       class="md-modal-container-wrapper"
       data-arrow-orientation="vertical"
       data-color="primary"
@@ -198,7 +197,6 @@ exports[`<Tooltip type"description /> snapshot should display only one tooltip a
   >
     <div
       aria-hidden="true"
-      aria-modal="false"
       class="md-modal-container-wrapper"
       data-arrow-orientation="vertical"
       data-color="primary"
@@ -392,7 +390,6 @@ exports[`<Tooltip type"description /> snapshot should display only one tooltip a
   >
     <div
       aria-hidden="true"
-      aria-modal="false"
       class="md-modal-container-wrapper"
       data-arrow-orientation="vertical"
       data-color="primary"
@@ -492,7 +489,6 @@ exports[`<Tooltip type"description /> snapshot should display only one tooltip a
   >
     <div
       aria-hidden="true"
-      aria-modal="false"
       class="md-modal-container-wrapper"
       data-arrow-orientation="vertical"
       data-color="primary"
@@ -630,7 +626,6 @@ exports[`<Tooltip type"description /> snapshot should match snapshot with aria-h
   >
     <div
       aria-hidden="true"
-      aria-modal="false"
       class="md-modal-container-wrapper"
       data-arrow-orientation="vertical"
       data-color="primary"
@@ -719,7 +714,6 @@ exports[`<Tooltip type"description /> snapshot should match snapshot with classN
   >
     <div
       aria-hidden="true"
-      aria-modal="false"
       class="example-class md-modal-container-wrapper"
       data-arrow-orientation="vertical"
       data-color="primary"
@@ -808,7 +802,6 @@ exports[`<Tooltip type"description /> snapshot should match snapshot with color 
   >
     <div
       aria-hidden="true"
-      aria-modal="false"
       class="md-modal-container-wrapper"
       data-arrow-orientation="vertical"
       data-color="tertiary"
@@ -897,7 +890,6 @@ exports[`<Tooltip type"description /> snapshot should match snapshot with id 2`]
   >
     <div
       aria-hidden="true"
-      aria-modal="false"
       class="md-modal-container-wrapper"
       data-arrow-orientation="vertical"
       data-color="primary"
@@ -987,7 +979,6 @@ exports[`<Tooltip type"description /> snapshot should match snapshot with labelO
   >
     <div
       aria-hidden="true"
-      aria-modal="false"
       class="md-modal-container-wrapper"
       data-arrow-orientation="vertical"
       data-color="primary"
@@ -1076,7 +1067,6 @@ exports[`<Tooltip type"description /> snapshot should match snapshot with labelO
   >
     <div
       aria-hidden="false"
-      aria-modal="false"
       class="md-modal-container-wrapper"
       data-arrow-orientation="vertical"
       data-color="primary"
@@ -1165,7 +1155,6 @@ exports[`<Tooltip type"description /> snapshot should match snapshot with offset
   >
     <div
       aria-hidden="true"
-      aria-modal="false"
       class="md-modal-container-wrapper"
       data-arrow-orientation="vertical"
       data-color="primary"
@@ -1254,7 +1243,6 @@ exports[`<Tooltip type"description /> snapshot should match snapshot with offset
   >
     <div
       aria-hidden="true"
-      aria-modal="false"
       class="md-modal-container-wrapper"
       data-arrow-orientation="vertical"
       data-color="primary"
@@ -1343,7 +1331,6 @@ exports[`<Tooltip type"description /> snapshot should match snapshot with offset
   >
     <div
       aria-hidden="true"
-      aria-modal="false"
       class="md-modal-container-wrapper"
       data-arrow-orientation="vertical"
       data-color="primary"
@@ -1432,7 +1419,6 @@ exports[`<Tooltip type"description /> snapshot should match snapshot with strate
   >
     <div
       aria-hidden="true"
-      aria-modal="false"
       class="md-modal-container-wrapper"
       data-arrow-orientation="vertical"
       data-color="primary"
@@ -1521,7 +1507,6 @@ exports[`<Tooltip type"description /> snapshot should match snapshot with style 
   >
     <div
       aria-hidden="true"
-      aria-modal="false"
       class="md-modal-container-wrapper"
       data-arrow-orientation="vertical"
       data-color="primary"
@@ -1611,7 +1596,6 @@ exports[`<Tooltip type"description /> snapshot should match snapshot with type d
   >
     <div
       aria-hidden="true"
-      aria-modal="false"
       class="md-modal-container-wrapper"
       data-arrow-orientation="vertical"
       data-color="primary"
@@ -1700,7 +1684,6 @@ exports[`<Tooltip type"description /> snapshot should match snapshot with type l
   >
     <div
       aria-hidden="false"
-      aria-modal="false"
       class="md-modal-container-wrapper"
       data-arrow-orientation="vertical"
       data-color="primary"
@@ -1769,7 +1752,6 @@ exports[`<Tooltip type"description /> snapshot should match snapshot with type n
   >
     <div
       aria-hidden="true"
-      aria-modal="false"
       class="md-modal-container-wrapper"
       data-arrow-orientation="vertical"
       data-color="primary"


### PR DESCRIPTION
# Description

This PR does the following:
- Removes the aria-modal property from ModalContainer if the role is not a `dialog` or `alertdialog`.
- Removes aria-label and aria-labelledby properties from Popover if the role is `generic`, `presentation`, `none`. By specification, these roles cannot have any accessible name.
- Updates the type definition of ModalContainer and Popover to use AriaRole as the type for role

# Links

Jira Ticket (comment to address): https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-505153?focusedId=6541811&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-6541811

`aria-label` / `aria-labelledby` shouldn't be on:
`generic` - https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/generic_role#sect2
`presentation/none` - https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/presentation_role#sect1

`aria-modal` only has relevence on `dialog` and `alertdialog`: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-modal
