### PR TITLE
feat(menu): add prop for inset focus ring

### DIFF
--- a/src/components/FocusRing/FocusRing.stories.args.ts
+++ b/src/components/FocusRing/FocusRing.stories.args.ts
@@ -63,7 +63,7 @@ export default {
       },
     },
   },
-  within: {
+  isInset: {
     description:
       'Whether to show the focus ring when something inside the container element has focus (true), or only if the container itself has focus (false).',
     control: { type: 'boolean' },

--- a/src/components/ListItemBase/ListItemBase.tsx
+++ b/src/components/ListItemBase/ListItemBase.tsx
@@ -279,7 +279,7 @@ const ListItemBase = (props: Props, providedRef: RefOrCallbackRef) => {
       return;
     }
     updateTabIndexes();
-  }, [currentFocus, updateTabIndexes, isFocusedWithin]);
+  }, [currentFocus, updateTabIndexes, isFocusedWithin, listContext]);
 
   useMutationObservable(ref.current, updateTabIndexes);
 

--- a/src/components/Menu/Menu.stories.args.ts
+++ b/src/components/Menu/Menu.stories.args.ts
@@ -150,4 +150,8 @@ export default {
       },
     },
   },
+  shouldItemFocusBeInset: {
+    description: 'Whether if the focus ring wrapping the list items should be inset',
+    control: 'boolean',
+  },
 };

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -19,6 +19,7 @@ import MenuSection from '../MenuSection';
 import MenuSelectionGroup from '../MenuSelectionGroup';
 import ContentSeparator from '../ContentSeparator';
 import { defaults } from 'lodash';
+import { ListContext } from '../List/List.utils';
 
 export const MenuContext = React.createContext<MenuContextValue>({});
 
@@ -48,6 +49,7 @@ const Menu = <T extends object>(props: Props<T>, providedRef: RefObject<HTMLDivE
     itemShape = DEFAULTS.ITEM_SHAPE,
     itemSize = DEFAULTS.ITEM_SIZE,
     ariaLabelledby,
+    shouldItemFocusBeInset,
   } = props;
 
   const contextProps = useMenuContext();
@@ -128,19 +130,21 @@ const Menu = <T extends object>(props: Props<T>, providedRef: RefObject<HTMLDivE
     <MenuAppearanceContext.Provider
       value={{ itemShape, itemSize, tickPosition, classNameSelectedItem }}
     >
-      <div
-        className={classnames(className, STYLE.wrapper)}
-        id={id}
-        style={style}
-        ref={ref}
-        aria-labelledby={ariaLabelledby}
-        {...menuProps}
-      >
-        {itemArray.map((key) => {
-          const item = state.collection.getItem(key) as Node<T>;
-          return renderItem(item, state);
-        })}
-      </div>
+      <ListContext.Provider value={{ shouldItemFocusBeInset: shouldItemFocusBeInset }}>
+        <div
+          className={classnames(className, STYLE.wrapper)}
+          id={id}
+          style={style}
+          ref={ref}
+          aria-labelledby={ariaLabelledby}
+          {...menuProps}
+        >
+          {itemArray.map((key) => {
+            const item = state.collection.getItem(key) as Node<T>;
+            return renderItem(item, state);
+          })}
+        </div>
+      </ListContext.Provider>
     </MenuAppearanceContext.Provider>
   );
 };

--- a/src/components/Menu/Menu.types.ts
+++ b/src/components/Menu/Menu.types.ts
@@ -54,6 +54,11 @@ export interface Props<T> extends AriaMenuProps<T> {
    * Custom class for overriding this component's items CSS when selected.
    */
   classNameSelectedItem?: string;
+
+  /**
+   * Whether if the focus ring wrapping the list items should be inset.
+   */
+  shouldItemFocusBeInset?: boolean;
 }
 
 export interface MenuContextValue extends HTMLAttributes<HTMLElement> {

--- a/src/components/Menu/Menu.unit.test.tsx
+++ b/src/components/Menu/Menu.unit.test.tsx
@@ -19,6 +19,7 @@ import {
 } from './Menu';
 import ListItemBaseSection from '../ListItemBaseSection';
 import ContentSeparator from '../ContentSeparator';
+import { FocusRing } from 'react-aria';
 
 describe('useMenuAppearanceContext', () => {
   const fakeMenuAppearanceContextValue: MenuAppearanceContextValue = {
@@ -295,6 +296,16 @@ describe('<Menu />', () => {
       const container = mount(<Menu {...props} />);
       expect(container).toMatchSnapshot();
     });
+
+    it('should match snapshot with shouldItemFocusBeInset', () => {
+      const props = {
+        ...defaultProps,
+        shouldItemFocusBeInset: true,
+      };
+
+      const container = mount(<Menu {...props} />);
+      expect(container).toMatchSnapshot();
+    });
   });
 
   describe('attributes', () => {
@@ -423,6 +434,26 @@ describe('<Menu />', () => {
         .getDOMNode();
 
       expect(selectedItem.classList.contains(classNameSelectedItem)).toBe(true);
+    });
+
+    it('focus ring should be inset if shouldItemFocusBeInset is true', () => {
+      expect.assertions(1);
+
+      const focusRing = mount(<Menu {...defaultProps} shouldItemFocusBeInset />)
+        .find(FocusRing)
+        .first();
+
+      expect(focusRing.prop('isInset')).toBe(true);
+    });
+
+    it('focus ring should be inset if shouldItemFocusBeInset is false', () => {
+      expect.assertions(1);
+
+      const focusRing = mount(<Menu {...defaultProps} shouldItemFocusBeInset={false} />)
+        .find(FocusRing)
+        .first();
+
+      expect(focusRing.prop('isInset')).toBe(false);
     });
   });
 

--- a/src/components/Menu/Menu.unit.test.tsx.snap
+++ b/src/components/Menu/Menu.unit.test.tsx.snap
@@ -10022,6 +10022,488 @@ exports[`<Menu /> snapshot should match snapshot with seperator within selection
 </_Menu>
 `;
 
+exports[`<Menu /> snapshot should match snapshot with shouldItemFocusBeInset 1`] = `
+<_Menu
+  aria-label="Menu component"
+  shouldItemFocusBeInset={true}
+>
+  <div
+    aria-label="Menu component"
+    className="md-menu-wrapper"
+    onBlur={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onKeyDownCapture={[Function]}
+    onMouseDown={[Function]}
+    role="menu"
+    tabIndex={0}
+  >
+    <MenuItem
+      item={
+        Object {
+          "aria-label": undefined,
+          "childNodes": Object {
+            Symbol(Symbol.iterator): [Function],
+          },
+          "hasChildNodes": false,
+          "index": 0,
+          "key": "one",
+          "level": 0,
+          "nextKey": "two",
+          "parentKey": null,
+          "prevKey": undefined,
+          "props": Object {
+            "children": "One",
+          },
+          "rendered": "One",
+          "shouldInvalidate": undefined,
+          "textValue": "One",
+          "type": "item",
+          "value": undefined,
+          "wrapper": undefined,
+        }
+      }
+      key="one"
+      state={
+        Object {
+          "collection": $f4c7caecb598119f63e2918a55ec91a9$export$TreeCollection {
+            "firstKey": "one",
+            "iterable": Object {
+              Symbol(Symbol.iterator): [Function],
+            },
+            "keyMap": Map {
+              "one" => Object {
+                "aria-label": undefined,
+                "childNodes": Object {
+                  Symbol(Symbol.iterator): [Function],
+                },
+                "hasChildNodes": false,
+                "index": 0,
+                "key": "one",
+                "level": 0,
+                "nextKey": "two",
+                "parentKey": null,
+                "prevKey": undefined,
+                "props": Object {
+                  "children": "One",
+                },
+                "rendered": "One",
+                "shouldInvalidate": undefined,
+                "textValue": "One",
+                "type": "item",
+                "value": undefined,
+                "wrapper": undefined,
+              },
+              "two" => Object {
+                "aria-label": undefined,
+                "childNodes": Object {
+                  Symbol(Symbol.iterator): [Function],
+                },
+                "hasChildNodes": false,
+                "index": 1,
+                "key": "two",
+                "level": 0,
+                "nextKey": undefined,
+                "parentKey": null,
+                "prevKey": "one",
+                "props": Object {
+                  "children": "Two",
+                },
+                "rendered": "Two",
+                "shouldInvalidate": undefined,
+                "textValue": "Two",
+                "type": "item",
+                "value": undefined,
+                "wrapper": undefined,
+              },
+            },
+            "lastKey": "two",
+          },
+          "disabledKeys": Set {},
+          "expandedKeys": Set {},
+          "selectionManager": SelectionManager {
+            "_isSelectAll": null,
+            "allowsCellSelection": false,
+            "collection": $f4c7caecb598119f63e2918a55ec91a9$export$TreeCollection {
+              "firstKey": "one",
+              "iterable": Object {
+                Symbol(Symbol.iterator): [Function],
+              },
+              "keyMap": Map {
+                "one" => Object {
+                  "aria-label": undefined,
+                  "childNodes": Object {
+                    Symbol(Symbol.iterator): [Function],
+                  },
+                  "hasChildNodes": false,
+                  "index": 0,
+                  "key": "one",
+                  "level": 0,
+                  "nextKey": "two",
+                  "parentKey": null,
+                  "prevKey": undefined,
+                  "props": Object {
+                    "children": "One",
+                  },
+                  "rendered": "One",
+                  "shouldInvalidate": undefined,
+                  "textValue": "One",
+                  "type": "item",
+                  "value": undefined,
+                  "wrapper": undefined,
+                },
+                "two" => Object {
+                  "aria-label": undefined,
+                  "childNodes": Object {
+                    Symbol(Symbol.iterator): [Function],
+                  },
+                  "hasChildNodes": false,
+                  "index": 1,
+                  "key": "two",
+                  "level": 0,
+                  "nextKey": undefined,
+                  "parentKey": null,
+                  "prevKey": "one",
+                  "props": Object {
+                    "children": "Two",
+                  },
+                  "rendered": "Two",
+                  "shouldInvalidate": undefined,
+                  "textValue": "Two",
+                  "type": "item",
+                  "value": undefined,
+                  "wrapper": undefined,
+                },
+              },
+              "lastKey": "two",
+            },
+            "state": Object {
+              "childFocusStrategy": null,
+              "disabledKeys": Set {},
+              "disallowEmptySelection": undefined,
+              "focusedKey": null,
+              "isFocused": false,
+              "selectedKeys": Set {},
+              "selectionMode": "none",
+              "setFocused": [Function],
+              "setFocusedKey": [Function],
+              "setSelectedKeys": [Function],
+            },
+          },
+          "toggleKey": [Function],
+        }
+      }
+    >
+      <ListItemBase
+        aria-disabled={false}
+        aria-labelledby={null}
+        className="md-menu-item-wrapper"
+        data-key="one"
+        isDisabled={false}
+        isPadded={true}
+        onClick={[Function]}
+        onDragStart={[Function]}
+        onFocus={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        onTouchCancel={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
+        role="menuitem"
+        shape="rectangle"
+        size={40}
+        tabIndex={-1}
+      >
+        <FocusRing
+          isInset={true}
+        >
+          <FocusRing
+            focusClass="md-focus-ring-wrapper isInset children md-focus-ring-inset"
+            focusRingClass="md-focus-ring-wrapper isInset children md-focus-ring-inset"
+            isInset={true}
+          >
+            <li
+              aria-disabled={false}
+              aria-labelledby={null}
+              className="md-menu-item-wrapper md-list-item-base-wrapper"
+              data-allow-text-select={false}
+              data-disabled={false}
+              data-interactive={true}
+              data-key="one"
+              data-padded={true}
+              data-shape="rectangle"
+              data-size={40}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onDragStart={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+              onPointerDown={[Function]}
+              onTouchCancel={[Function]}
+              onTouchEnd={[Function]}
+              onTouchMove={[Function]}
+              onTouchStart={[Function]}
+              role="menuitem"
+              tabIndex={-1}
+            >
+              <ListItemBaseSection
+                position="fill"
+                title="One"
+              >
+                <div
+                  data-position="fill"
+                  title="One"
+                >
+                  One
+                </div>
+              </ListItemBaseSection>
+            </li>
+          </FocusRing>
+        </FocusRing>
+      </ListItemBase>
+    </MenuItem>
+    <MenuItem
+      item={
+        Object {
+          "aria-label": undefined,
+          "childNodes": Object {
+            Symbol(Symbol.iterator): [Function],
+          },
+          "hasChildNodes": false,
+          "index": 1,
+          "key": "two",
+          "level": 0,
+          "nextKey": undefined,
+          "parentKey": null,
+          "prevKey": "one",
+          "props": Object {
+            "children": "Two",
+          },
+          "rendered": "Two",
+          "shouldInvalidate": undefined,
+          "textValue": "Two",
+          "type": "item",
+          "value": undefined,
+          "wrapper": undefined,
+        }
+      }
+      key="two"
+      state={
+        Object {
+          "collection": $f4c7caecb598119f63e2918a55ec91a9$export$TreeCollection {
+            "firstKey": "one",
+            "iterable": Object {
+              Symbol(Symbol.iterator): [Function],
+            },
+            "keyMap": Map {
+              "one" => Object {
+                "aria-label": undefined,
+                "childNodes": Object {
+                  Symbol(Symbol.iterator): [Function],
+                },
+                "hasChildNodes": false,
+                "index": 0,
+                "key": "one",
+                "level": 0,
+                "nextKey": "two",
+                "parentKey": null,
+                "prevKey": undefined,
+                "props": Object {
+                  "children": "One",
+                },
+                "rendered": "One",
+                "shouldInvalidate": undefined,
+                "textValue": "One",
+                "type": "item",
+                "value": undefined,
+                "wrapper": undefined,
+              },
+              "two" => Object {
+                "aria-label": undefined,
+                "childNodes": Object {
+                  Symbol(Symbol.iterator): [Function],
+                },
+                "hasChildNodes": false,
+                "index": 1,
+                "key": "two",
+                "level": 0,
+                "nextKey": undefined,
+                "parentKey": null,
+                "prevKey": "one",
+                "props": Object {
+                  "children": "Two",
+                },
+                "rendered": "Two",
+                "shouldInvalidate": undefined,
+                "textValue": "Two",
+                "type": "item",
+                "value": undefined,
+                "wrapper": undefined,
+              },
+            },
+            "lastKey": "two",
+          },
+          "disabledKeys": Set {},
+          "expandedKeys": Set {},
+          "selectionManager": SelectionManager {
+            "_isSelectAll": null,
+            "allowsCellSelection": false,
+            "collection": $f4c7caecb598119f63e2918a55ec91a9$export$TreeCollection {
+              "firstKey": "one",
+              "iterable": Object {
+                Symbol(Symbol.iterator): [Function],
+              },
+              "keyMap": Map {
+                "one" => Object {
+                  "aria-label": undefined,
+                  "childNodes": Object {
+                    Symbol(Symbol.iterator): [Function],
+                  },
+                  "hasChildNodes": false,
+                  "index": 0,
+                  "key": "one",
+                  "level": 0,
+                  "nextKey": "two",
+                  "parentKey": null,
+                  "prevKey": undefined,
+                  "props": Object {
+                    "children": "One",
+                  },
+                  "rendered": "One",
+                  "shouldInvalidate": undefined,
+                  "textValue": "One",
+                  "type": "item",
+                  "value": undefined,
+                  "wrapper": undefined,
+                },
+                "two" => Object {
+                  "aria-label": undefined,
+                  "childNodes": Object {
+                    Symbol(Symbol.iterator): [Function],
+                  },
+                  "hasChildNodes": false,
+                  "index": 1,
+                  "key": "two",
+                  "level": 0,
+                  "nextKey": undefined,
+                  "parentKey": null,
+                  "prevKey": "one",
+                  "props": Object {
+                    "children": "Two",
+                  },
+                  "rendered": "Two",
+                  "shouldInvalidate": undefined,
+                  "textValue": "Two",
+                  "type": "item",
+                  "value": undefined,
+                  "wrapper": undefined,
+                },
+              },
+              "lastKey": "two",
+            },
+            "state": Object {
+              "childFocusStrategy": null,
+              "disabledKeys": Set {},
+              "disallowEmptySelection": undefined,
+              "focusedKey": null,
+              "isFocused": false,
+              "selectedKeys": Set {},
+              "selectionMode": "none",
+              "setFocused": [Function],
+              "setFocusedKey": [Function],
+              "setSelectedKeys": [Function],
+            },
+          },
+          "toggleKey": [Function],
+        }
+      }
+    >
+      <ListItemBase
+        aria-disabled={false}
+        aria-labelledby={null}
+        className="md-menu-item-wrapper"
+        data-key="two"
+        isDisabled={false}
+        isPadded={true}
+        onClick={[Function]}
+        onDragStart={[Function]}
+        onFocus={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        onTouchCancel={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
+        role="menuitem"
+        shape="rectangle"
+        size={40}
+        tabIndex={-1}
+      >
+        <FocusRing
+          isInset={true}
+        >
+          <FocusRing
+            focusClass="md-focus-ring-wrapper isInset children md-focus-ring-inset"
+            focusRingClass="md-focus-ring-wrapper isInset children md-focus-ring-inset"
+            isInset={true}
+          >
+            <li
+              aria-disabled={false}
+              aria-labelledby={null}
+              className="md-menu-item-wrapper md-list-item-base-wrapper"
+              data-allow-text-select={false}
+              data-disabled={false}
+              data-interactive={true}
+              data-key="two"
+              data-padded={true}
+              data-shape="rectangle"
+              data-size={40}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onDragStart={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+              onPointerDown={[Function]}
+              onTouchCancel={[Function]}
+              onTouchEnd={[Function]}
+              onTouchMove={[Function]}
+              onTouchStart={[Function]}
+              role="menuitem"
+              tabIndex={-1}
+            >
+              <ListItemBaseSection
+                position="fill"
+                title="Two"
+              >
+                <div
+                  data-position="fill"
+                  title="Two"
+                >
+                  Two
+                </div>
+              </ListItemBaseSection>
+            </li>
+          </FocusRing>
+        </FocusRing>
+      </ListItemBase>
+    </MenuItem>
+  </div>
+</_Menu>
+`;
+
 exports[`<Menu /> snapshot should match snapshot with style 1`] = `
 <_Menu
   aria-label="Menu component"


### PR DESCRIPTION
# IMPORTANT

**Currently, this project is closed to any external contributions. Any pull request made against this project from external sources will likely be closed. If you would like to make changes to this project, please fork this project.**

# Guide

**This "Help" section can be deleted before submitting this pull request.**

*Update the name of this pull request to reflect the following shape:*

```
{type}/{scope?}/{message}
```

* **type** - A [conventional commit type](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional#type-enum) **REQUIRED**
* **scope** - The kabab-case scope of the changes in this request
* **message** - A short, kebab-case statement describing the changes **REQUIRED**

*Provide a general summary of the scope of the changes in this pull request.*

* [Readme](https://github.com/momentum-design/momentum-react-v2/blob/master/README.md)
* [Getting Started Guide](https://github.com/momentum-design/momentum-react-v2/blob/master/GETTING_STARTED.md)
* [Contributing Guide](https://github.com/momentum-design/momentum-react-v2/blob/master/CONTRIBUTING.md)

# Description
- add `shouldItemFocusBeInset` prop to menu, similar to `shouldNodeFocusBeInset` of TreeNodeBase
- update focusing storybook, we're using `isInset` not `within` (though we should probably switch to within at some point)

# Links

*Links to relevent resources.*
