### PR TITLE
feat(text-input): add sr automatic announcement on error message

### DIFF
--- a/src/components/ComboBox/ComboBox.unit.test.tsx
+++ b/src/components/ComboBox/ComboBox.unit.test.tsx
@@ -19,6 +19,13 @@ jest.mock('uuid', () => {
 describe('ComboBox', () => {
   let container;
 
+  afterEach(() => {
+    if (container) {
+      container.unmount();
+      container = undefined;
+    }
+  });
+
   const withoutSection: IComboBoxGroup[] = [
     {
       items: [
@@ -53,23 +60,23 @@ describe('ComboBox', () => {
     },
   ];
 
+  const renderChildren = (group) => {
+    const itemsEle: any = group?.items?.map((menuItem) => {
+      return menuItem.popoverText ? (
+        <Item key={menuItem.key} textValue={menuItem.key} data-test="menuItem">
+          <div>{menuItem.popoverText}</div>
+        </Item>
+      ) : (
+        <Item key={menuItem.key} textValue={menuItem.key}>
+          <div>{menuItem.label}</div>
+        </Item>
+      );
+    });
+
+    return <Section key="noSection">{itemsEle}</Section>;
+  };
+
   describe('snapshot', () => {
-    const renderChildren = (group) => {
-      const itemsEle: any = group?.items?.map((menuItem) => {
-        return menuItem.popoverText ? (
-          <Item key={menuItem.key} textValue={menuItem.key} data-test="menuItem">
-            <div>{menuItem.popoverText}</div>
-          </Item>
-        ) : (
-          <Item key={menuItem.key} textValue={menuItem.key}>
-            <div>{menuItem.label}</div>
-          </Item>
-        );
-      });
-
-      return <Section key="noSection">{itemsEle}</Section>;
-    };
-
     it('should match snapshot label', async () => {
       expect.assertions(1);
 
@@ -181,625 +188,623 @@ describe('ComboBox', () => {
 
       expect(container).toMatchSnapshot();
     });
+  });
 
-    describe('attributes', () => {
-      it('should have its wrapper class', async () => {
-        container = await mountAndWait(
-          <ComboBox comboBoxGroups={withoutSection}>{renderChildren}</ComboBox>
-        );
-        const element = container.find(ComboBox).getDOMNode();
+  describe('attributes', () => {
+    it('should have its wrapper class', async () => {
+      container = await mountAndWait(
+        <ComboBox comboBoxGroups={withoutSection}>{renderChildren}</ComboBox>
+      );
+      const element = container.find(ComboBox).getDOMNode();
 
-        expect(element.classList.contains(STYLE.wrapper));
+      expect(element.classList.contains(STYLE.wrapper));
+    });
+
+    it('should have provided class when className is provided', async () => {
+      expect.assertions(1);
+      const className = 'example-class';
+
+      container = await mountAndWait(
+        <ComboBox className={className} comboBoxGroups={withoutSection}>
+          {renderChildren}
+        </ComboBox>
+      );
+
+      const element = container.find(ComboBox).getDOMNode();
+
+      expect(element.classList.contains(className)).toBe(true);
+    });
+
+    it('should have provided style when style is provided', async () => {
+      expect.assertions(1);
+
+      const style = { color: 'pink' };
+      const styleString = 'color: pink;';
+
+      container = await mountAndWait(
+        <ComboBox style={style} comboBoxGroups={withoutSection}>
+          {renderChildren}
+        </ComboBox>
+      );
+      const element = container.find(ComboBox).getDOMNode();
+
+      expect(element.getAttribute('style')).toBe(`--local-width: 16.25rem; ${styleString}`);
+    });
+
+    it('should have provided style when style is width', async () => {
+      expect.assertions(1);
+
+      const width = '16rem';
+      const styleString = '--local-width: 16rem;';
+
+      container = await mountAndWait(
+        <ComboBox width={width} comboBoxGroups={withoutSection}>
+          {renderChildren}
+        </ComboBox>
+      );
+      const element = container.find(ComboBox).getDOMNode();
+
+      expect(element.getAttribute('style')).toBe(`${styleString}`);
+    });
+
+    it('should have provided label when label is provided', async () => {
+      expect.assertions(1);
+
+      const label = 'ComboBox';
+
+      container = await mountAndWait(
+        <ComboBox label={label} comboBoxGroups={withoutSection}>
+          {renderChildren}
+        </ComboBox>
+      );
+
+      const labelContainer = container.find('div').filter({ className: 'md-combo-box-label' });
+
+      expect(labelContainer.props()).toEqual({
+        className: 'md-combo-box-label',
+        children: label,
+      });
+    });
+
+    it('should have provided description when description is provided', async () => {
+      expect.assertions(1);
+
+      const description = 'ComboBox description';
+
+      container = await mountAndWait(
+        <ComboBox description={description} comboBoxGroups={withoutSection}>
+          {renderChildren}
+        </ComboBox>
+      );
+
+      const descriptionContainer = container
+        .find('div')
+        .filter({ className: 'md-combo-box-description' });
+
+      expect(descriptionContainer.props()).toEqual({
+        className: 'md-combo-box-description',
+        children: description,
+      });
+    });
+
+    it('should have provided error style when error is provided', async () => {
+      expect.assertions(1);
+
+      const error = true;
+
+      container = await mountAndWait(
+        <ComboBox error={error} comboBoxGroups={withoutSection}>
+          {renderChildren}
+        </ComboBox>
+      );
+      const element = container.find(ComboBox).getDOMNode();
+
+      expect(element.getAttribute('data-error')).toBe(`${error}`);
+    });
+
+    it('should have expected props on selectedKey', async () => {
+      expect.assertions(1);
+
+      const selectedKey = 'key1';
+
+      container = await mountAndWait(
+        <ComboBox selectedKey={selectedKey} comboBoxGroups={withoutSection}>
+          {renderChildren}
+        </ComboBox>
+      );
+
+      expect(container.find('[aria-label="md-combo-box-input"]').at(0).props()).toHaveProperty(
+        'value',
+        'item1'
+      );
+    });
+
+    it('should have expected props on placeholder', async () => {
+      expect.assertions(1);
+
+      const placeholder = 'please select';
+
+      container = await mountAndWait(
+        <ComboBox placeholder={placeholder} comboBoxGroups={withoutSection}>
+          {renderChildren}
+        </ComboBox>
+      );
+
+      expect(container.find('[aria-label="md-combo-box-input"]').at(0).props()).toHaveProperty(
+        'placeholder',
+        placeholder
+      );
+    });
+
+    it('should match inputRef props', async () => {
+      expect.assertions(1);
+
+      const inputRef = createRef<HTMLInputElement>();
+
+      container = await mountAndWait(
+        <ComboBox inputRef={inputRef} comboBoxGroups={withoutSection}>
+          {renderChildren}
+        </ComboBox>
+      );
+
+      expect(container.find(TextInput).props()['aria-label']).toEqual(
+        inputRef.current.getAttribute('aria-label')
+      );
+    });
+
+    describe('actions', () => {
+      it('should show menu on click', async () => {
+        const user = userEvent.setup();
+
+        render(<ComboBox comboBoxGroups={withoutSection}>{renderChildren}</ComboBox>);
+
+        const menuItem = screen.queryByRole('menu');
+        expect(menuItem).not.toBeInTheDocument();
+
+        await user.click(screen.getByRole('button'));
+
+        expect(screen.getByRole('menu')).toBeVisible();
       });
 
-      it('should have provided class when className is provided', async () => {
-        expect.assertions(1);
-        const className = 'example-class';
-
-        container = await mountAndWait(
-          <ComboBox className={className} comboBoxGroups={withoutSection}>
-            {renderChildren}
-          </ComboBox>
-        );
-
-        const element = container.find(ComboBox).getDOMNode();
-
-        expect(element.classList.contains(className)).toBe(true);
-      });
-
-      it('should have provided style when style is provided', async () => {
-        expect.assertions(1);
-
-        const style = { color: 'pink' };
-        const styleString = 'color: pink;';
-
-        const wrapper = await mountAndWait(
-          <ComboBox style={style} comboBoxGroups={withoutSection}>
-            {renderChildren}
-          </ComboBox>
-        );
-        const element = wrapper.find(ComboBox).getDOMNode();
-
-        expect(element.getAttribute('style')).toBe(`--local-width: 16.25rem; ${styleString}`);
-      });
-
-      it('should have provided style when style is width', async () => {
-        expect.assertions(1);
-
-        const width = '16rem';
-        const styleString = '--local-width: 16rem;';
-
-        const wrapper = await mountAndWait(
-          <ComboBox width={width} comboBoxGroups={withoutSection}>
-            {renderChildren}
-          </ComboBox>
-        );
-        const element = wrapper.find(ComboBox).getDOMNode();
-
-        expect(element.getAttribute('style')).toBe(`${styleString}`);
-      });
-
-      it('should have provided label when label is provided', async () => {
-        expect.assertions(1);
-
-        const label = 'ComboBox';
-
-        const wrapper = await mountAndWait(
-          <ComboBox label={label} comboBoxGroups={withoutSection}>
-            {renderChildren}
-          </ComboBox>
-        );
-
-        const labelContainer = wrapper.find('div').filter({ className: 'md-combo-box-label' });
-
-        expect(labelContainer.props()).toEqual({
-          className: 'md-combo-box-label',
-          children: label,
-        });
-      });
-
-      it('should have provided description when description is provided', async () => {
-        expect.assertions(1);
-
-        const description = 'ComboBox description';
-
-        const wrapper = await mountAndWait(
-          <ComboBox description={description} comboBoxGroups={withoutSection}>
-            {renderChildren}
-          </ComboBox>
-        );
-
-        const descriptionContainer = wrapper
-          .find('div')
-          .filter({ className: 'md-combo-box-description' });
-
-        expect(descriptionContainer.props()).toEqual({
-          className: 'md-combo-box-description',
-          children: description,
-        });
-      });
-
-      it('should have provided error style when error is provided', async () => {
-        expect.assertions(1);
-
-        const error = true;
-
-        const wrapper = await mountAndWait(
-          <ComboBox error={error} comboBoxGroups={withoutSection}>
-            {renderChildren}
-          </ComboBox>
-        );
-        const element = wrapper.find(ComboBox).getDOMNode();
-
-        expect(element.getAttribute('data-error')).toBe(`${error}`);
-      });
-
-      it('should have expected props on selectedKey', async () => {
-        expect.assertions(1);
-
-        const selectedKey = 'key1';
-
-        const wrapper = await mountAndWait(
-          <ComboBox selectedKey={selectedKey} comboBoxGroups={withoutSection}>
-            {renderChildren}
-          </ComboBox>
-        );
-
-        expect(wrapper.find('[aria-label="md-combo-box-input"]').at(0).props()).toHaveProperty(
-          'value',
-          'item1'
-        );
-      });
-
-      it('should have expected props on placeholder', async () => {
-        expect.assertions(1);
-
-        const placeholder = 'please select';
-
-        const wrapper = await mountAndWait(
-          <ComboBox placeholder={placeholder} comboBoxGroups={withoutSection}>
-            {renderChildren}
-          </ComboBox>
-        );
-
-        expect(wrapper.find('[aria-label="md-combo-box-input"]').at(0).props()).toHaveProperty(
-          'placeholder',
-          placeholder
-        );
-      });
-
-      it('should match inputRef props', async () => {
-        expect.assertions(1);
-
-        const inputRef = createRef<HTMLInputElement>();
-
-        const wrapper = await mountAndWait(
-          <ComboBox inputRef={inputRef} comboBoxGroups={withoutSection}>
-            {renderChildren}
-          </ComboBox>
-        );
-
-        expect(wrapper.find(TextInput).props()['aria-label']).toEqual(
-          inputRef.current.getAttribute('aria-label')
-        );
-      });
-
-      describe('actions', () => {
-        it('should show menu on click', async () => {
-          const user = userEvent.setup();
-
-          render(<ComboBox comboBoxGroups={withoutSection}>{renderChildren}</ComboBox>);
-
-          const menuItem = screen.queryByRole('menu');
-          expect(menuItem).not.toBeInTheDocument();
-
-          await user.click(screen.getByRole('button'));
-
-          expect(screen.getByRole('menu')).toBeVisible();
-        });
-
-        it('should call onArrowButtonPress when click', async () => {
-          const user = userEvent.setup();
-          const onArrowButtonPress = jest.fn();
-
-          render(
-            <ComboBox onArrowButtonPress={onArrowButtonPress} comboBoxGroups={withoutSection}>
-              {renderChildren}
-            </ComboBox>
-          );
-
-          await user.click(screen.getByRole('button'));
-
-          expect(onArrowButtonPress).toHaveBeenCalled();
-        });
-
-        it('should call onInputChange when type on input', async () => {
-          const onInputChange = jest.fn();
-
-          render(
-            <ComboBox onInputChange={onInputChange} comboBoxGroups={withoutSection}>
-              {renderChildren}
-            </ComboBox>
-          );
-
-          await userEvent.type(screen.getByLabelText('md-combo-box-input'), 'hello');
-
-          expect(onInputChange).toHaveBeenCalled();
-        });
-
-        it('should call onSelectionChange when an item is selected', async () => {
-          const user = userEvent.setup();
-          const onSelectionChange = jest.fn();
-
-          render(
-            <ComboBox onSelectionChange={onSelectionChange} comboBoxGroups={withoutSection}>
-              {renderChildren}
-            </ComboBox>
-          );
-
-          const button = screen
-            .queryAllByRole('button')
-            .find((button) => button.classList.contains('md-combo-box-button'));
-
-          act(() => {
-            button.focus();
-          });
-          await user.keyboard('{Enter}');
-          expect(screen.getByRole('menu')).toBeVisible();
-
-          const item = screen.getByText('item1').parentElement;
-          await waitFor(() => {
-            expect(item.parentElement).toHaveFocus();
-          });
-          expect(onSelectionChange).not.toHaveBeenCalled();
-          await user.keyboard('{Enter}');
-          expect(onSelectionChange).toHaveBeenCalled();
-        });
-
-        it('should call openStateChange when list is expanded or collapsed', async () => {
-          const user = userEvent.setup();
-          const openStateChange = jest.fn();
-
-          render(
-            <ComboBox openStateChange={openStateChange} comboBoxGroups={withoutSection}>
-              {renderChildren}
-            </ComboBox>
-          );
-
-          const button = screen
-            .queryAllByRole('button')
-            .find((button) => button.classList.contains('md-combo-box-button'));
-
-          act(() => {
-            button.focus();
-          });
-          expect(openStateChange).toBeCalledWith(false);
-          await user.keyboard('{Enter}');
-          expect(screen.getByRole('menu')).toBeVisible();
-          expect(openStateChange).toBeCalledWith(true);
-          await user.keyboard('{Escape}');
-          expect(openStateChange).toBeCalledWith(false);
-        });
-
-        it('should show disabledKeys when click', async () => {
-          const user = userEvent.setup();
-
-          const disabledKeys = ['key1'];
-
-          const { container } = render(
-            <ComboBox disabledKeys={disabledKeys} comboBoxGroups={withoutSection}>
-              {renderChildren}
-            </ComboBox>
-          );
-
-          await user.click(screen.getByRole('button'));
-
-          expect(container.querySelector('li[data-key="key1"]')).toHaveAttribute(
-            'data-disabled',
-            'true'
-          );
-        });
-
-        it('should show menu when focused and pressing enter', async () => {
-          const user = userEvent.setup();
-
-          render(<ComboBox comboBoxGroups={withoutSection}>{renderChildren}</ComboBox>);
-
-          const menuItem = screen.queryByRole('menu');
-          expect(menuItem).not.toBeInTheDocument();
-
-          const button = screen.getByRole('button');
-          act(() => {
-            button.focus();
-          });
-          expect(button).toHaveFocus();
-
-          await user.keyboard('{Enter}');
-          expect(screen.getByRole('menu')).toBeVisible();
-        });
-
-        it('should hide menu when clicking outside', async () => {
-          const user = userEvent.setup();
-
-          render(
-            <>
-              <ComboBox comboBoxGroups={withoutSection}>{renderChildren}</ComboBox>
-              <button>button-outside</button>
-            </>
-          );
-
-          const ele = screen
-            .queryAllByRole('button')
-            .find((button) => button.classList.contains('md-combo-box-button'));
-
-          await user.click(ele);
-          expect(screen.getByRole('menu')).toBeVisible();
-
-          await user.click(screen.getByRole('button', { name: 'button-outside' }));
-          await waitFor(() => {
-            expect(screen.queryByRole('menu')).not.toBeInTheDocument();
-          });
-        });
-      });
-
-      it('should have show noResultText when items is empty', async () => {
-        const noResultText = 'empty result';
+      it('should call onArrowButtonPress when click', async () => {
+        const user = userEvent.setup();
+        const onArrowButtonPress = jest.fn();
 
         render(
-          <ComboBox noResultText={noResultText} comboBoxGroups={withoutSection}>
+          <ComboBox onArrowButtonPress={onArrowButtonPress} comboBoxGroups={withoutSection}>
             {renderChildren}
           </ComboBox>
         );
 
-        const user = userEvent.setup();
         await user.click(screen.getByRole('button'));
+
+        expect(onArrowButtonPress).toHaveBeenCalled();
+      });
+
+      it('should call onInputChange when type on input', async () => {
+        const onInputChange = jest.fn();
+
+        render(
+          <ComboBox onInputChange={onInputChange} comboBoxGroups={withoutSection}>
+            {renderChildren}
+          </ComboBox>
+        );
 
         await userEvent.type(screen.getByLabelText('md-combo-box-input'), 'hello');
 
-        expect(screen.getByLabelText('md-combo-box-no-result-text')).toHaveTextContent(
-          noResultText
-        );
+        expect(onInputChange).toHaveBeenCalled();
       });
 
-      it('if shouldFilterOnArrowButton is false, should not filter when press arrowButton', async () => {
+      it('should call onSelectionChange when an item is selected', async () => {
+        const user = userEvent.setup();
+        const onSelectionChange = jest.fn();
+
         render(
-          <ComboBox shouldFilterOnArrowButton={false} comboBoxGroups={withoutSection}>
+          <ComboBox onSelectionChange={onSelectionChange} comboBoxGroups={withoutSection}>
             {renderChildren}
           </ComboBox>
         );
 
-        const user = userEvent.setup();
-        const input = screen.getByLabelText('md-combo-box-input');
-        const button = screen.getByRole('button');
-        act(() => {
-          input.focus();
-        });
-        await user.keyboard('{4}');
-        await user.keyboard('{Escape}');
-        await user.click(button);
-        expect(screen.getByRole('menu')).toBeVisible();
-
-        const item = screen.getByText('item1').parentElement;
-        expect(item).toBeVisible();
-      });
-
-      it('When list is hidden, entering text in the input, list will display', async () => {
-        const user = userEvent.setup();
-
-        render(
-          <>
-            <ComboBox comboBoxGroups={withoutSection}>{renderChildren}</ComboBox>
-          </>
-        );
-
-        const input = screen.getByLabelText('md-combo-box-input');
-        act(() => {
-          input.focus();
-        });
-        await user.keyboard('{Enter}');
-        expect(screen.getByRole('menu')).toBeVisible();
-
-        await waitFor(() => {
-          expect(screen.queryByRole('menu')).toBeInTheDocument();
-        });
-      });
-
-      it('when input is focused, list is hidden, press Enter, list will display, and item will be focused', async () => {
-        const user = userEvent.setup();
-
-        render(
-          <>
-            <ComboBox selectedKey={'key2'} comboBoxGroups={withoutSection}>
-              {renderChildren}
-            </ComboBox>
-          </>
-        );
-
-        const input = screen.getByLabelText('md-combo-box-input');
-        act(() => {
-          input.focus();
-        });
-        await user.keyboard('{Enter}');
-        expect(screen.getByRole('menu')).toBeVisible();
-
-        const item = screen.getByText('item2').parentElement;
-        await waitFor(() => {
-          expect(item.parentElement).toHaveFocus();
-        });
-      });
-
-      it('when input is focused, list is hidden, press ArrowDown, list will display, and item will be focused', async () => {
-        const user = userEvent.setup();
-
-        render(
-          <>
-            <ComboBox comboBoxGroups={withoutSection}>{renderChildren}</ComboBox>
-          </>
-        );
-
-        const input = screen.getByLabelText('md-combo-box-input');
-        act(() => {
-          input.focus();
-        });
-        await user.keyboard('{ArrowDown}');
-        expect(screen.getByRole('menu')).toBeVisible();
-
-        const item = screen.getByText('item1').parentElement;
-
-        await waitFor(() => {
-          expect(item.parentElement).toHaveFocus();
-        });
-      });
-      it('when input is focused, list is displayed, press Escape, list will be hidden', async () => {
-        const user = userEvent.setup();
-
-        render(
-          <>
-            <ComboBox comboBoxGroups={withoutSection}>{renderChildren}</ComboBox>
-          </>
-        );
-
-        const input = screen.getByLabelText('md-combo-box-input');
-        act(() => {
-          input.focus();
-        });
-        await user.keyboard('{i}');
-        expect(screen.getByRole('menu')).toBeVisible();
-
-        await user.keyboard('{Escape}');
-        await waitFor(() => {
-          expect(screen.queryByRole('menu')).not.toBeInTheDocument();
-        });
-      });
-
-      it('when input is focused, input has value, press Escape, clear input value', async () => {
-        const user = userEvent.setup();
-
-        render(
-          <>
-            <ComboBox selectedKey="key1" comboBoxGroups={withoutSection}>
-              {renderChildren}
-            </ComboBox>
-          </>
-        );
-
-        const input = screen.getByLabelText('md-combo-box-input');
-        expect(input).toHaveProperty('value', 'item1');
-        act(() => {
-          input.focus();
-        });
-        await user.keyboard('{Escape}');
-
-        expect(input).toHaveProperty('value', '');
-      });
-
-      it('when listitem is focused, press Escape, input will be focused', async () => {
-        const user = userEvent.setup();
-
-        render(
-          <>
-            <ComboBox comboBoxGroups={withoutSection}>{renderChildren}</ComboBox>
-          </>
-        );
-        const input = screen.getByLabelText('md-combo-box-input');
-        act(() => {
-          input.focus();
-        });
-        await user.keyboard('{Enter}');
-        expect(screen.getByRole('menu')).toBeVisible();
-
-        const item = screen.getByText('item1').parentElement;
-        await waitFor(() => {
-          expect(item.parentElement).toHaveFocus();
-        });
-
-        await user.keyboard('{Escape}');
-        await waitFor(() => {
-          expect(input).toHaveFocus();
-        });
-      });
-
-      it('when listitem is focused, press Tab, The focus will not escape.', async () => {
-        const user = userEvent.setup();
-
-        render(
-          <>
-            <ComboBox comboBoxGroups={withoutSection}>{renderChildren}</ComboBox>
-          </>
-        );
-        const input = screen.getByLabelText('md-combo-box-input');
-        act(() => {
-          input.focus();
-        });
-        await user.keyboard('{Enter}');
-        expect(screen.getByRole('menu')).toBeVisible();
-
-        const item = screen.getByText('item1').parentElement;
-        await waitFor(() => {
-          expect(item.parentElement).toHaveFocus();
-        });
-
-        await user.keyboard('{Tab}');
-        await waitFor(() => {
-          expect(item.parentElement).toHaveFocus();
-        });
-      });
-
-      it('reset inputValue, when focus shifts from inside the component to outside', async () => {
-        const user = userEvent.setup();
-
-        render(
-          <>
-            <ComboBox selectedKey="key1" comboBoxGroups={withoutSection}>
-              {renderChildren}
-            </ComboBox>
-            <button>button-outside</button>
-          </>
-        );
-        const input = screen.getByLabelText('md-combo-box-input');
-        act(() => {
-          input.focus();
-        });
-        await user.keyboard('{Escape}');
-        expect(input).toHaveProperty('value', '');
-
-        const button = screen.getByRole('button', { name: 'button-outside' });
-        act(() => {
-          button.focus();
-        });
-
-        await waitFor(() => {
-          expect(input).toHaveProperty('value', 'item1');
-        });
-      });
-
-      it('reset inputValue, when mousedown outside the component', async () => {
-        const user = userEvent.setup();
-
-        render(
-          <>
-            <ComboBox selectedKey="key1" comboBoxGroups={withoutSection}>
-              {renderChildren}
-            </ComboBox>
-            <button>button-outside</button>
-          </>
-        );
-        const input = screen.getByLabelText('md-combo-box-input');
-
-        await waitFor(() => {
-          expect(input).toHaveProperty('value', 'item1');
-        });
-        act(() => {
-          input.focus();
-        });
-        await user.keyboard('{1}');
-        await waitFor(() => {
-          expect(input).toHaveProperty('value', 'item11');
-        });
-
-        const button = screen.getByRole('button', { name: 'button-outside' });
-        await user.click(button);
-
-        await waitFor(() => {
-          expect(input).toHaveProperty('value', 'item1');
-        });
-      });
-
-      it('filter list when the input is focused', async () => {
-        const user = userEvent.setup();
-
-        render(
-          <>
-            <ComboBox
-              selectedKey="key1"
-              shouldFilterOnArrowButton={false}
-              comboBoxGroups={withoutSection}
-            >
-              {renderChildren}
-            </ComboBox>
-          </>
-        );
-        const input = screen.getByLabelText('md-combo-box-input');
         const button = screen
           .queryAllByRole('button')
           .find((button) => button.classList.contains('md-combo-box-button'));
 
-        await waitFor(() => {
-          expect(input).toHaveProperty('value', 'item1');
+        act(() => {
+          button.focus();
         });
-        await user.click(button);
-        const menu = screen.getByRole('menu');
-        expect(menu).toBeVisible();
-        const item2 = screen.getByText('item2').parentElement;
-        await user.click(button);
-        await user.click(input);
         await user.keyboard('{Enter}');
-        expect(input).toHaveProperty('value', 'item1');
-        const item1 = screen.getByText('item1').parentElement;
+        expect(screen.getByRole('menu')).toBeVisible();
+
+        const item = screen.getByText('item1').parentElement;
         await waitFor(() => {
-          expect(item1.parentElement).toHaveFocus();
-          expect(item2).not.toBeInTheDocument();
+          expect(item.parentElement).toHaveFocus();
         });
+        expect(onSelectionChange).not.toHaveBeenCalled();
+        await user.keyboard('{Enter}');
+        expect(onSelectionChange).toHaveBeenCalled();
+      });
+
+      it('should call openStateChange when list is expanded or collapsed', async () => {
+        const user = userEvent.setup();
+        const openStateChange = jest.fn();
+
+        render(
+          <ComboBox openStateChange={openStateChange} comboBoxGroups={withoutSection}>
+            {renderChildren}
+          </ComboBox>
+        );
+
+        const button = screen
+          .queryAllByRole('button')
+          .find((button) => button.classList.contains('md-combo-box-button'));
+
+        act(() => {
+          button.focus();
+        });
+        expect(openStateChange).toBeCalledWith(false);
+        await user.keyboard('{Enter}');
+        expect(screen.getByRole('menu')).toBeVisible();
+        expect(openStateChange).toBeCalledWith(true);
+        await user.keyboard('{Escape}');
+        expect(openStateChange).toBeCalledWith(false);
+      });
+
+      it('should show disabledKeys when click', async () => {
+        const user = userEvent.setup();
+
+        const disabledKeys = ['key1'];
+
+        const { container } = render(
+          <ComboBox disabledKeys={disabledKeys} comboBoxGroups={withoutSection}>
+            {renderChildren}
+          </ComboBox>
+        );
+
+        await user.click(screen.getByRole('button'));
+
+        expect(container.querySelector('li[data-key="key1"]')).toHaveAttribute(
+          'data-disabled',
+          'true'
+        );
+      });
+
+      it('should show menu when focused and pressing enter', async () => {
+        const user = userEvent.setup();
+
+        render(<ComboBox comboBoxGroups={withoutSection}>{renderChildren}</ComboBox>);
+
+        const menuItem = screen.queryByRole('menu');
+        expect(menuItem).not.toBeInTheDocument();
+
+        const button = screen.getByRole('button');
+        act(() => {
+          button.focus();
+        });
+        expect(button).toHaveFocus();
+
+        await user.keyboard('{Enter}');
+        expect(screen.getByRole('menu')).toBeVisible();
+      });
+
+      it('should hide menu when clicking outside', async () => {
+        const user = userEvent.setup();
+
+        render(
+          <>
+            <ComboBox comboBoxGroups={withoutSection}>{renderChildren}</ComboBox>
+            <button>button-outside</button>
+          </>
+        );
+
+        const ele = screen
+          .queryAllByRole('button')
+          .find((button) => button.classList.contains('md-combo-box-button'));
+
+        await user.click(ele);
+        expect(screen.getByRole('menu')).toBeVisible();
+
+        await user.click(screen.getByRole('button', { name: 'button-outside' }));
+        await waitFor(() => {
+          expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+        });
+      });
+    });
+
+    it('should have show noResultText when items is empty', async () => {
+      const noResultText = 'empty result';
+
+      render(
+        <ComboBox noResultText={noResultText} comboBoxGroups={withoutSection}>
+          {renderChildren}
+        </ComboBox>
+      );
+
+      const user = userEvent.setup();
+      await user.click(screen.getByRole('button'));
+
+      await userEvent.type(screen.getByLabelText('md-combo-box-input'), 'hello');
+
+      expect(screen.getByLabelText('md-combo-box-no-result-text')).toHaveTextContent(noResultText);
+    });
+
+    it('if shouldFilterOnArrowButton is false, should not filter when press arrowButton', async () => {
+      render(
+        <ComboBox shouldFilterOnArrowButton={false} comboBoxGroups={withoutSection}>
+          {renderChildren}
+        </ComboBox>
+      );
+
+      const user = userEvent.setup();
+      const input = screen.getByLabelText('md-combo-box-input');
+      const button = screen.getByRole('button');
+      act(() => {
+        input.focus();
+      });
+      await user.keyboard('{4}');
+      await user.keyboard('{Escape}');
+      await user.click(button);
+      expect(screen.getByRole('menu')).toBeVisible();
+
+      const item = screen.getByText('item1').parentElement;
+      expect(item).toBeVisible();
+    });
+
+    it('When list is hidden, entering text in the input, list will display', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <>
+          <ComboBox comboBoxGroups={withoutSection}>{renderChildren}</ComboBox>
+        </>
+      );
+
+      const input = screen.getByLabelText('md-combo-box-input');
+      act(() => {
+        input.focus();
+      });
+      await user.keyboard('{Enter}');
+      expect(screen.getByRole('menu')).toBeVisible();
+
+      await waitFor(() => {
+        expect(screen.queryByRole('menu')).toBeInTheDocument();
+      });
+    });
+
+    it('when input is focused, list is hidden, press Enter, list will display, and item will be focused', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <>
+          <ComboBox selectedKey={'key2'} comboBoxGroups={withoutSection}>
+            {renderChildren}
+          </ComboBox>
+        </>
+      );
+
+      const input = screen.getByLabelText('md-combo-box-input');
+      act(() => {
+        input.focus();
+      });
+      await user.keyboard('{Enter}');
+      expect(screen.getByRole('menu')).toBeVisible();
+
+      const item = screen.getByText('item2').parentElement;
+      await waitFor(() => {
+        expect(item.parentElement).toHaveFocus();
+      });
+    });
+
+    it('when input is focused, list is hidden, press ArrowDown, list will display, and item will be focused', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <>
+          <ComboBox comboBoxGroups={withoutSection}>{renderChildren}</ComboBox>
+        </>
+      );
+
+      const input = screen.getByLabelText('md-combo-box-input');
+      act(() => {
+        input.focus();
+      });
+      await user.keyboard('{ArrowDown}');
+      expect(screen.getByRole('menu')).toBeVisible();
+
+      const item = screen.getByText('item1').parentElement;
+
+      await waitFor(() => {
+        expect(item.parentElement).toHaveFocus();
+      });
+    });
+    it('when input is focused, list is displayed, press Escape, list will be hidden', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <>
+          <ComboBox comboBoxGroups={withoutSection}>{renderChildren}</ComboBox>
+        </>
+      );
+
+      const input = screen.getByLabelText('md-combo-box-input');
+      act(() => {
+        input.focus();
+      });
+      await user.keyboard('{i}');
+      expect(screen.getByRole('menu')).toBeVisible();
+
+      await user.keyboard('{Escape}');
+      await waitFor(() => {
+        expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+      });
+    });
+
+    it('when input is focused, input has value, press Escape, clear input value', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <>
+          <ComboBox selectedKey="key1" comboBoxGroups={withoutSection}>
+            {renderChildren}
+          </ComboBox>
+        </>
+      );
+
+      const input = screen.getByLabelText('md-combo-box-input');
+      expect(input).toHaveProperty('value', 'item1');
+      act(() => {
+        input.focus();
+      });
+      await user.keyboard('{Escape}');
+
+      expect(input).toHaveProperty('value', '');
+    });
+
+    it('when listitem is focused, press Escape, input will be focused', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <>
+          <ComboBox comboBoxGroups={withoutSection}>{renderChildren}</ComboBox>
+        </>
+      );
+      const input = screen.getByLabelText('md-combo-box-input');
+      act(() => {
+        input.focus();
+      });
+      await user.keyboard('{Enter}');
+      expect(screen.getByRole('menu')).toBeVisible();
+
+      const item = screen.getByText('item1').parentElement;
+      await waitFor(() => {
+        expect(item.parentElement).toHaveFocus();
+      });
+
+      await user.keyboard('{Escape}');
+      await waitFor(() => {
+        expect(input).toHaveFocus();
+      });
+    });
+
+    it('when listitem is focused, press Tab, The focus will not escape.', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <>
+          <ComboBox comboBoxGroups={withoutSection}>{renderChildren}</ComboBox>
+        </>
+      );
+      const input = screen.getByLabelText('md-combo-box-input');
+      act(() => {
+        input.focus();
+      });
+      await user.keyboard('{Enter}');
+      expect(screen.getByRole('menu')).toBeVisible();
+
+      const item = screen.getByText('item1').parentElement;
+      await waitFor(() => {
+        expect(item.parentElement).toHaveFocus();
+      });
+
+      await user.keyboard('{Tab}');
+      await waitFor(() => {
+        expect(item.parentElement).toHaveFocus();
+      });
+    });
+
+    it('reset inputValue, when focus shifts from inside the component to outside', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <>
+          <ComboBox selectedKey="key1" comboBoxGroups={withoutSection}>
+            {renderChildren}
+          </ComboBox>
+          <button>button-outside</button>
+        </>
+      );
+      const input = screen.getByLabelText('md-combo-box-input');
+      act(() => {
+        input.focus();
+      });
+      await user.keyboard('{Escape}');
+      expect(input).toHaveProperty('value', '');
+
+      const button = screen.getByRole('button', { name: 'button-outside' });
+      act(() => {
+        button.focus();
+      });
+
+      await waitFor(() => {
+        expect(input).toHaveProperty('value', 'item1');
+      });
+    });
+
+    it('reset inputValue, when mousedown outside the component', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <>
+          <ComboBox selectedKey="key1" comboBoxGroups={withoutSection}>
+            {renderChildren}
+          </ComboBox>
+          <button>button-outside</button>
+        </>
+      );
+      const input = screen.getByLabelText('md-combo-box-input');
+
+      await waitFor(() => {
+        expect(input).toHaveProperty('value', 'item1');
+      });
+      act(() => {
+        input.focus();
+      });
+      await user.keyboard('{1}');
+      await waitFor(() => {
+        expect(input).toHaveProperty('value', 'item11');
+      });
+
+      const button = screen.getByRole('button', { name: 'button-outside' });
+      await user.click(button);
+
+      await waitFor(() => {
+        expect(input).toHaveProperty('value', 'item1');
+      });
+    });
+
+    it('filter list when the input is focused', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <>
+          <ComboBox
+            selectedKey="key1"
+            shouldFilterOnArrowButton={false}
+            comboBoxGroups={withoutSection}
+          >
+            {renderChildren}
+          </ComboBox>
+        </>
+      );
+      const input = screen.getByLabelText('md-combo-box-input');
+      const button = screen
+        .queryAllByRole('button')
+        .find((button) => button.classList.contains('md-combo-box-button'));
+
+      await waitFor(() => {
+        expect(input).toHaveProperty('value', 'item1');
+      });
+      await user.click(button);
+      const menu = screen.getByRole('menu');
+      expect(menu).toBeVisible();
+      const item2 = screen.getByText('item2').parentElement;
+      await user.click(button);
+      await user.click(input);
+      await user.keyboard('{Enter}');
+      expect(input).toHaveProperty('value', 'item1');
+      const item1 = screen.getByText('item1').parentElement;
+      await waitFor(() => {
+        expect(item1.parentElement).toHaveFocus();
+        expect(item2).not.toBeInTheDocument();
       });
     });
   });

--- a/src/components/ComboBox/ComboBox.unit.test.tsx.snap
+++ b/src/components/ComboBox/ComboBox.unit.test.tsx.snap
@@ -87,6 +87,25 @@ exports[`ComboBox snapshot should match snapshot label 1`] = `
               value=""
             />
           </div>
+          <ScreenReaderAnnouncer
+            identity="test-ID"
+          >
+            <div
+              className="md-screen-reader-announcer-wrapper"
+              data-testid="screen-reader-announcer"
+              style={
+                Object {
+                  "clip": "rect(0 0 0 0)",
+                  "clipPath": "inset(50%)",
+                  "height": "1px",
+                  "overflow": "hidden",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+            />
+          </ScreenReaderAnnouncer>
         </div>
       </TextInput>
       <div
@@ -258,6 +277,25 @@ exports[`ComboBox snapshot should match snapshot with className 1`] = `
               value=""
             />
           </div>
+          <ScreenReaderAnnouncer
+            identity="test-ID"
+          >
+            <div
+              className="md-screen-reader-announcer-wrapper"
+              data-testid="screen-reader-announcer"
+              style={
+                Object {
+                  "clip": "rect(0 0 0 0)",
+                  "clipPath": "inset(50%)",
+                  "height": "1px",
+                  "overflow": "hidden",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+            />
+          </ScreenReaderAnnouncer>
         </div>
       </TextInput>
       <div
@@ -429,6 +467,25 @@ exports[`ComboBox snapshot should match snapshot with noResultText 1`] = `
               value=""
             />
           </div>
+          <ScreenReaderAnnouncer
+            identity="test-ID"
+          >
+            <div
+              className="md-screen-reader-announcer-wrapper"
+              data-testid="screen-reader-announcer"
+              style={
+                Object {
+                  "clip": "rect(0 0 0 0)",
+                  "clipPath": "inset(50%)",
+                  "height": "1px",
+                  "overflow": "hidden",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+            />
+          </ScreenReaderAnnouncer>
         </div>
       </TextInput>
       <div
@@ -600,6 +657,25 @@ exports[`ComboBox snapshot should match snapshot with placeholder 1`] = `
               value=""
             />
           </div>
+          <ScreenReaderAnnouncer
+            identity="test-ID"
+          >
+            <div
+              className="md-screen-reader-announcer-wrapper"
+              data-testid="screen-reader-announcer"
+              style={
+                Object {
+                  "clip": "rect(0 0 0 0)",
+                  "clipPath": "inset(50%)",
+                  "height": "1px",
+                  "overflow": "hidden",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+            />
+          </ScreenReaderAnnouncer>
         </div>
       </TextInput>
       <div
@@ -776,6 +852,25 @@ exports[`ComboBox snapshot should match snapshot with style 1`] = `
               value=""
             />
           </div>
+          <ScreenReaderAnnouncer
+            identity="test-ID"
+          >
+            <div
+              className="md-screen-reader-announcer-wrapper"
+              data-testid="screen-reader-announcer"
+              style={
+                Object {
+                  "clip": "rect(0 0 0 0)",
+                  "clipPath": "inset(50%)",
+                  "height": "1px",
+                  "overflow": "hidden",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+            />
+          </ScreenReaderAnnouncer>
         </div>
       </TextInput>
       <div
@@ -947,6 +1042,25 @@ exports[`ComboBox snapshot should match snapshot with width 1`] = `
               value=""
             />
           </div>
+          <ScreenReaderAnnouncer
+            identity="test-ID"
+          >
+            <div
+              className="md-screen-reader-announcer-wrapper"
+              data-testid="screen-reader-announcer"
+              style={
+                Object {
+                  "clip": "rect(0 0 0 0)",
+                  "clipPath": "inset(50%)",
+                  "height": "1px",
+                  "overflow": "hidden",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+            />
+          </ScreenReaderAnnouncer>
         </div>
       </TextInput>
       <div
@@ -1131,6 +1245,25 @@ exports[`ComboBox snapshot should match snapshot withSection 1`] = `
               value=""
             />
           </div>
+          <ScreenReaderAnnouncer
+            identity="test-ID"
+          >
+            <div
+              className="md-screen-reader-announcer-wrapper"
+              data-testid="screen-reader-announcer"
+              style={
+                Object {
+                  "clip": "rect(0 0 0 0)",
+                  "clipPath": "inset(50%)",
+                  "height": "1px",
+                  "overflow": "hidden",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+            />
+          </ScreenReaderAnnouncer>
         </div>
       </TextInput>
       <div

--- a/src/components/InputMessage/InputMessage.tsx
+++ b/src/components/InputMessage/InputMessage.tsx
@@ -39,7 +39,7 @@ const InputMessage = (props: Props): ReactElement => {
 
   return (
     <div className={classnames(STYLE.wrapper, className)} id={id}>
-      <div className={STYLE.message} role="alert" message-level={level}>
+      <div className={STYLE.message} message-level={level}>
         {(level == 'error' || level == 'warning') && (
           <div className={STYLE.icon}>
             <Icon

--- a/src/components/InputMessage/InputMessage.unit.test.tsx.snap
+++ b/src/components/InputMessage/InputMessage.unit.test.tsx.snap
@@ -11,7 +11,6 @@ exports[`InputMessage snapshot should match snapshot 1`] = `
     <div
       className="md-input-message-message"
       message-level="error"
-      role="alert"
     >
       <div
         className="md-input-message--icon"

--- a/src/components/SearchInput/SearchInput.unit.test.tsx.snap
+++ b/src/components/SearchInput/SearchInput.unit.test.tsx.snap
@@ -62,7 +62,6 @@ exports[`<SearchInput /> snapshot should match snapshot 1`] = `
           <div
             className="md-input-message-message"
             message-level="none"
-            role="alert"
           >
             <Text
               className="md-input-message--text"
@@ -236,7 +235,6 @@ exports[`<SearchInput /> snapshot should match snapshot when filters are set 1`]
           <div
             className="md-input-message-message"
             message-level="none"
-            role="alert"
           >
             <Text
               className="md-input-message--text"
@@ -325,7 +323,6 @@ exports[`<SearchInput /> snapshot should match snapshot when isCombobox is true 
           <div
             className="md-input-message-message"
             message-level="none"
-            role="alert"
           >
             <Text
               className="md-input-message--text"
@@ -446,7 +443,6 @@ exports[`<SearchInput /> snapshot should match snapshot when searching 1`] = `
           <div
             className="md-input-message-message"
             message-level="none"
-            role="alert"
           >
             <Text
               className="md-input-message--text"
@@ -541,7 +537,6 @@ exports[`<SearchInput /> snapshot should match snapshot with a label 1`] = `
           <div
             className="md-input-message-message"
             message-level="none"
-            role="alert"
           >
             <Text
               className="md-input-message--text"
@@ -629,7 +624,6 @@ exports[`<SearchInput /> snapshot should match snapshot with className 1`] = `
           <div
             className="md-input-message-message"
             message-level="none"
-            role="alert"
           >
             <Text
               className="md-input-message--text"
@@ -717,7 +711,6 @@ exports[`<SearchInput /> snapshot should match snapshot with height 1`] = `
           <div
             className="md-input-message-message"
             message-level="none"
-            role="alert"
           >
             <Text
               className="md-input-message--text"
@@ -805,7 +798,6 @@ exports[`<SearchInput /> snapshot should match snapshot with id 1`] = `
           <div
             className="md-input-message-message"
             message-level="none"
-            role="alert"
           >
             <Text
               className="md-input-message--text"
@@ -902,7 +894,6 @@ exports[`<SearchInput /> snapshot should match snapshot with style 1`] = `
           <div
             className="md-input-message-message"
             message-level="none"
-            role="alert"
           >
             <Text
               className="md-input-message--text"

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -7,7 +7,6 @@ import React, {
   forwardRef,
   useRef,
   useEffect,
-  useState,
 } from 'react';
 import { useTextField } from '@react-aria/textfield';
 import { useSearchFieldState } from '@react-stately/searchfield';
@@ -40,7 +39,6 @@ const TextInput = (props: Props, ref: RefObject<HTMLInputElement>): ReactElement
   const inputRef = ref || componentRef;
 
   const [messageType, messages] = getFilteredMessages(messageArr);
-  const [messagesToAnnounces] = useState(messages);
   const errorMessage = messageType === 'error' ? messages[0] : undefined;
 
   const { labelProps, inputProps, descriptionProps, errorMessageProps } = useTextField(
@@ -70,11 +68,11 @@ const TextInput = (props: Props, ref: RefObject<HTMLInputElement>): ReactElement
   };
 
   useEffect(() => {
-    // Automatically SR-announce the input message as soon as it appears visibly on the screen to comply with a11y rules
-    if (messagesToAnnounces && !!messagesToAnnounces.length) {
-      ScreenReaderAnnouncer.announce({ body: messagesToAnnounces.join() }, announcerId);
+    // Automatically SR-announce the error message as soon as it appears visibly on the screen to comply with a11y rules
+    if (errorMessage) {
+      ScreenReaderAnnouncer.announce({ body: errorMessage }, announcerId);
     }
-  }, [announcerId, messagesToAnnounces]);
+  }, [announcerId, errorMessage]);
 
   return (
     <div

--- a/src/components/TextInput/TextInput.unit.test.tsx
+++ b/src/components/TextInput/TextInput.unit.test.tsx
@@ -7,6 +7,7 @@ import { act } from 'react-dom/test-utils';
 import { Message } from '../InputMessage/InputMessage.types';
 import InputMessage from '../InputMessage';
 import * as screenReaderAnnouncer from '../ScreenReaderAnnouncer';
+import { ReactWrapper } from 'enzyme';
 
 jest.mock('uuid', () => {
   return {
@@ -15,8 +16,8 @@ jest.mock('uuid', () => {
 });
 
 describe('<TextInput/>', () => {
-  let announceSpy;
-  let container;
+  let announceSpy: jest.SpiedFunction<(typeof screenReaderAnnouncer)['default']['announce']>;
+  let container: ReactWrapper;
 
   beforeEach(() => {
     announceSpy = jest.spyOn(screenReaderAnnouncer.default, 'announce').mockReturnValue();

--- a/src/components/TextInput/TextInput.unit.test.tsx
+++ b/src/components/TextInput/TextInput.unit.test.tsx
@@ -323,7 +323,7 @@ describe('<TextInput/>', () => {
         />
       );
 
-      expect(announceSpy).toHaveBeenCalledWith({ body: 'test1,test2' }, 'test-ID');
+      expect(announceSpy).toHaveBeenCalledWith({ body: 'test1' }, 'test-ID');
     });
   });
 });

--- a/src/components/TextInput/TextInput.unit.test.tsx.snap
+++ b/src/components/TextInput/TextInput.unit.test.tsx.snap
@@ -216,7 +216,6 @@ exports[`<TextInput/> snapshot should match snapshot with description 1`] = `
           <div
             className="md-input-message-message"
             message-level="help"
-            role="alert"
           >
             <Text
               className="md-input-message--text"
@@ -321,7 +320,6 @@ exports[`<TextInput/> snapshot should match snapshot with error text 1`] = `
             <div
               className="md-input-message-message"
               message-level="error"
-              role="alert"
             >
               <div
                 className="md-input-message--icon"

--- a/src/components/TextInput/TextInput.unit.test.tsx.snap
+++ b/src/components/TextInput/TextInput.unit.test.tsx.snap
@@ -32,6 +32,25 @@ exports[`<TextInput/> snapshot should match snapshot 1`] = `
           type="text"
         />
       </div>
+      <ScreenReaderAnnouncer
+        identity="test-ID"
+      >
+        <div
+          className="md-screen-reader-announcer-wrapper"
+          data-testid="screen-reader-announcer"
+          style={
+            Object {
+              "clip": "rect(0 0 0 0)",
+              "clipPath": "inset(50%)",
+              "height": "1px",
+              "overflow": "hidden",
+              "position": "absolute",
+              "whiteSpace": "nowrap",
+              "width": "1px",
+            }
+          }
+        />
+      </ScreenReaderAnnouncer>
     </div>
   </TextInput>
 </SSRProvider>
@@ -70,6 +89,25 @@ exports[`<TextInput/> snapshot should match snapshot with className 1`] = `
           type="text"
         />
       </div>
+      <ScreenReaderAnnouncer
+        identity="test-ID"
+      >
+        <div
+          className="md-screen-reader-announcer-wrapper"
+          data-testid="screen-reader-announcer"
+          style={
+            Object {
+              "clip": "rect(0 0 0 0)",
+              "clipPath": "inset(50%)",
+              "height": "1px",
+              "overflow": "hidden",
+              "position": "absolute",
+              "whiteSpace": "nowrap",
+              "width": "1px",
+            }
+          }
+        />
+      </ScreenReaderAnnouncer>
     </div>
   </TextInput>
 </SSRProvider>
@@ -108,6 +146,25 @@ exports[`<TextInput/> snapshot should match snapshot with clearAriaLabel 1`] = `
           type="text"
         />
       </div>
+      <ScreenReaderAnnouncer
+        identity="test-ID"
+      >
+        <div
+          className="md-screen-reader-announcer-wrapper"
+          data-testid="screen-reader-announcer"
+          style={
+            Object {
+              "clip": "rect(0 0 0 0)",
+              "clipPath": "inset(50%)",
+              "height": "1px",
+              "overflow": "hidden",
+              "position": "absolute",
+              "whiteSpace": "nowrap",
+              "width": "1px",
+            }
+          }
+        />
+      </ScreenReaderAnnouncer>
     </div>
   </TextInput>
 </SSRProvider>
@@ -181,6 +238,25 @@ exports[`<TextInput/> snapshot should match snapshot with description 1`] = `
           </div>
         </div>
       </InputMessage>
+      <ScreenReaderAnnouncer
+        identity="test-ID"
+      >
+        <div
+          className="md-screen-reader-announcer-wrapper"
+          data-testid="screen-reader-announcer"
+          style={
+            Object {
+              "clip": "rect(0 0 0 0)",
+              "clipPath": "inset(50%)",
+              "height": "1px",
+              "overflow": "hidden",
+              "position": "absolute",
+              "whiteSpace": "nowrap",
+              "width": "1px",
+            }
+          }
+        />
+      </ScreenReaderAnnouncer>
     </div>
   </TextInput>
 </SSRProvider>
@@ -300,6 +376,25 @@ exports[`<TextInput/> snapshot should match snapshot with error text 1`] = `
           </div>
         </InputMessage>
       </div>
+      <ScreenReaderAnnouncer
+        identity="test-ID"
+      >
+        <div
+          className="md-screen-reader-announcer-wrapper"
+          data-testid="screen-reader-announcer"
+          style={
+            Object {
+              "clip": "rect(0 0 0 0)",
+              "clipPath": "inset(50%)",
+              "height": "1px",
+              "overflow": "hidden",
+              "position": "absolute",
+              "whiteSpace": "nowrap",
+              "width": "1px",
+            }
+          }
+        />
+      </ScreenReaderAnnouncer>
     </div>
   </TextInput>
 </SSRProvider>
@@ -338,6 +433,25 @@ exports[`<TextInput/> snapshot should match snapshot with id 1`] = `
           type="text"
         />
       </div>
+      <ScreenReaderAnnouncer
+        identity="test-ID"
+      >
+        <div
+          className="md-screen-reader-announcer-wrapper"
+          data-testid="screen-reader-announcer"
+          style={
+            Object {
+              "clip": "rect(0 0 0 0)",
+              "clipPath": "inset(50%)",
+              "height": "1px",
+              "overflow": "hidden",
+              "position": "absolute",
+              "whiteSpace": "nowrap",
+              "width": "1px",
+            }
+          }
+        />
+      </ScreenReaderAnnouncer>
     </div>
   </TextInput>
 </SSRProvider>
@@ -377,6 +491,25 @@ exports[`<TextInput/> snapshot should match snapshot with inputMaxLen 1`] = `
           type="text"
         />
       </div>
+      <ScreenReaderAnnouncer
+        identity="test-ID"
+      >
+        <div
+          className="md-screen-reader-announcer-wrapper"
+          data-testid="screen-reader-announcer"
+          style={
+            Object {
+              "clip": "rect(0 0 0 0)",
+              "clipPath": "inset(50%)",
+              "height": "1px",
+              "overflow": "hidden",
+              "position": "absolute",
+              "whiteSpace": "nowrap",
+              "width": "1px",
+            }
+          }
+        />
+      </ScreenReaderAnnouncer>
     </div>
   </TextInput>
 </SSRProvider>
@@ -416,6 +549,25 @@ exports[`<TextInput/> snapshot should match snapshot with isDisabled 1`] = `
           type="text"
         />
       </div>
+      <ScreenReaderAnnouncer
+        identity="test-ID"
+      >
+        <div
+          className="md-screen-reader-announcer-wrapper"
+          data-testid="screen-reader-announcer"
+          style={
+            Object {
+              "clip": "rect(0 0 0 0)",
+              "clipPath": "inset(50%)",
+              "height": "1px",
+              "overflow": "hidden",
+              "position": "absolute",
+              "whiteSpace": "nowrap",
+              "width": "1px",
+            }
+          }
+        />
+      </ScreenReaderAnnouncer>
     </div>
   </TextInput>
 </SSRProvider>
@@ -463,6 +615,25 @@ exports[`<TextInput/> snapshot should match snapshot with style 1`] = `
           type="text"
         />
       </div>
+      <ScreenReaderAnnouncer
+        identity="test-ID"
+      >
+        <div
+          className="md-screen-reader-announcer-wrapper"
+          data-testid="screen-reader-announcer"
+          style={
+            Object {
+              "clip": "rect(0 0 0 0)",
+              "clipPath": "inset(50%)",
+              "height": "1px",
+              "overflow": "hidden",
+              "position": "absolute",
+              "whiteSpace": "nowrap",
+              "width": "1px",
+            }
+          }
+        />
+      </ScreenReaderAnnouncer>
     </div>
   </TextInput>
 </SSRProvider>


### PR DESCRIPTION
# Description

As we can see in the a11y audit reports, if an error gets displayed related to an input, this should be announced automatically by SR. 

# Links

[*Links to relevent resources.*](https://confluence-eng-gpk2.cisco.com/conf/display/WTWC/2.+INPUTS#:~:text=%E2%9A%AA%20ALLOW%20SR%20TO%20ANNOUNCE%20IF%20A%20TEXT%20INPUT%20HAS%20AN%20ERROR)
