### PR TITLE
feat(tree): initial focus on selected item

### DIFF
--- a/src/components/Tree/Tree.test.tsx
+++ b/src/components/Tree/Tree.test.tsx
@@ -545,7 +545,7 @@ describe('<Tree />', () => {
 
       // Only adding back Node 1 will remove the cloned node
       expect(getByText('1')).not.toBeNull();
-      expect(scrollToNode).toHaveBeenCalledTimes(0);
+      expect(scrollToNode).toHaveBeenCalledTimes(1);
     });
 
     it.each`

--- a/src/components/Tree/Tree.test.tsx
+++ b/src/components/Tree/Tree.test.tsx
@@ -545,7 +545,7 @@ describe('<Tree />', () => {
 
       // Only adding back Node 1 will remove the cloned node
       expect(getByText('1')).not.toBeNull();
-      expect(scrollToNode).toHaveBeenCalledTimes(1);
+      expect(scrollToNode).toHaveBeenCalledTimes(0);
     });
 
     it.each`

--- a/src/components/Tree/Tree.tsx
+++ b/src/components/Tree/Tree.tsx
@@ -15,7 +15,7 @@ import './Tree.style.scss';
 import {
   convertNestedTree2MappedTree,
   isActiveNodeInDOM,
-  getFistActiveNode,
+  getInitialActiveNode,
   getNextActiveNode,
   getNodeDOMId,
   getTreeRootId,
@@ -61,7 +61,7 @@ const Tree = forwardRef((props: Props, ref: ForwardedRef<TreeRefObject>) => {
   });
   const [tree, setTree] = useState<TreeIdNodeMap>(convertNestedTree2MappedTree(treeStructure));
   const [activeNode, setActiveNode] = useState<TreeNodeId | undefined>(
-    getFistActiveNode(tree, excludeTreeRoot)
+    getInitialActiveNode(tree, excludeTreeRoot, itemSelection)
   );
   const [isFocusWithin, setIsFocusWithin] = useState(false);
   const activeNodeIdRef = useRef<TreeNodeId>(activeNode);
@@ -80,7 +80,7 @@ const Tree = forwardRef((props: Props, ref: ForwardedRef<TreeRefObject>) => {
     }
     // Fallback to the first node
     if (!newActiveNodeId || newActiveNodeId === getTreeRootId(newTree)) {
-      newActiveNodeId = getFistActiveNode(newTree, excludeTreeRoot);
+      newActiveNodeId = getInitialActiveNode(newTree, excludeTreeRoot, itemSelection);
     }
     setActiveNodeId(newActiveNodeId);
   }, [treeStructure]);

--- a/src/components/Tree/Tree.utils.test.tsx
+++ b/src/components/Tree/Tree.utils.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {
   convertNestedTree2MappedTree,
-  getFistActiveNode,
+  getInitialActiveNode,
   getNextActiveNode,
   getTreeRootId,
   isActiveNodeInDOM,
@@ -803,7 +803,14 @@ describe('Tree utils', () => {
     `(
       'should return $expected when $msg and $excludeTreeRoot',
       ({ tree, excludeTreeRoot, expected }) => {
-        const result = getFistActiveNode(convertNestedTree2MappedTree(tree), excludeTreeRoot);
+        const result = getInitialActiveNode(convertNestedTree2MappedTree(tree), excludeTreeRoot, {
+          selectionMode: 'none',
+          selectedItems: [],
+          isSelected: () => null,
+          toggle: () => null,
+          update: () => null,
+          clear: () => null,
+        });
         expect(result).toEqual(expected);
       }
     );

--- a/src/components/Tree/Tree.utils.test.tsx
+++ b/src/components/Tree/Tree.utils.test.tsx
@@ -787,25 +787,29 @@ describe('Tree utils', () => {
     });
   });
 
-  describe('getFistActiveNode', () => {
+  describe('getInitialActiveNode', () => {
     it.each`
-      msg                         | tree                                                                                | excludeTreeRoot | expected
-      ${'empty tree'}             | ${{}}                                                                               | ${false}        | ${undefined}
-      ${'empty tree'}             | ${{}}                                                                               | ${true}         | ${undefined}
-      ${'only root tree'}         | ${{ id: 'root', children: [] }}                                                     | ${true}         | ${undefined}
-      ${'only root tree'}         | ${{ id: 'root', children: [] }}                                                     | ${false}        | ${'root'}
-      ${'only closed root tree'}  | ${{ id: 'root', children: [], isOpenByDefault: false }}                             | ${true}         | ${undefined}
-      ${'only closed  root tree'} | ${{ id: 'root', children: [], isOpenByDefault: false }}                             | ${false}        | ${'root'}
-      ${'tree with child'}        | ${{ id: 'root', children: [{ id: 'node', children: [] }] }}                         | ${true}         | ${'node'}
-      ${'tree with child'}        | ${{ id: 'root', children: [{ id: 'node', children: [] }] }}                         | ${false}        | ${'root'}
-      ${'tree with hidden child'} | ${{ id: 'root', isOpenByDefault: false, children: [{ id: 'node', children: [] }] }} | ${false}        | ${'root'}
-      ${'tree with hidden child'} | ${{ id: 'root', isOpenByDefault: false, children: [{ id: 'node', children: [] }] }} | ${false}        | ${'root'}
+      msg                              | tree                                                                                       | excludeTreeRoot | expected     | selectionMode | selectedItems
+      ${'is empty'}                    | ${{}}                                                                                      | ${false}        | ${undefined} | ${'none'}     | ${[]}
+      ${'is empty'}                    | ${{}}                                                                                      | ${true}         | ${undefined} | ${'none'}     | ${[]}
+      ${'only has root'}               | ${{ id: 'root', children: [] }}                                                            | ${true}         | ${undefined} | ${'none'}     | ${[]}
+      ${'only has root'}               | ${{ id: 'root', children: [] }}                                                            | ${false}        | ${'root'}    | ${'none'}     | ${[]}
+      ${'only has closed root'}        | ${{ id: 'root', children: [], isOpenByDefault: false }}                                    | ${true}         | ${undefined} | ${'none'}     | ${[]}
+      ${'only has closed root'}        | ${{ id: 'root', children: [], isOpenByDefault: false }}                                    | ${false}        | ${'root'}    | ${'none'}     | ${[]}
+      ${'has child'}                   | ${{ id: 'root', children: [{ id: 'node', children: [] }] }}                                | ${true}         | ${'node'}    | ${'none'}     | ${[]}
+      ${'has child'}                   | ${{ id: 'root', children: [{ id: 'node', children: [] }] }}                                | ${false}        | ${'root'}    | ${'none'}     | ${[]}
+      ${'has hidden child'}            | ${{ id: 'root', isOpenByDefault: false, children: [{ id: 'node', children: [] }] }}        | ${false}        | ${'root'}    | ${'none'}     | ${[]}
+      ${'has hidden child'}            | ${{ id: 'root', isOpenByDefault: false, children: [{ id: 'node', children: [] }] }}        | ${false}        | ${'root'}    | ${'none'}     | ${[]}
+      ${'has child'}                   | ${{ id: 'root', children: [{ id: 'node', children: [] }] }}                                | ${true}         | ${'node'}    | ${'none'}     | ${[]}
+      ${'has single selected child'}   | ${{ id: 'root', children: [{ id: 'node', children: [] }] }}                                | ${true}         | ${'node'}    | ${'single'}   | ${['node']}
+      ${'has single selected child'}   | ${{ id: 'root', children: [{ id: 'node', children: [] }] }}                                | ${false}        | ${'node'}    | ${'single'}   | ${['node']}
+      ${'has multiple selected child'} | ${{ id: 'root', children: [{ id: 'node', children: [] }, { id: 'node2', children: [] }] }} | ${false}        | ${'root'}    | ${'multiple'} | ${['node', 'node2']}
     `(
-      'should return $expected when $msg and $excludeTreeRoot',
-      ({ tree, excludeTreeRoot, expected }) => {
+      'should return $expected when tree $msg and excludeTreeRoot is $excludeTreeRoot',
+      ({ tree, excludeTreeRoot, expected, selectionMode, selectedItems }) => {
         const result = getInitialActiveNode(convertNestedTree2MappedTree(tree), excludeTreeRoot, {
-          selectionMode: 'none',
-          selectedItems: [],
+          selectionMode,
+          selectedItems,
           isSelected: () => null,
           toggle: () => null,
           update: () => null,

--- a/src/components/Tree/Tree.utils.ts
+++ b/src/components/Tree/Tree.utils.ts
@@ -11,6 +11,7 @@ import {
 } from './Tree.types';
 import { NODE_ID_ATTRIBUTE_NAME } from '../TreeNodeBase/TreeNodeBase.constants';
 import { DEFAULTS } from './Tree.constants';
+import { ItemSelection } from '../../hooks/useItemSelected';
 
 export const TreeContext = React.createContext<TreeContextValue>(null);
 
@@ -403,12 +404,28 @@ export const isActiveNodeInDOM = (
 };
 
 /**
- * Get the first active node id in the tree.
+ * Get the initial active node id in the tree.
+ *
+ * If selection mode is single and there is only one shown and selected item, it returns the selected item.
+ * Otherwise, it returns the first shown node in the tree.
  *
  * @param tree
  * @param excludeTreeRoot
+ * @param itemSelection
  */
-export const getFistActiveNode = (tree: TreeIdNodeMap, excludeTreeRoot: boolean): TreeNodeId => {
+export const getInitialActiveNode = (
+  tree: TreeIdNodeMap,
+  excludeTreeRoot: boolean,
+  itemSelection: ItemSelection<string>
+): TreeNodeId => {
+  if (
+    itemSelection.selectionMode === 'single' &&
+    itemSelection.selectedItems.length === 1 &&
+    tree.has(itemSelection.selectedItems[0])
+  ) {
+    return itemSelection.selectedItems[0];
+  }
+
   const rootId = getTreeRootId(tree);
   if (rootId) {
     const treeNode = tree.get(rootId);


### PR DESCRIPTION
# Description

if selection mode is single, and 1 item is selected, and that item exists in the tree, then the initial focus should land on that item instead of the first item in the tree

# Links

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-503141