### PR TITLE
fix(SPARK-573927): add text color judgment in light theme

### DIFF
--- a/src/legacy/Lightbox/index.js
+++ b/src/legacy/Lightbox/index.js
@@ -501,7 +501,6 @@ class Lightbox extends React.Component {
                   className="md-lightbox__control"
                   data-test="zoom-out-button"
                   onPress={() => this.setZoom(-0.25)}
-                  color="red"
                 >
                   <IconNext
                     name="zoom-out"

--- a/src/legacy/Lightbox/index.js
+++ b/src/legacy/Lightbox/index.js
@@ -543,6 +543,7 @@ class Lightbox extends React.Component {
         </div>
       );
     };
+    
     return (
       <Modal
         includeDefaultStyles={false}
@@ -570,7 +571,7 @@ class Lightbox extends React.Component {
             </div>
             <div className="md-lightbox__header-item--right">
               <TooltipNext
-                style={{color:'var(--mds-color-theme-text-primary-normal)'}}
+                style={LightThemeStyle}
                 type="label"
                 placement="bottom-start"
                 triggerComponent={

--- a/src/legacy/Lightbox/index.js
+++ b/src/legacy/Lightbox/index.js
@@ -9,6 +9,7 @@ import TooltipNext from '../../components/Tooltip';
 import IconNext from '../../components/Icon';
 import MomentumThemeProvider from '../../components/ThemeProvider';
 import LoadingSpinner from '../../components/LoadingSpinner';
+import {THEME_NAMES} from '../../components/ThemeProvider/ThemeProvider.constants';
 
 import { v4 as uuidv4 } from 'uuid';
 
@@ -27,7 +28,6 @@ class Lightbox extends React.Component {
       height: 600,
     },
     zoom: 1,
-    theme: 'lightWebex',
   };
 
   componentDidMount() {
@@ -170,7 +170,7 @@ class Lightbox extends React.Component {
     const currentPage = pages[index];
     const showColumn = pages.length > 1;
 
-    const LightThemeStyle = this.props.theme === this.state.theme   
+    const LightThemeStyle = this.props.theme === THEME_NAMES.LIGHT_WEBEX   
     ? { color: 'var(--mds-color-theme-text-primary-normal)' }   
     : {}; 
 

--- a/src/legacy/Lightbox/index.js
+++ b/src/legacy/Lightbox/index.js
@@ -27,6 +27,7 @@ class Lightbox extends React.Component {
       height: 600,
     },
     zoom: 1,
+    theme: 'lightWebex',
   };
 
   componentDidMount() {
@@ -168,6 +169,10 @@ class Lightbox extends React.Component {
     const { zoom, viewportDimensions } = this.state;
     const currentPage = pages[index];
     const showColumn = pages.length > 1;
+
+    const LightThemeStyle = this.props.theme === this.state.theme   
+    ? { color: 'var(--mds-color-theme-text-primary-normal)' }   
+    : {}; 
 
     const calculateAspectRatioFit = (srcWidth, srcHeight, maxWidth, maxHeight) => {
       let maxW, maxH;
@@ -352,6 +357,7 @@ class Lightbox extends React.Component {
 
     const leftArrowControl = (
       <TooltipNext
+        style={LightThemeStyle}
         type="label"
         placement="right"
         triggerComponent={
@@ -373,6 +379,7 @@ class Lightbox extends React.Component {
 
     const rightArrowControl = (
       <TooltipNext
+        style={LightThemeStyle}
         type="label"
         placement="left"
         triggerComponent={
@@ -395,6 +402,7 @@ class Lightbox extends React.Component {
     const viewportControls = () => {
       const downloadButton = (
         <TooltipNext
+        style={LightThemeStyle}
           type="label"
           placement="top"
           triggerComponent={
@@ -429,6 +437,7 @@ class Lightbox extends React.Component {
         pages.length > 1 ? (
           <div className="md-lightbox__controls md-lightbox__controls--center">
             <TooltipNext
+            style={LightThemeStyle}
               type="label"
               placement="top"
               triggerComponent={
@@ -449,6 +458,7 @@ class Lightbox extends React.Component {
             </TooltipNext>
             <span className="md-lightbox__control-value">{`${index + 1} / ${pages.length}`}</span>
             <TooltipNext
+            style={LightThemeStyle}
               type="label"
               placement="top"
               triggerComponent={
@@ -483,6 +493,7 @@ class Lightbox extends React.Component {
         >
           <div className="md-lightbox__controls" style={controlStyle}>
             <TooltipNext
+            style={LightThemeStyle}
               type="label"
               placement="top"
               triggerComponent={
@@ -490,6 +501,7 @@ class Lightbox extends React.Component {
                   className="md-lightbox__control"
                   data-test="zoom-out-button"
                   onPress={() => this.setZoom(-0.25)}
+                  color="red"
                 >
                   <IconNext
                     name="zoom-out"
@@ -506,6 +518,7 @@ class Lightbox extends React.Component {
               {`${Math.round(((newHeight * 1.0) / height) * 100)}%`}
             </span>
             <TooltipNext
+            style={LightThemeStyle}
               type="label"
               placement="top"
               triggerComponent={
@@ -531,7 +544,6 @@ class Lightbox extends React.Component {
         </div>
       );
     };
-
     return (
       <Modal
         includeDefaultStyles={false}
@@ -559,6 +571,7 @@ class Lightbox extends React.Component {
             </div>
             <div className="md-lightbox__header-item--right">
               <TooltipNext
+                style={{color:'var(--mds-color-theme-text-primary-normal)'}}
                 type="label"
                 placement="bottom-start"
                 triggerComponent={

--- a/src/legacy/Lightbox/tests/index.spec.js.snap
+++ b/src/legacy/Lightbox/tests/index.spec.js.snap
@@ -290,11 +290,7 @@ exports[`tests for <Lightbox /> should match SnapShot 1`] = `
                       >
                         <Tooltip
                           placement="bottom-start"
-                          style={
-                            {
-                              "color": "var(--mds-color-theme-text-primary-normal)",
-                            }
-                          }
+                          style={{}}
                           triggerComponent={
                             <ButtonSimple
                               className="md-lightbox__control md-lightbox__control-close"
@@ -323,11 +319,7 @@ exports[`tests for <Lightbox /> should match SnapShot 1`] = `
                             setInstance={[Function]}
                             showArrow={true}
                             strategy="absolute"
-                            style={
-                              {
-                                "color": "var(--mds-color-theme-text-primary-normal)",
-                              }
-                            }
+                            style={{}}
                             trigger="mouseenter focus"
                             triggerComponent={
                               <ButtonSimple

--- a/src/legacy/Lightbox/tests/index.spec.js.snap
+++ b/src/legacy/Lightbox/tests/index.spec.js.snap
@@ -290,6 +290,11 @@ exports[`tests for <Lightbox /> should match SnapShot 1`] = `
                       >
                         <Tooltip
                           placement="bottom-start"
+                          style={
+                            {
+                              "color": "var(--mds-color-theme-text-primary-normal)",
+                            }
+                          }
                           triggerComponent={
                             <ButtonSimple
                               className="md-lightbox__control md-lightbox__control-close"
@@ -318,6 +323,11 @@ exports[`tests for <Lightbox /> should match SnapShot 1`] = `
                             setInstance={[Function]}
                             showArrow={true}
                             strategy="absolute"
+                            style={
+                              {
+                                "color": "var(--mds-color-theme-text-primary-normal)",
+                              }
+                            }
                             trigger="mouseenter focus"
                             triggerComponent={
                               <ButtonSimple
@@ -616,6 +626,7 @@ exports[`tests for <Lightbox /> should match SnapShot 1`] = `
                           >
                             <Tooltip
                               placement="top"
+                              style={{}}
                               triggerComponent={
                                 <ButtonSimple
                                   className="md-lightbox__control"
@@ -645,6 +656,7 @@ exports[`tests for <Lightbox /> should match SnapShot 1`] = `
                                 setInstance={[Function]}
                                 showArrow={true}
                                 strategy="absolute"
+                                style={{}}
                                 trigger="mouseenter focus"
                                 triggerComponent={
                                   <ButtonSimple
@@ -896,6 +908,7 @@ exports[`tests for <Lightbox /> should match SnapShot 1`] = `
                             </span>
                             <Tooltip
                               placement="top"
+                              style={{}}
                               triggerComponent={
                                 <ButtonSimple
                                   className="md-lightbox__control"
@@ -925,6 +938,7 @@ exports[`tests for <Lightbox /> should match SnapShot 1`] = `
                                 setInstance={[Function]}
                                 showArrow={true}
                                 strategy="absolute"
+                                style={{}}
                                 trigger="mouseenter focus"
                                 triggerComponent={
                                   <ButtonSimple
@@ -1181,6 +1195,7 @@ exports[`tests for <Lightbox /> should match SnapShot 1`] = `
                           </div>
                           <Tooltip
                             placement="top"
+                            style={{}}
                             triggerComponent={
                               <ButtonSimple
                                 className="md-lightbox__control md-lightbox__control-download"
@@ -1209,6 +1224,7 @@ exports[`tests for <Lightbox /> should match SnapShot 1`] = `
                               setInstance={[Function]}
                               showArrow={true}
                               strategy="absolute"
+                              style={{}}
                               trigger="mouseenter focus"
                               triggerComponent={
                                 <ButtonSimple


### PR DESCRIPTION
# IMPORTANT

**Currently, this project is closed to any external contributions. Any pull request made against this project from external sources will likely be closed. If you would like to make changes to this project, please fork this project.**

# Guide

**This "Help" section can be deleted before submitting this pull request.**

*Update the name of this pull request to reflect the following shape:*

```
{type}/{scope?}/{message}
```

* **type** - A [conventional commit type](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional#type-enum) **REQUIRED**
* **scope** - The kabab-case scope of the changes in this request
* **message** - A short, kebab-case statement describing the changes **REQUIRED**

*Provide a general summary of the scope of the changes in this pull request.*

* [Readme](https://github.com/momentum-design/momentum-react-v2/blob/master/README.md)
* [Getting Started Guide](https://github.com/momentum-design/momentum-react-v2/blob/master/GETTING_STARTED.md)
* [Contributing Guide](https://github.com/momentum-design/momentum-react-v2/blob/master/CONTRIBUTING.md)

# Description
    Original behavior: Overwrite tooltip text color, no judgment on tooltip text color change, use the color inherited from the parent element
*The full description of the changes made in this request.*
Now changed to: When the theme is lightWebex, add style={{color:""}} attribute to each tooltip, because the inline style has a higher weight than the style inherited from the parent, so the text color will not be overwritten
# Links
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-573927?filter=-1
*Links to relevent resources.*
