### PR TITLE
docs/select/typo-in-the-select-description

### DIFF
--- a/src/components/Select/Select.stories.args.ts
+++ b/src/components/Select/Select.stories.args.ts
@@ -19,7 +19,7 @@ export default {
   },
   direction: {
     defaultValue: CONSTANTS.DIRECTIONS.bottom,
-    description: 'Text to display inside the dropdown when there is no selection.',
+    description: 'Direction in which the option list will display.',
     control: { type: 'select' },
     options: [...Object.values(CONSTANTS.DIRECTIONS)],
     table: {


### PR DESCRIPTION
# Description

- There appears to have been an accidental duplicate entry in the Select stories file, discovered using Storybook.
- Corrected to match the description in the types file.