### PR TITLE
fix(ScreenReaderAnnouncer): fix storybook docs page

### DIFF
--- a/src/components/ScreenReaderAnnouncer/ScreenReaderAnnouncer.stories.args.ts
+++ b/src/components/ScreenReaderAnnouncer/ScreenReaderAnnouncer.stories.args.ts
@@ -1,4 +1,3 @@
-import { commonStyles } from '../../storybook/helper.stories.argtypes';
 import { LEVELS, DEFAULTS } from './ScreenReaderAnnouncer.constants';
 
 const screenReaderAnnouncerArgTypes = {
@@ -16,14 +15,14 @@ const screenReaderAnnouncerArgTypes = {
   },
   level: {
     description: 'The aria-live value for the announcement',
-    options: [undefined, ...LEVELS.ASSERTIVE],
+    options: [undefined, LEVELS.POLITE, LEVELS.ASSERTIVE],
     control: { type: 'select' },
     table: {
       type: {
         summary: 'string',
       },
       defaultValue: {
-        summary: 'undefined',
+        summary: DEFAULTS.LEVEL,
       },
     },
   },
@@ -58,6 +57,5 @@ const screenReaderAnnouncerArgTypes = {
 export { screenReaderAnnouncerArgTypes };
 
 export default {
-  ...commonStyles,
   ...screenReaderAnnouncerArgTypes,
 };

--- a/src/components/ScreenReaderAnnouncer/ScreenReaderAnnouncer.stories.tsx
+++ b/src/components/ScreenReaderAnnouncer/ScreenReaderAnnouncer.stories.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { DocumentationPage } from '../../storybook/helper.stories.docs';
-import StyleDocs from '../../storybook/docs.stories.style.mdx';
-import { Story } from '@storybook/react';
+import { ComponentMeta, Story } from '@storybook/react';
 
 import ScreenReaderAnnouncer, { ScreenReaderAnnounceOptions } from './';
 import argTypes from './ScreenReaderAnnouncer.stories.args';
@@ -15,10 +14,11 @@ export default {
   parameters: {
     expanded: true,
     docs: {
-      page: DocumentationPage(Documentation, StyleDocs),
+      page: DocumentationPage(Documentation),
+      inlineStories: false,
     },
   },
-};
+} as ComponentMeta<typeof ScreenReaderAnnouncer>;
 
 const buttonid1 = 'id-1';
 const buttonid2 = 'id-2';


### PR DESCRIPTION
# Description

This PR fixes the Screen Reader Announcer docs page. Currently it crashes when trying to load due to duplicate screen reader identities. This PR makes the doc use iframes instead of inline loading the components.
