### PR TITLE
fix(types): use AriaRole instead of string for role prop

### DIFF
--- a/src/components/ButtonGroup/ButtonGroup.types.ts
+++ b/src/components/ButtonGroup/ButtonGroup.types.ts
@@ -1,4 +1,4 @@
-import { CSSProperties, ReactElement } from 'react';
+import { AriaRole, CSSProperties, ReactElement } from 'react';
 
 import { ButtonCircleProps } from '../ButtonCircle';
 import { ButtonPillProps } from '../ButtonPill';
@@ -59,7 +59,7 @@ export interface Props {
   /**
    * Role for adding accessibility
    */
-  role?: string;
+  role?: AriaRole;
 
   /**
    * Orientation of ButtonGroup

--- a/src/components/ButtonSimple/ButtonSimple.types.ts
+++ b/src/components/ButtonSimple/ButtonSimple.types.ts
@@ -1,4 +1,4 @@
-import { CSSProperties, ReactNode } from 'react';
+import { AriaRole, CSSProperties, ReactNode } from 'react';
 import { AriaButtonProps } from '@react-types/button';
 import { HoverProps } from '@react-aria/interactions';
 
@@ -38,7 +38,7 @@ export interface Props extends AriaButtonProps, HoverProps {
   /**
    * Role for adding accessibility
    */
-  role?: string;
+  role?: AriaRole;
 
   /**
    * Tabindex for accessibility

--- a/src/components/List/List.types.ts
+++ b/src/components/List/List.types.ts
@@ -1,4 +1,4 @@
-import { CSSProperties, Dispatch, ReactNode, SetStateAction } from 'react';
+import { AriaRole, CSSProperties, Dispatch, ReactNode, SetStateAction } from 'react';
 
 export type ListOrientation = 'horizontal' | 'vertical';
 
@@ -36,7 +36,7 @@ export interface Props {
   /**
    * Aria role
    */
-  role?: string;
+  role?: AriaRole;
 
   /**
    * Determines if the onPress handler should also focus the selected item

--- a/src/components/ListItemBase/ListItemBase.types.ts
+++ b/src/components/ListItemBase/ListItemBase.types.ts
@@ -1,4 +1,4 @@
-import { CSSProperties, ReactNode } from 'react';
+import { AriaRole, CSSProperties, ReactNode } from 'react';
 import { PressEvents } from '@react-types/shared';
 import { FocusProps, FocusWithinProps } from '@react-aria/interactions';
 
@@ -63,7 +63,7 @@ export interface Props
    * Aria role
    * @default "listitem"
    */
-  role?: string;
+  role?: AriaRole;
 
   /**
    * Indicates wether this item is currently focusable


### PR DESCRIPTION
# Description

A small PR to update the types of components to use AriaRole instead of string for the role property.
