### PR TITLE
fix(space-list-content): compact mode text layout issue

### DIFF
--- a/src/components/SpaceRowContent/SpaceRowContent.style.scss
+++ b/src/components/SpaceRowContent/SpaceRowContent.style.scss
@@ -27,13 +27,13 @@
     justify-content: flex-start;
   }
 
-  p, .md-text-wrapper {
+  div.md-text-wrapper {
     margin: 0;
-    float: left;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    width: 100%;
+    flex-shrink: 0;
+    max-width: 100%;
   }
 
   small {


### PR DESCRIPTION
# Description

an earlier change updated the element types of the text, leading to unwanted styles applied on the wrong elements

before:
<img width="886" alt="Screenshot 2024-10-24 at 01 34 05" src="https://github.com/user-attachments/assets/3be5b127-b2ba-4c21-8e41-caae24d461e1">

after:
<img width="886" alt="Screenshot 2024-10-24 at 01 34 18" src="https://github.com/user-attachments/assets/7e69bf4c-39a6-4ab7-95cb-6d772c0a9deb">

I've also verified that it's working for compact / non-compact mode, as well as on narrow / wide displays:
<img width="282" alt="Screenshot 2024-10-24 at 01 34 35" src="https://github.com/user-attachments/assets/ebb7e90f-12e4-49d4-bdd4-6fea05009104">
<img width="282" alt="Screenshot 2024-10-24 at 01 35 05" src="https://github.com/user-attachments/assets/b51ded14-0100-46d7-ba5e-4d82e096b269">
<img width="1030" alt="Screenshot 2024-10-24 at 01 35 14" src="https://github.com/user-attachments/assets/9c12025f-cdaa-44fc-a22a-de0a6ba9ecd3">


# Links

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-573770
