### PR TITLE
feat(TextInput): add warning if aria label and label are same

### DIFF
--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -35,6 +35,14 @@ const TextInput = (props: Props, ref: RefObject<HTMLInputElement>): ReactElement
     inputMaxLen,
   } = props;
 
+  const ariaLabel = props['aria-label'];
+
+  if (ariaLabel && label && ariaLabel === label) {
+    console.warn(
+      `MRV2: The aria-label and visible label of the Text Input are the same, making SR read it twice. Please provide only 1. Aria-label: ${ariaLabel}. Visible label: ${label}`
+    );
+  }
+
   const componentRef = React.useRef<HTMLInputElement>();
   const inputRef = ref || componentRef;
 


### PR DESCRIPTION
# Description

Many times I have seen devs falling into adding the same string to the label and to the aria-label with the aim of ensuring a11y. That would, however, open an a11y bug as SR would read the same string twice when focusing on the input. 
To avoid that, we have added a console warn.

# Links

SPARK-582966