### PR TITLE
fix(space-tree-node): read vs unread text should have different colors

### DIFF
--- a/src/components/SpaceTreeNode/SpaceTreeNode.style.scss
+++ b/src/components/SpaceTreeNode/SpaceTreeNode.style.scss
@@ -1,5 +1,5 @@
 .md-space-tree-node-wrapper {
-  color: var(--mds-color-theme-text-secondary-normal);
+  color: var(--mds-color-theme-text-secondary-normal) !important;
 
   &[data-size='32'] {
     // All immediate children and any deep .md-text-wrapper child


### PR DESCRIPTION
# IMPORTANT

**Currently, this project is closed to any external contributions. Any pull request made against this project from external sources will likely be closed. If you would like to make changes to this project, please fork this project.**

# Guide

**This "Help" section can be deleted before submitting this pull request.**

*Update the name of this pull request to reflect the following shape:*

```
{type}/{scope?}/{message}
```

* **type** - A [conventional commit type](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional#type-enum) **REQUIRED**
* **scope** - The kabab-case scope of the changes in this request
* **message** - A short, kebab-case statement describing the changes **REQUIRED**

*Provide a general summary of the scope of the changes in this pull request.*

* [Readme](https://github.com/momentum-design/momentum-react-v2/blob/master/README.md)
* [Getting Started Guide](https://github.com/momentum-design/momentum-react-v2/blob/master/GETTING_STARTED.md)
* [Contributing Guide](https://github.com/momentum-design/momentum-react-v2/blob/master/CONTRIBUTING.md)

# Description
before:
<img width="425" alt="Screenshot 2024-10-31 at 15 57 16" src="https://github.com/user-attachments/assets/2adfb7b1-a6ed-4ce6-8738-478afe8c0f71">

after:
<img width="425" alt="Screenshot 2024-10-31 at 15 57 03" src="https://github.com/user-attachments/assets/89fcb33b-8f59-4cb7-91f3-68be49195c84">

colors between space list item is now same as space tree node
<img width="920" alt="Screenshot 2024-10-31 at 15 59 52" src="https://github.com/user-attachments/assets/86a677a4-9b82-44ca-93b2-45b79f87d1c1">
<img width="920" alt="Screenshot 2024-10-31 at 15 59 57" src="https://github.com/user-attachments/assets/4785e33f-becc-43fc-8c8e-dcf06d982be9">


# Links

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-574098
