### PR TITLE
feat(loading-spinner): required accessible name or aria-hidden and add role img

### DIFF
--- a/src/components/LoadingSpinner/LoadingSpinner.tsx
+++ b/src/components/LoadingSpinner/LoadingSpinner.tsx
@@ -10,7 +10,13 @@ const LoadingSpinner: FC<Props> = (props: Props) => {
   const { className, id, style, scale = DEFAULTS.SCALE, ...rest } = props;
 
   return (
-    <div className={classnames(className, STYLE.wrapper)} id={id} style={style} {...rest}>
+    <div
+      className={classnames(className, STYLE.wrapper)}
+      id={id}
+      style={style}
+      {...rest}
+      role="img"
+    >
       <Icon scale={scale} name="spinner" weight="regular" />
       <Icon scale={scale} className={STYLE.arch} name="spinner-in-progress" weight="regular" />
     </div>

--- a/src/components/LoadingSpinner/LoadingSpinner.types.ts
+++ b/src/components/LoadingSpinner/LoadingSpinner.types.ts
@@ -1,30 +1,41 @@
 import { CSSProperties, ReactNode } from 'react';
 import { IconScale } from '../Icon';
+import { AriaLabelRequired } from '../../utils/a11y';
+import { AriaLabelingProps } from '@react-types/shared';
 
-export interface Props {
-  /**
-   * Child components of this LoadingSpinner.
-   */
-  children?: ReactNode;
+export type Props = AriaLabelingProps &
+  (
+    | {
+        /**
+         * Whether this loading spinner should be hidden from SR as it's meaning is redundant
+         */
+        'aria-hidden': boolean;
+      }
+    | ({ 'aria-hidden'?: never } & AriaLabelRequired)
+  ) & { // if aria-hidden is not provided, a label is required
+    /**
+     * Child components of this LoadingSpinner.
+     */
+    children?: ReactNode;
 
-  /**
-   * Custom class for overriding this component's CSS.
-   */
-  className?: string;
+    /**
+     * Custom class for overriding this component's CSS.
+     */
+    className?: string;
 
-  /**
-   * Custom id for overriding this component's CSS.
-   */
-  id?: string;
+    /**
+     * Custom id for overriding this component's CSS.
+     */
+    id?: string;
 
-  /**
-   * Custom style for overriding this component's CSS.
-   */
-  style?: CSSProperties;
+    /**
+     * Custom style for overriding this component's CSS.
+     */
+    style?: CSSProperties;
 
-  /**
-   * Size of the loading spinner (same as IconScale).
-   * @default 24
-   */
-  scale?: IconScale;
-}
+    /**
+     * Size of the loading spinner (same as IconScale).
+     * @default 24
+     */
+    scale?: IconScale;
+  };

--- a/src/components/LoadingSpinner/LoadingSpinner.unit.test.tsx
+++ b/src/components/LoadingSpinner/LoadingSpinner.unit.test.tsx
@@ -8,7 +8,7 @@ describe('<LoadingSpinner />', () => {
     it('should match snapshot', async () => {
       expect.assertions(1);
 
-      const container = await mountAndWait(<LoadingSpinner />);
+      const container = await mountAndWait(<LoadingSpinner aria-label="Loading, please wait" />);
 
       expect(container).toMatchSnapshot();
     });
@@ -18,7 +18,9 @@ describe('<LoadingSpinner />', () => {
 
       const className = 'example-class';
 
-      const container = await mountAndWait(<LoadingSpinner className={className} />);
+      const container = await mountAndWait(
+        <LoadingSpinner aria-label="Loading, please wait" className={className} />
+      );
 
       expect(container).toMatchSnapshot();
     });
@@ -28,7 +30,9 @@ describe('<LoadingSpinner />', () => {
 
       const id = 'example-id';
 
-      const container = await mountAndWait(<LoadingSpinner id={id} />);
+      const container = await mountAndWait(
+        <LoadingSpinner aria-label="Loading, please wait" id={id} />
+      );
 
       expect(container).toMatchSnapshot();
     });
@@ -38,7 +42,9 @@ describe('<LoadingSpinner />', () => {
 
       const style = { color: 'pink' };
 
-      const container = await mountAndWait(<LoadingSpinner style={style} />);
+      const container = await mountAndWait(
+        <LoadingSpinner aria-label="Loading, please wait" style={style} />
+      );
 
       expect(container).toMatchSnapshot();
     });
@@ -48,7 +54,17 @@ describe('<LoadingSpinner />', () => {
 
       const scale = 32 as const;
 
-      const container = await mountAndWait(<LoadingSpinner scale={scale} />);
+      const container = await mountAndWait(
+        <LoadingSpinner aria-label="Loading, please wait" scale={scale} />
+      );
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match snapshot with aria-hidden', async () => {
+      expect.assertions(1);
+
+      const container = await mountAndWait(<LoadingSpinner aria-hidden />);
 
       expect(container).toMatchSnapshot();
     });
@@ -58,7 +74,9 @@ describe('<LoadingSpinner />', () => {
     it('should have its wrapper class', async () => {
       expect.assertions(1);
 
-      const element = (await mountAndWait(<LoadingSpinner />)).find(LoadingSpinner).getDOMNode();
+      const element = (await mountAndWait(<LoadingSpinner aria-label="Loading, please wait" />))
+        .find(LoadingSpinner)
+        .getDOMNode();
 
       expect(element.classList.contains(CONSTANTS.STYLE.wrapper)).toBe(true);
     });
@@ -68,7 +86,11 @@ describe('<LoadingSpinner />', () => {
 
       const className = 'example-class';
 
-      const element = (await mountAndWait(<LoadingSpinner className={className} />))
+      const element = (
+        await mountAndWait(
+          <LoadingSpinner aria-label="Loading, please wait" className={className} />
+        )
+      )
         .find(LoadingSpinner)
         .getDOMNode();
 
@@ -80,7 +102,9 @@ describe('<LoadingSpinner />', () => {
 
       const id = 'example-id';
 
-      const element = (await mountAndWait(<LoadingSpinner id={id} />))
+      const element = (
+        await mountAndWait(<LoadingSpinner aria-label="Loading, please wait" id={id} />)
+      )
         .find(LoadingSpinner)
         .getDOMNode();
 
@@ -93,7 +117,9 @@ describe('<LoadingSpinner />', () => {
       const style = { color: 'pink' };
       const styleString = 'color: pink;';
 
-      const element = (await mountAndWait(<LoadingSpinner style={style} />))
+      const element = (
+        await mountAndWait(<LoadingSpinner aria-label="Loading, please wait" style={style} />)
+      )
         .find(LoadingSpinner)
         .getDOMNode();
 
@@ -105,9 +131,21 @@ describe('<LoadingSpinner />', () => {
 
       const scale = 32 as const;
 
-      (await mountAndWait(<LoadingSpinner scale={scale} />)).find('svg').forEach((icon) => {
-        expect(icon.getDOMNode().getAttribute('data-scale')).toBe(`${scale}`);
-      });
+      (await mountAndWait(<LoadingSpinner aria-label="Loading, please wait" scale={scale} />))
+        .find('svg')
+        .forEach((icon) => {
+          expect(icon.getDOMNode().getAttribute('data-scale')).toBe(`${scale}`);
+        });
+    });
+
+    it('should have provided aria-hidden when aria-hidden is provided', async () => {
+      expect.assertions(1);
+
+      const element = (await mountAndWait(<LoadingSpinner aria-hidden />))
+        .find(LoadingSpinner)
+        .getDOMNode();
+
+      expect(element.getAttribute('aria-hidden')).toBe('true');
     });
   });
 });

--- a/src/components/LoadingSpinner/LoadingSpinner.unit.test.tsx.snap
+++ b/src/components/LoadingSpinner/LoadingSpinner.unit.test.tsx.snap
@@ -1,9 +1,75 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<LoadingSpinner /> snapshot should match snapshot 1`] = `
-<LoadingSpinner>
+<LoadingSpinner
+  aria-label="Loading, please wait"
+>
   <div
+    aria-label="Loading, please wait"
     className="md-loading-spinner-wrapper"
+    role="img"
+  >
+    <Icon
+      name="spinner"
+      scale={24}
+      weight="regular"
+    >
+      <div
+        aria-hidden="true"
+        className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-icon-no-shrink"
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          className=""
+          data-autoscale={false}
+          data-scale={24}
+          data-test="spinner"
+          fill="currentColor"
+          height="100%"
+          style={Object {}}
+          viewBox="0, 0, 32, 32"
+          width="100%"
+        />
+      </div>
+    </Icon>
+    <Icon
+      className="md-loading-spinner-arch"
+      name="spinner-in-progress"
+      scale={24}
+      weight="regular"
+    >
+      <div
+        aria-hidden="true"
+        className="md-icon-wrapper md-icon-auto-scales md-icon-scales md-loading-spinner-arch md-icon-no-shrink"
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          className=""
+          data-autoscale={false}
+          data-scale={24}
+          data-test="spinner-in-progress"
+          fill="currentColor"
+          height="100%"
+          style={Object {}}
+          viewBox="0, 0, 32, 32"
+          width="100%"
+        />
+      </div>
+    </Icon>
+  </div>
+</LoadingSpinner>
+`;
+
+exports[`<LoadingSpinner /> snapshot should match snapshot with aria-hidden 1`] = `
+<LoadingSpinner
+  aria-hidden={true}
+>
+  <div
+    aria-hidden={true}
+    className="md-loading-spinner-wrapper"
+    role="img"
   >
     <Icon
       name="spinner"
@@ -60,10 +126,13 @@ exports[`<LoadingSpinner /> snapshot should match snapshot 1`] = `
 
 exports[`<LoadingSpinner /> snapshot should match snapshot with className 1`] = `
 <LoadingSpinner
+  aria-label="Loading, please wait"
   className="example-class"
 >
   <div
+    aria-label="Loading, please wait"
     className="example-class md-loading-spinner-wrapper"
+    role="img"
   >
     <Icon
       name="spinner"
@@ -120,11 +189,14 @@ exports[`<LoadingSpinner /> snapshot should match snapshot with className 1`] = 
 
 exports[`<LoadingSpinner /> snapshot should match snapshot with id 1`] = `
 <LoadingSpinner
+  aria-label="Loading, please wait"
   id="example-id"
 >
   <div
+    aria-label="Loading, please wait"
     className="md-loading-spinner-wrapper"
     id="example-id"
+    role="img"
   >
     <Icon
       name="spinner"
@@ -181,10 +253,13 @@ exports[`<LoadingSpinner /> snapshot should match snapshot with id 1`] = `
 
 exports[`<LoadingSpinner /> snapshot should match snapshot with scale 1`] = `
 <LoadingSpinner
+  aria-label="Loading, please wait"
   scale={32}
 >
   <div
+    aria-label="Loading, please wait"
     className="md-loading-spinner-wrapper"
+    role="img"
   >
     <Icon
       name="spinner"
@@ -241,6 +316,7 @@ exports[`<LoadingSpinner /> snapshot should match snapshot with scale 1`] = `
 
 exports[`<LoadingSpinner /> snapshot should match snapshot with style 1`] = `
 <LoadingSpinner
+  aria-label="Loading, please wait"
   style={
     Object {
       "color": "pink",
@@ -248,7 +324,9 @@ exports[`<LoadingSpinner /> snapshot should match snapshot with style 1`] = `
   }
 >
   <div
+    aria-label="Loading, please wait"
     className="md-loading-spinner-wrapper"
+    role="img"
     style={
       Object {
         "color": "pink",


### PR DESCRIPTION
# Description

As part of SPARK-582976, we are requiring an accessible name for LoadingSpinner or an aria-hidden in case the spinner meaning is redundant. 

We are also adding a role of img to the spinner for sr to read it as such.

# Links

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-582976
