### PR TITLE
test(Lightbox): fix broken tests due to jest downgrade

### DIFF
--- a/src/legacy/Lightbox/tests/index.spec.js.snap
+++ b/src/legacy/Lightbox/tests/index.spec.js.snap
@@ -290,7 +290,7 @@ exports[`tests for <Lightbox /> should match SnapShot 1`] = `
                       >
                         <Tooltip
                           placement="bottom-start"
-                          style={{}}
+                          style={Object {}}
                           triggerComponent={
                             <ButtonSimple
                               className="md-lightbox__control md-lightbox__control-close"
@@ -319,7 +319,7 @@ exports[`tests for <Lightbox /> should match SnapShot 1`] = `
                             setInstance={[Function]}
                             showArrow={true}
                             strategy="absolute"
-                            style={{}}
+                            style={Object {}}
                             trigger="mouseenter focus"
                             triggerComponent={
                               <ButtonSimple
@@ -618,7 +618,7 @@ exports[`tests for <Lightbox /> should match SnapShot 1`] = `
                           >
                             <Tooltip
                               placement="top"
-                              style={{}}
+                              style={Object {}}
                               triggerComponent={
                                 <ButtonSimple
                                   className="md-lightbox__control"
@@ -648,7 +648,7 @@ exports[`tests for <Lightbox /> should match SnapShot 1`] = `
                                 setInstance={[Function]}
                                 showArrow={true}
                                 strategy="absolute"
-                                style={{}}
+                                style={Object {}}
                                 trigger="mouseenter focus"
                                 triggerComponent={
                                   <ButtonSimple
@@ -900,7 +900,7 @@ exports[`tests for <Lightbox /> should match SnapShot 1`] = `
                             </span>
                             <Tooltip
                               placement="top"
-                              style={{}}
+                              style={Object {}}
                               triggerComponent={
                                 <ButtonSimple
                                   className="md-lightbox__control"
@@ -930,7 +930,7 @@ exports[`tests for <Lightbox /> should match SnapShot 1`] = `
                                 setInstance={[Function]}
                                 showArrow={true}
                                 strategy="absolute"
-                                style={{}}
+                                style={Object {}}
                                 trigger="mouseenter focus"
                                 triggerComponent={
                                   <ButtonSimple
@@ -1187,7 +1187,7 @@ exports[`tests for <Lightbox /> should match SnapShot 1`] = `
                           </div>
                           <Tooltip
                             placement="top"
-                            style={{}}
+                            style={Object {}}
                             triggerComponent={
                               <ButtonSimple
                                 className="md-lightbox__control md-lightbox__control-download"
@@ -1216,7 +1216,7 @@ exports[`tests for <Lightbox /> should match SnapShot 1`] = `
                               setInstance={[Function]}
                               showArrow={true}
                               strategy="absolute"
-                              style={{}}
+                              style={Object {}}
                               trigger="mouseenter focus"
                               triggerComponent={
                                 <ButtonSimple


### PR DESCRIPTION
# Description

Fix broken snapshot for legacy lightbox component. This was due to the jest downgrade, the up to date version (29.7.0) uses `{}` to represent objects whereas the version mrv2 uses now (26.6.3) uses `Object {}`
