### PR TITLE
fix(ButtonHyperlink): remove role button from anchor element

### DIFF
--- a/src/components/ButtonHyperlink/ButtonHyperlink.tsx
+++ b/src/components/ButtonHyperlink/ButtonHyperlink.tsx
@@ -23,6 +23,8 @@ const ButtonHyperlink = forwardRef((props: Props, providedRef: RefObject<HTMLAnc
 
   const { buttonProps } = useButton({ ...mutatedProps, elementType: 'a' }, ref);
 
+  delete buttonProps.role; // remove role="button" from the anchor element
+
   return (
     <FocusRing disabled={props.disabled}>
       <a

--- a/src/components/ButtonHyperlink/ButtonHyperlink.unit.test.tsx.snap
+++ b/src/components/ButtonHyperlink/ButtonHyperlink.unit.test.tsx.snap
@@ -25,7 +25,6 @@ exports[`ButtonHyperlink snapshot should match snapshot 1`] = `
         onTouchEnd={[Function]}
         onTouchMove={[Function]}
         onTouchStart={[Function]}
-        role="button"
         tabIndex={0}
       >
         Hyperlink
@@ -66,7 +65,6 @@ exports[`ButtonHyperlink snapshot should match snapshot when disabled 1`] = `
         onTouchEnd={[Function]}
         onTouchMove={[Function]}
         onTouchStart={[Function]}
-        role="button"
       >
         Hyperlink
       </a>
@@ -102,7 +100,6 @@ exports[`ButtonHyperlink snapshot should match snapshot when inverted 1`] = `
         onTouchEnd={[Function]}
         onTouchMove={[Function]}
         onTouchStart={[Function]}
-        role="button"
         tabIndex={0}
       >
         Hyperlink
@@ -139,7 +136,6 @@ exports[`ButtonHyperlink snapshot should match snapshot with title 1`] = `
         onTouchEnd={[Function]}
         onTouchMove={[Function]}
         onTouchStart={[Function]}
-        role="button"
         tabIndex={0}
         title="Example Text"
       />

--- a/src/components/MeetingContainer/MeetingContainer.unit.test.tsx.snap
+++ b/src/components/MeetingContainer/MeetingContainer.unit.test.tsx.snap
@@ -988,7 +988,6 @@ exports[`<MeetingContainer /> snapshot should match snapshot with disable suppli
                           onTouchEnd={[Function]}
                           onTouchMove={[Function]}
                           onTouchStart={[Function]}
-                          role="button"
                           tabIndex={0}
                         >
                           Example Link
@@ -2359,7 +2358,6 @@ exports[`<MeetingContainer /> snapshot should match snapshot with spacelink supp
                           onTouchEnd={[Function]}
                           onTouchMove={[Function]}
                           onTouchStart={[Function]}
-                          role="button"
                           tabIndex={0}
                         >
                           Example Link

--- a/src/components/MeetingRowContent/MeetingRowContent.unit.test.tsx.snap
+++ b/src/components/MeetingRowContent/MeetingRowContent.unit.test.tsx.snap
@@ -126,7 +126,6 @@ exports[`<MeetingRowContent /> snapshot should match snapshot with buttonGroup 1
                   onTouchEnd={[Function]}
                   onTouchMove={[Function]}
                   onTouchStart={[Function]}
-                  role="button"
                   tabIndex={0}
                 >
                   Link


### PR DESCRIPTION
# IMPORTANT

**Currently, this project is closed to any external contributions. Any pull request made against this project from external sources will likely be closed. If you would like to make changes to this project, please fork this project.**

# Guide

**This "Help" section can be deleted before submitting this pull request.**

*Update the name of this pull request to reflect the following shape:*

```
{type}/{scope?}/{message}
```

* **type** - A [conventional commit type](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional#type-enum) **REQUIRED**
* **scope** - The kabab-case scope of the changes in this request
* **message** - A short, kebab-case statement describing the changes **REQUIRED**

*Provide a general summary of the scope of the changes in this pull request.*

* [Readme](https://github.com/momentum-design/momentum-react-v2/blob/master/README.md)
* [Getting Started Guide](https://github.com/momentum-design/momentum-react-v2/blob/master/GETTING_STARTED.md)
* [Contributing Guide](https://github.com/momentum-design/momentum-react-v2/blob/master/CONTRIBUTING.md)

# Description

- button hyperlink is shown & acts like a link, it should not have role="button" (which comes from the useButton react aria hook)
- it's a button (therefore we use useButton) that acts like a link (therefore we remove role="button")

# Links

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-565187
