### PR TITLE
fix(tree): stop scrolling away when selecting a new node in virtualized tree

### DIFF
--- a/src/components/Tree/Tree.test.tsx
+++ b/src/components/Tree/Tree.test.tsx
@@ -548,6 +548,27 @@ describe('<Tree />', () => {
       expect(scrollToNode).toHaveBeenCalledTimes(0);
     });
 
+    it('should not call scrollToNode when the focus moves back to the tree to a different node even if the active node is not in the DOM', async () => {
+      expect.assertions(4);
+      const scrollToNode = jest.fn();
+      const { getByText } = await renderTreeAndRemoveNode({
+        scrollToNode,
+        setNodeOpen: jest.fn(),
+      });
+
+      document.body.focus();
+      await userEvent.tab();
+      expect(scrollToNode).toHaveBeenCalledTimes(1);
+      expect(scrollToNode).toHaveBeenCalledWith('1');
+      scrollToNode.mockReset();
+
+      await userEvent.click(getByText('4.1'));
+
+      // Only adding back Node 1 will remove the cloned node
+      expect(getByText('1')).not.toBeNull();
+      expect(scrollToNode).toHaveBeenCalledTimes(0);
+    });
+
     it.each`
       keyPressed
       ${'ArrowUp'}

--- a/src/components/Tree/Tree.tsx
+++ b/src/components/Tree/Tree.tsx
@@ -212,7 +212,7 @@ const Tree = forwardRef((props: Props, ref: ForwardedRef<TreeRefObject>) => {
       setIsFocusWithin(true);
       const targetNode = e.target.closest('[data-nodeid]');
       if (!!targetNode && targetNode.getAttribute('data-nodeid') !== activeNode) {
-        // if the user's focus is on a different tree node, then don't scroll to the current actie node
+        // if the user's focus is on a different tree node, then don't scroll to the current active node
         return;
       }
       scrollToVTreeNode(activeNode);

--- a/src/components/Tree/Tree.tsx
+++ b/src/components/Tree/Tree.tsx
@@ -107,7 +107,7 @@ const Tree = forwardRef((props: Props, ref: ForwardedRef<TreeRefObject>) => {
         scrollToVTreeNode(newNodeId);
       }
     },
-    [isVirtualTree, setActiveNode]
+    [scrollToVTreeNode]
   );
 
   const toggleTreeNode = useCallback(
@@ -181,14 +181,15 @@ const Tree = forwardRef((props: Props, ref: ForwardedRef<TreeRefObject>) => {
       isFocusWithin,
     }),
     [
-      activeNode,
       getNodeAriaProps,
       getNodeDetails,
       isRenderedFlat,
       shouldNodeFocusBeInset,
+      activeNode,
+      setActiveNodeId,
       toggleTreeNode,
-      itemSelection,
       selectableNodes,
+      itemSelection,
       isFocusWithin,
     ]
   );
@@ -207,11 +208,17 @@ const Tree = forwardRef((props: Props, ref: ForwardedRef<TreeRefObject>) => {
   );
 
   const { focusWithinProps } = useFocusWithin({
-    onFocusWithinChange: (val) => {
-      setIsFocusWithin(val);
-      if (val) {
-        scrollToVTreeNode(activeNode);
+    onFocusWithin: (e) => {
+      setIsFocusWithin(true);
+      const targetNode = e.target.closest('[data-nodeid]');
+      if (!!targetNode && targetNode.getAttribute('data-nodeid') !== activeNode) {
+        // if the user's focus is on a different tree node, then don't scroll to the current actie node
+        return;
       }
+      scrollToVTreeNode(activeNode);
+    },
+    onBlurWithin: () => {
+      setIsFocusWithin(false);
     },
   });
 


### PR DESCRIPTION
# Description

bug: (virtualized tree) after clicking on a node, then scrolling away to click on another node, the tree attempts to scroll back to the last selected node

cause: for keyboard users, it's important that the node is rendered in the virtualized tree, thus there's some code that makes the virtualized tree scroll to the active node if focus comes within the tree. however, this caused the bug above

fix: we don't do the scrolling thing IF the focus is on / within another tree node

# Links

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-573336