### PR TITLE
fix(alertbanner): change children type to ReactNnode

### DIFF
--- a/src/components/AlertBanner/AlertBanner.stories.docs.mdx
+++ b/src/components/AlertBanner/AlertBanner.stories.docs.mdx
@@ -6,4 +6,4 @@ The `<AlertBanner />` component. This component accepts multiple scopes of child
   This supports escape codes, such as `\n`.
 - `buttons` - One or more `<ButtonSimple />` components to be mapped to this `<AlertBanner />`.
   These are heavily re-styled for this component, use custom styling with caution.
-- `children` - Virtually identical to the `label` prop, but is overriden by the `label` prop.
+- `children` - Virtually identical to the `label` prop, but is overridden by the `label` prop.

--- a/src/components/AlertBanner/AlertBanner.tsx
+++ b/src/components/AlertBanner/AlertBanner.tsx
@@ -38,7 +38,15 @@ const AlertBanner: FC<Props> = (props: Props) => {
     <div className={STYLE.image} />
   );
 
-  const labelComponent = <p className={STYLE.label}>{label || children}</p>;
+  let labelComponent;
+
+  if (label) {
+    labelComponent = <p className={STYLE.label}>{label}</p>;
+  } else if (children) {
+    labelComponent = <div className={STYLE.label}>{children}</div>;
+  } else {
+    labelComponent = <div className={STYLE.label} />;
+  }
 
   return (
     <div

--- a/src/components/AlertBanner/AlertBanner.tsx
+++ b/src/components/AlertBanner/AlertBanner.tsx
@@ -1,4 +1,4 @@
-import React, { Children, cloneElement, FC } from 'react';
+import React, { Children, cloneElement, FC, isValidElement } from 'react';
 import classnames from 'classnames';
 
 import { DEFAULTS, STYLE } from './AlertBanner.constants';
@@ -44,7 +44,7 @@ const AlertBanner: FC<Props> = (props: Props) => {
     labelComponent = <p className={STYLE.label}>{label}</p>;
   } else if (typeof children === 'string' || typeof children === 'number') {
     labelComponent = <p className={STYLE.label}>{children}</p>;
-  } else if (React.isValidElement(children)) {
+  } else if (isValidElement(children)) {
     labelComponent = <div className={STYLE.label}>{children}</div>;
   } else {
     labelComponent = <p className={STYLE.label} />;

--- a/src/components/AlertBanner/AlertBanner.tsx
+++ b/src/components/AlertBanner/AlertBanner.tsx
@@ -42,10 +42,12 @@ const AlertBanner: FC<Props> = (props: Props) => {
 
   if (label) {
     labelComponent = <p className={STYLE.label}>{label}</p>;
-  } else if (children) {
+  } else if (typeof children === 'string' || typeof children === 'number') {
+    labelComponent = <p className={STYLE.label}>{children}</p>;
+  } else if (React.isValidElement(children)) {
     labelComponent = <div className={STYLE.label}>{children}</div>;
   } else {
-    labelComponent = <div className={STYLE.label} />;
+    labelComponent = <p className={STYLE.label} />;
   }
 
   return (

--- a/src/components/AlertBanner/AlertBanner.types.ts
+++ b/src/components/AlertBanner/AlertBanner.types.ts
@@ -1,4 +1,4 @@
-import { CSSProperties, ReactElement } from 'react';
+import { CSSProperties, ReactElement, ReactNode } from 'react';
 import { ButtonSimpleProps } from '../ButtonSimple';
 import { IconProps } from '../Icon';
 
@@ -14,7 +14,7 @@ export interface Props {
   /**
    * Label/message to be displayed with this component. Overrides `label`.
    */
-  children?: string;
+  children?: ReactNode;
 
   /**
    * Custom class for overriding this component's CSS.

--- a/src/components/AlertBanner/AlertBanner.unit.test.tsx
+++ b/src/components/AlertBanner/AlertBanner.unit.test.tsx
@@ -68,7 +68,7 @@ describe('<AlertBanner />', () => {
     it('should match snapshot with children', () => {
       expect.assertions(1);
 
-      const children = 'children';
+      const children = <div>Example Text</div>;
 
       const container = mount(<AlertBanner>{children}</AlertBanner>);
 

--- a/src/components/AlertBanner/AlertBanner.unit.test.tsx
+++ b/src/components/AlertBanner/AlertBanner.unit.test.tsx
@@ -65,10 +65,20 @@ describe('<AlertBanner />', () => {
       expect(container).toMatchSnapshot();
     });
 
-    it('should match snapshot with children', () => {
+    it('should match snapshot with children as ReactElement', () => {
       expect.assertions(1);
 
       const children = <div>Example Text</div>;
+
+      const container = mount(<AlertBanner>{children}</AlertBanner>);
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match snapshot with children as string', () => {
+      expect.assertions(1);
+
+      const children = 'Example Text';
 
       const container = mount(<AlertBanner>{children}</AlertBanner>);
 

--- a/src/components/AlertBanner/AlertBanner.unit.test.tsx
+++ b/src/components/AlertBanner/AlertBanner.unit.test.tsx
@@ -65,20 +65,20 @@ describe('<AlertBanner />', () => {
       expect(container).toMatchSnapshot();
     });
 
-    it('should match snapshot with children as ReactElement', () => {
+    it('should match snapshot with children as string', () => {
       expect.assertions(1);
 
-      const children = <div>Example Text</div>;
+      const children = 'Example Text';
 
       const container = mount(<AlertBanner>{children}</AlertBanner>);
 
       expect(container).toMatchSnapshot();
     });
 
-    it('should match snapshot with children as string', () => {
+    it('should match snapshot with children as ReactElement', () => {
       expect.assertions(1);
 
-      const children = 'Example Text';
+      const children = <div>Example Text</div>;
 
       const container = mount(<AlertBanner>{children}</AlertBanner>);
 

--- a/src/components/AlertBanner/AlertBanner.unit.test.tsx.snap
+++ b/src/components/AlertBanner/AlertBanner.unit.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`<AlertBanner /> snapshot should match snapshot 1`] = `
     <div
       className="md-alert-banner-image"
     />
-    <div
+    <p
       className="md-alert-banner-label"
     />
     <div
@@ -49,7 +49,7 @@ exports[`<AlertBanner /> snapshot should match snapshot with buttons 1`] = `
     <div
       className="md-alert-banner-image"
     />
-    <div
+    <p
       className="md-alert-banner-label"
     />
     <div
@@ -72,7 +72,7 @@ exports[`<AlertBanner /> snapshot should match snapshot with buttons 1`] = `
 </AlertBanner>
 `;
 
-exports[`<AlertBanner /> snapshot should match snapshot with children 1`] = `
+exports[`<AlertBanner /> snapshot should match snapshot with children as ReactElement 1`] = `
 <AlertBanner>
   <div
     className="md-alert-banner-wrapper"
@@ -100,6 +100,32 @@ exports[`<AlertBanner /> snapshot should match snapshot with children 1`] = `
 </AlertBanner>
 `;
 
+exports[`<AlertBanner /> snapshot should match snapshot with children as string 1`] = `
+<AlertBanner>
+  <div
+    className="md-alert-banner-wrapper"
+    data-centered={false}
+    data-color="default"
+    data-grow={false}
+    data-pill={false}
+    data-size="default"
+    data-static={false}
+  >
+    <div
+      className="md-alert-banner-image"
+    />
+    <p
+      className="md-alert-banner-label"
+    >
+      Example Text
+    </p>
+    <div
+      className="md-alert-banner-buttons"
+    />
+  </div>
+</AlertBanner>
+`;
+
 exports[`<AlertBanner /> snapshot should match snapshot with className 1`] = `
 <AlertBanner
   className="example-class"
@@ -116,7 +142,7 @@ exports[`<AlertBanner /> snapshot should match snapshot with className 1`] = `
     <div
       className="md-alert-banner-image"
     />
-    <div
+    <p
       className="md-alert-banner-label"
     />
     <div
@@ -142,11 +168,11 @@ exports[`<AlertBanner /> snapshot should match snapshot with color 1`] = `
     <div
       className="md-alert-banner-image"
     />
-    <div
+    <p
       className="md-alert-banner-label"
     >
       Example Text
-    </div>
+    </p>
     <div
       className="md-alert-banner-buttons"
     />
@@ -171,7 +197,7 @@ exports[`<AlertBanner /> snapshot should match snapshot with id 1`] = `
     <div
       className="md-alert-banner-image"
     />
-    <div
+    <p
       className="md-alert-banner-label"
     />
     <div
@@ -203,7 +229,7 @@ exports[`<AlertBanner /> snapshot should match snapshot with image 1`] = `
     >
       A
     </div>
-    <div
+    <p
       className="md-alert-banner-label"
     />
     <div
@@ -229,7 +255,7 @@ exports[`<AlertBanner /> snapshot should match snapshot with isCentered 1`] = `
     <div
       className="md-alert-banner-image"
     />
-    <div
+    <p
       className="md-alert-banner-label"
     />
     <div
@@ -255,7 +281,7 @@ exports[`<AlertBanner /> snapshot should match snapshot with isGrown 1`] = `
     <div
       className="md-alert-banner-image"
     />
-    <div
+    <p
       className="md-alert-banner-label"
     />
     <div
@@ -281,7 +307,7 @@ exports[`<AlertBanner /> snapshot should match snapshot with isPilled 1`] = `
     <div
       className="md-alert-banner-image"
     />
-    <div
+    <p
       className="md-alert-banner-label"
     />
     <div
@@ -306,7 +332,7 @@ exports[`<AlertBanner /> snapshot should match snapshot with isStatic 1`] = `
     <div
       className="md-alert-banner-image"
     />
-    <div
+    <p
       className="md-alert-banner-label"
     />
     <div
@@ -360,11 +386,11 @@ exports[`<AlertBanner /> snapshot should match snapshot with size 1`] = `
     <div
       className="md-alert-banner-image"
     />
-    <div
+    <p
       className="md-alert-banner-label"
     >
       Example Text
-    </div>
+    </p>
     <div
       className="md-alert-banner-buttons"
     />
@@ -397,7 +423,7 @@ exports[`<AlertBanner /> snapshot should match snapshot with style 1`] = `
     <div
       className="md-alert-banner-image"
     />
-    <div
+    <p
       className="md-alert-banner-label"
     />
     <div

--- a/src/components/AlertBanner/AlertBanner.unit.test.tsx.snap
+++ b/src/components/AlertBanner/AlertBanner.unit.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`<AlertBanner /> snapshot should match snapshot 1`] = `
     <div
       className="md-alert-banner-image"
     />
-    <p
+    <div
       className="md-alert-banner-label"
     />
     <div
@@ -49,7 +49,7 @@ exports[`<AlertBanner /> snapshot should match snapshot with buttons 1`] = `
     <div
       className="md-alert-banner-image"
     />
-    <p
+    <div
       className="md-alert-banner-label"
     />
     <div
@@ -86,11 +86,13 @@ exports[`<AlertBanner /> snapshot should match snapshot with children 1`] = `
     <div
       className="md-alert-banner-image"
     />
-    <p
+    <div
       className="md-alert-banner-label"
     >
-      children
-    </p>
+      <div>
+        Example Text
+      </div>
+    </div>
     <div
       className="md-alert-banner-buttons"
     />
@@ -114,7 +116,7 @@ exports[`<AlertBanner /> snapshot should match snapshot with className 1`] = `
     <div
       className="md-alert-banner-image"
     />
-    <p
+    <div
       className="md-alert-banner-label"
     />
     <div
@@ -140,11 +142,11 @@ exports[`<AlertBanner /> snapshot should match snapshot with color 1`] = `
     <div
       className="md-alert-banner-image"
     />
-    <p
+    <div
       className="md-alert-banner-label"
     >
       Example Text
-    </p>
+    </div>
     <div
       className="md-alert-banner-buttons"
     />
@@ -169,7 +171,7 @@ exports[`<AlertBanner /> snapshot should match snapshot with id 1`] = `
     <div
       className="md-alert-banner-image"
     />
-    <p
+    <div
       className="md-alert-banner-label"
     />
     <div
@@ -201,7 +203,7 @@ exports[`<AlertBanner /> snapshot should match snapshot with image 1`] = `
     >
       A
     </div>
-    <p
+    <div
       className="md-alert-banner-label"
     />
     <div
@@ -227,7 +229,7 @@ exports[`<AlertBanner /> snapshot should match snapshot with isCentered 1`] = `
     <div
       className="md-alert-banner-image"
     />
-    <p
+    <div
       className="md-alert-banner-label"
     />
     <div
@@ -253,7 +255,7 @@ exports[`<AlertBanner /> snapshot should match snapshot with isGrown 1`] = `
     <div
       className="md-alert-banner-image"
     />
-    <p
+    <div
       className="md-alert-banner-label"
     />
     <div
@@ -279,7 +281,7 @@ exports[`<AlertBanner /> snapshot should match snapshot with isPilled 1`] = `
     <div
       className="md-alert-banner-image"
     />
-    <p
+    <div
       className="md-alert-banner-label"
     />
     <div
@@ -304,7 +306,7 @@ exports[`<AlertBanner /> snapshot should match snapshot with isStatic 1`] = `
     <div
       className="md-alert-banner-image"
     />
-    <p
+    <div
       className="md-alert-banner-label"
     />
     <div
@@ -358,11 +360,11 @@ exports[`<AlertBanner /> snapshot should match snapshot with size 1`] = `
     <div
       className="md-alert-banner-image"
     />
-    <p
+    <div
       className="md-alert-banner-label"
     >
       Example Text
-    </p>
+    </div>
     <div
       className="md-alert-banner-buttons"
     />
@@ -395,7 +397,7 @@ exports[`<AlertBanner /> snapshot should match snapshot with style 1`] = `
     <div
       className="md-alert-banner-image"
     />
-    <p
+    <div
       className="md-alert-banner-label"
     />
     <div


### PR DESCRIPTION
# IMPORTANT

**Currently, this project is closed to any external contributions. Any pull request made against this project from external sources will likely be closed. If you would like to make changes to this project, please fork this project.**

# Guide

**This "Help" section can be deleted before submitting this pull request.**

*Update the name of this pull request to reflect the following shape:*

```
{type}/{scope?}/{message}
```

* **type** - A [conventional commit type](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional#type-enum) **REQUIRED**
* **scope** - The kabab-case scope of the changes in this request
* **message** - A short, kebab-case statement describing the changes **REQUIRED**

*Provide a general summary of the scope of the changes in this pull request.*

* [Readme](https://github.com/momentum-design/momentum-react-v2/blob/master/README.md)
* [Getting Started Guide](https://github.com/momentum-design/momentum-react-v2/blob/master/GETTING_STARTED.md)
* [Contributing Guide](https://github.com/momentum-design/momentum-react-v2/blob/master/CONTRIBUTING.md)

# Description

*The full description of the changes made in this request.*
Change ```AlertBanner``` children type from ```string``` to ```ReactNode```

# Links

*Links to relevent resources.*
