### PR TITLE
feat(alert-dialog): fix role

### DIFF
--- a/src/components/ToastNotification/ToastNotification.tsx
+++ b/src/components/ToastNotification/ToastNotification.tsx
@@ -26,6 +26,18 @@ const ToastNotification: FC<Props> = (props: Props) => {
     ...rest
   } = props;
 
+  const isInteractiveDialog = !!onClose || !!buttonGroup;
+
+  // According to: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/alertdialog_role
+  // "The alertdialog role should only be used for alert messages that have associated interactive controls.
+  // If an alert dialog only contains static content and has no interactive controls at all, use alert instead."
+  // However, we have decided not to use role="alert" and use solely ScreenReaderAnnouncer instaed.
+  // So for non-interactive ToastNotifications, we are adding role="generic" and aria-hidden="true"
+
+  const role = props.role || (isInteractiveDialog ? 'alertdialog' : 'generic');
+
+  const isAriaHidden = !isInteractiveDialog;
+
   return (
     <ModalContainer
       className={classnames(className, STYLE.wrapper)}
@@ -33,7 +45,8 @@ const ToastNotification: FC<Props> = (props: Props) => {
       id={id}
       style={style}
       round={50}
-      role="generic"
+      role={role}
+      aria-hidden={isAriaHidden}
       ariaModal={false}
       {...rest}
     >

--- a/src/components/ToastNotification/ToastNotification.types.ts
+++ b/src/components/ToastNotification/ToastNotification.types.ts
@@ -34,33 +34,39 @@ export type ToastNotificationCloseButtonProps =
       closeButtonLabel: string;
     };
 
-export type Props = ToastNotificationCloseButtonProps & AriaLabelRequired & {
-  /**
-   * The free string or a ReactElement that appears inside the Notification toast.
-   */
-  content: ReactNode;
-  /**
-   * Leading visual of this notification toast. It can be an Icon, Avatar or Badge.
-   */
-  leadingVisual?: ReactElement<SupportedLeadingVisuals>;
+export type Props = ToastNotificationCloseButtonProps &
+  AriaLabelRequired & {
+    /**
+     * The free string or a ReactElement that appears inside the Notification toast.
+     */
+    content: ReactNode;
+    /**
+     * Leading visual of this notification toast. It can be an Icon, Avatar or Badge.
+     */
+    leadingVisual?: ReactElement<SupportedLeadingVisuals>;
 
-  /**
-   * Button group that appears on the bottom of this Notification toast.
-   */
-  buttonGroup?: ReactElement<SupportedButtonGroup>;
+    /**
+     * Button group that appears on the bottom of this Notification toast.
+     */
+    buttonGroup?: ReactElement<SupportedButtonGroup>;
 
-  /**
-   * Custom class for overriding this component's CSS.
-   */
-  className?: string;
+    /**
+     * Custom class for overriding this component's CSS.
+     */
+    className?: string;
 
-  /**
-   * Custom id for overriding this component's CSS.
-   */
-  id?: string;
+    /**
+     * Custom id for overriding this component's CSS.
+     */
+    id?: string;
 
-  /**
-   * Custom style for overriding this component's CSS.
-   */
-  style?: CSSProperties;
-};
+    /**
+     * Custom style for overriding this component's CSS.
+     */
+    style?: CSSProperties;
+
+    /**
+     * Custom role for overriding this component's role. Use 'alertdialog' for interactive dialogs if onClose and buttonGroup are provided are undefined.
+     */
+    role?: string;
+  };

--- a/src/components/ToastNotification/ToastNotification.unit.test.tsx
+++ b/src/components/ToastNotification/ToastNotification.unit.test.tsx
@@ -87,6 +87,18 @@ describe('<ToastNotification />', () => {
       expect(container).toMatchSnapshot();
     });
 
+    it('should match snapshot with role', async () => {
+      expect.assertions(1);
+
+      const role = 'example-id';
+
+      const container = await mountAndWait(
+        <ToastNotification aria-label="Some label" role={role} content={exampleContent} />
+      );
+
+      expect(container).toMatchSnapshot();
+    });
+
     it('should match snapshot with style', async () => {
       expect.assertions(1);
 
@@ -229,6 +241,19 @@ describe('<ToastNotification />', () => {
       expect(element.id).toBe(id);
     });
 
+    it('should have provided role when role is provided', async () => {
+      expect.assertions(1);
+
+      const role = 'some-fake-role';
+
+      const wrapper = await mountAndWait(
+        <ToastNotification aria-label="Some label" role={role} content={exampleContent} />
+      );
+      const element = wrapper.find(ToastNotification).getDOMNode();
+
+      expect(element.getAttribute('role')).toBe(role);
+    });
+
     it('should have provided style when style is provided', async () => {
       expect.assertions(1);
 
@@ -274,6 +299,22 @@ describe('<ToastNotification />', () => {
       expect(button.props()['aria-label']).toBe('close');
     });
 
+    it('should assign role="alertdialog" when onClose is defined', async () => {
+      expect.assertions(1);
+
+      const wrapper = await mountAndWait(
+        <ToastNotification
+          aria-label="Some label"
+          onClose={onClose}
+          closeButtonLabel={'close'}
+          content={exampleContent}
+        />
+      );
+      const modalContainer = wrapper.find(ToastNotification).getDOMNode();
+
+      expect(modalContainer.getAttribute('role')).toBe('alertdialog');
+    });
+
     it('should wrap Icon inside leadingVisual when Icon is provided', async () => {
       expect.assertions(1);
 
@@ -304,6 +345,33 @@ describe('<ToastNotification />', () => {
 
       expect(element1).toBeDefined();
       expect(element2).toBeDefined();
+    });
+
+    it('should assign role="alertdialog" when buttons are provided', async () => {
+      expect.assertions(1);
+
+      const wrapper = await mountAndWait(
+        <ToastNotification
+          aria-label="Some label"
+          buttonGroup={buttonGroup}
+          content={exampleContent}
+        />
+      );
+      const modalContainer = wrapper.find(ToastNotification).getDOMNode();
+
+      expect(modalContainer.getAttribute('role')).toBe('alertdialog');
+    });
+
+    it('should assign role="generic" and aria-hidden="true" when no onClose and no buttons are provided', async () => {
+      expect.assertions(2);
+
+      const wrapper = await mountAndWait(
+        <ToastNotification aria-label="Some label" content={exampleContent} />
+      );
+      const modalContainer = wrapper.find(ToastNotification).getDOMNode();
+
+      expect(modalContainer.getAttribute('role')).toBe('generic');
+      expect(modalContainer.getAttribute('aria-hidden')).toBe('true');
     });
 
     it('should wrap notification content inside Text component if content is a free string', async () => {
@@ -340,7 +408,7 @@ describe('<ToastNotification />', () => {
 
       const wrapper = await mountAndWait(
         <ToastNotification
-          aria-label='Some label'
+          aria-label="Some label"
           onClose={mockCallback}
           content={exampleContent}
           closeButtonLabel="Close notification"

--- a/src/components/ToastNotification/ToastNotification.unit.test.tsx.snap
+++ b/src/components/ToastNotification/ToastNotification.unit.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`<ToastNotification /> snapshot should match snapshot 1`] = `
   content="Example text"
 >
   <ModalContainer
+    aria-hidden={true}
     aria-label="Some label"
     ariaModal={false}
     className="md-toast-notification-wrapper"
@@ -14,6 +15,7 @@ exports[`<ToastNotification /> snapshot should match snapshot 1`] = `
     round={50}
   >
     <div
+      aria-hidden={true}
       aria-label="Some label"
       className="md-toast-notification-wrapper md-modal-container-wrapper"
       data-color="primary"
@@ -57,6 +59,7 @@ exports[`<ToastNotification /> snapshot should match snapshot with aria-label 1`
   content="Example text"
 >
   <ModalContainer
+    aria-hidden={true}
     aria-label="test"
     ariaModal={false}
     className="md-toast-notification-wrapper"
@@ -65,6 +68,7 @@ exports[`<ToastNotification /> snapshot should match snapshot with aria-label 1`
     round={50}
   >
     <div
+      aria-hidden={true}
       aria-label="test"
       className="md-toast-notification-wrapper md-modal-container-wrapper"
       data-color="primary"
@@ -108,6 +112,7 @@ exports[`<ToastNotification /> snapshot should match snapshot with aria-labelled
   content="Example text"
 >
   <ModalContainer
+    aria-hidden={true}
     aria-labelledby="test-id"
     ariaModal={false}
     className="md-toast-notification-wrapper"
@@ -116,6 +121,7 @@ exports[`<ToastNotification /> snapshot should match snapshot with aria-labelled
     round={50}
   >
     <div
+      aria-hidden={true}
       aria-labelledby="test-id"
       className="md-toast-notification-wrapper md-modal-container-wrapper"
       data-color="primary"
@@ -174,22 +180,25 @@ exports[`<ToastNotification /> snapshot should match snapshot with button group 
   content="Example text"
 >
   <ModalContainer
+    aria-hidden={false}
     aria-label="Some label"
     ariaModal={false}
     className="md-toast-notification-wrapper"
     isPadded={true}
-    role="generic"
+    role="alertdialog"
     round={50}
   >
     <div
+      aria-hidden={false}
       aria-label="Some label"
+      aria-modal={false}
       className="md-toast-notification-wrapper md-modal-container-wrapper"
       data-color="primary"
       data-elevation={0}
       data-exclude-focus={true}
       data-padded={true}
       data-round={50}
-      role="generic"
+      role="alertdialog"
       tabIndex={-1}
     >
       <div
@@ -343,6 +352,7 @@ exports[`<ToastNotification /> snapshot should match snapshot with className 1`]
   content="Example text"
 >
   <ModalContainer
+    aria-hidden={true}
     aria-label="Some label"
     ariaModal={false}
     className="example-class md-toast-notification-wrapper"
@@ -351,6 +361,7 @@ exports[`<ToastNotification /> snapshot should match snapshot with className 1`]
     round={50}
   >
     <div
+      aria-hidden={true}
       aria-label="Some label"
       className="example-class md-toast-notification-wrapper md-modal-container-wrapper"
       data-color="primary"
@@ -395,6 +406,7 @@ exports[`<ToastNotification /> snapshot should match snapshot with id 1`] = `
   id="example-id"
 >
   <ModalContainer
+    aria-hidden={true}
     aria-label="Some label"
     ariaModal={false}
     className="md-toast-notification-wrapper"
@@ -404,6 +416,7 @@ exports[`<ToastNotification /> snapshot should match snapshot with id 1`] = `
     round={50}
   >
     <div
+      aria-hidden={true}
       aria-label="Some label"
       className="md-toast-notification-wrapper md-modal-container-wrapper"
       data-color="primary"
@@ -455,6 +468,7 @@ exports[`<ToastNotification /> snapshot should match snapshot with leading visua
   }
 >
   <ModalContainer
+    aria-hidden={true}
     aria-label="Some label"
     ariaModal={false}
     className="md-toast-notification-wrapper"
@@ -463,6 +477,7 @@ exports[`<ToastNotification /> snapshot should match snapshot with leading visua
     round={50}
   >
     <div
+      aria-hidden={true}
       aria-label="Some label"
       className="md-toast-notification-wrapper md-modal-container-wrapper"
       data-color="primary"
@@ -538,6 +553,7 @@ exports[`<ToastNotification /> snapshot should match snapshot with non string co
   }
 >
   <ModalContainer
+    aria-hidden={true}
     aria-label="Some label"
     ariaModal={false}
     className="md-toast-notification-wrapper"
@@ -546,6 +562,7 @@ exports[`<ToastNotification /> snapshot should match snapshot with non string co
     round={50}
   >
     <div
+      aria-hidden={true}
       aria-label="Some label"
       className="md-toast-notification-wrapper md-modal-container-wrapper"
       data-color="primary"
@@ -580,22 +597,25 @@ exports[`<ToastNotification /> snapshot should match snapshot with onClose and c
   onClose={[Function]}
 >
   <ModalContainer
+    aria-hidden={false}
     aria-label="Some label"
     ariaModal={false}
     className="md-toast-notification-wrapper"
     isPadded={true}
-    role="generic"
+    role="alertdialog"
     round={50}
   >
     <div
+      aria-hidden={false}
       aria-label="Some label"
+      aria-modal={false}
       className="md-toast-notification-wrapper md-modal-container-wrapper"
       data-color="primary"
       data-elevation={0}
       data-exclude-focus={true}
       data-padded={true}
       data-round={50}
-      role="generic"
+      role="alertdialog"
       tabIndex={-1}
     >
       <div
@@ -710,12 +730,67 @@ exports[`<ToastNotification /> snapshot should match snapshot with onClose and c
 </ToastNotification>
 `;
 
+exports[`<ToastNotification /> snapshot should match snapshot with role 1`] = `
+<ToastNotification
+  aria-label="Some label"
+  content="Example text"
+  role="example-id"
+>
+  <ModalContainer
+    aria-hidden={true}
+    aria-label="Some label"
+    ariaModal={false}
+    className="md-toast-notification-wrapper"
+    isPadded={true}
+    role="example-id"
+    round={50}
+  >
+    <div
+      aria-hidden={true}
+      aria-label="Some label"
+      className="md-toast-notification-wrapper md-modal-container-wrapper"
+      data-color="primary"
+      data-elevation={0}
+      data-exclude-focus={true}
+      data-padded={true}
+      data-round={50}
+      role="example-id"
+      tabIndex={-1}
+    >
+      <div
+        className="md-toast-notification-body"
+      >
+        <Text
+          className="md-toast-notification-content"
+          tagName="p"
+          type="body-primary"
+        >
+          <Text
+            className="md-text-wrapper md-toast-notification-content"
+            tagname="p"
+            type="body-large-regular"
+          >
+            <mdc-text
+              class="md-text-wrapper md-toast-notification-content"
+              suppressHydrationWarning={true}
+            >
+              Example text
+            </mdc-text>
+          </Text>
+        </Text>
+      </div>
+    </div>
+  </ModalContainer>
+</ToastNotification>
+`;
+
 exports[`<ToastNotification /> snapshot should match snapshot with string content 1`] = `
 <ToastNotification
   aria-label="Some label"
   content="Example text"
 >
   <ModalContainer
+    aria-hidden={true}
     aria-label="Some label"
     ariaModal={false}
     className="md-toast-notification-wrapper"
@@ -724,6 +799,7 @@ exports[`<ToastNotification /> snapshot should match snapshot with string conten
     round={50}
   >
     <div
+      aria-hidden={true}
       aria-label="Some label"
       className="md-toast-notification-wrapper md-modal-container-wrapper"
       data-color="primary"
@@ -772,6 +848,7 @@ exports[`<ToastNotification /> snapshot should match snapshot with style 1`] = `
   }
 >
   <ModalContainer
+    aria-hidden={true}
     aria-label="Some label"
     ariaModal={false}
     className="md-toast-notification-wrapper"
@@ -785,6 +862,7 @@ exports[`<ToastNotification /> snapshot should match snapshot with style 1`] = `
     }
   >
     <div
+      aria-hidden={true}
       aria-label="Some label"
       className="md-toast-notification-wrapper md-modal-container-wrapper"
       data-color="primary"


### PR DESCRIPTION
# Description

The role="generic" was added to the ToastNotification with the aim of making the NotificationSystem role="alert" work. However, we have decided not to use role="alert" anymore and use ScreenReaderAnnouncer instaed.

After speaking with the A11y team on Office Hours, and reading the [A11y documentation online](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/alertdialog_role), the correct role for the Toast Notification is "alertdialog" if it has interactive buttons inside. If it doesn't, the documentation says the right role should be "alert", but as we have decided not to use this, I am keeping the role="generic" and adding "aria-hidden"=true. 

This work will complement work on [SPARK-598178](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-598178) of adding SRAnnouncements to the NotificationSystem for SR to automatically announce any new toast that appears on the screen.

# Links

[*Links to relevent resources.*](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/alertdialog_role)