### PR TITLE
feat(aria-toolbar): require aria-label or aria-labelledby

### DIFF
--- a/src/components/AriaToolbar/AriaToolbar.stories.args.ts
+++ b/src/components/AriaToolbar/AriaToolbar.stories.args.ts
@@ -13,18 +13,6 @@ const ariaToolbarArgTypes = {
       },
     },
   },
-  ariaLabel: {
-    description: 'The aria-label for the toolbar',
-    control: { type: 'text' },
-    table: {
-      type: {
-        summary: 'string',
-      },
-      defaultValue: {
-        summary: 'aria toolbar',
-      },
-    },
-  },
   ariaToolbarItemsSize: {
     description: 'The number of items in the toolbar',
     control: { type: 'number' },

--- a/src/components/AriaToolbar/AriaToolbar.stories.tsx
+++ b/src/components/AriaToolbar/AriaToolbar.stories.tsx
@@ -35,8 +35,8 @@ const Horizontal = (props: Partial<Props>) => {
   return (
     <>
       <AriaToolbar
-        ariaLabel="toolbar 1"
-        ariaControls="textInput"
+        aria-label="toolbar 1"
+        aria-controls="textInput"
         style={{ display: 'flex', columnGap: '0.5rem', marginBottom: '1rem' }}
         ariaToolbarItemsSize={3}
         {...props}
@@ -63,8 +63,8 @@ const Vertical = () => {
     <>
       <AriaToolbar
         orientation="vertical"
-        ariaControls="textInput"
-        ariaLabel="toolbar 1"
+        aria-controls="textInput"
+        aria-label="toolbar 1"
         style={{ display: 'flex', rowGap: '0.5rem', flexDirection: 'column' }}
         ariaToolbarItemsSize={3}
       >
@@ -82,8 +82,8 @@ const Vertical = () => {
       </AriaToolbar>
       <AriaToolbar
         orientation="vertical"
-        ariaControls="textInput"
-        ariaLabel="toolbar 2"
+        aria-controls="textInput"
+        aria-label="toolbar 2"
         style={{
           display: 'flex',
           rowGap: '0.5rem',
@@ -122,8 +122,8 @@ const WithinPopover = () => {
       >
         <AriaToolbar
           orientation="vertical"
-          ariaControls="textInput"
-          ariaLabel="toolbar 1"
+          aria-controls="textInput"
+          aria-label="toolbar 1"
           style={{ display: 'flex', rowGap: '0.5rem', flexDirection: 'column' }}
           ariaToolbarItemsSize={3}
         >
@@ -141,8 +141,8 @@ const WithinPopover = () => {
         </AriaToolbar>
         <AriaToolbar
           orientation="vertical"
-          ariaControls="textInput"
-          ariaLabel="toolbar 2"
+          aria-controls="textInput"
+          aria-label="toolbar 2"
           style={{
             display: 'flex',
             rowGap: '0.5rem',
@@ -175,8 +175,8 @@ const IncludesPopoverAndTooltips = () => {
     <>
       <AriaToolbar
         orientation="vertical"
-        ariaControls="textInput"
-        ariaLabel="toolbar 1"
+        aria-controls="textInput"
+        aria-label="toolbar 1"
         style={{ display: 'flex', rowGap: '0.5rem', flexDirection: 'column' }}
         ariaToolbarItemsSize={3}
       >

--- a/src/components/AriaToolbar/AriaToolbar.tsx
+++ b/src/components/AriaToolbar/AriaToolbar.tsx
@@ -13,7 +13,6 @@ import { getKeyboardFocusableElements } from '../../utils/navigation';
  */
 const AriaToolbar: FC<Props> = (props: Props) => {
   const {
-    ariaLabel,
     className,
     id,
     style,
@@ -21,7 +20,6 @@ const AriaToolbar: FC<Props> = (props: Props) => {
     orientation = DEFAULTS.ORIENTATION,
     shouldRenderAsButtonGroup = DEFAULTS.SHOULD_RENDER_AS_BUTTON_GROUP,
     onTabPress,
-    ariaControls,
     buttonGroupProps,
     ariaToolbarItemsSize,
     ...rest
@@ -52,8 +50,6 @@ const AriaToolbar: FC<Props> = (props: Props) => {
     className: classnames(className, STYLE.wrapper),
     id: id,
     style: style,
-    'aria-label': ariaLabel,
-    'aria-controls': ariaControls,
     role: 'toolbar',
     'aria-orientation': orientation,
     ...rest,

--- a/src/components/AriaToolbar/AriaToolbar.types.ts
+++ b/src/components/AriaToolbar/AriaToolbar.types.ts
@@ -1,8 +1,9 @@
 import { CSSProperties, MutableRefObject, ReactElement } from 'react';
 import { ButtonGroupProps } from '../ButtonGroup';
 import { SupportedComponents } from '../ButtonGroup/ButtonGroup.types';
+import { AriaLabelRequired } from '../../utils/a11y';
 
-export interface Props {
+export type Props = AriaLabelRequired & {
   /**
    * Child components of this AriaToolbar.
    */
@@ -37,12 +38,7 @@ export interface Props {
   /**
    * The HTML ID of the element that this toolbar relates to
    */
-  ariaControls?: string;
-
-  /**
-   * aria-label attribute for the toolbar
-   */
-  ariaLabel: string;
+  'aria-controls'?: string;
 
   /**
    * This handler is called when tab is pressed by one of the elements
@@ -65,7 +61,7 @@ export interface Props {
    * to calculate the correct item focus.
    */
   ariaToolbarItemsSize: number;
-}
+};
 
 export interface AriaToolbarContextValue {
   currentFocus?: number;

--- a/src/components/AriaToolbar/AriaToolbar.unit.test.tsx
+++ b/src/components/AriaToolbar/AriaToolbar.unit.test.tsx
@@ -14,7 +14,7 @@ describe('<AriaToolbar />', () => {
     it('should match snapshot', () => {
       expect.assertions(1);
 
-      const container = mount(<AriaToolbar ariaLabel="test" ariaToolbarItemsSize={0} />);
+      const container = mount(<AriaToolbar aria-label="test" ariaToolbarItemsSize={0} />);
 
       expect(container).toMatchSnapshot();
     });
@@ -25,7 +25,7 @@ describe('<AriaToolbar />', () => {
       const className = 'example-class';
 
       const container = mount(
-        <AriaToolbar ariaLabel="test" className={className} ariaToolbarItemsSize={0} />
+        <AriaToolbar aria-label="test" className={className} ariaToolbarItemsSize={0} />
       );
 
       expect(container).toMatchSnapshot();
@@ -36,7 +36,7 @@ describe('<AriaToolbar />', () => {
 
       const id = 'example-id';
 
-      const container = mount(<AriaToolbar ariaLabel="test" id={id} ariaToolbarItemsSize={0} />);
+      const container = mount(<AriaToolbar aria-label="test" id={id} ariaToolbarItemsSize={0} />);
 
       expect(container).toMatchSnapshot();
     });
@@ -47,7 +47,7 @@ describe('<AriaToolbar />', () => {
       const style = { color: 'pink' };
 
       const container = mount(
-        <AriaToolbar ariaLabel="test" style={style} ariaToolbarItemsSize={0} />
+        <AriaToolbar aria-label="test" style={style} ariaToolbarItemsSize={0} />
       );
 
       expect(container).toMatchSnapshot();
@@ -61,7 +61,7 @@ describe('<AriaToolbar />', () => {
       const container = mount(
         <AriaToolbar
           shouldRenderAsButtonGroup={true}
-          ariaLabel="test"
+          aria-label="test"
           style={style}
           ariaToolbarItemsSize={0}
         />
@@ -74,7 +74,7 @@ describe('<AriaToolbar />', () => {
       expect.assertions(4);
 
       const container = mount(
-        <AriaToolbar ariaLabel="test" ariaToolbarItemsSize={3}>
+        <AriaToolbar aria-label="test" ariaToolbarItemsSize={3}>
           <AriaToolbarItem itemIndex={0}>
             <ButtonSimple />
           </AriaToolbarItem>
@@ -106,7 +106,7 @@ describe('<AriaToolbar />', () => {
       expect.assertions(4);
 
       const container = mount(
-        <AriaToolbar orientation="vertical" ariaLabel="test" ariaToolbarItemsSize={3}>
+        <AriaToolbar orientation="vertical" aria-label="test" ariaToolbarItemsSize={3}>
           <AriaToolbarItem itemIndex={0}>
             <ButtonSimple />
           </AriaToolbarItem>
@@ -138,7 +138,7 @@ describe('<AriaToolbar />', () => {
       expect.assertions(7);
       const user = userEvent.setup();
       const { getAllByRole, container } = render(
-        <AriaToolbar orientation="vertical" ariaLabel="test" ariaToolbarItemsSize={3}>
+        <AriaToolbar orientation="vertical" aria-label="test" ariaToolbarItemsSize={3}>
           <AriaToolbarItem itemIndex={0}>
             <ButtonSimple />
           </AriaToolbarItem>
@@ -177,7 +177,7 @@ describe('<AriaToolbar />', () => {
       const dataTest = 'data-test';
 
       const container = mount(
-        <AriaToolbar ariaLabel="test" data-test={dataTest} ariaToolbarItemsSize={0} />
+        <AriaToolbar aria-label="test" data-test={dataTest} ariaToolbarItemsSize={0} />
       );
 
       expect(container).toMatchSnapshot();
@@ -188,7 +188,7 @@ describe('<AriaToolbar />', () => {
     it('should have its wrapper class', () => {
       expect.assertions(1);
 
-      const element = mount(<AriaToolbar ariaLabel="test" ariaToolbarItemsSize={0} />)
+      const element = mount(<AriaToolbar aria-label="test" ariaToolbarItemsSize={0} />)
         .find(AriaToolbar)
         .getDOMNode();
 
@@ -201,7 +201,7 @@ describe('<AriaToolbar />', () => {
       const className = 'example-class';
 
       const element = mount(
-        <AriaToolbar ariaLabel="test" className={className} ariaToolbarItemsSize={0} />
+        <AriaToolbar aria-label="test" className={className} ariaToolbarItemsSize={0} />
       )
         .find(AriaToolbar)
         .getDOMNode();
@@ -214,7 +214,7 @@ describe('<AriaToolbar />', () => {
 
       const id = 'example-id';
 
-      const element = mount(<AriaToolbar ariaLabel="test" id={id} ariaToolbarItemsSize={0} />)
+      const element = mount(<AriaToolbar aria-label="test" id={id} ariaToolbarItemsSize={0} />)
         .find(AriaToolbar)
         .getDOMNode();
 
@@ -227,7 +227,9 @@ describe('<AriaToolbar />', () => {
       const style = { color: 'pink' };
       const styleString = 'color: pink;';
 
-      const element = mount(<AriaToolbar ariaLabel="test" style={style} ariaToolbarItemsSize={0} />)
+      const element = mount(
+        <AriaToolbar aria-label="test" style={style} ariaToolbarItemsSize={0} />
+      )
         .find(AriaToolbar)
         .getDOMNode();
 
@@ -240,7 +242,7 @@ describe('<AriaToolbar />', () => {
       const ariaControls = 'testid';
 
       const element = mount(
-        <AriaToolbar ariaLabel="test" ariaControls={ariaControls} ariaToolbarItemsSize={0} />
+        <AriaToolbar aria-label="test" aria-controls={ariaControls} ariaToolbarItemsSize={0} />
       )
         .find(AriaToolbar)
         .getDOMNode();
@@ -253,7 +255,7 @@ describe('<AriaToolbar />', () => {
 
       const ariaLabel = 'test label';
 
-      const element = mount(<AriaToolbar ariaLabel={ariaLabel} ariaToolbarItemsSize={0} />)
+      const element = mount(<AriaToolbar aria-label={ariaLabel} ariaToolbarItemsSize={0} />)
         .find(AriaToolbar)
         .getDOMNode();
 
@@ -266,7 +268,7 @@ describe('<AriaToolbar />', () => {
       const ariaLabel = 'test label';
 
       const element = mount(
-        <AriaToolbar shouldRenderAsButtonGroup ariaLabel={ariaLabel} ariaToolbarItemsSize={0} />
+        <AriaToolbar shouldRenderAsButtonGroup aria-label={ariaLabel} ariaToolbarItemsSize={0} />
       )
         .find(AriaToolbar)
         .getDOMNode();
@@ -287,7 +289,7 @@ describe('<AriaToolbar />', () => {
         const element = mount(
           <AriaToolbar
             shouldRenderAsButtonGroup
-            ariaLabel="test"
+            aria-label="test"
             orientation={orientation}
             ariaToolbarItemsSize={0}
           />
@@ -307,7 +309,7 @@ describe('<AriaToolbar />', () => {
       const onTabPress = jest.fn();
 
       const element = mount(
-        <AriaToolbar ariaLabel="test" onTabPress={onTabPress} ariaToolbarItemsSize={1}>
+        <AriaToolbar aria-label="test" onTabPress={onTabPress} ariaToolbarItemsSize={1}>
           <AriaToolbarItem itemIndex={0}>
             <ButtonSimple>test button</ButtonSimple>
           </AriaToolbarItem>
@@ -325,7 +327,7 @@ describe('<AriaToolbar />', () => {
       const onPress = jest.fn();
 
       const element = mount(
-        <AriaToolbar ariaLabel="test" ariaToolbarItemsSize={1}>
+        <AriaToolbar aria-label="test" ariaToolbarItemsSize={1}>
           <AriaToolbarItem itemIndex={0}>
             <ButtonSimple onPress={onPress}>test button</ButtonSimple>
           </AriaToolbarItem>
@@ -343,7 +345,7 @@ describe('<AriaToolbar />', () => {
       const element = mount(
         // eslint-disable-next-line jsx-a11y/no-static-element-interactions
         <div onKeyDown={onKeyDown}>
-          <AriaToolbar ariaLabel="test" ariaToolbarItemsSize={1}>
+          <AriaToolbar aria-label="test" ariaToolbarItemsSize={1}>
             <AriaToolbarItem itemIndex={0}>
               <ButtonSimple>test button</ButtonSimple>
             </AriaToolbarItem>

--- a/src/components/AriaToolbar/AriaToolbar.unit.test.tsx.snap
+++ b/src/components/AriaToolbar/AriaToolbar.unit.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<AriaToolbar /> snapshot should match snapshot 1`] = `
 <AriaToolbar
-  ariaLabel="test"
+  aria-label="test"
   ariaToolbarItemsSize={0}
 >
   <div
@@ -16,7 +16,7 @@ exports[`<AriaToolbar /> snapshot should match snapshot 1`] = `
 
 exports[`<AriaToolbar /> snapshot should match snapshot with aria label + button group render 1`] = `
 <AriaToolbar
-  ariaLabel="test"
+  aria-label="test"
   ariaToolbarItemsSize={0}
   shouldRenderAsButtonGroup={true}
   style={
@@ -59,7 +59,7 @@ exports[`<AriaToolbar /> snapshot should match snapshot with aria label + button
 
 exports[`<AriaToolbar /> snapshot should match snapshot with className 1`] = `
 <AriaToolbar
-  ariaLabel="test"
+  aria-label="test"
   ariaToolbarItemsSize={0}
   className="example-class"
 >
@@ -74,7 +74,7 @@ exports[`<AriaToolbar /> snapshot should match snapshot with className 1`] = `
 
 exports[`<AriaToolbar /> snapshot should match snapshot with data-test 1`] = `
 <AriaToolbar
-  ariaLabel="test"
+  aria-label="test"
   ariaToolbarItemsSize={0}
   data-test="data-test"
 >
@@ -90,7 +90,7 @@ exports[`<AriaToolbar /> snapshot should match snapshot with data-test 1`] = `
 
 exports[`<AriaToolbar /> snapshot should match snapshot with id 1`] = `
 <AriaToolbar
-  ariaLabel="test"
+  aria-label="test"
   ariaToolbarItemsSize={0}
   id="example-id"
 >
@@ -106,7 +106,7 @@ exports[`<AriaToolbar /> snapshot should match snapshot with id 1`] = `
 
 exports[`<AriaToolbar /> snapshot should match snapshot with style 1`] = `
 <AriaToolbar
-  ariaLabel="test"
+  aria-label="test"
   ariaToolbarItemsSize={0}
   style={
     Object {
@@ -130,7 +130,7 @@ exports[`<AriaToolbar /> snapshot should match snapshot with style 1`] = `
 
 exports[`<AriaToolbar /> snapshot should set tab index appropriately - horizontal orientation 1`] = `
 <AriaToolbar
-  ariaLabel="test"
+  aria-label="test"
   ariaToolbarItemsSize={3}
 >
   <div
@@ -258,7 +258,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - horizonta
 
 exports[`<AriaToolbar /> snapshot should set tab index appropriately - horizontal orientation 2`] = `
 <AriaToolbar
-  ariaLabel="test"
+  aria-label="test"
   ariaToolbarItemsSize={3}
 >
   <div
@@ -386,7 +386,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - horizonta
 
 exports[`<AriaToolbar /> snapshot should set tab index appropriately - horizontal orientation 3`] = `
 <AriaToolbar
-  ariaLabel="test"
+  aria-label="test"
   ariaToolbarItemsSize={3}
 >
   <div
@@ -514,7 +514,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - horizonta
 
 exports[`<AriaToolbar /> snapshot should set tab index appropriately - horizontal orientation 4`] = `
 <AriaToolbar
-  ariaLabel="test"
+  aria-label="test"
   ariaToolbarItemsSize={3}
 >
   <div
@@ -642,7 +642,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - horizonta
 
 exports[`<AriaToolbar /> snapshot should set tab index appropriately - vertical orientation 1`] = `
 <AriaToolbar
-  ariaLabel="test"
+  aria-label="test"
   ariaToolbarItemsSize={3}
   orientation="vertical"
 >
@@ -771,7 +771,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - vertical 
 
 exports[`<AriaToolbar /> snapshot should set tab index appropriately - vertical orientation 2`] = `
 <AriaToolbar
-  ariaLabel="test"
+  aria-label="test"
   ariaToolbarItemsSize={3}
   orientation="vertical"
 >
@@ -900,7 +900,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - vertical 
 
 exports[`<AriaToolbar /> snapshot should set tab index appropriately - vertical orientation 3`] = `
 <AriaToolbar
-  ariaLabel="test"
+  aria-label="test"
   ariaToolbarItemsSize={3}
   orientation="vertical"
 >
@@ -1029,7 +1029,7 @@ exports[`<AriaToolbar /> snapshot should set tab index appropriately - vertical 
 
 exports[`<AriaToolbar /> snapshot should set tab index appropriately - vertical orientation 4`] = `
 <AriaToolbar
-  ariaLabel="test"
+  aria-label="test"
   ariaToolbarItemsSize={3}
   orientation="vertical"
 >

--- a/src/components/List/List.stories.tsx
+++ b/src/components/List/List.stories.tsx
@@ -339,7 +339,7 @@ const ListWithAriaToolbarWrapper = () => {
         <ListItemBase size="auto" itemIndex={0} key={0}>
           <ListItemBaseSection position="fill">
             <Text tagName="p">List Item 0</Text>
-            <AriaToolbar ariaLabel="toolbar" ariaToolbarItemsSize={2}>
+            <AriaToolbar aria-label="toolbar" ariaToolbarItemsSize={2}>
               <AriaToolbarItem itemIndex={0}>
                 <ButtonPill>Toolbar Button 1</ButtonPill>
               </AriaToolbarItem>

--- a/src/components/List/List.unit.test.tsx
+++ b/src/components/List/List.unit.test.tsx
@@ -1118,7 +1118,7 @@ describe('<List />', () => {
           <ButtonPill data-testid="before">Before</ButtonPill>
           <List listSize={2}>
             <ListItemBase data-testid="list-item-0" size="auto" itemIndex={0} key={0}>
-              <AriaToolbar ariaLabel="toolbar" ariaToolbarItemsSize={2}>
+              <AriaToolbar aria-label="toolbar" ariaToolbarItemsSize={2}>
                 <AriaToolbarItem itemIndex={0}>
                   <ButtonPill data-testid="button-1">Button 1</ButtonPill>
                 </AriaToolbarItem>

--- a/src/components/Popover/Popover.stories.tsx
+++ b/src/components/Popover/Popover.stories.tsx
@@ -143,7 +143,7 @@ const PopoverWithFirstFocus = (props) => {
 
   return (
     <Popover firstFocusElement={ref} {...props}>
-      <AriaToolbar ariaToolbarItemsSize={4} ariaLabel="toolbar">
+      <AriaToolbar ariaToolbarItemsSize={4} aria-label="toolbar">
         <AriaToolbarItem itemIndex={0}>
           <ButtonPill key={1}>1</ButtonPill>
         </AriaToolbarItem>

--- a/src/components/ReactionPicker/ReactionPicker.tsx
+++ b/src/components/ReactionPicker/ReactionPicker.tsx
@@ -7,11 +7,10 @@ import './ReactionPicker.style.scss';
 import AriaToolbar from '../AriaToolbar';
 
 const ReactionPicker: FC<Props> = (props: Props) => {
-  const { children, className, id, style, ariaLabel, ...other } = props;
+  const { children, className, id, style, ...other } = props;
 
   return (
     <AriaToolbar
-      ariaLabel={ariaLabel}
       className={classnames(className, STYLE.wrapper)}
       id={id}
       style={style}

--- a/src/components/ReactionPicker/ReactionPicker.unit.test.tsx
+++ b/src/components/ReactionPicker/ReactionPicker.unit.test.tsx
@@ -11,7 +11,7 @@ describe('<ReactionPicker />', () => {
       expect.assertions(1);
 
       const container = mount(
-        <ReactionPicker ariaToolbarItemsSize={0} ariaLabel="test-aria-label" />
+        <ReactionPicker ariaToolbarItemsSize={0} aria-label="test-aria-label" />
       );
 
       expect(container).toMatchSnapshot();
@@ -26,7 +26,7 @@ describe('<ReactionPicker />', () => {
         <ReactionPicker
           className={className}
           ariaToolbarItemsSize={0}
-          ariaLabel="test-aria-label"
+          aria-label="test-aria-label"
         />
       );
 
@@ -39,7 +39,7 @@ describe('<ReactionPicker />', () => {
       const id = 'example-id';
 
       const container = mount(
-        <ReactionPicker id={id} ariaToolbarItemsSize={0} ariaLabel="test-aria-label" />
+        <ReactionPicker id={id} ariaToolbarItemsSize={0} aria-label="test-aria-label" />
       );
 
       expect(container).toMatchSnapshot();
@@ -51,7 +51,7 @@ describe('<ReactionPicker />', () => {
       const style = { color: 'pink' };
 
       const container = mount(
-        <ReactionPicker style={style} ariaToolbarItemsSize={0} ariaLabel="test-aria-label" />
+        <ReactionPicker style={style} ariaToolbarItemsSize={0} aria-label="test-aria-label" />
       );
 
       expect(container).toMatchSnapshot();
@@ -67,7 +67,7 @@ describe('<ReactionPicker />', () => {
       );
 
       const container = mount(
-        <ReactionPicker ariaToolbarItemsSize={1} ariaLabel="test-aria-label">
+        <ReactionPicker ariaToolbarItemsSize={1} aria-label="test-aria-label">
           {children}
         </ReactionPicker>
       );
@@ -80,7 +80,9 @@ describe('<ReactionPicker />', () => {
     it('should have its wrapper class', () => {
       expect.assertions(1);
 
-      const element = mount(<ReactionPicker ariaToolbarItemsSize={0} ariaLabel="test-aria-label" />)
+      const element = mount(
+        <ReactionPicker ariaToolbarItemsSize={0} aria-label="test-aria-label" />
+      )
         .find(ReactionPicker)
         .getDOMNode();
 
@@ -96,7 +98,7 @@ describe('<ReactionPicker />', () => {
         <ReactionPicker
           className={className}
           ariaToolbarItemsSize={0}
-          ariaLabel="test-aria-label"
+          aria-label="test-aria-label"
         />
       )
         .find(ReactionPicker)
@@ -111,7 +113,7 @@ describe('<ReactionPicker />', () => {
       const id = 'example-id';
 
       const element = mount(
-        <ReactionPicker id={id} ariaToolbarItemsSize={0} ariaLabel="test-aria-label" />
+        <ReactionPicker id={id} ariaToolbarItemsSize={0} aria-label="test-aria-label" />
       )
         .find(ReactionPicker)
         .getDOMNode();
@@ -126,7 +128,7 @@ describe('<ReactionPicker />', () => {
       const styleString = 'color: pink;';
 
       const element = mount(
-        <ReactionPicker style={style} ariaToolbarItemsSize={0} ariaLabel="test-aria-label" />
+        <ReactionPicker style={style} ariaToolbarItemsSize={0} aria-label="test-aria-label" />
       )
         .find(ReactionPicker)
         .getDOMNode();

--- a/src/components/ReactionPicker/ReactionPicker.unit.test.tsx.snap
+++ b/src/components/ReactionPicker/ReactionPicker.unit.test.tsx.snap
@@ -2,11 +2,11 @@
 
 exports[`<ReactionPicker /> snapshot should match snapshot 1`] = `
 <ReactionPicker
-  ariaLabel="test-aria-label"
+  aria-label="test-aria-label"
   ariaToolbarItemsSize={0}
 >
   <AriaToolbar
-    ariaLabel="test-aria-label"
+    aria-label="test-aria-label"
     ariaToolbarItemsSize={0}
     className="md-reaction-picker-wrapper"
     orientation="horizontal"
@@ -23,11 +23,11 @@ exports[`<ReactionPicker /> snapshot should match snapshot 1`] = `
 
 exports[`<ReactionPicker /> snapshot should match snapshot with children 1`] = `
 <ReactionPicker
-  ariaLabel="test-aria-label"
+  aria-label="test-aria-label"
   ariaToolbarItemsSize={1}
 >
   <AriaToolbar
-    ariaLabel="test-aria-label"
+    aria-label="test-aria-label"
     ariaToolbarItemsSize={1}
     className="md-reaction-picker-wrapper"
     orientation="horizontal"
@@ -122,12 +122,12 @@ exports[`<ReactionPicker /> snapshot should match snapshot with children 1`] = `
 
 exports[`<ReactionPicker /> snapshot should match snapshot with className 1`] = `
 <ReactionPicker
-  ariaLabel="test-aria-label"
+  aria-label="test-aria-label"
   ariaToolbarItemsSize={0}
   className="example-class"
 >
   <AriaToolbar
-    ariaLabel="test-aria-label"
+    aria-label="test-aria-label"
     ariaToolbarItemsSize={0}
     className="example-class md-reaction-picker-wrapper"
     orientation="horizontal"
@@ -144,12 +144,12 @@ exports[`<ReactionPicker /> snapshot should match snapshot with className 1`] = 
 
 exports[`<ReactionPicker /> snapshot should match snapshot with id 1`] = `
 <ReactionPicker
-  ariaLabel="test-aria-label"
+  aria-label="test-aria-label"
   ariaToolbarItemsSize={0}
   id="example-id"
 >
   <AriaToolbar
-    ariaLabel="test-aria-label"
+    aria-label="test-aria-label"
     ariaToolbarItemsSize={0}
     className="md-reaction-picker-wrapper"
     id="example-id"
@@ -168,7 +168,7 @@ exports[`<ReactionPicker /> snapshot should match snapshot with id 1`] = `
 
 exports[`<ReactionPicker /> snapshot should match snapshot with style 1`] = `
 <ReactionPicker
-  ariaLabel="test-aria-label"
+  aria-label="test-aria-label"
   ariaToolbarItemsSize={0}
   style={
     Object {
@@ -177,7 +177,7 @@ exports[`<ReactionPicker /> snapshot should match snapshot with style 1`] = `
   }
 >
   <AriaToolbar
-    ariaLabel="test-aria-label"
+    aria-label="test-aria-label"
     ariaToolbarItemsSize={0}
     className="md-reaction-picker-wrapper"
     orientation="horizontal"


### PR DESCRIPTION
Before this PR, AriaToolbar component had ariaLabel prop required. For consistency, we have decided to keep aria properties in its original-case. 
Also, aria-labelledby would also be a valid way of labelling this component.