### PR TITLE
feat(a11y): require Tree aria-label or aria-labelledby

### DIFF
--- a/src/components/SpaceTreeNode/SpaceTreeNode.stories.tsx
+++ b/src/components/SpaceTreeNode/SpaceTreeNode.stories.tsx
@@ -30,7 +30,11 @@ export default {
 };
 
 const TreeWrapper = (Story) => (
-  <Tree excludeTreeRoot={false} treeStructure={createTreeNode('root', true, [])}>
+  <Tree
+    excludeTreeRoot={false}
+    treeStructure={createTreeNode('root', true, [])}
+    aria-label="some tree"
+  >
     <Story />
   </Tree>
 );

--- a/src/components/SpaceTreeNode/SpaceTreeNode.unit.test.tsx
+++ b/src/components/SpaceTreeNode/SpaceTreeNode.unit.test.tsx
@@ -13,7 +13,11 @@ import Tree from '../Tree';
 describe('<SpaceTreeNode />', () => {
   const mount = async (component) => {
     return mountAndWait(
-      <Tree excludeTreeRoot={false} treeStructure={createTreeNode('root', true, [])}>
+      <Tree
+        excludeTreeRoot={false}
+        treeStructure={createTreeNode('root', true, [])}
+        aria-label="some tree"
+      >
         {component}
       </Tree>
     );

--- a/src/components/SpaceTreeNode/SpaceTreeNode.unit.test.tsx.snap
+++ b/src/components/SpaceTreeNode/SpaceTreeNode.unit.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`<SpaceTreeNode /> snapshot checks divider dot position in compact mode 1`] = `
 <Tree
+  aria-label="some tree"
   excludeTreeRoot={false}
   treeStructure={
     Object {
@@ -12,6 +13,7 @@ exports[`<SpaceTreeNode /> snapshot checks divider dot position in compact mode 
   }
 >
   <div
+    aria-label="some tree"
     className="md-tree-wrapper"
     onBlur={[Function]}
     onFocus={[Function]}
@@ -185,6 +187,7 @@ exports[`<SpaceTreeNode /> snapshot checks divider dot position in compact mode 
 
 exports[`<SpaceTreeNode /> snapshot should match snapshot 1`] = `
 <Tree
+  aria-label="some tree"
   excludeTreeRoot={false}
   treeStructure={
     Object {
@@ -195,6 +198,7 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot 1`] = `
   }
 >
   <div
+    aria-label="some tree"
     className="md-tree-wrapper"
     onBlur={[Function]}
     onFocus={[Function]}
@@ -311,6 +315,7 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot 1`] = `
 
 exports[`<SpaceTreeNode /> snapshot should match snapshot with action 1`] = `
 <Tree
+  aria-label="some tree"
   excludeTreeRoot={false}
   treeStructure={
     Object {
@@ -321,6 +326,7 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with action 1`] = `
   }
 >
   <div
+    aria-label="some tree"
     className="md-tree-wrapper"
     onBlur={[Function]}
     onFocus={[Function]}
@@ -451,6 +457,7 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with action 1`] = `
 
 exports[`<SpaceTreeNode /> snapshot should match snapshot with className 1`] = `
 <Tree
+  aria-label="some tree"
   excludeTreeRoot={false}
   treeStructure={
     Object {
@@ -461,6 +468,7 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with className 1`] = `
   }
 >
   <div
+    aria-label="some tree"
     className="md-tree-wrapper"
     onBlur={[Function]}
     onFocus={[Function]}
@@ -578,6 +586,7 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with className 1`] = `
 
 exports[`<SpaceTreeNode /> snapshot should match snapshot with firstLine 1`] = `
 <Tree
+  aria-label="some tree"
   excludeTreeRoot={false}
   treeStructure={
     Object {
@@ -588,6 +597,7 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with firstLine 1`] = `
   }
 >
   <div
+    aria-label="some tree"
     className="md-tree-wrapper"
     onBlur={[Function]}
     onFocus={[Function]}
@@ -708,6 +718,7 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with firstLine 1`] = `
 
 exports[`<SpaceTreeNode /> snapshot should match snapshot with id 1`] = `
 <Tree
+  aria-label="some tree"
   excludeTreeRoot={false}
   treeStructure={
     Object {
@@ -718,6 +729,7 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with id 1`] = `
   }
 >
   <div
+    aria-label="some tree"
     className="md-tree-wrapper"
     onBlur={[Function]}
     onFocus={[Function]}
@@ -836,6 +848,7 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with id 1`] = `
 
 exports[`<SpaceTreeNode /> snapshot should match snapshot with isAlert 1`] = `
 <Tree
+  aria-label="some tree"
   excludeTreeRoot={false}
   treeStructure={
     Object {
@@ -846,6 +859,7 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isAlert 1`] = `
   }
 >
   <div
+    aria-label="some tree"
     className="md-tree-wrapper"
     onBlur={[Function]}
     onFocus={[Function]}
@@ -995,6 +1009,7 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isAlert 1`] = `
 
 exports[`<SpaceTreeNode /> snapshot should match snapshot with isAlertMuted 1`] = `
 <Tree
+  aria-label="some tree"
   excludeTreeRoot={false}
   treeStructure={
     Object {
@@ -1005,6 +1020,7 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isAlertMuted 1`] 
   }
 >
   <div
+    aria-label="some tree"
     className="md-tree-wrapper"
     onBlur={[Function]}
     onFocus={[Function]}
@@ -1154,6 +1170,7 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isAlertMuted 1`] 
 
 exports[`<SpaceTreeNode /> snapshot should match snapshot with isDisabled 1`] = `
 <Tree
+  aria-label="some tree"
   excludeTreeRoot={false}
   treeStructure={
     Object {
@@ -1164,6 +1181,7 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isDisabled 1`] = 
   }
 >
   <div
+    aria-label="some tree"
     className="md-tree-wrapper"
     onBlur={[Function]}
     onFocus={[Function]}
@@ -1281,6 +1299,7 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isDisabled 1`] = 
 
 exports[`<SpaceTreeNode /> snapshot should match snapshot with isEnterRoom 1`] = `
 <Tree
+  aria-label="some tree"
   excludeTreeRoot={false}
   treeStructure={
     Object {
@@ -1291,6 +1310,7 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isEnterRoom 1`] =
   }
 >
   <div
+    aria-label="some tree"
     className="md-tree-wrapper"
     onBlur={[Function]}
     onFocus={[Function]}
@@ -1440,6 +1460,7 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isEnterRoom 1`] =
 
 exports[`<SpaceTreeNode /> snapshot should match snapshot with isError 1`] = `
 <Tree
+  aria-label="some tree"
   excludeTreeRoot={false}
   treeStructure={
     Object {
@@ -1450,6 +1471,7 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isError 1`] = `
   }
 >
   <div
+    aria-label="some tree"
     className="md-tree-wrapper"
     onBlur={[Function]}
     onFocus={[Function]}
@@ -1599,6 +1621,7 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isError 1`] = `
 
 exports[`<SpaceTreeNode /> snapshot should match snapshot with isMention 1`] = `
 <Tree
+  aria-label="some tree"
   excludeTreeRoot={false}
   treeStructure={
     Object {
@@ -1609,6 +1632,7 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isMention 1`] = `
   }
 >
   <div
+    aria-label="some tree"
     className="md-tree-wrapper"
     onBlur={[Function]}
     onFocus={[Function]}
@@ -1758,6 +1782,7 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isMention 1`] = `
 
 exports[`<SpaceTreeNode /> snapshot should match snapshot with isNewActivity 1`] = `
 <Tree
+  aria-label="some tree"
   excludeTreeRoot={false}
   treeStructure={
     Object {
@@ -1768,6 +1793,7 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isNewActivity 1`]
   }
 >
   <div
+    aria-label="some tree"
     className="md-tree-wrapper"
     onBlur={[Function]}
     onFocus={[Function]}
@@ -1886,6 +1912,7 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isNewActivity 1`]
 
 exports[`<SpaceTreeNode /> snapshot should match snapshot with isSelected 1`] = `
 <Tree
+  aria-label="some tree"
   excludeTreeRoot={false}
   treeStructure={
     Object {
@@ -1896,6 +1923,7 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isSelected 1`] = 
   }
 >
   <div
+    aria-label="some tree"
     className="md-tree-wrapper"
     onBlur={[Function]}
     onFocus={[Function]}
@@ -2014,6 +2042,7 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isSelected 1`] = 
 
 exports[`<SpaceTreeNode /> snapshot should match snapshot with isSelected and draft 1`] = `
 <Tree
+  aria-label="some tree"
   excludeTreeRoot={false}
   treeStructure={
     Object {
@@ -2024,6 +2053,7 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isSelected and dr
   }
 >
   <div
+    aria-label="some tree"
     className="md-tree-wrapper"
     onBlur={[Function]}
     onFocus={[Function]}
@@ -2175,6 +2205,7 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isSelected and dr
 
 exports[`<SpaceTreeNode /> snapshot should match snapshot with isUnread 1`] = `
 <Tree
+  aria-label="some tree"
   excludeTreeRoot={false}
   treeStructure={
     Object {
@@ -2185,6 +2216,7 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isUnread 1`] = `
   }
 >
   <div
+    aria-label="some tree"
     className="md-tree-wrapper"
     onBlur={[Function]}
     onFocus={[Function]}
@@ -2334,6 +2366,7 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isUnread 1`] = `
 
 exports[`<SpaceTreeNode /> snapshot should match snapshot with multiple string secondLine 1`] = `
 <Tree
+  aria-label="some tree"
   excludeTreeRoot={false}
   treeStructure={
     Object {
@@ -2344,6 +2377,7 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with multiple string s
   }
 >
   <div
+    aria-label="some tree"
     className="md-tree-wrapper"
     onBlur={[Function]}
     onFocus={[Function]}
@@ -2543,6 +2577,7 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with multiple string s
 
 exports[`<SpaceTreeNode /> snapshot should match snapshot with secondLine 1`] = `
 <Tree
+  aria-label="some tree"
   excludeTreeRoot={false}
   treeStructure={
     Object {
@@ -2553,6 +2588,7 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with secondLine 1`] = 
   }
 >
   <div
+    aria-label="some tree"
     className="md-tree-wrapper"
     onBlur={[Function]}
     onFocus={[Function]}
@@ -2714,6 +2750,7 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with secondLine 1`] = 
 
 exports[`<SpaceTreeNode /> snapshot should match snapshot with style 1`] = `
 <Tree
+  aria-label="some tree"
   excludeTreeRoot={false}
   treeStructure={
     Object {
@@ -2724,6 +2761,7 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with style 1`] = `
   }
 >
   <div
+    aria-label="some tree"
     className="md-tree-wrapper"
     onBlur={[Function]}
     onFocus={[Function]}
@@ -2855,6 +2893,7 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with style 1`] = `
 
 exports[`<SpaceTreeNode /> snapshot should match snapshot with teamColor 1`] = `
 <Tree
+  aria-label="some tree"
   excludeTreeRoot={false}
   treeStructure={
     Object {
@@ -2865,6 +2904,7 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with teamColor 1`] = `
   }
 >
   <div
+    aria-label="some tree"
     className="md-tree-wrapper"
     onBlur={[Function]}
     onFocus={[Function]}

--- a/src/components/Tree/Tree.stories.tsx
+++ b/src/components/Tree/Tree.stories.tsx
@@ -121,6 +121,7 @@ Example.args = {
   children: mapTree(exampleTreeMap, (node) => (
     <ExampleTreeNode key={node.id.toString()} node={node} />
   )),
+  'aria-label': 'some tree',
 };
 
 const WithRoot = Template<ComponentProps<typeof Tree>>(Tree).bind({});
@@ -137,6 +138,7 @@ WithRoot.args = {
     (node) => <ExampleTreeNode key={node.id.toString()} node={node} />,
     { excludeRootNode: false }
   ),
+  'aria-label': 'some tree',
 };
 const TreeWithScroll = Template<ComponentProps<typeof Tree>>(Tree).bind({});
 
@@ -153,6 +155,7 @@ TreeWithScroll.args = {
     (node) => <ExampleTreeNode key={node.id.toString()} node={node} />,
     { excludeRootNode: false }
   ),
+  'aria-label': 'some tree',
 };
 
 const DynamicTree = Template(() => {
@@ -180,6 +183,7 @@ const DynamicTree = Template(() => {
         isRenderedFlat={true}
         shouldNodeFocusBeInset={true}
         excludeTreeRoot={true}
+        aria-label="some tree"
       >
         {mapTree(
           mappedTree,

--- a/src/components/Tree/Tree.test.tsx
+++ b/src/components/Tree/Tree.test.tsx
@@ -3,6 +3,7 @@ import { mount } from 'enzyme';
 import '@testing-library/jest-dom';
 import { render, waitFor, waitForElementToBeRemoved } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { omit } from 'lodash';
 
 import Tree, { TREE_CONSTANTS, TreeProps } from './index';
 import { createTreeNode as tNode } from './test.utils';
@@ -36,6 +37,7 @@ const getSampleTree = () => {
 describe('<Tree />', () => {
   const commonProps = {
     treeStructure: tNode('root', true, [tNode('1'), tNode('2')]),
+    'aria-label': 'some tree',
   };
 
   afterAll(() => {
@@ -162,7 +164,7 @@ describe('<Tree />', () => {
       expect.assertions(1);
 
       const label = 'test';
-      const container = mount(<Tree aria-label={label} {...commonProps} />);
+      const container = mount(<Tree aria-label={label} {...omit(commonProps, ['aria-label'])} />);
       const element = container.find(Tree).getDOMNode();
 
       expect(element.getAttribute('aria-label')).toBe('test');
@@ -172,7 +174,9 @@ describe('<Tree />', () => {
       expect.assertions(1);
 
       const labelBy = 'label-id';
-      const container = mount(<Tree aria-labelledby={labelBy} {...commonProps} />);
+      const container = mount(
+        <Tree aria-labelledby={labelBy} {...omit(commonProps, ['aria-label'])} />
+      );
       const element = container.find(Tree).getDOMNode();
 
       expect(element.getAttribute('aria-labelledby')).toBe(labelBy);
@@ -200,7 +204,7 @@ describe('<Tree />', () => {
     it.each(['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'])(
       'should do nothing when tree structure is empty and user presses %s',
       async (key) => {
-        render(<Tree treeStructure={{}} excludeTreeRoot={false} />);
+        render(<Tree treeStructure={{}} excludeTreeRoot={false} aria-label="some tree" />);
         const focusedElement = document.activeElement;
 
         await userEvent.keyboard(`{${key}}`);
@@ -215,7 +219,7 @@ describe('<Tree />', () => {
       const { getByRole } = render(
         // eslint-disable-next-line jsx-a11y/no-static-element-interactions
         <div onKeyDown={keyDownHandler}>
-          <Tree treeStructure={getSampleTree()} excludeTreeRoot={false}>
+          <Tree treeStructure={getSampleTree()} excludeTreeRoot={false} aria-label="some tree">
             <TreeNodeBase key="0" nodeId="root">
               {() => 'TreeNodeBase 1'}
             </TreeNodeBase>
@@ -238,7 +242,7 @@ describe('<Tree />', () => {
       const tree = getSampleTree();
 
       const { getByTestId } = render(
-        <Tree treeStructure={tree} excludeTreeRoot={false}>
+        <Tree treeStructure={tree} excludeTreeRoot={false} aria-label="some tree">
           {mapTree(
             convertNestedTree2MappedTree(tree),
             (node) => (
@@ -316,6 +320,7 @@ describe('<Tree />', () => {
             scrollToNode,
           }}
           onToggleNode={onToggleNode}
+          aria-label="some tree"
         >
           {mapTree(
             convertNestedTree2MappedTree(tree),
@@ -385,7 +390,11 @@ describe('<Tree />', () => {
       const user = userEvent.setup();
 
       const { getByTestId, getByText } = render(
-        <Tree treeStructure={{ id: 'root', children: [] }} excludeTreeRoot={false}>
+        <Tree
+          treeStructure={{ id: 'root', children: [] }}
+          excludeTreeRoot={false}
+          aria-label="some tree"
+        >
           <TreeNodeBase nodeId="root" data-testid="root">
             {() => (
               <>
@@ -422,6 +431,7 @@ describe('<Tree />', () => {
           treeStructure={tree}
           excludeTreeRoot={false}
           virtualTreeConnector={virtualTreeConnector}
+          aria-label="some tree"
         >
           {mapTree(
             convertNestedTree2MappedTree(tree),
@@ -668,7 +678,7 @@ describe('<Tree />', () => {
   describe('dynamically changing tree', () => {
     const getTreeComponent = (tree, excludeTreeRoot = false) => {
       return (
-        <Tree treeStructure={tree} excludeTreeRoot={excludeTreeRoot}>
+        <Tree treeStructure={tree} excludeTreeRoot={excludeTreeRoot} aria-label="some tree">
           {mapTree(
             convertNestedTree2MappedTree(tree),
             (node) =>
@@ -883,7 +893,13 @@ describe('<Tree />', () => {
   describe('selection', () => {
     const getTreeComponent = (tree, { ref, ...props }: Partial<TreeProps> = {}) => {
       return (
-        <Tree treeStructure={tree} excludeTreeRoot={false} {...props} ref={ref as any}>
+        <Tree
+          treeStructure={tree}
+          excludeTreeRoot={false}
+          aria-label="some tree"
+          {...props}
+          ref={ref as any}
+        >
           {mapTree(
             convertNestedTree2MappedTree(tree),
             (node) => (

--- a/src/components/Tree/Tree.test.tsx.snap
+++ b/src/components/Tree/Tree.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`<Tree /> snapshot should match snapshot 1`] = `
 <Tree
+  aria-label="some tree"
   treeStructure={
     Object {
       "children": Array [
@@ -22,6 +23,7 @@ exports[`<Tree /> snapshot should match snapshot 1`] = `
   }
 >
   <div
+    aria-label="some tree"
     className="md-tree-wrapper"
     onBlur={[Function]}
     onFocus={[Function]}
@@ -33,6 +35,7 @@ exports[`<Tree /> snapshot should match snapshot 1`] = `
 
 exports[`<Tree /> snapshot should match snapshot with className 1`] = `
 <Tree
+  aria-label="some tree"
   className="example-class"
   treeStructure={
     Object {
@@ -54,6 +57,7 @@ exports[`<Tree /> snapshot should match snapshot with className 1`] = `
   }
 >
   <div
+    aria-label="some tree"
     className="example-class md-tree-wrapper"
     onBlur={[Function]}
     onFocus={[Function]}
@@ -65,6 +69,7 @@ exports[`<Tree /> snapshot should match snapshot with className 1`] = `
 
 exports[`<Tree /> snapshot should match snapshot with id 1`] = `
 <Tree
+  aria-label="some tree"
   id="example-id"
   treeStructure={
     Object {
@@ -86,6 +91,7 @@ exports[`<Tree /> snapshot should match snapshot with id 1`] = `
   }
 >
   <div
+    aria-label="some tree"
     className="md-tree-wrapper"
     id="example-id"
     onBlur={[Function]}
@@ -98,6 +104,7 @@ exports[`<Tree /> snapshot should match snapshot with id 1`] = `
 
 exports[`<Tree /> snapshot should match snapshot with style 1`] = `
 <Tree
+  aria-label="some tree"
   style={
     Object {
       "color": "pink",
@@ -123,6 +130,7 @@ exports[`<Tree /> snapshot should match snapshot with style 1`] = `
   }
 >
   <div
+    aria-label="some tree"
     className="md-tree-wrapper"
     onBlur={[Function]}
     onFocus={[Function]}
@@ -139,6 +147,7 @@ exports[`<Tree /> snapshot should match snapshot with style 1`] = `
 
 exports[`<Tree /> snapshot should match snapshot with style 2`] = `
 <Tree
+  aria-label="some tree"
   style={
     Object {
       "color": "pink",
@@ -164,6 +173,7 @@ exports[`<Tree /> snapshot should match snapshot with style 2`] = `
   }
 >
   <div
+    aria-label="some tree"
     className="md-tree-wrapper"
     onBlur={[Function]}
     onFocus={[Function]}
@@ -180,6 +190,7 @@ exports[`<Tree /> snapshot should match snapshot with style 2`] = `
 
 exports[`<Tree /> snapshot should match snapshot with style 3`] = `
 <Tree
+  aria-label="some tree"
   style={
     Object {
       "color": "pink",
@@ -205,6 +216,7 @@ exports[`<Tree /> snapshot should match snapshot with style 3`] = `
   }
 >
   <div
+    aria-label="some tree"
     className="md-tree-wrapper"
     onBlur={[Function]}
     onFocus={[Function]}

--- a/src/components/Tree/Tree.tsx
+++ b/src/components/Tree/Tree.tsx
@@ -50,6 +50,11 @@ const Tree = forwardRef((props: Props, ref: ForwardedRef<TreeRefObject>) => {
     ...rest
   } = props;
 
+  // aria-label or aria-labelledby is required on the Props type, but union type enforcement doesn't work properly with forwardRef
+  if (!rest['aria-label'] && !rest['aria-labelledby']) {
+    console.warn('MRV2: Tree must have aria-label or aria-labelledby');
+  }
+
   const treeRef = useRef<HTMLDivElement>();
 
   const itemSelection = useItemSelected<TreeNodeId>({

--- a/src/components/Tree/Tree.types.ts
+++ b/src/components/Tree/Tree.types.ts
@@ -6,6 +6,7 @@ import {
   ReactNode,
 } from 'react';
 import { ItemSelection, UseItemSelectedProps } from '../../hooks/useItemSelected';
+import { AriaLabelRequired } from '../../utils/a11y';
 
 /**
  * The key codes used to navigate the tree.
@@ -97,106 +98,107 @@ export type TreeIdNodeMap = Map<TreeNodeId, TreeNodeRecord>;
 
 /**
  * The props of the Tree component.
+ * aria-label or aria-labelledby is required, but union type enforcement doesn't work properly with forwardRef
  */
-export interface Props
-  extends Partial<UseItemSelectedProps<TreeNodeId>>,
-    DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> {
-  /**
-   * Custom class for overriding this component's CSS.
-   */
-  className?: string;
-
-  /**
-   * Custom id for overriding this component's CSS.
-   */
-  id?: string;
-
-  /**
-   * Child components of this component.
-   */
-  children?: ReactNode;
-
-  /**
-   * Custom style for overriding this component's CSS.
-   */
-  style?: CSSProperties;
-
-  /**
-   * Determines whether the focus ring around tree nodes should be inset or outset
-   * It has only visual effect.
-   */
-  shouldNodeFocusBeInset?: boolean;
-
-  /**
-   * The initial tree structure
-   *
-   * It is used to build an internal tree for navigation and follow open/close states.
-   *
-   * The tree can be updated dynamically via `treeStructure`, but `isOpen` will be migrated from the old tree:
-   * If the node exists the both old and new tree then the value used from the old tree otherwise
-   * falls back to the `isOpenByDefault ?? true`
-   */
-  treeStructure: TreeRoot;
-
-  /**
-   * Tree structure can be rendered 2 ways in the DOM:
-   * 1) Nested: The tree is rendered as a nested list where the structure reflect the semantic structure of the tree
-   * 2) Flat: The tree is rendered as a single level list where the DOM does not reflect the semantic structure of the tree, and
-   *    we need to provide additional aria attributes to re-build it for the accessibility tree.
-   *    Virtualized trees are usually rendered flat.
-   * @default true
-   */
-  isRenderedFlat?: boolean;
-
-  /**
-   * Determines if the tree root should be excluded from the tree keyboard navigation.
-   *
-   * In many case we want to hide the root of the tree, for example when the tree used for grouping some list items.
-   *
-   * Note: it does not change the visibility of the root node.
-   * @default true
-   */
-  excludeTreeRoot?: boolean;
-
-  /**
-   * The selection mode of the tree nodes.
-   *
-   * Note: When user click to select a node and `selectableNodes` is `any` and the node is not a leaf node, the node will be opened/closed.
-   * WCAG Tree patter sample implementation has the same behavior.
-   *
-   * @see {@link https://www.w3.org/WAI/ARIA/apg/patterns/treeview/ WCAG Tree Pattern}
-   */
-  selectableNodes?: 'leafOnly' | 'any';
-
-  /**
-   * Set of functions to communicate with virtualized tree and sync states.
-   */
-  virtualTreeConnector?: {
+export type Props = Partial<UseItemSelectedProps<TreeNodeId>> &
+  DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> &
+  AriaLabelRequired & {
     /**
-     * External function to scroll to a node.
-     * This is used when the tree is rendered in a virtualized tree.
-     *
-     * @param id
+     * Custom class for overriding this component's CSS.
      */
-    scrollToNode: (id: TreeNodeId) => void;
+    className?: string;
 
     /**
-     * Toggle open/close state of the tree node.
+     * Custom id for overriding this component's CSS.
+     */
+    id?: string;
+
+    /**
+     * Child components of this component.
+     */
+    children?: ReactNode;
+
+    /**
+     * Custom style for overriding this component's CSS.
+     */
+    style?: CSSProperties;
+
+    /**
+     * Determines whether the focus ring around tree nodes should be inset or outset
+     * It has only visual effect.
+     */
+    shouldNodeFocusBeInset?: boolean;
+
+    /**
+     * The initial tree structure
+     *
+     * It is used to build an internal tree for navigation and follow open/close states.
+     *
+     * The tree can be updated dynamically via `treeStructure`, but `isOpen` will be migrated from the old tree:
+     * If the node exists the both old and new tree then the value used from the old tree otherwise
+     * falls back to the `isOpenByDefault ?? true`
+     */
+    treeStructure: TreeRoot;
+
+    /**
+     * Tree structure can be rendered 2 ways in the DOM:
+     * 1) Nested: The tree is rendered as a nested list where the structure reflect the semantic structure of the tree
+     * 2) Flat: The tree is rendered as a single level list where the DOM does not reflect the semantic structure of the tree, and
+     *    we need to provide additional aria attributes to re-build it for the accessibility tree.
+     *    Virtualized trees are usually rendered flat.
+     * @default true
+     */
+    isRenderedFlat?: boolean;
+
+    /**
+     * Determines if the tree root should be excluded from the tree keyboard navigation.
+     *
+     * In many case we want to hide the root of the tree, for example when the tree used for grouping some list items.
+     *
+     * Note: it does not change the visibility of the root node.
+     * @default true
+     */
+    excludeTreeRoot?: boolean;
+
+    /**
+     * The selection mode of the tree nodes.
+     *
+     * Note: When user click to select a node and `selectableNodes` is `any` and the node is not a leaf node, the node will be opened/closed.
+     * WCAG Tree patter sample implementation has the same behavior.
+     *
+     * @see {@link https://www.w3.org/WAI/ARIA/apg/patterns/treeview/ WCAG Tree Pattern}
+     */
+    selectableNodes?: 'leafOnly' | 'any';
+
+    /**
+     * Set of functions to communicate with virtualized tree and sync states.
+     */
+    virtualTreeConnector?: {
+      /**
+       * External function to scroll to a node.
+       * This is used when the tree is rendered in a virtualized tree.
+       *
+       * @param id
+       */
+      scrollToNode: (id: TreeNodeId) => void;
+
+      /**
+       * Toggle open/close state of the tree node.
+       *
+       * @param id
+       * @param isOpen
+       */
+      setNodeOpen?: (id: TreeNodeId, isOpen: boolean) => void | Promise<void>;
+    };
+
+    /**
+     * Called when a node's open / close state is toggled.
      *
      * @param id
      * @param isOpen
      */
-    setNodeOpen?: (id: TreeNodeId, isOpen: boolean) => void | Promise<void>;
+    onToggleNode?: (id: TreeNodeId, isOpen: boolean) => void;
   };
-
-  /**
-   * Called when a node's open / close state is toggled.
-   *
-   * @param id
-   * @param isOpen
-   */
-  onToggleNode?: (id: TreeNodeId, isOpen: boolean) => void;
-}
 
 /**
  * Props of the virtualized tree hook

--- a/src/components/Tree/Tree.typetest.ts
+++ b/src/components/Tree/Tree.typetest.ts
@@ -1,0 +1,22 @@
+import { Expect, ExpectExtends, ExpectFalse } from '../../utils/typetest.util';
+import { Props, TreeRoot } from './Tree.types';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type cases = [
+  Expect<ExpectExtends<Props, { treeStructure: TreeRoot; 'aria-label': 'abc' }>>,
+  Expect<ExpectExtends<Props, { treeStructure: TreeRoot; 'aria-labelledby': 'some-id' }>>,
+  Expect<
+    ExpectExtends<
+      Props,
+      { treeStructure: TreeRoot; 'aria-label': 'abc'; 'aria-labelledby': 'some-id' }
+    >
+  >,
+
+  ExpectFalse<ExpectExtends<Props, { 'aria-label': 'abc' }>>,
+  ExpectFalse<ExpectExtends<Props, { 'aria-labelledby': 'some-id' }>>,
+  ExpectFalse<ExpectExtends<Props, { 'aria-label': 'abc'; 'aria-labelledby': 'some-id' }>>,
+
+  ExpectFalse<ExpectExtends<Props, { treeStructure: TreeRoot }>>,
+
+  ExpectFalse<ExpectExtends<Props, Record<string, never>>>
+];

--- a/src/components/TreeNodeBase/TreeNodeBase.stories.tsx
+++ b/src/components/TreeNodeBase/TreeNodeBase.stories.tsx
@@ -36,7 +36,7 @@ export default {
 };
 
 const TreeWrapper = ({ children }) => (
-  <Tree excludeTreeRoot={false} treeStructure={tNode('root', true, [])}>
+  <Tree excludeTreeRoot={false} treeStructure={tNode('root', true, [])} aria-label="some tree">
     {children}
   </Tree>
 );

--- a/src/components/TreeNodeBase/TreeNodeBase.test.tsx
+++ b/src/components/TreeNodeBase/TreeNodeBase.test.tsx
@@ -195,7 +195,12 @@ describe('TreeNodeBase', () => {
       const tree: TreeNode = tNode('root', true, [tNode('1'), tNode('2')]);
 
       container = mount(
-        <Tree treeStructure={tree} isRenderedFlat={true} excludeTreeRoot={false}>
+        <Tree
+          treeStructure={tree}
+          isRenderedFlat={true}
+          excludeTreeRoot={false}
+          aria-label="some tree"
+        >
           {mapTree(
             convertNestedTree2MappedTree(tree),
             (node) => (
@@ -255,7 +260,12 @@ describe('TreeNodeBase', () => {
       const tree: TreeNode = tNode('root', true, [tNode('1'), tNode('2')]);
 
       container = mount(
-        <Tree treeStructure={tree} isRenderedFlat={true} excludeTreeRoot={false}>
+        <Tree
+          treeStructure={tree}
+          isRenderedFlat={true}
+          excludeTreeRoot={false}
+          aria-label="some tree"
+        >
           {mapTree(
             convertNestedTree2MappedTree(tree),
             (node) => (
@@ -285,7 +295,7 @@ describe('TreeNodeBase', () => {
       const tree: TreeNode = tNode('root', false, [tNode('1'), tNode('2')]);
       // prettier-ignore
       container = mount(
-        <Tree treeStructure={tree} isRenderedFlat={true} excludeTreeRoot={false}>
+        <Tree treeStructure={tree} isRenderedFlat={true} excludeTreeRoot={false} aria-label='some tree'>
           {mapTree(
             convertNestedTree2MappedTree(tree),
             (node) => (
@@ -310,7 +320,7 @@ describe('TreeNodeBase', () => {
       const tree: TreeNode = tNode('root', false, [tNode('1'), tNode('2')]);
       // prettier-ignore
       container = mount(
-        <Tree treeStructure={tree} isRenderedFlat={true} excludeTreeRoot={false}>
+        <Tree treeStructure={tree} isRenderedFlat={true} excludeTreeRoot={false} aria-label='some tree'>
           {mapTree(
             convertNestedTree2MappedTree(tree),
             (node) => (
@@ -547,7 +557,7 @@ describe('TreeNodeBase', () => {
       const tree = getSampleTree();
       // prettier-ignore
       return render(
-        <Tree treeStructure={tree}>
+        <Tree treeStructure={tree} aria-label='some tree'>
           {mapTree(convertNestedTree2MappedTree(tree), (node) => (
             <TreeNodeBase key={node.id} nodeId={node.id} data-testid={`node-${node.id}`}>
               {() =>(<ListItemBaseSection position="end">
@@ -609,7 +619,11 @@ describe('TreeNodeBase', () => {
       const user = userEvent.setup();
 
       render(
-        <Tree treeStructure={{ id: 'root', children: [] }} excludeTreeRoot={false}>
+        <Tree
+          treeStructure={{ id: 'root', children: [] }}
+          excludeTreeRoot={false}
+          aria-label="some tree"
+        >
           <TreeNodeBase data-testid="list-item-1" key="1" nodeId="root" onPress={mockCallback} />
         </Tree>
       );

--- a/src/components/TreeNodeBase/TreeNodeBase.test.tsx.snap
+++ b/src/components/TreeNodeBase/TreeNodeBase.test.tsx.snap
@@ -362,6 +362,7 @@ exports[`TreeNodeBase snapshot should match snapshot without tree context 1`] = 
 
 exports[`TreeNodeBase snapshot should not render the content of the hidden nodes 1`] = `
 <Tree
+  aria-label="some tree"
   excludeTreeRoot={false}
   isRenderedFlat={true}
   treeStructure={
@@ -384,6 +385,7 @@ exports[`TreeNodeBase snapshot should not render the content of the hidden nodes
   }
 >
   <div
+    aria-label="some tree"
     className="md-tree-wrapper"
     onBlur={[Function]}
     onFocus={[Function]}
@@ -468,6 +470,7 @@ exports[`TreeNodeBase snapshot should not render the content of the hidden nodes
 
 exports[`TreeNodeBase snapshot should not render the content when the node details are not available 1`] = `
 <Tree
+  aria-label="some tree"
   excludeTreeRoot={false}
   isRenderedFlat={true}
   treeStructure={
@@ -490,6 +493,7 @@ exports[`TreeNodeBase snapshot should not render the content when the node detai
   }
 >
   <div
+    aria-label="some tree"
     className="md-tree-wrapper"
     onBlur={[Function]}
     onFocus={[Function]}
@@ -517,6 +521,7 @@ exports[`TreeNodeBase snapshot should not render the content when the node detai
 
 exports[`TreeNodeBase snapshot should render grouping element when the tree is flat 1`] = `
 <Tree
+  aria-label="some tree"
   excludeTreeRoot={false}
   isRenderedFlat={true}
   treeStructure={
@@ -539,6 +544,7 @@ exports[`TreeNodeBase snapshot should render grouping element when the tree is f
   }
 >
   <div
+    aria-label="some tree"
     className="md-tree-wrapper"
     onBlur={[Function]}
     onFocus={[Function]}


### PR DESCRIPTION
# Description

Require aria-label or aria-labelledby in Tree Props type. Unfortunately this union type doesn't survive going through forwardRef, so I also added a console warning.

# Links

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-582999
