### PR TITLE
fix(alertbanner): add other props for alert banner

### DIFF
--- a/src/components/AlertBanner/AlertBanner.tsx
+++ b/src/components/AlertBanner/AlertBanner.tsx
@@ -20,6 +20,7 @@ const AlertBanner: FC<Props> = (props: Props) => {
     isStatic,
     size,
     style,
+    ...otherProps
   } = props;
 
   const mutatedButtons = Children.map(buttons, (button) =>
@@ -61,6 +62,7 @@ const AlertBanner: FC<Props> = (props: Props) => {
       data-static={isStatic || DEFAULTS.IS_STATIC}
       id={id}
       style={style}
+      {...otherProps}
     >
       {imageComponent}
       {labelComponent}

--- a/src/components/AlertBanner/AlertBanner.unit.test.tsx
+++ b/src/components/AlertBanner/AlertBanner.unit.test.tsx
@@ -275,5 +275,15 @@ describe('<AlertBanner />', () => {
 
       expect(element.getAttribute('data-size')).toBe(size);
     });
+
+    it('should have provided data-test when data-test is provided', () => {
+      expect.assertions(1);
+
+      const element = mount(<AlertBanner data-test='mock-data-test-id' />)
+        .find(AlertBanner)
+        .getDOMNode();
+
+      expect(element.getAttribute('data-test')).toBe('mock-data-test-id');
+    });
   });
 });


### PR DESCRIPTION
# IMPORTANT

**Currently, this project is closed to any external contributions. Any pull request made against this project from external sources will likely be closed. If you would like to make changes to this project, please fork this project.**

# Guide

**This "Help" section can be deleted before submitting this pull request.**

*Update the name of this pull request to reflect the following shape:*

```
{type}/{scope?}/{message}
```

* **type** - A [conventional commit type](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional#type-enum) **REQUIRED**
* **scope** - The kabab-case scope of the changes in this request
* **message** - A short, kebab-case statement describing the changes **REQUIRED**

*Provide a general summary of the scope of the changes in this pull request.*

* [Readme](https://github.com/momentum-design/momentum-react-v2/blob/master/README.md)
* [Getting Started Guide](https://github.com/momentum-design/momentum-react-v2/blob/master/GETTING_STARTED.md)
* [Contributing Guide](https://github.com/momentum-design/momentum-react-v2/blob/master/CONTRIBUTING.md)

# Description

*The full description of the changes made in this request.*
Add ```...otherProps``` to ```props``` to let ```AlertBanner``` accept ```data-test``` from Cantina.

# Links

*Links to relevent resources.*
