### PR TITLE
fix(Avatar): update default size in comment

### DIFF
--- a/src/components/Avatar/Avatar.types.ts
+++ b/src/components/Avatar/Avatar.types.ts
@@ -38,7 +38,7 @@ export interface Props extends Omit<AriaButtonProps, 'type'> {
 
   /**
    * Size of the avatar
-   * @default 32
+   * @default 24
    */
   size?: AvatarSize;
 


### PR DESCRIPTION
# Description

size prop comment had default as 32, the actual default is 24.
