### PR TITLE
fix: add high contrast colors, mainly around active/selected states

### DIFF
--- a/src/components/Avatar/Avatar.style.scss
+++ b/src/components/Avatar/Avatar.style.scss
@@ -23,6 +23,9 @@
   position: relative;
   width: fit-content;
 
+  // The color of these elements are descriptive therefore don't override them in high contrast
+  forced-color-adjust: none;
+
   .md-avatar-wrapper-children {
     position: absolute;
   }

--- a/src/components/Badge/Badge.style.scss
+++ b/src/components/Badge/Badge.style.scss
@@ -7,6 +7,11 @@
     background-color: var(--mds-color-theme-background-accent-normal);
     color: var(--mds-color-theme-common-text-primary-normal); // Update with component token
 
+    @media (forced-colors: active) {
+      background-color: AccentColor !important;
+      color: AccentColorText !important;
+    }
+
     /* Sizing */
     border-radius: 2rem;
     height: 1.125rem;

--- a/src/components/ButtonCircleToggle/ButtonCircleToggle.style.scss
+++ b/src/components/ButtonCircleToggle/ButtonCircleToggle.style.scss
@@ -1,6 +1,5 @@
 .md-button-circle-toggle-wrapper {
   &[data-selected='true'] {
-    // TODO: Check whether all of these !importants are required
     &[data-outline='true'],
     &[data-ghost='true'] {
       background-color: var(--mds-color-theme-button-secondary-active-normal) !important;
@@ -44,8 +43,10 @@
       }
     }
 
-    &[data-selected='true'][data-selected='true'] {
-      @media (forced-colors: active) {
+    @media (forced-colors: active) {
+      // Because of all of the above !importants, the specificity of this selector needs to be really high
+      // All of the above selectors match 1 or 2 attributes, we need to do the same to override them all
+      &[data-selected='true'][data-selected='true'] {
         background-color: SelectedItem !important;
         color: SelectedItemText !important;
 

--- a/src/components/ButtonCircleToggle/ButtonCircleToggle.style.scss
+++ b/src/components/ButtonCircleToggle/ButtonCircleToggle.style.scss
@@ -1,5 +1,6 @@
 .md-button-circle-toggle-wrapper {
   &[data-selected='true'] {
+    // TODO: Check whether all of these !importants are required
     &[data-outline='true'],
     &[data-ghost='true'] {
       background-color: var(--mds-color-theme-button-secondary-active-normal) !important;
@@ -40,6 +41,18 @@
       &[data-disabled='true'],
       &.disable {
         border-color: var(--mds-color-theme-outline-primary-disabled) !important;
+      }
+    }
+
+    &[data-selected='true'][data-selected='true'] {
+      @media (forced-colors: active) {
+        background-color: SelectedItem !important;
+        color: SelectedItemText !important;
+
+        &[data-disabled='true'],
+        &.disable {
+          color: GrayText !important;
+        }
       }
     }
   }

--- a/src/components/ButtonPillToggle/ButtonPillToggle.style.scss
+++ b/src/components/ButtonPillToggle/ButtonPillToggle.style.scss
@@ -43,8 +43,10 @@
       }
     }
 
-    &[data-selected='true'][data-selected='true'] {
-      @media (forced-colors: active) {
+    @media (forced-colors: active) {
+      // Because of all of the above !importants, the specificity of this selector needs to be really high
+      // All of the above selectors match 1 or 2 attributes, we need to do the same to override them all
+      &[data-selected='true'][data-selected='true'] {
         background-color: SelectedItem !important;
         color: SelectedItemText !important;
 

--- a/src/components/ButtonPillToggle/ButtonPillToggle.style.scss
+++ b/src/components/ButtonPillToggle/ButtonPillToggle.style.scss
@@ -42,5 +42,17 @@
         border-color: var(--mds-color-theme-outline-primary-disabled) !important;
       }
     }
+
+    &[data-selected='true'][data-selected='true'] {
+      @media (forced-colors: active) {
+        background-color: SelectedItem !important;
+        color: SelectedItemText !important;
+
+        &[data-disabled='true'],
+        &.disable {
+          color: GrayText !important;
+        }
+      }
+    }
   }
 }

--- a/src/components/FocusRing/FocusRing.style.scss
+++ b/src/components/FocusRing/FocusRing.style.scss
@@ -1,7 +1,7 @@
 .md-focus-ring-wrapper,
 .focus {
   box-shadow: var(--md-globals-focus-ring-box-shadow);
-  outline: var(--md-globals-focus-ring-outline);
+  outline: var(--md-globals-focus-ring-outline) !important;
   position: relative; // Needed to apply z-index.
   z-index: 9999; // Needed to bring box-shadow to front.
 

--- a/src/components/Icon/Icon.style.scss
+++ b/src/components/Icon/Icon.style.scss
@@ -194,6 +194,15 @@ svg.md-icon-coloured {
   height: fit-content;
   justify-content: center;
   width: fit-content;
+
+  @media (forced-colors: active) {
+    background: Canvas !important;
+
+    svg {
+      fill: CanvasText !important;
+      stroke: CanvasText !important;
+    }
+  }
 }
 
 .md-icon-not-found {

--- a/src/components/Icon/Icon.style.scss
+++ b/src/components/Icon/Icon.style.scss
@@ -194,15 +194,6 @@ svg.md-icon-coloured {
   height: fit-content;
   justify-content: center;
   width: fit-content;
-
-  @media (forced-colors: active) {
-    background: Canvas !important;
-
-    svg {
-      fill: CanvasText !important;
-      stroke: CanvasText !important;
-    }
-  }
 }
 
 .md-icon-not-found {

--- a/src/components/ListItemBase/ListItemBase.style.scss
+++ b/src/components/ListItemBase/ListItemBase.style.scss
@@ -26,6 +26,11 @@
     &.active {
       color: var(--mds-color-theme-text-primary-normal);
       background-color: var(--mds-color-theme-background-primary-active);
+
+      @media (forced-colors: active) {
+        background-color: SelectedItem !important;
+        color: SelectedItemText !important;
+      }
     }
 
     &.focus {
@@ -40,10 +45,18 @@
       &,
       .md-text-wrapper {
         color: var(--mds-color-theme-text-primary-disabled);
+
+        @media (forced-colors: active) {
+          color: GrayText !important;
+        }
       }
 
       svg {
         fill: var(--mds-color-theme-text-primary-disabled);
+
+        @media (forced-colors: active) {
+          fill: GrayText !important;
+        }
       }
     }
   }

--- a/src/components/NavigationTab/NavigationTab.style.scss
+++ b/src/components/NavigationTab/NavigationTab.style.scss
@@ -18,6 +18,18 @@
     color: var(--mds-color-theme-text-secondary-normal);
   }
 
+  @media (forced-colors: active) {
+    background-color: ButtonFace;
+
+    > .md-navigation-tab-icon > * {
+      color: ButtonText;
+    }
+
+    > .md-navigation-tab-label {
+      color: ButtonText;
+    }
+  }
+
   &:hover {
     background-color: var(--mds-color-theme-button-secondary-hover);
 
@@ -44,18 +56,6 @@
 
   &[data-active='true'] {
     background-color: var(--mds-color-theme-button-secondary-pressed);
-
-    @media (forced-colors: active) {
-      background-color: SelectedItem;
-
-      > .md-navigation-tab-icon > * {
-        color: SelectedItemText;
-      }
-
-      > .md-navigation-tab-label {
-        color: SelectedItemText;
-      }
-    }
 
     > .md-navigation-tab-icon > * {
       color: var(--mds-color-theme-text-primary-normal);
@@ -86,6 +86,18 @@
 
       > .md-navigation-tab-label {
         color: var(--mds-color-theme-text-primary-normal);
+      }
+    }
+
+    @media (forced-colors: active) {
+      background-color: SelectedItem;
+
+      > .md-navigation-tab-icon > * {
+        color: SelectedItemText;
+      }
+
+      > .md-navigation-tab-label {
+        color: SelectedItemText;
       }
     }
   }

--- a/src/components/NavigationTab/NavigationTab.style.scss
+++ b/src/components/NavigationTab/NavigationTab.style.scss
@@ -47,7 +47,14 @@
 
     @media (forced-colors: active) {
       background-color: SelectedItem;
-      color: SelectedItemText;
+
+      > .md-navigation-tab-icon > * {
+        color: SelectedItemText;
+      }
+
+      > .md-navigation-tab-label {
+        color: SelectedItemText;
+      }
     }
 
     > .md-navigation-tab-icon > * {

--- a/src/components/RadioSimple/RadioSimple.style.scss
+++ b/src/components/RadioSimple/RadioSimple.style.scss
@@ -6,7 +6,7 @@
   background-color: var(--mds-color-theme-background-primary-ghost);
 
   @media (forced-colors: active) {
-    outline: 1px solid ButtonBorder;
+    border: 1px solid ButtonBorder;
   }
 
   &:hover {
@@ -33,7 +33,7 @@
 
   &[data-focused='true'] {
     border-color: transparent;
-    outline: none;
+    outline: var(--md-globals-focus-ring-outline);
     box-shadow: var(--md-globals-focus-ring-box-shadow);
   }
 

--- a/src/components/RadioSimple/RadioSimple.style.scss
+++ b/src/components/RadioSimple/RadioSimple.style.scss
@@ -11,11 +11,6 @@
 
   &:hover {
     background-color: var(--mds-color-theme-background-primary-hover);
-
-    @media (forced-colors: active) {
-      background-color: SelectedItem;
-      color: SelectedItemText;
-    }
   }
 
   &:active {

--- a/src/components/RadioSimple/RadioSimple.style.scss
+++ b/src/components/RadioSimple/RadioSimple.style.scss
@@ -5,8 +5,17 @@
   width: 6rem;
   background-color: var(--mds-color-theme-background-primary-ghost);
 
+  @media (forced-colors: active) {
+    outline: 1px solid ButtonBorder;
+  }
+
   &:hover {
     background-color: var(--mds-color-theme-background-primary-hover);
+
+    @media (forced-colors: active) {
+      background-color: SelectedItem;
+      color: SelectedItemText;
+    }
   }
 
   &:active {
@@ -15,6 +24,11 @@
 
   &[data-selected='true'] {
     background-color: var(--mds-color-theme-background-primary-active);
+
+    @media (forced-colors: active) {
+      background-color: SelectedItem;
+      color: SelectedItemText;
+    }
   }
 
   &[data-focused='true'] {

--- a/src/components/Tab/Tab.style.scss
+++ b/src/components/Tab/Tab.style.scss
@@ -5,6 +5,10 @@
   outline: none !important;
   transition: background-color 0.2s, color 0.2s, border-color 0.2s;
 
+  @media (forced-colors: active) {
+    border: 1px solid ButtonBorder;
+  }
+
   /* Colorization */
   &[data-active='false'] {
     &[data-disabled='false'] {

--- a/src/components/ThemeProvider/ThemeProvider.style.scss
+++ b/src/components/ThemeProvider/ThemeProvider.style.scss
@@ -54,7 +54,7 @@
   --md-globals-border-style-solid: solid;
 
   @media (forced-colors: active) {
-    --md-globals-focus-ring-outline: 0.125rem solid var(--mds-color-theme-outline-theme-normal);
+    --md-globals-focus-ring-outline: 0.125rem solid CanvasText;
   }
 
   // Gradient backgrounds

--- a/src/components/TreeNodeBase/TreeNodeBase.style.scss
+++ b/src/components/TreeNodeBase/TreeNodeBase.style.scss
@@ -17,6 +17,11 @@
   &.selected {
     color: var(--mds-color-theme-text-primary-normal);
     background-color: var(--mds-color-theme-background-primary-active);
+
+    @media (forced-colors: active) {
+      background: SelectedItem !important;
+      color: SelectedItemText !important;
+    }
   }
 
   &.focus {


### PR DESCRIPTION
# Description

This PR introduces the following changes, only for Windows High Contrast:
- Added SelectedItem system colors to active state of RadioSimple
- Added SelectedItem system colors to active state of ListItemBase
- Added SelectedItem system colors to selected state of TreeNodeBase
- Added AccentColor system colors to Badge
- Added SelectedItem system colors to active state of ButtonCircleToggle
- Added SelectedItem system colors to active state of ButtonPillToggle
- Tell the browser not to override the avatar background colors

# Links
Jira Ticket: https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-506028
Confluence: https://confluence-eng-gpk2.cisco.com/conf/pages/viewpage.action?pageId=546082395
System Color Definition: https://drafts.csswg.org/css-color/#css-system-colors