### PR TITLE
fix(select): fix multi select popovers within parent popover

### DIFF
--- a/src/components/Popover/Popover.stories.tsx
+++ b/src/components/Popover/Popover.stories.tsx
@@ -20,6 +20,7 @@ import SearchInput from '../SearchInput';
 import List from '../List';
 import AriaToolbarItem from '../AriaToolbarItem';
 import ListItemBase from '../ListItemBase';
+import Select from '../Select';
 
 export default {
   title: 'Momentum UI/Popover',
@@ -302,6 +303,84 @@ NestedPopover.args = {
     <ButtonSimple style={{ margin: '10rem auto', display: 'flex' }}>
       Hover or click me!
     </ButtonSimple>
+  ),
+};
+
+const MultipleSelectPopoversInsidePopoverInteractiveContentManaged = Template<PopoverProps>(
+  Popover
+).bind({});
+
+MultipleSelectPopoversInsidePopoverInteractiveContentManaged.argTypes = { ...argTypes };
+
+MultipleSelectPopoversInsidePopoverInteractiveContentManaged.args = {
+  trigger: 'click',
+  placement: PLACEMENTS.BOTTOM,
+  showArrow: true,
+  interactive: true,
+  variant: 'small',
+  color: COLORS.TERTIARY,
+  delay: [0, 0],
+  triggerComponent: (
+    <ButtonPill style={{ margin: '10rem auto', display: 'flex' }}>Click me!</ButtonPill>
+  ),
+  children: (
+    <>
+      <Select popoverSingleOpenGroupId="select1" aria-label="select1">
+        <Item>
+          <Text tagName="p">option1</Text>
+        </Item>
+        <Item>
+          <Text tagName="p">option2</Text>
+        </Item>
+      </Select>
+      <Select popoverSingleOpenGroupId="select1" aria-label="select2">
+        <Item>
+          <Text tagName="p">option3</Text>
+        </Item>
+        <Item>
+          <Text tagName="p">option4</Text>
+        </Item>
+      </Select>
+    </>
+  ),
+};
+
+const MultipleSelectPopoversInsidePopoverInteractiveContentUnmanaged = Template<PopoverProps>(
+  Popover
+).bind({});
+
+MultipleSelectPopoversInsidePopoverInteractiveContentUnmanaged.argTypes = { ...argTypes };
+
+MultipleSelectPopoversInsidePopoverInteractiveContentUnmanaged.args = {
+  trigger: 'click',
+  placement: PLACEMENTS.BOTTOM,
+  showArrow: true,
+  interactive: true,
+  variant: 'small',
+  color: COLORS.TERTIARY,
+  delay: [0, 0],
+  triggerComponent: (
+    <ButtonPill style={{ margin: '10rem auto', display: 'flex' }}>Click me!</ButtonPill>
+  ),
+  children: (
+    <>
+      <Select aria-label="select1">
+        <Item>
+          <Text tagName="p">option1</Text>
+        </Item>
+        <Item>
+          <Text tagName="p">option2</Text>
+        </Item>
+      </Select>
+      <Select aria-label="select2">
+        <Item>
+          <Text tagName="p">option3</Text>
+        </Item>
+        <Item>
+          <Text tagName="p">option4</Text>
+        </Item>
+      </Select>
+    </>
   ),
 };
 
@@ -591,6 +670,8 @@ export {
   WithCloseButton,
   Offset,
   MultiplePopovers,
+  MultipleSelectPopoversInsidePopoverInteractiveContentManaged,
+  MultipleSelectPopoversInsidePopoverInteractiveContentUnmanaged,
   NestedPopover,
   AvatarExample,
   Common,

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -44,6 +44,7 @@ const Popover = forwardRef((props: Props, ref: ForwardedRef<HTMLElement>) => {
     boundary = DEFAULTS.BOUNDARY,
     hideOnEsc = DEFAULTS.HIDE_ON_ESC,
     hideOnBlur = DEFAULTS.HIDE_ON_BLUR,
+    singleOpenGroupId = undefined,
     isChildPopoverOpen = DEFAULTS.IS_CHILD_POPOVER_OPEN,
     addBackdrop = DEFAULTS.ADD_BACKDROP,
     focusBackOnTrigger: focusBackOnTriggerFromProps,
@@ -239,7 +240,7 @@ const Popover = forwardRef((props: Props, ref: ForwardedRef<HTMLElement>) => {
       }}
       animation={false}
       delay={delay}
-      plugins={addTippyPlugins(hideOnEsc, hideOnBlur, addBackdrop)}
+      plugins={addTippyPlugins(hideOnEsc, hideOnBlur, addBackdrop, singleOpenGroupId)}
       // add arrow height to default offset if arrow is shown:
       offset={[offsetSkidding, showArrow ? ARROW_HEIGHT + offsetDistance : offsetDistance]}
       {...{

--- a/src/components/Popover/Popover.types.ts
+++ b/src/components/Popover/Popover.types.ts
@@ -83,6 +83,9 @@ export type PopoverCommonStyleProps = {
    */
   hideOnBlur?: boolean;
 
+  /**
+   * Used when provided by a select which renders a popover. This is used to ensure only one popover is open at a time.
+   */
   singleOpenGroupId?: string;
 
   /**

--- a/src/components/Popover/Popover.types.ts
+++ b/src/components/Popover/Popover.types.ts
@@ -83,6 +83,8 @@ export type PopoverCommonStyleProps = {
    */
   hideOnBlur?: boolean;
 
+  singleOpenGroupId?: string;
+
   /**
    * Manual control of if the Popover contains child elements that may be open, and not nested within the
    * Popover. it's possible the focus may shift to something that in the DOM is not actually within the Popover,

--- a/src/components/Popover/Popover.unit.test.tsx
+++ b/src/components/Popover/Popover.unit.test.tsx
@@ -828,6 +828,41 @@ describe('<Popover />', () => {
     expect(modalContainer).toBeInTheDocument();
   });
 
+  describe('singleOpenGroupId functionality', () => {
+    it('should only allow one popover to be open within the same group', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <>
+          <Popover
+            triggerComponent={<ButtonSimple>Popover 1</ButtonSimple>}
+            singleOpenGroupId="group1"
+          >
+            <p>Content 1</p>
+          </Popover>
+          <Popover
+            triggerComponent={<ButtonSimple>Popover 2</ButtonSimple>}
+            singleOpenGroupId="group1"
+          >
+            <p>Content 2</p>
+          </Popover>
+        </>
+      );
+
+      // Open first popover
+      await openPopoverByClickingOnTriggerAndCheckContent(user, /Popover 1/i, /Content 1/i);
+
+      // Ensure first popover is open
+      expect(screen.queryByText('Content 2')).not.toBeInTheDocument();
+
+      // Open second popover
+      await openPopoverByClickingOnTriggerAndCheckContent(user, /Popover 2/i, /Content 2/i);
+
+      // Ensure first popover is closed and second is open
+      expect(screen.queryByText('Content 1')).not.toBeInTheDocument();
+    });
+  });
+
   const nullRef = null;
   const callbackRef = jest.fn();
   const mutableRef = { current: null };

--- a/src/components/Popover/Popover.utils.test.ts
+++ b/src/components/Popover/Popover.utils.test.ts
@@ -2,46 +2,131 @@ import { addTippyPlugins } from './Popover.utils';
 import { hideOnEscPlugin } from './tippy-plugins/hideOnEscPlugin';
 import { addBackdropPlugin } from './tippy-plugins/backdropPlugin';
 import { hideOnBlurPlugin } from './tippy-plugins/hideOnBlurPlugin';
+import { getSingleOpenPlugin } from './tippy-plugins/singleOpenPlugin';
 
 describe('addTippyPlugins', () => {
   it.each([
-    { hideOnEsc: false, hideOnBlur: false, addBackdrop: false, expected: [] },
-    { hideOnEsc: true, hideOnBlur: false, addBackdrop: false, expected: [hideOnEscPlugin] },
+    {
+      hideOnEsc: false,
+      hideOnBlur: false,
+      addBackdrop: false,
+      singleOpenGroupId: undefined,
+      expected: [],
+    },
+    {
+      hideOnEsc: true,
+      hideOnBlur: false,
+      addBackdrop: false,
+      singleOpenGroupId: undefined,
+      expected: [hideOnEscPlugin],
+    },
     {
       hideOnEsc: false,
       hideOnBlur: true,
       addBackdrop: false,
+      singleOpenGroupId: undefined,
       expected: [hideOnBlurPlugin],
     },
-    { hideOnEsc: false, hideOnBlur: false, addBackdrop: true, expected: [addBackdropPlugin] },
+    {
+      hideOnEsc: false,
+      hideOnBlur: false,
+      addBackdrop: true,
+      singleOpenGroupId: undefined,
+      expected: [addBackdropPlugin],
+    },
     {
       hideOnEsc: true,
       hideOnBlur: true,
       addBackdrop: false,
+      singleOpenGroupId: undefined,
       expected: [hideOnEscPlugin, hideOnBlurPlugin],
     },
     {
       hideOnEsc: true,
       hideOnBlur: false,
       addBackdrop: true,
+      singleOpenGroupId: undefined,
       expected: [hideOnEscPlugin, addBackdropPlugin],
     },
     {
       hideOnEsc: false,
       hideOnBlur: true,
       addBackdrop: true,
+      singleOpenGroupId: undefined,
       expected: [addBackdropPlugin, hideOnBlurPlugin],
     },
     {
       hideOnEsc: true,
       hideOnBlur: true,
       addBackdrop: true,
+      singleOpenGroupId: undefined,
       expected: [hideOnEscPlugin, addBackdropPlugin, hideOnBlurPlugin],
     },
+    {
+      hideOnEsc: false,
+      hideOnBlur: false,
+      addBackdrop: false,
+      singleOpenGroupId: 'group1',
+      expected: [getSingleOpenPlugin('group1')],
+    },
+    {
+      hideOnEsc: true,
+      hideOnBlur: false,
+      addBackdrop: false,
+      singleOpenGroupId: 'group1',
+      expected: [hideOnEscPlugin, getSingleOpenPlugin('group1')],
+    },
+    {
+      hideOnEsc: false,
+      hideOnBlur: true,
+      addBackdrop: false,
+      singleOpenGroupId: 'group1',
+      expected: [hideOnBlurPlugin, getSingleOpenPlugin('group1')],
+    },
+    {
+      hideOnEsc: false,
+      hideOnBlur: false,
+      addBackdrop: true,
+      singleOpenGroupId: 'group1',
+      expected: [addBackdropPlugin, getSingleOpenPlugin('group1')],
+    },
+    {
+      hideOnEsc: true,
+      hideOnBlur: true,
+      addBackdrop: false,
+      singleOpenGroupId: 'group1',
+      expected: [hideOnEscPlugin, hideOnBlurPlugin, getSingleOpenPlugin('group1')],
+    },
+    {
+      hideOnEsc: true,
+      hideOnBlur: false,
+      addBackdrop: true,
+      singleOpenGroupId: 'group1',
+      expected: [hideOnEscPlugin, addBackdropPlugin, getSingleOpenPlugin('group1')],
+    },
+    {
+      hideOnEsc: false,
+      hideOnBlur: true,
+      addBackdrop: true,
+      singleOpenGroupId: 'group1',
+      expected: [addBackdropPlugin, hideOnBlurPlugin, getSingleOpenPlugin('group1')],
+    },
+    {
+      hideOnEsc: true,
+      hideOnBlur: true,
+      addBackdrop: true,
+      singleOpenGroupId: 'group1',
+      expected: [
+        hideOnEscPlugin,
+        addBackdropPlugin,
+        hideOnBlurPlugin,
+        getSingleOpenPlugin('group1'),
+      ],
+    },
   ])(
-    'should return $expected when hideOnEsc is $hideOnEsc, hideOnBlur is $hideOnBlur, and addBackdrop is $addBackdrop',
-    ({ hideOnEsc, hideOnBlur, addBackdrop, expected }) => {
-      const result = addTippyPlugins(hideOnEsc, hideOnBlur, addBackdrop);
+    'should return $expected when hideOnEsc is $hideOnEsc, hideOnBlur is $hideOnBlur, addBackdrop is $addBackdrop, and singleOpenGroupId is $singleOpenGroupId',
+    ({ hideOnEsc, hideOnBlur, addBackdrop, singleOpenGroupId, expected }) => {
+      const result = addTippyPlugins(hideOnEsc, hideOnBlur, addBackdrop, singleOpenGroupId);
       expect(result).toEqual(expected);
     }
   );

--- a/src/components/Popover/Popover.utils.ts
+++ b/src/components/Popover/Popover.utils.ts
@@ -2,11 +2,13 @@ import type { Plugin } from 'tippy.js';
 import { hideOnEscPlugin } from './tippy-plugins/hideOnEscPlugin';
 import { addBackdropPlugin } from './tippy-plugins/backdropPlugin';
 import { hideOnBlurPlugin } from './tippy-plugins/hideOnBlurPlugin';
+import { getSingleOpenPlugin } from './tippy-plugins/singleOpenPlugin';
 
 export const addTippyPlugins = (
   hideOnEsc: boolean,
   hideOnBlur: boolean,
-  addBackdrop: boolean
+  addBackdrop: boolean,
+  singleOpenGroupId?: string
 ): Array<Plugin> => {
   const plugins = [];
   if (hideOnEsc) {
@@ -17,6 +19,9 @@ export const addTippyPlugins = (
   }
   if (hideOnBlur) {
     plugins.push(hideOnBlurPlugin);
+  }
+  if (singleOpenGroupId) {
+    plugins.push(getSingleOpenPlugin(singleOpenGroupId));
   }
   return plugins;
 };

--- a/src/components/Popover/tippy-plugins/singleOpenPlugin.test.ts
+++ b/src/components/Popover/tippy-plugins/singleOpenPlugin.test.ts
@@ -1,0 +1,94 @@
+import { getSingleOpenPlugin } from './singleOpenPlugin';
+import { Instance, Props } from 'tippy.js';
+
+const createTippyInstance = (): Instance<Props> =>
+  ({
+    hide: jest.fn(),
+    show: jest.fn(),
+    clearDelayTimeouts: jest.fn(),
+    destroy: jest.fn(),
+    disable: jest.fn(),
+    enable: jest.fn(),
+    setProps: jest.fn(),
+    setContent: jest.fn(),
+    popper: document.createElement('div'),
+    reference: document.createElement('div'),
+    state: { isVisible: false },
+  } as unknown as Instance<Props>);
+
+describe('getSingleOpenPlugin', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return undefined if no groupId is provided', () => {
+    const plugin = getSingleOpenPlugin();
+    expect(plugin).toBeUndefined();
+  });
+
+  it('should return the same plugin for the same groupId', () => {
+    const groupId = 'test-group';
+    const plugin1 = getSingleOpenPlugin(groupId);
+    const plugin2 = getSingleOpenPlugin(groupId);
+
+    expect(plugin1).toBe(plugin2);
+  });
+
+  it('should create a new plugin if groupId is not in the map', () => {
+    const groupId = 'new-group';
+    const plugin = getSingleOpenPlugin(groupId);
+
+    expect(plugin).toBeDefined();
+    expect(plugin.name).toBe(`singleOpen-${groupId}`);
+  });
+
+  it('should hide other instances within the same group when one is shown', () => {
+    const groupId = 'group-1';
+    const plugin = getSingleOpenPlugin(groupId);
+
+    const tippy1 = createTippyInstance();
+    const tippy2 = createTippyInstance();
+
+    const instancePlugin1 = plugin.fn(tippy1);
+    const instancePlugin2 = plugin.fn(tippy2);
+
+    instancePlugin1.onShow(tippy1);
+    instancePlugin2.onShow(tippy2);
+
+    expect(tippy1.hide).toHaveBeenCalledTimes(1);
+    expect(tippy2.hide).toHaveBeenCalledTimes(0);
+  });
+
+  it('should not hide instances from different groups', () => {
+    const groupId1 = 'group-1';
+    const groupId2 = 'group-2';
+
+    const plugin1 = getSingleOpenPlugin(groupId1);
+    const plugin2 = getSingleOpenPlugin(groupId2);
+
+    const tippy1 = createTippyInstance();
+    const tippy2 = createTippyInstance();
+
+    const instancePlugin1 = plugin1.fn(tippy1);
+    const instancePlugin2 = plugin2.fn(tippy2);
+
+    instancePlugin1.onShow(tippy1);
+    instancePlugin2.onShow(tippy2);
+
+    expect(tippy1.hide).toHaveBeenCalledTimes(0);
+    expect(tippy2.hide).toHaveBeenCalledTimes(0);
+  });
+
+  it('should remove the instance from the set on hide', () => {
+    const groupId = 'group-3';
+    const plugin = getSingleOpenPlugin(groupId);
+
+    const tippy = createTippyInstance();
+    const instancePlugin = plugin.fn(tippy);
+
+    instancePlugin.onShow(tippy);
+    instancePlugin.onHide(tippy);
+
+    expect(tippy.hide).toHaveBeenCalledTimes(0);
+  });
+});

--- a/src/components/Popover/tippy-plugins/singleOpenPlugin.ts
+++ b/src/components/Popover/tippy-plugins/singleOpenPlugin.ts
@@ -1,0 +1,45 @@
+import type { Plugin, Instance } from 'tippy.js';
+
+const pluginMap = new Map<string, Plugin>();
+
+/*
+ Before this plugin there is a bug with opening multiple selects inside of a popover, where the PopoverParent renders 2 PopoverChildren and clicking on either PopoverChildren, events get swallowed and the other PopoverChild will not close
+ this plugin solves this by managing these popovers within a groupID to hide
+*/
+export const getSingleOpenPlugin = (groupId?: string): Plugin | undefined => {
+  if (!groupId) {
+    return undefined;
+  }
+
+  if (pluginMap.has(groupId)) {
+    const plugin = pluginMap.get(groupId);
+
+    return plugin ? plugin : undefined;
+  }
+
+  const openTippies = new Set<Instance>();
+
+  const newPlugin: Plugin = {
+    name: `singleOpen-${groupId}`,
+    fn(instance) {
+      return {
+        onShow() {
+          openTippies.forEach((openInstance) => {
+            if (openInstance !== instance) {
+              openInstance.hide();
+            }
+          });
+
+          openTippies.add(instance);
+        },
+        onHide() {
+          openTippies.delete(instance);
+        },
+      };
+    },
+  };
+
+  pluginMap.set(groupId, newPlugin);
+
+  return newPlugin;
+};

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -42,6 +42,7 @@ function Select<T extends object>(props: Props<T>, ref: RefObject<HTMLDivElement
     isInForm = DEFAULTS.IS_IN_FORM,
     listboxWidth,
     shallowDisabled,
+    popoverSingleOpenGroupId,
   } = props;
   const [popoverInstance, setPopoverInstance] = useState<PopoverInstance>();
   const hasBeenOpened = useRef<boolean>(false);
@@ -219,6 +220,7 @@ function Select<T extends object>(props: Props<T>, ref: RefObject<HTMLDivElement
         style={{ maxHeight: listboxMaxHeight || 'none' }}
         className={STYLE.popover}
         strategy={listboxWidth ? 'fixed' : 'absolute'}
+        singleOpenGroupId={popoverSingleOpenGroupId}
       >
         <ListBoxBase
           {...menuProps}

--- a/src/components/Select/Select.types.ts
+++ b/src/components/Select/Select.types.ts
@@ -65,6 +65,9 @@ interface SelectProps<T> extends AriaSelectProps<T> {
    */
   shallowDisabled?: boolean;
 
+  /**
+   * Used to ensure only one select popover group is open at a time. Pass a unique string to this prop to group selects together.
+   */
   popoverSingleOpenGroupId?: string;
 }
 

--- a/src/components/Select/Select.types.ts
+++ b/src/components/Select/Select.types.ts
@@ -64,6 +64,8 @@ interface SelectProps<T> extends AriaSelectProps<T> {
    * Whether or not this Select should look disabled, but allow focus, etc.
    */
   shallowDisabled?: boolean;
+
+  popoverSingleOpenGroupId?: string;
 }
 
 export type Props<T> = SelectProps<T> &

--- a/src/components/Select/Select.unit.test.tsx
+++ b/src/components/Select/Select.unit.test.tsx
@@ -463,6 +463,44 @@ describe('Select', () => {
       });
     });
 
+    it('should have expected props on Popover with groupId', async () => {
+      expect.assertions(1);
+
+      const direction = 'top';
+      const popoverSingleOpenGroupId = 'test-group';
+
+      const wrapper = await mountAndWait(
+        <Select
+          direction={direction}
+          popoverSingleOpenGroupId={popoverSingleOpenGroupId}
+          label="test"
+        >
+          <Item>Item 1</Item>
+          <Item>Item 2</Item>
+        </Select>
+      );
+
+      expect(wrapper.find(Popover).props()).toEqual({
+        interactive: true,
+        role: null,
+        showArrow: false,
+        singleOpenGroupId: 'test-group',
+        triggerComponent: expect.any(Object),
+        trigger: 'manual',
+        setInstance: expect.any(Function),
+        placement: direction,
+        onClickOutside: expect.any(Function),
+        onHide: expect.any(Function),
+        hideOnEsc: false,
+        style: { maxHeight: 'none' },
+        className: 'md-select-popover',
+        children: expect.any(Object),
+        onKeyDown: expect.any(Function),
+        onKeyUp: undefined,
+        strategy: 'absolute',
+      });
+    });
+
     it('should have expected attributes set when listboxWidth is passed in', async () => {
       expect.assertions(2);
 
@@ -501,8 +539,6 @@ describe('Select', () => {
 
     it('should have expected attributes set when shallowDisabled', async () => {
       expect.assertions(2);
-
-      const direction = 'top';
 
       const wrapper = await mountAndWait(
         <Select shallowDisabled={true} label="test">


### PR DESCRIPTION
# IMPORTANT

**Currently, this project is closed to any external contributions. Any pull request made against this project from external sources will likely be closed. If you would like to make changes to this project, please fork this project.**

# Guide

**This "Help" section can be deleted before submitting this pull request.**

*Update the name of this pull request to reflect the following shape:*

```
{type}/{scope?}/{message}
```

* **type** - A [conventional commit type](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional#type-enum) **REQUIRED**
* **scope** - The kabab-case scope of the changes in this request
* **message** - A short, kebab-case statement describing the changes **REQUIRED**

*Provide a general summary of the scope of the changes in this pull request.*

* [Readme](https://github.com/momentum-design/momentum-react-v2/blob/master/README.md)
* [Getting Started Guide](https://github.com/momentum-design/momentum-react-v2/blob/master/GETTING_STARTED.md)
* [Contributing Guide](https://github.com/momentum-design/momentum-react-v2/blob/master/CONTRIBUTING.md)

# Description
create a new plugin to handle tippy instances inside of a parent tippy instance. Unclear on why, but none of the existing event handling works to close other tippy instances specifically when there are 2 children tippys (as selects->popover). This is reproducible with a simple storybook (provided). I've also provided a story including the plugin fix. Unit tests have been provided and updated accordingly. The tippy plugin simply manages a map (which is optional) of the groups the children/sibling tippy instances should be associated to, and allows passing through from the select.


# Links

https://github.com/user-attachments/assets/218bd065-9722-4f66-96ab-7bda17acb242
