### PR TITLE
fix(Toggle): add AriaLabelRequired

### DIFF
--- a/src/components/Toggle/Toggle.types.ts
+++ b/src/components/Toggle/Toggle.types.ts
@@ -1,7 +1,8 @@
 import { CSSProperties } from 'react';
 import { AriaSwitchBase } from '@react-types/switch';
+import { AriaLabelRequired } from 'src/utils/a11y';
 
-export interface Props extends Omit<AriaSwitchBase, 'children'> {
+export type Props = Omit<AriaSwitchBase, 'children'> & {
   /**
    * Custom class for overriding this component's CSS.
    */
@@ -16,4 +17,4 @@ export interface Props extends Omit<AriaSwitchBase, 'children'> {
    * Custom style for overriding this component's CSS.
    */
   style?: CSSProperties;
-}
+} & AriaLabelRequired;

--- a/src/components/Toggle/Toggle.types.ts
+++ b/src/components/Toggle/Toggle.types.ts
@@ -1,6 +1,6 @@
 import { CSSProperties } from 'react';
 import { AriaSwitchBase } from '@react-types/switch';
-import { AriaLabelRequired } from 'src/utils/a11y';
+import { AriaLabelRequired } from '../../utils/a11y';
 
 export type Props = Omit<AriaSwitchBase, 'children'> & {
   /**


### PR DESCRIPTION
# Description

Add AriaLabelRequired to <Toggle /> since react-aria/toggle complains that it is required.

# Links

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-591688