### PR TITLE
fix(ListBoxBase): set shouldSelectOnPressUp to false

### DIFF
--- a/src/components/ListBoxBase/ListBoxBase.tsx
+++ b/src/components/ListBoxBase/ListBoxBase.tsx
@@ -26,6 +26,7 @@ const ListBoxBase = <T extends object>(props: Props<T>, ref: RefObject<HTMLUList
     {
       autoFocus: props.autoFocus,
       ...mutatedProps,
+      shouldSelectOnPressUp: false,
       id,
     },
     state,

--- a/src/components/ListBoxItem/ListBoxItem.tsx
+++ b/src/components/ListBoxItem/ListBoxItem.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/ban-types */
 import React, { ReactElement, useContext } from 'react';
 
 import './ListBoxItem.style.scss';
@@ -24,7 +23,6 @@ function ListBoxItem<T>(props: Props<T>): ReactElement {
       isDisabled,
       'aria-label': item['aria-label'],
       isSelected,
-      shouldSelectOnPressUp: true,
       shouldFocusOnHover: false,
     },
     state,


### PR DESCRIPTION
# Description

Set the `shouldSelectOnPressUp` option for `useSelect` hook to false to stop select options to be chosen on the pressUp event.

Fixes automatically selecting an option when the viewport is small enough for the options to render above the dropdown.

Also moves the option out of ListBoxItem and into ListBoxBase since it is deprecated in the `useOption` hook

# Links

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-577692
