### PR TITLE
fix(TooltipPopoverCombo): allow type prop in otherTooltipProps

### DIFF
--- a/src/components/TooltipPopoverCombo/TooltipPopoverCombo.stories.tsx
+++ b/src/components/TooltipPopoverCombo/TooltipPopoverCombo.stories.tsx
@@ -13,6 +13,8 @@ import Icon from '../Icon';
 import Menu from '../Menu';
 import { Item } from '@react-stately/collections';
 import { PopoverInstance } from '../Popover/Popover.types';
+import ButtonPill from '../ButtonPill';
+import Flex from '../Flex';
 
 export default {
   title: 'Momentum UI/TooltipPopoverCombo',
@@ -69,4 +71,53 @@ const Example: Story<TooltipPopoverComboProps> = () => {
   );
 };
 
-export { Example };
+const AsDescription: Story<TooltipPopoverComboProps> = () => {
+  const triggerComponent = (
+    <ButtonPill
+      style={{
+        alignItems: 'center',
+        justifyContent: 'center',
+        margin: '10rem auto',
+        display: 'flex',
+      }}
+      id="storybook-id-example"
+    >
+      <Flex xgap="0.5rem" alignItems="center">
+        <Icon name="plus" />
+        <Text>Create</Text>
+      </Flex>
+    </ButtonPill>
+  );
+
+  const [popoverInstance, setPopoverInstance] = useState<PopoverInstance>();
+
+  const onItemPress = (key: string) => {
+    switch (key) {
+      default:
+        popoverInstance?.hide();
+    }
+  };
+
+  const popoverContent = (
+    <Menu onAction={onItemPress} style={{ width: '15rem' }}>
+      <Item key="option-1">
+        <Flex xgap="0.5rem" alignItems="center">
+          <Icon name="chat" scale={24} />
+          <Text>Space</Text>
+        </Flex>
+      </Item>
+    </Menu>
+  );
+
+  return (
+    <TooltipPopoverCombo
+      popoverContent={popoverContent}
+      triggerComponent={triggerComponent}
+      tooltipContent={<Text>Press to see options</Text>}
+      otherTooltipProps={{ placement: 'top', type: 'description' }}
+      otherPopoverProps={{ placement: 'top', setInstance: setPopoverInstance }}
+    />
+  );
+};
+
+export { Example, AsDescription };

--- a/src/components/TooltipPopoverCombo/TooltipPopoverCombo.tsx
+++ b/src/components/TooltipPopoverCombo/TooltipPopoverCombo.tsx
@@ -1,11 +1,11 @@
-import React, { FC, useCallback, useEffect, useRef, useState } from 'react';
+import React, { FC, useCallback, useEffect, useState } from 'react';
 
 import { Props } from './TooltipPopoverCombo.types';
 import Popover from '../Popover';
 import { TooltipPopoverComboProps } from '.';
 import Tooltip from '../Tooltip/Tooltip';
 import { PopoverInstance } from '../Popover/Popover.types';
-import { v4 as uuidV4 } from 'uuid';
+import { useId } from '@react-aria/utils';
 
 /**
  * The TooltipPopoverCombo component.
@@ -17,8 +17,8 @@ const TooltipPopoverCombo: FC<Props> = (props: TooltipPopoverComboProps) => {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const [isTooltipOpen, setIsTooltipOpen] = useState(false);
 
-  const labelIdRef = useRef(uuidV4());
-  const labelId = labelIdRef.current;
+  const labelId = useId();
+  const triggerComponentId = useId(triggerComponent.props?.id);
 
   // Modified tooltipSetInstance to call both setInstance and updateInstance
   const setMergedTooltipInstances = useCallback(
@@ -26,7 +26,7 @@ const TooltipPopoverCombo: FC<Props> = (props: TooltipPopoverComboProps) => {
       otherTooltipProps?.setInstance?.(popoverInstance);
       setTooltipInstance(popoverInstance);
     },
-    [otherTooltipProps?.setInstance, setTooltipInstance]
+    [otherTooltipProps]
   );
 
   const handleOnShowPopover = useCallback(
@@ -34,7 +34,7 @@ const TooltipPopoverCombo: FC<Props> = (props: TooltipPopoverComboProps) => {
       otherPopoverProps?.onShow?.(instance);
       setIsPopoverOpen(true);
     },
-    [otherPopoverProps?.onShow, setIsPopoverOpen]
+    [otherPopoverProps]
   );
 
   const handleOnHidePopover = useCallback(
@@ -42,7 +42,7 @@ const TooltipPopoverCombo: FC<Props> = (props: TooltipPopoverComboProps) => {
       otherPopoverProps?.onHide?.(instance);
       setIsPopoverOpen(false);
     },
-    [otherPopoverProps?.onHide, setIsPopoverOpen]
+    [otherPopoverProps]
   );
 
   const handleOnHideTooltip = useCallback(
@@ -50,7 +50,7 @@ const TooltipPopoverCombo: FC<Props> = (props: TooltipPopoverComboProps) => {
       otherTooltipProps?.onHide?.(instance);
       setIsTooltipOpen(false);
     },
-    [otherTooltipProps?.onHide, setIsTooltipOpen]
+    [otherTooltipProps]
   );
 
   const handleOnShowTooltip = useCallback(
@@ -58,7 +58,7 @@ const TooltipPopoverCombo: FC<Props> = (props: TooltipPopoverComboProps) => {
       otherTooltipProps?.onShow?.(instance);
       setIsTooltipOpen(true);
     },
-    [otherTooltipProps?.onShow, setIsTooltipOpen]
+    [otherTooltipProps]
   );
 
   // if the tooltip and popover are both open at the same time we close the tooltip to avoid them overlapping
@@ -66,17 +66,24 @@ const TooltipPopoverCombo: FC<Props> = (props: TooltipPopoverComboProps) => {
     if (isPopoverOpen && isTooltipOpen) {
       tooltipInstance?.hide();
     }
-  }, [isPopoverOpen, isTooltipOpen]);
+  }, [isPopoverOpen, isTooltipOpen, tooltipInstance]);
+
+  const popoverLabelledById =
+    otherTooltipProps?.type === 'description' ? triggerComponentId : labelId;
 
   return (
     <Popover
       trigger="click"
       interactive
-      aria-labelledby={labelId}
+      aria-labelledby={popoverLabelledById}
       triggerComponent={
         <Tooltip
           type="label"
-          triggerComponent={triggerComponent}
+          triggerComponent={
+            otherTooltipProps?.type === 'description'
+              ? React.cloneElement(triggerComponent, { id: triggerComponentId })
+              : triggerComponent
+          }
           {...otherTooltipProps}
           onHide={handleOnHideTooltip}
           onShow={handleOnShowTooltip}

--- a/src/components/TooltipPopoverCombo/TooltipPopoverCombo.types.ts
+++ b/src/components/TooltipPopoverCombo/TooltipPopoverCombo.types.ts
@@ -2,6 +2,10 @@ import { ReactElement } from 'react';
 import { PopoverProps } from '../Popover';
 import { TooltipProps } from '../Tooltip';
 
+type OtherTooltipProps = Omit<TooltipProps, 'id' | 'type'> & {
+  type: Exclude<TooltipProps['type'], 'description'>;
+};
+
 export interface Props {
   /**
    * The content of the Popover.
@@ -26,5 +30,5 @@ export interface Props {
   /**
    * An object of Tooltip props to be passed through to the Tooltip component.
    */
-  otherTooltipProps?: Partial<Omit<TooltipProps, 'id' | 'type'>>;
+  otherTooltipProps?: Partial<OtherTooltipProps>;
 }

--- a/src/components/TooltipPopoverCombo/TooltipPopoverCombo.types.ts
+++ b/src/components/TooltipPopoverCombo/TooltipPopoverCombo.types.ts
@@ -2,10 +2,6 @@ import { ReactElement } from 'react';
 import { PopoverProps } from '../Popover';
 import { TooltipProps } from '../Tooltip';
 
-type OtherTooltipProps = Omit<TooltipProps, 'id' | 'type'> & {
-  type: Exclude<TooltipProps['type'], 'description'>;
-};
-
 export interface Props {
   /**
    * The content of the Popover.
@@ -30,5 +26,5 @@ export interface Props {
   /**
    * An object of Tooltip props to be passed through to the Tooltip component.
    */
-  otherTooltipProps?: Partial<OtherTooltipProps>;
+  otherTooltipProps?: Partial<Omit<TooltipProps, 'id'>>;
 }

--- a/src/components/TooltipPopoverCombo/TooltipPopoverCombo.unit.test.tsx
+++ b/src/components/TooltipPopoverCombo/TooltipPopoverCombo.unit.test.tsx
@@ -10,11 +10,9 @@ import userEvent from '@testing-library/user-event';
 import { getByText, queryByText, render, screen, waitFor } from '@testing-library/react';
 import Popover from '../Popover';
 
-jest.mock('uuid', () => {
-  return {
-    v4: () => '1',
-  };
-});
+jest.mock('uuid', () => ({
+  v4: () => '1',
+}));
 
 describe('<TooltipPopoverCombo />', () => {
   const triggerComponent = <button>Example button</button>;
@@ -65,6 +63,21 @@ describe('<TooltipPopoverCombo />', () => {
 
       expect(container).toMatchSnapshot();
     });
+
+    it('should match snaphshot with otherTooltipsProps.type = "description"', () => {
+      expect.assertions(1);
+
+      const container = mount(
+        <TooltipPopoverCombo
+          triggerComponent={triggerComponent}
+          tooltipContent={tooltipContent}
+          popoverContent={popoverContent}
+          otherTooltipProps={{ placement: 'bottom', type: 'description' }}
+        />
+      );
+
+      expect(container).toMatchSnapshot();
+    });
   });
 
   describe('attributes', () => {
@@ -82,7 +95,7 @@ describe('<TooltipPopoverCombo />', () => {
       const popover = comboElement.find(Popover).first();
 
       expect(popover.props()).toStrictEqual({
-        'aria-labelledby': '1',
+        'aria-labelledby': 'test-ID',
         children: popoverContent,
         interactive: true,
         onHide: expect.any(Function),
@@ -101,7 +114,7 @@ describe('<TooltipPopoverCombo />', () => {
         triggerComponent: triggerComponent,
         type: 'label',
         'aria-haspopup': 'dialog',
-        labelOrDescriptionId: '1',
+        labelOrDescriptionId: 'test-ID',
       });
     });
 
@@ -120,7 +133,7 @@ describe('<TooltipPopoverCombo />', () => {
       const popover = comboElement.find(Popover).first();
 
       expect(popover.props()).toStrictEqual({
-        'aria-labelledby': '1',
+        'aria-labelledby': 'test-ID',
         children: popoverContent,
         interactive: true,
         onHide: expect.any(Function),
@@ -153,9 +166,39 @@ describe('<TooltipPopoverCombo />', () => {
         triggerComponent: triggerComponent,
         type: 'label',
         'aria-haspopup': 'dialog',
-        labelOrDescriptionId: '1',
+        labelOrDescriptionId: 'test-ID',
         placement: 'top',
       });
+    });
+
+    it('should have given an id to the triggerComponent if otherTooltipProps.type = "description"', () => {
+      const comboElement = mount(
+        <TooltipPopoverCombo
+          triggerComponent={triggerComponent}
+          tooltipContent={tooltipContent}
+          popoverContent={popoverContent}
+          otherTooltipProps={{ placement: 'top', type: 'description' }}
+        />
+      ).find(TooltipPopoverCombo);
+
+      const button = comboElement.find('button');
+      expect(button.prop('id')).not.toBeUndefined();
+      expect(comboElement.children(Popover).prop('aria-labelledby')).toBe(button.prop('id'));
+    });
+
+    it('should not give an id to the triggerComponent when otherTooltipProps.type = "description" if the triggerComponent has an id', () => {
+      const comboElement = mount(
+        <TooltipPopoverCombo
+          triggerComponent={<button id="this-is-an-id">This is a button</button>}
+          tooltipContent={tooltipContent}
+          popoverContent={popoverContent}
+          otherTooltipProps={{ placement: 'top', type: 'description' }}
+        />
+      ).find(TooltipPopoverCombo);
+
+      const button = comboElement.find('button');
+      expect(button.prop('id')).toBe('this-is-an-id');
+      expect(comboElement.children(Popover).prop('aria-labelledby')).toBe('this-is-an-id');
     });
   });
 

--- a/src/components/TooltipPopoverCombo/TooltipPopoverCombo.unit.test.tsx.snap
+++ b/src/components/TooltipPopoverCombo/TooltipPopoverCombo.unit.test.tsx.snap
@@ -1,5 +1,510 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<TooltipPopoverCombo /> snapshot should match snaphshot with otherTooltipsProps.type = "description" 1`] = `
+<TooltipPopoverCombo
+  otherTooltipProps={
+    Object {
+      "placement": "bottom",
+      "type": "description",
+    }
+  }
+  popoverContent={
+    <button>
+      Example popover content button
+    </button>
+  }
+  tooltipContent={
+    <Text>
+      Example tooltip content
+    </Text>
+  }
+  triggerComponent={
+    <button>
+      Example button
+    </button>
+  }
+>
+  <Popover
+    aria-labelledby="test-ID"
+    interactive={true}
+    onHide={[Function]}
+    onShow={[Function]}
+    trigger="click"
+    triggerComponent={
+      <Tooltip
+        labelOrDescriptionId="test-ID"
+        onHide={[Function]}
+        onShow={[Function]}
+        placement="bottom"
+        setInstance={[Function]}
+        triggerComponent={
+          <button
+            id="test-ID"
+          >
+            Example button
+          </button>
+        }
+        type="description"
+      >
+        <Text>
+          Example tooltip content
+        </Text>
+      </Tooltip>
+    }
+  >
+    <LazyTippy
+      animation={false}
+      appendTo="parent"
+      hideOnClick={true}
+      interactive={true}
+      offset={
+        Array [
+          0,
+          17,
+        ]
+      }
+      onHidden={[Function]}
+      onHide={[Function]}
+      onShow={[Function]}
+      placement="auto"
+      plugins={
+        Array [
+          Object {
+            "defaultValue": true,
+            "fn": [Function],
+            "name": "hideOnEsc",
+          },
+          Object {
+            "fn": [Function],
+            "name": "addBackdropPlugin",
+          },
+        ]
+      }
+      popperOptions={
+        Object {
+          "modifiers": Array [
+            Object {
+              "enabled": true,
+              "name": "arrow",
+              "options": Object {
+                "element": "#arrow1",
+                "padding": 5,
+              },
+            },
+            Object {
+              "name": "preventOverflow",
+              "options": Object {
+                "altAxis": true,
+                "boundariesElement": "scrollParent",
+                "padding": 8,
+              },
+            },
+          ],
+          "strategy": "absolute",
+        }
+      }
+      render={[Function]}
+      setInstance={[Function]}
+      trigger="click"
+    >
+      <ForwardRef(TippyWrapper)
+        animation={false}
+        appendTo="parent"
+        hideOnClick={true}
+        interactive={true}
+        offset={
+          Array [
+            0,
+            17,
+          ]
+        }
+        onHidden={[Function]}
+        onHide={[Function]}
+        onShow={[Function]}
+        placement="auto"
+        plugins={
+          Array [
+            Object {
+              "fn": [Function],
+            },
+            Object {
+              "fn": [Function],
+            },
+            Object {
+              "fn": [Function],
+            },
+            Object {
+              "defaultValue": true,
+              "fn": [Function],
+              "name": "hideOnEsc",
+            },
+            Object {
+              "fn": [Function],
+              "name": "addBackdropPlugin",
+            },
+          ]
+        }
+        popperOptions={
+          Object {
+            "modifiers": Array [
+              Object {
+                "enabled": true,
+                "name": "arrow",
+                "options": Object {
+                  "element": "#arrow1",
+                  "padding": 5,
+                },
+              },
+              Object {
+                "name": "preventOverflow",
+                "options": Object {
+                  "altAxis": true,
+                  "boundariesElement": "scrollParent",
+                  "padding": 8,
+                },
+              },
+            ],
+            "strategy": "absolute",
+          }
+        }
+        render={[Function]}
+        trigger="click"
+      >
+        <Tippy
+          animation={false}
+          appendTo="parent"
+          hideOnClick={true}
+          interactive={true}
+          offset={
+            Array [
+              0,
+              17,
+            ]
+          }
+          onHidden={[Function]}
+          onHide={[Function]}
+          onShow={[Function]}
+          placement="auto"
+          plugins={
+            Array [
+              Object {
+                "fn": [Function],
+              },
+              Object {
+                "fn": [Function],
+              },
+              Object {
+                "fn": [Function],
+              },
+              Object {
+                "defaultValue": true,
+                "fn": [Function],
+                "name": "hideOnEsc",
+              },
+              Object {
+                "fn": [Function],
+                "name": "addBackdropPlugin",
+              },
+            ]
+          }
+          popperOptions={
+            Object {
+              "modifiers": Array [
+                Object {
+                  "enabled": true,
+                  "name": "arrow",
+                  "options": Object {
+                    "element": "#arrow1",
+                    "padding": 5,
+                  },
+                },
+                Object {
+                  "name": "preventOverflow",
+                  "options": Object {
+                    "altAxis": true,
+                    "boundariesElement": "scrollParent",
+                    "padding": 8,
+                  },
+                },
+              ],
+              "strategy": "absolute",
+            }
+          }
+          render={[Function]}
+          trigger="click"
+        >
+          <Tooltip
+            aria-haspopup="dialog"
+            labelOrDescriptionId="test-ID"
+            onHide={[Function]}
+            onShow={[Function]}
+            placement="bottom"
+            setInstance={[Function]}
+            triggerComponent={
+              <button
+                id="test-ID"
+              >
+                Example button
+              </button>
+            }
+            type="description"
+          >
+            <Popover
+              addBackdrop={false}
+              aria-hidden={true}
+              boundary="scrollParent"
+              color="primary"
+              interactive={false}
+              offsetDistance={5}
+              offsetSkidding={0}
+              onHide={[Function]}
+              onShow={[Function]}
+              placement="bottom"
+              role="tooltip"
+              setInstance={[Function]}
+              showArrow={true}
+              strategy="absolute"
+              trigger="mouseenter focus"
+              triggerComponent={
+                <button
+                  aria-describedby="test-ID"
+                  aria-haspopup="dialog"
+                  id="test-ID"
+                >
+                  Example button
+                </button>
+              }
+              variant="small"
+            >
+              <LazyTippy
+                animation={false}
+                appendTo="parent"
+                hideOnClick={true}
+                interactive={false}
+                offset={
+                  Array [
+                    0,
+                    17,
+                  ]
+                }
+                onHidden={[Function]}
+                onHide={[Function]}
+                onShow={[Function]}
+                placement="bottom"
+                plugins={
+                  Array [
+                    Object {
+                      "defaultValue": true,
+                      "fn": [Function],
+                      "name": "hideOnEsc",
+                    },
+                  ]
+                }
+                popperOptions={
+                  Object {
+                    "modifiers": Array [
+                      Object {
+                        "enabled": true,
+                        "name": "arrow",
+                        "options": Object {
+                          "element": "#arrow1",
+                          "padding": 5,
+                        },
+                      },
+                      Object {
+                        "name": "preventOverflow",
+                        "options": Object {
+                          "altAxis": true,
+                          "boundariesElement": "scrollParent",
+                          "padding": 8,
+                        },
+                      },
+                    ],
+                    "strategy": "absolute",
+                  }
+                }
+                render={[Function]}
+                setInstance={[Function]}
+                trigger="mouseenter focus"
+              >
+                <ForwardRef(TippyWrapper)
+                  animation={false}
+                  appendTo="parent"
+                  hideOnClick={true}
+                  interactive={false}
+                  offset={
+                    Array [
+                      0,
+                      17,
+                    ]
+                  }
+                  onHidden={[Function]}
+                  onHide={[Function]}
+                  onShow={[Function]}
+                  placement="bottom"
+                  plugins={
+                    Array [
+                      Object {
+                        "fn": [Function],
+                      },
+                      Object {
+                        "fn": [Function],
+                      },
+                      Object {
+                        "fn": [Function],
+                      },
+                      Object {
+                        "defaultValue": true,
+                        "fn": [Function],
+                        "name": "hideOnEsc",
+                      },
+                    ]
+                  }
+                  popperOptions={
+                    Object {
+                      "modifiers": Array [
+                        Object {
+                          "enabled": true,
+                          "name": "arrow",
+                          "options": Object {
+                            "element": "#arrow1",
+                            "padding": 5,
+                          },
+                        },
+                        Object {
+                          "name": "preventOverflow",
+                          "options": Object {
+                            "altAxis": true,
+                            "boundariesElement": "scrollParent",
+                            "padding": 8,
+                          },
+                        },
+                      ],
+                      "strategy": "absolute",
+                    }
+                  }
+                  render={[Function]}
+                  trigger="mouseenter focus"
+                >
+                  <Tippy
+                    animation={false}
+                    appendTo="parent"
+                    hideOnClick={true}
+                    interactive={false}
+                    offset={
+                      Array [
+                        0,
+                        17,
+                      ]
+                    }
+                    onHidden={[Function]}
+                    onHide={[Function]}
+                    onShow={[Function]}
+                    placement="bottom"
+                    plugins={
+                      Array [
+                        Object {
+                          "fn": [Function],
+                        },
+                        Object {
+                          "fn": [Function],
+                        },
+                        Object {
+                          "fn": [Function],
+                        },
+                        Object {
+                          "defaultValue": true,
+                          "fn": [Function],
+                          "name": "hideOnEsc",
+                        },
+                      ]
+                    }
+                    popperOptions={
+                      Object {
+                        "modifiers": Array [
+                          Object {
+                            "enabled": true,
+                            "name": "arrow",
+                            "options": Object {
+                              "element": "#arrow1",
+                              "padding": 5,
+                            },
+                          },
+                          Object {
+                            "name": "preventOverflow",
+                            "options": Object {
+                              "altAxis": true,
+                              "boundariesElement": "scrollParent",
+                              "padding": 8,
+                            },
+                          },
+                        ],
+                        "strategy": "absolute",
+                      }
+                    }
+                    render={[Function]}
+                    trigger="mouseenter focus"
+                  >
+                    <button
+                      aria-describedby="test-ID"
+                      aria-haspopup="dialog"
+                      id="test-ID"
+                    >
+                      Example button
+                    </button>
+                    <Portal
+                      containerInfo={
+                        <div
+                          data-tippy-root=""
+                          id="tippy-7"
+                          style="pointer-events: none; z-index: 9999;"
+                        >
+                          
+                        </div>
+                      }
+                    />
+                  </Tippy>
+                </ForwardRef(TippyWrapper)>
+              </LazyTippy>
+            </Popover>
+            <div
+              className="md-tooltip-label"
+              id="test-ID"
+            >
+              <Text>
+                <Text
+                  className="md-text-wrapper"
+                  tagname="p"
+                  type="body-large-regular"
+                >
+                  <mdc-text
+                    class="md-text-wrapper"
+                    suppressHydrationWarning={true}
+                  >
+                    Example tooltip content
+                  </mdc-text>
+                </Text>
+              </Text>
+            </div>
+          </Tooltip>
+          <Portal
+            containerInfo={
+              <div
+                data-tippy-root=""
+                id="tippy-8"
+                style="z-index: 9999;"
+              >
+                
+              </div>
+            }
+          />
+        </Tippy>
+      </ForwardRef(TippyWrapper)>
+    </LazyTippy>
+  </Popover>
+</TooltipPopoverCombo>
+`;
+
 exports[`<TooltipPopoverCombo /> snapshot should match snapshot 1`] = `
 <TooltipPopoverCombo
   popoverContent={
@@ -19,14 +524,14 @@ exports[`<TooltipPopoverCombo /> snapshot should match snapshot 1`] = `
   }
 >
   <Popover
-    aria-labelledby="1"
+    aria-labelledby="test-ID"
     interactive={true}
     onHide={[Function]}
     onShow={[Function]}
     trigger="click"
     triggerComponent={
       <Tooltip
-        labelOrDescriptionId="1"
+        labelOrDescriptionId="test-ID"
         onHide={[Function]}
         onShow={[Function]}
         setInstance={[Function]}
@@ -226,7 +731,7 @@ exports[`<TooltipPopoverCombo /> snapshot should match snapshot 1`] = `
         >
           <Tooltip
             aria-haspopup="dialog"
-            labelOrDescriptionId="1"
+            labelOrDescriptionId="test-ID"
             onHide={[Function]}
             onShow={[Function]}
             setInstance={[Function]}
@@ -256,7 +761,7 @@ exports[`<TooltipPopoverCombo /> snapshot should match snapshot 1`] = `
               triggerComponent={
                 <button
                   aria-haspopup="dialog"
-                  aria-labelledby="1"
+                  aria-labelledby="test-ID"
                 >
                   Example button
                 </button>
@@ -434,7 +939,7 @@ exports[`<TooltipPopoverCombo /> snapshot should match snapshot 1`] = `
                   >
                     <button
                       aria-haspopup="dialog"
-                      aria-labelledby="1"
+                      aria-labelledby="test-ID"
                     >
                       Example button
                     </button>
@@ -455,7 +960,7 @@ exports[`<TooltipPopoverCombo /> snapshot should match snapshot 1`] = `
             </Popover>
             <div
               className="md-tooltip-label"
-              id="1"
+              id="test-ID"
             >
               <Text>
                 <Text
@@ -515,14 +1020,14 @@ exports[`<TooltipPopoverCombo /> snapshot should match snapshot with otherPopove
   }
 >
   <Popover
-    aria-labelledby="1"
+    aria-labelledby="test-ID"
     interactive={true}
     onHide={[Function]}
     onShow={[Function]}
     trigger="click"
     triggerComponent={
       <Tooltip
-        labelOrDescriptionId="1"
+        labelOrDescriptionId="test-ID"
         onHide={[Function]}
         onShow={[Function]}
         placement="bottom"
@@ -723,7 +1228,7 @@ exports[`<TooltipPopoverCombo /> snapshot should match snapshot with otherPopove
         >
           <Tooltip
             aria-haspopup="dialog"
-            labelOrDescriptionId="1"
+            labelOrDescriptionId="test-ID"
             onHide={[Function]}
             onShow={[Function]}
             placement="bottom"
@@ -754,7 +1259,7 @@ exports[`<TooltipPopoverCombo /> snapshot should match snapshot with otherPopove
               triggerComponent={
                 <button
                   aria-haspopup="dialog"
-                  aria-labelledby="1"
+                  aria-labelledby="test-ID"
                 >
                   Example button
                 </button>
@@ -932,7 +1437,7 @@ exports[`<TooltipPopoverCombo /> snapshot should match snapshot with otherPopove
                   >
                     <button
                       aria-haspopup="dialog"
-                      aria-labelledby="1"
+                      aria-labelledby="test-ID"
                     >
                       Example button
                     </button>
@@ -953,7 +1458,7 @@ exports[`<TooltipPopoverCombo /> snapshot should match snapshot with otherPopove
             </Popover>
             <div
               className="md-tooltip-label"
-              id="1"
+              id="test-ID"
             >
               <Text>
                 <Text
@@ -1013,14 +1518,14 @@ exports[`<TooltipPopoverCombo /> snapshot should match snapshot with otherToolti
   }
 >
   <Popover
-    aria-labelledby="1"
+    aria-labelledby="test-ID"
     interactive={true}
     onHide={[Function]}
     onShow={[Function]}
     trigger="click"
     triggerComponent={
       <Tooltip
-        labelOrDescriptionId="1"
+        labelOrDescriptionId="test-ID"
         onHide={[Function]}
         onShow={[Function]}
         placement="top"
@@ -1221,7 +1726,7 @@ exports[`<TooltipPopoverCombo /> snapshot should match snapshot with otherToolti
         >
           <Tooltip
             aria-haspopup="dialog"
-            labelOrDescriptionId="1"
+            labelOrDescriptionId="test-ID"
             onHide={[Function]}
             onShow={[Function]}
             placement="top"
@@ -1252,7 +1757,7 @@ exports[`<TooltipPopoverCombo /> snapshot should match snapshot with otherToolti
               triggerComponent={
                 <button
                   aria-haspopup="dialog"
-                  aria-labelledby="1"
+                  aria-labelledby="test-ID"
                 >
                   Example button
                 </button>
@@ -1430,7 +1935,7 @@ exports[`<TooltipPopoverCombo /> snapshot should match snapshot with otherToolti
                   >
                     <button
                       aria-haspopup="dialog"
-                      aria-labelledby="1"
+                      aria-labelledby="test-ID"
                     >
                       Example button
                     </button>
@@ -1451,7 +1956,7 @@ exports[`<TooltipPopoverCombo /> snapshot should match snapshot with otherToolti
             </Popover>
             <div
               className="md-tooltip-label"
-              id="1"
+              id="test-ID"
             >
               <Text>
                 <Text


### PR DESCRIPTION
# Description

Add `type` prop back to otherTooltipProps.

If the type is set to "description", use the button as the label for the Popover instead of the Tooltip.

# Links
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-584297
