### PR TITLE
fix(legacy/list-separator): remove low font-weight

### DIFF
--- a/scss/components/list-separator/list-separator.scss
+++ b/scss/components/list-separator/list-separator.scss
@@ -30,10 +30,6 @@
 
     &__text {
       padding: 0 8px;
-      font-family: $brand-font-regular;
-      font-size: 13px;
-      line-height: 1.5em;
-      letter-spacing: 0.015em;
       color: $md-gray-70;
     }
   }

--- a/scss/components/list-separator/list-separator.scss
+++ b/scss/components/list-separator/list-separator.scss
@@ -32,7 +32,6 @@
       padding: 0 8px;
       font-family: $brand-font-regular;
       font-size: 13px;
-      font-weight: 250;
       line-height: 1.5em;
       letter-spacing: 0.015em;
       color: $md-gray-70;

--- a/src/legacy/ListSeparator/index.js
+++ b/src/legacy/ListSeparator/index.js
@@ -3,10 +3,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { prefix } from '../utils/index';
+import { Text } from '../../components';
 
 /**
-* @deprecated - Components in the legacy folder (/src/legacy) are deprecated. Please use a component from the components folder (/src/components) instead. Legacy components may not follow accessibility standards.
-**/
+ * @deprecated - Components in the legacy folder (/src/legacy) are deprecated. Please use a component from the components folder (/src/components) instead. Legacy components may not follow accessibility standards.
+ **/
 const ListSeparator = (props) => {
   const { children, className, lineColor, margin, textColor, text, textPadding, ...otherProps } =
     props;
@@ -25,15 +26,17 @@ const ListSeparator = (props) => {
       <span className={`${lsClass}__container`}>
         {children ||
           (text && (
-            <span
+            <Text
               className={`${lsClass}__text`}
               style={{
                 ...(textColor && { color: textColor }),
                 ...(textPadding && { padding: textPadding }),
               }}
+              type="subheader-secondary"
+              tagName="span"
             >
               {children ? children : text}
-            </span>
+            </Text>
           ))}
       </span>
     </div>

--- a/src/legacy/ListSeparator/tests/index.spec.js
+++ b/src/legacy/ListSeparator/tests/index.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow, mount } from 'enzyme';
+import { shallow, mount, render } from 'enzyme';
 import { ListSeparator } from '@momentum-ui/react-collaboration';
 
 describe('tests for <ListSeparator />', () => {
@@ -16,7 +16,7 @@ describe('tests for <ListSeparator />', () => {
   });
 
   it('should render text prop', () => {
-    const container = shallow(<ListSeparator text="Today" />);
+    const container = render(<ListSeparator text="Today" />);
 
     expect(container.find('.md-list-separator__text').length).toEqual(1);
     expect(container.find('.md-list-separator__text').text()).toEqual('Today');


### PR DESCRIPTION
# Description

Remove `font-weight: 250` from legacy list separator component.

Before:
<img width="175" alt="Screenshot 2024-11-14 at 15 58 11" src="https://github.com/user-attachments/assets/bdd05fa0-26f1-468a-84ac-75b07562cb11">

After:
<img width="144" alt="Screenshot 2024-11-14 at 16 27 49" src="https://github.com/user-attachments/assets/bbb6657f-7bcb-4e74-911d-81d58b3fb8a7">


# Links
Jira Ticket: https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-579344
Figma Design: https://www.figma.com/design/FmXv8xvun1xAZiOMfztwqg/%F0%9F%A7%A9-Webex-App---Web?m=auto&node-id=5585-13072&t=oauxKqnz3RqbQApS-1
