### PR TITLE
feat(radio-simple and group): make aria-label(ledby) required

### DIFF
--- a/src/components/RadioSimple/RadioSimple.stories.args.ts
+++ b/src/components/RadioSimple/RadioSimple.stories.args.ts
@@ -22,26 +22,6 @@ const radioSimpleArgTypes = {
       defaultValue: undefined,
     },
   },
-  ariaLabel: {
-    description: 'The ariaLabel is used to provide an aria-label for the RadioSimple.',
-    control: { type: 'text', required: false },
-    table: {
-      type: {
-        summary: 'string',
-      },
-      defaultValue: 'example-ariaLabel',
-    },
-  },
-  ariaLabelledBy: {
-    description: 'The ariaLabelledBy is used to provide an aria-labelledby for the RadioSimple.',
-    control: { type: 'text', required: false },
-    table: {
-      type: {
-        summary: 'string',
-      },
-      defaultValue: 'example-ariaLabelledBy',
-    },
-  },
   isDisabled: {
     description: 'The isDisabled is to set the disable state for the RadioSimple.',
     control: { type: 'boolean', required: false },

--- a/src/components/RadioSimple/RadioSimple.stories.tsx
+++ b/src/components/RadioSimple/RadioSimple.stories.tsx
@@ -49,6 +49,7 @@ Example.args = {
     padding: '8px',
     margin: '8px 8px',
   },
+  'aria-label': 'Some label',
 };
 
 export { Example };

--- a/src/components/RadioSimple/RadioSimple.tsx
+++ b/src/components/RadioSimple/RadioSimple.tsx
@@ -14,25 +14,12 @@ import { RadioSimpleGroupContext } from '../RadioSimpleGroup';
  * The RadioSimple component.
  */
 const RadioSimple: FC<RadioSimpleProps> = (props: RadioSimpleProps) => {
-  const {
-    ariaLabel,
-    ariaLabelledBy,
-    children,
-    className,
-    id,
-    isDisabled = DEFAULTS.DISABLED,
-    style,
-    value,
-  } = props;
+  const { children, className, id, isDisabled = DEFAULTS.DISABLED, style, value } = props;
   const state = useContext(RadioSimpleGroupContext);
   const ref = useRef(null);
   const isSelected = state?.selectedValue === value;
   const { focusProps, isFocusVisible } = useFocusRing();
-  const { inputProps } = useRadio(
-    { 'aria-label': ariaLabel, 'aria-labelledby': ariaLabelledBy, ...props },
-    state,
-    ref
-  );
+  const { inputProps } = useRadio(props, state, ref);
 
   return (
     <label

--- a/src/components/RadioSimple/RadioSimple.types.ts
+++ b/src/components/RadioSimple/RadioSimple.types.ts
@@ -1,17 +1,7 @@
 import { CSSProperties, ReactNode } from 'react';
-import { AriaRadioProps } from '@react-types/radio';
+import { AriaLabelRequired } from '../../utils/a11y';
 
-export interface RadioSimpleProps extends AriaRadioProps {
-  /**
-   * Optional ariaLabel on the RadioSimple component.
-   */
-  ariaLabel?: string;
-
-  /**
-   * Optional ariaLabelledBy on the RadioSimple component.
-   */
-  ariaLabelledBy?: string;
-
+export type RadioSimpleProps = AriaLabelRequired & {
   /**
    * Child components of this RadioSimple.
    */
@@ -41,4 +31,4 @@ export interface RadioSimpleProps extends AriaRadioProps {
    * The value of the RadioSimple component.
    */
   value: string;
-}
+};

--- a/src/components/RadioSimple/RadioSimple.typetest.ts
+++ b/src/components/RadioSimple/RadioSimple.typetest.ts
@@ -1,0 +1,14 @@
+import { Expect, ExpectExtends, ExpectFalse } from '../../utils/typetest.util';
+import { RadioSimpleProps } from './RadioSimple.types';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type cases = [
+  Expect<ExpectExtends<RadioSimpleProps, { 'aria-label': 'Some label'; value: 'A' }>>,
+  Expect<ExpectExtends<RadioSimpleProps, { 'aria-labelledby': 'some-id'; value: 'A' }>>,
+
+  ExpectFalse<ExpectExtends<RadioSimpleProps, { 'aria-label': 'Some label' }>>,
+  ExpectFalse<ExpectExtends<RadioSimpleProps, { 'aria-labelledby': 'some-id' }>>,
+  ExpectFalse<ExpectExtends<RadioSimpleProps, { value: 'A' }>>,
+
+  ExpectFalse<ExpectExtends<RadioSimpleProps, Record<string, never>>>
+];

--- a/src/components/RadioSimple/RadioSimple.unit.test.tsx
+++ b/src/components/RadioSimple/RadioSimple.unit.test.tsx
@@ -22,7 +22,7 @@ describe('<RadioSimple />', () => {
 
       const { asFragment } = render(
         <RadioSimpleGroupContext.Provider value={'red'}>
-          <RadioSimple children={children} value="red" />
+          <RadioSimple aria-label="Some label" children={children} value="red" />
         </RadioSimpleGroupContext.Provider>
       );
 
@@ -36,7 +36,7 @@ describe('<RadioSimple />', () => {
 
       const { asFragment } = render(
         <RadioSimpleGroupContext.Provider value={'red'}>
-          <RadioSimple children={children} value="red" ariaLabel={ariaLabel} />
+          <RadioSimple children={children} value="red" aria-label={ariaLabel} />
         </RadioSimpleGroupContext.Provider>
       );
 
@@ -50,7 +50,7 @@ describe('<RadioSimple />', () => {
 
       const { asFragment } = render(
         <RadioSimpleGroupContext.Provider value={'red'}>
-          <RadioSimple children={children} value="red" ariaLabelledBy={ariaLabelledBy} />
+          <RadioSimple children={children} value="red" aria-labelledby={ariaLabelledBy} />
         </RadioSimpleGroupContext.Provider>
       );
 
@@ -64,7 +64,12 @@ describe('<RadioSimple />', () => {
 
       const { asFragment } = render(
         <RadioSimpleGroupContext.Provider value={'red'}>
-          <RadioSimple children={children} value="red" className={className} />
+          <RadioSimple
+            aria-label="Some label"
+            children={children}
+            value="red"
+            className={className}
+          />
         </RadioSimpleGroupContext.Provider>
       );
 
@@ -78,7 +83,7 @@ describe('<RadioSimple />', () => {
 
       const { asFragment } = render(
         <RadioSimpleGroupContext.Provider value={'red'}>
-          <RadioSimple children={children} value="red" id={id} />
+          <RadioSimple aria-label="Some label" children={children} value="red" id={id} />
         </RadioSimpleGroupContext.Provider>
       );
 
@@ -92,7 +97,12 @@ describe('<RadioSimple />', () => {
 
       const { asFragment } = render(
         <RadioSimpleGroupContext.Provider value={'red'}>
-          <RadioSimple children={children} value="red" isDisabled={isDisabled} />
+          <RadioSimple
+            aria-label="Some label"
+            children={children}
+            value="red"
+            isDisabled={isDisabled}
+          />
         </RadioSimpleGroupContext.Provider>
       );
 
@@ -106,7 +116,7 @@ describe('<RadioSimple />', () => {
 
       const { asFragment } = render(
         <RadioSimpleGroupContext.Provider value={'red'}>
-          <RadioSimple children={children} value="red" style={style} />
+          <RadioSimple aria-label="Some label" children={children} value="red" style={style} />
         </RadioSimpleGroupContext.Provider>
       );
 
@@ -120,7 +130,7 @@ describe('<RadioSimple />', () => {
 
       const { container } = render(
         <RadioSimpleGroupContext.Provider value={'red'}>
-          <RadioSimple children={children} value="red" />
+          <RadioSimple aria-label="Some label" children={children} value="red" />
         </RadioSimpleGroupContext.Provider>
       );
 
@@ -136,7 +146,7 @@ describe('<RadioSimple />', () => {
 
       const { container } = render(
         <RadioSimpleGroupContext.Provider value={'red'}>
-          <RadioSimple children={children} value="red" ariaLabel={ariaLabel} />
+          <RadioSimple children={children} value="red" aria-label={ariaLabel} />
         </RadioSimpleGroupContext.Provider>
       );
 
@@ -152,7 +162,7 @@ describe('<RadioSimple />', () => {
 
       const { container } = render(
         <RadioSimpleGroupContext.Provider value={'red'}>
-          <RadioSimple children={children} value="red" ariaLabelledBy={ariaLabelledBy} />
+          <RadioSimple children={children} value="red" aria-labelledby={ariaLabelledBy} />
         </RadioSimpleGroupContext.Provider>
       );
 
@@ -168,7 +178,12 @@ describe('<RadioSimple />', () => {
 
       const { container } = render(
         <RadioSimpleGroupContext.Provider value={'red'}>
-          <RadioSimple children={children} value="red" className={className} />
+          <RadioSimple
+            aria-label="Some label"
+            children={children}
+            value="red"
+            className={className}
+          />
         </RadioSimpleGroupContext.Provider>
       );
 
@@ -184,7 +199,7 @@ describe('<RadioSimple />', () => {
 
       const { container } = render(
         <RadioSimpleGroupContext.Provider value={'red'}>
-          <RadioSimple children={children} value="red" id={id} />
+          <RadioSimple aria-label="Some label" children={children} value="red" id={id} />
         </RadioSimpleGroupContext.Provider>
       );
 
@@ -200,7 +215,12 @@ describe('<RadioSimple />', () => {
 
       const { container } = render(
         <RadioSimpleGroupContext.Provider value={'red'}>
-          <RadioSimple children={children} value="red" isDisabled={isDisabled} />
+          <RadioSimple
+            aria-label="Some label"
+            children={children}
+            value="red"
+            isDisabled={isDisabled}
+          />
         </RadioSimpleGroupContext.Provider>
       );
 
@@ -216,7 +236,7 @@ describe('<RadioSimple />', () => {
 
       const { container } = render(
         <RadioSimpleGroupContext.Provider value={'red'}>
-          <RadioSimple children={children} value="red" style={style} />
+          <RadioSimple aria-label="Some label" children={children} value="red" style={style} />
         </RadioSimpleGroupContext.Provider>
       );
 

--- a/src/components/RadioSimple/RadioSimple.unit.test.tsx.snap
+++ b/src/components/RadioSimple/RadioSimple.unit.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`<RadioSimple /> snapshot should match snapshot 1`] = `
       style="border: 0px; clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
     >
       <input
+        aria-label="Some label"
         tabindex="0"
         type="radio"
         value="red"
@@ -98,6 +99,7 @@ exports[`<RadioSimple /> snapshot should match snapshot with className 1`] = `
       style="border: 0px; clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
     >
       <input
+        aria-label="Some label"
         tabindex="0"
         type="radio"
         value="red"
@@ -127,6 +129,7 @@ exports[`<RadioSimple /> snapshot should match snapshot with id 1`] = `
       style="border: 0px; clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
     >
       <input
+        aria-label="Some label"
         id="example-id"
         tabindex="0"
         type="radio"
@@ -156,6 +159,7 @@ exports[`<RadioSimple /> snapshot should match snapshot with isDisabled 1`] = `
       style="border: 0px; clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
     >
       <input
+        aria-label="Some label"
         disabled=""
         type="radio"
         value="red"
@@ -185,6 +189,7 @@ exports[`<RadioSimple /> snapshot should match snapshot with style 1`] = `
       style="border: 0px; clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
     >
       <input
+        aria-label="Some label"
         tabindex="0"
         type="radio"
         value="red"

--- a/src/components/RadioSimpleGroup/RadioSimpleGroup.types.ts
+++ b/src/components/RadioSimpleGroup/RadioSimpleGroup.types.ts
@@ -1,29 +1,36 @@
 import { CSSProperties, ReactNode } from 'react';
 import { AriaRadioGroupProps } from '@react-types/radio';
+import { AriaLabelingProps } from '@react-types/shared';
+import { AriaLabelRequired } from '../../utils/a11y';
 
-export interface RadioSimpleGroupProps extends AriaRadioGroupProps {
-  /**
-   * Custom class for overriding this component's CSS.
-   */
-  className?: string;
+export type RadioSimpleGroupProps = AriaRadioGroupProps &
+  AriaLabelingProps &
+  (
+    | {
+        /**
+         * The RadioSimpleGroup's visible label (if any).
+         */
+        label: ReactNode;
+      }
+    | ({ label?: never } & AriaLabelRequired)
+  ) & { // if a label is not provided, an aria-label(ledby) is required
+    /**
+     * Custom class for overriding this component's CSS.
+     */
+    className?: string;
 
-  /**
-   * A wrapper that contains the RadioSimples inside this RadioSimpleGroup
-   */
-  children: ReactNode;
+    /**
+     * A wrapper that contains the RadioSimples inside this RadioSimpleGroup
+     */
+    children: ReactNode;
 
-  /**
-   *  The RadioSimpleGroup description element, if any.
-   */
-  description?: ReactNode;
+    /**
+     *  The RadioSimpleGroup description element, if any.
+     */
+    description?: ReactNode;
 
-  /**
-   * 	The RadioSimpleGroup's visible label (if any).
-   */
-  label?: ReactNode;
-
-  /**
-   * Custom style for overriding this component's CSS.
-   */
-  style?: CSSProperties;
-}
+    /**
+     * Custom style for overriding this component's CSS.
+     */
+    style?: CSSProperties;
+  };

--- a/src/components/RadioSimpleGroup/RadioSimpleGroup.typetest.ts
+++ b/src/components/RadioSimpleGroup/RadioSimpleGroup.typetest.ts
@@ -1,0 +1,23 @@
+import { Expect, ExpectExtends, ExpectFalse } from '../../utils/typetest.util';
+import { RadioSimpleGroupProps } from './RadioSimpleGroup.types';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type cases = [
+  Expect<ExpectExtends<RadioSimpleGroupProps, { label: 'Some label'; children: 'Some children' }>>,
+  Expect<
+    ExpectExtends<RadioSimpleGroupProps, { 'aria-label': 'Some label'; children: 'Some children' }>
+  >,
+  Expect<
+    ExpectExtends<
+      RadioSimpleGroupProps,
+      { 'aria-labelledby': 'some-id'; children: 'Some children' }
+    >
+  >,
+
+  ExpectFalse<ExpectExtends<RadioSimpleGroupProps, { label: 'Some label' }>>,
+  ExpectFalse<ExpectExtends<RadioSimpleGroupProps, { 'aria-label': 'Some label' }>>,
+  ExpectFalse<ExpectExtends<RadioSimpleGroupProps, { 'aria-labelledby': 'some-id' }>>,
+  ExpectFalse<ExpectExtends<RadioSimpleGroupProps, { children: 'Some children' }>>,
+
+  ExpectFalse<ExpectExtends<RadioSimpleGroupProps, Record<string, never>>>
+];

--- a/src/components/RadioSimpleGroup/RadioSimpleGroup.unit.test.tsx
+++ b/src/components/RadioSimpleGroup/RadioSimpleGroup.unit.test.tsx
@@ -17,19 +17,19 @@ jest.mock('uuid', () => {
 
 describe('<RadioSimpleGroup />', () => {
   const children = [
-    <RadioSimple value="red" key="0">
+    <RadioSimple aria-label="Some label" value="red" key="0">
       <Icon key="0" name="accessibility" autoScale />
       <Text key="1" tagName="p">
         Red
       </Text>
     </RadioSimple>,
-    <RadioSimple value="blue" key="1">
+    <RadioSimple aria-label="Some label" value="blue" key="1">
       <Icon key="0" name="search" autoScale />
       <Text key="1" tagName="p">
         Blue
       </Text>
     </RadioSimple>,
-    <RadioSimple value="yellow" key="2">
+    <RadioSimple aria-label="Some label" value="yellow" key="2">
       <Icon key="0" name="accessories" autoScale />
       <Text key="1" tagName="p">
         Yellow
@@ -53,7 +53,9 @@ describe('<RadioSimpleGroup />', () => {
     it('should match snapshot with children', () => {
       expect.assertions(1);
 
-      const { asFragment } = render(<RadioSimpleGroup children={children} />);
+      const { asFragment } = render(
+        <RadioSimpleGroup aria-label="Some label" children={children} />
+      );
 
       expect(asFragment()).toMatchSnapshot();
     });
@@ -63,7 +65,9 @@ describe('<RadioSimpleGroup />', () => {
 
       const className = 'example-className';
 
-      const { asFragment } = render(<RadioSimpleGroup children={children} className={className} />);
+      const { asFragment } = render(
+        <RadioSimpleGroup aria-label="Some label" children={children} className={className} />
+      );
 
       expect(asFragment()).toMatchSnapshot();
     });
@@ -73,7 +77,9 @@ describe('<RadioSimpleGroup />', () => {
 
       const id = 'example-id';
 
-      const { asFragment } = render(<RadioSimpleGroup children={children} id={id} />);
+      const { asFragment } = render(
+        <RadioSimpleGroup aria-label="Some label" children={children} id={id} />
+      );
 
       expect(asFragment()).toMatchSnapshot();
     });
@@ -83,7 +89,9 @@ describe('<RadioSimpleGroup />', () => {
 
       const style = { color: 'pink' };
 
-      const { asFragment } = render(<RadioSimpleGroup children={children} style={style} />);
+      const { asFragment } = render(
+        <RadioSimpleGroup aria-label="Some label" children={children} style={style} />
+      );
 
       expect(asFragment()).toMatchSnapshot();
     });
@@ -92,7 +100,12 @@ describe('<RadioSimpleGroup />', () => {
       expect.assertions(1);
 
       const { asFragment } = render(
-        <RadioSimpleGroup children={children} description={description} id="example-id" />
+        <RadioSimpleGroup
+          aria-label="Some label"
+          children={children}
+          description={description}
+          id="example-id"
+        />
       );
 
       expect(asFragment()).toMatchSnapshot();
@@ -101,7 +114,9 @@ describe('<RadioSimpleGroup />', () => {
     it('should match snapshot with child thats selected', () => {
       expect.assertions(1);
 
-      const { asFragment } = render(<RadioSimpleGroup children={children} defaultValue="red" />);
+      const { asFragment } = render(
+        <RadioSimpleGroup aria-label="Some label" children={children} defaultValue="red" />
+      );
 
       expect(asFragment()).toMatchSnapshot();
     });
@@ -109,7 +124,9 @@ describe('<RadioSimpleGroup />', () => {
     it('should match snapshot with children with group disabled', () => {
       expect.assertions(1);
 
-      const { asFragment } = render(<RadioSimpleGroup children={children} isDisabled={true} />);
+      const { asFragment } = render(
+        <RadioSimpleGroup aria-label="Some label" children={children} isDisabled={true} />
+      );
 
       expect(asFragment()).toMatchSnapshot();
     });
@@ -117,7 +134,9 @@ describe('<RadioSimpleGroup />', () => {
     it('should match snapshot with children with read only', () => {
       expect.assertions(1);
 
-      const { asFragment } = render(<RadioSimpleGroup children={children} isReadOnly={true} />);
+      const { asFragment } = render(
+        <RadioSimpleGroup aria-label="Some label" children={children} isReadOnly={true} />
+      );
 
       expect(asFragment()).toMatchSnapshot();
     });
@@ -137,7 +156,14 @@ describe('<RadioSimpleGroup />', () => {
     it('should have provided aria-describedby when description is provided', () => {
       expect.assertions(1);
 
-      render(<RadioSimpleGroup children={children} description={description} id="example-id" />);
+      render(
+        <RadioSimpleGroup
+          aria-label="Some label"
+          children={children}
+          description={description}
+          id="example-id"
+        />
+      );
 
       const radioGroup = screen.getByRole('radiogroup');
 
@@ -152,7 +178,9 @@ describe('<RadioSimpleGroup />', () => {
 
       const className = 'example-className';
 
-      render(<RadioSimpleGroup children={children} className={className} />);
+      render(
+        <RadioSimpleGroup aria-label="Some label" children={children} className={className} />
+      );
 
       const radioGroup = screen.getByRole('radiogroup');
 
@@ -164,7 +192,7 @@ describe('<RadioSimpleGroup />', () => {
 
       const id = 'example-id';
 
-      render(<RadioSimpleGroup children={children} id={id} />);
+      render(<RadioSimpleGroup aria-label="Some label" children={children} id={id} />);
 
       const radioGroup = screen.getByRole('radiogroup');
 
@@ -177,7 +205,7 @@ describe('<RadioSimpleGroup />', () => {
       const style = { color: 'pink' };
       const styleString = 'color: pink;';
 
-      render(<RadioSimpleGroup children={children} style={style} />);
+      render(<RadioSimpleGroup aria-label="Some label" children={children} style={style} />);
 
       const radioGroup = screen.getByRole('radiogroup');
 
@@ -187,7 +215,7 @@ describe('<RadioSimpleGroup />', () => {
     it('should have provided isReadOnly when isReadOnly is provided', () => {
       expect.assertions(1);
 
-      render(<RadioSimpleGroup children={children} isReadOnly={true} />);
+      render(<RadioSimpleGroup aria-label="Some label" children={children} isReadOnly={true} />);
 
       const radioGroup = screen.getByRole('radiogroup');
 
@@ -197,7 +225,7 @@ describe('<RadioSimpleGroup />', () => {
     it('should have provided isDisabled when isDisabled is provided', () => {
       expect.assertions(1);
 
-      render(<RadioSimpleGroup children={children} isDisabled={true} />);
+      render(<RadioSimpleGroup aria-label="Some label" children={children} isDisabled={true} />);
 
       const radioGroup = screen.getByRole('radiogroup');
 
@@ -207,7 +235,7 @@ describe('<RadioSimpleGroup />', () => {
     it('should give only the select element the selected style', () => {
       expect.assertions(3);
 
-      render(<RadioSimpleGroup children={children} defaultValue={'red'} />);
+      render(<RadioSimpleGroup aria-label="Some label" children={children} defaultValue={'red'} />);
 
       const optionRed = screen.getByLabelText('Red');
       const optionBlue = screen.getByLabelText('Blue');
@@ -224,7 +252,7 @@ describe('<RadioSimpleGroup />', () => {
       expect.assertions(9);
       const user = userEvent.setup();
 
-      render(<RadioSimpleGroup>{children}</RadioSimpleGroup>);
+      render(<RadioSimpleGroup aria-label="Some label">{children}</RadioSimpleGroup>);
 
       const optionRed = screen.getByLabelText('Red');
       const optionBlue = screen.getByLabelText('Blue');
@@ -255,7 +283,11 @@ describe('<RadioSimpleGroup />', () => {
 
       const onChange = jest.fn();
 
-      render(<RadioSimpleGroup onChange={onChange}>{children}</RadioSimpleGroup>);
+      render(
+        <RadioSimpleGroup aria-label="Some label" onChange={onChange}>
+          {children}
+        </RadioSimpleGroup>
+      );
 
       const optionRed = screen.getByLabelText('Red');
 
@@ -271,7 +303,7 @@ describe('<RadioSimpleGroup />', () => {
       const onChange = jest.fn();
 
       render(
-        <RadioSimpleGroup defaultValue={'red'} onChange={onChange}>
+        <RadioSimpleGroup aria-label="Some label" defaultValue={'red'} onChange={onChange}>
           {children}
         </RadioSimpleGroup>
       );
@@ -289,7 +321,11 @@ describe('<RadioSimpleGroup />', () => {
 
       const onChange = jest.fn();
 
-      render(<RadioSimpleGroup onChange={onChange}>{children}</RadioSimpleGroup>);
+      render(
+        <RadioSimpleGroup aria-label="Some label" onChange={onChange}>
+          {children}
+        </RadioSimpleGroup>
+      );
 
       const optionRed = screen.getByLabelText('Red');
 
@@ -306,7 +342,7 @@ describe('<RadioSimpleGroup />', () => {
       const onChange = jest.fn();
 
       render(
-        <RadioSimpleGroup isReadOnly={true} onChange={onChange}>
+        <RadioSimpleGroup aria-label="Some label" isReadOnly={true} onChange={onChange}>
           {children}
         </RadioSimpleGroup>
       );
@@ -325,7 +361,7 @@ describe('<RadioSimpleGroup />', () => {
       const onChange = jest.fn();
 
       render(
-        <RadioSimpleGroup isDisabled={true} onChange={onChange}>
+        <RadioSimpleGroup aria-label="Some label" isDisabled={true} onChange={onChange}>
           {children}
         </RadioSimpleGroup>
       );
@@ -344,18 +380,18 @@ describe('<RadioSimpleGroup />', () => {
       const onChange = jest.fn();
 
       render(
-        <RadioSimpleGroup onChange={onChange}>
-          <RadioSimple value="red" key="0" isDisabled={true}>
+        <RadioSimpleGroup aria-label="Some label" onChange={onChange}>
+          <RadioSimple aria-label="Some label" value="red" key="0" isDisabled={true}>
             <Icon name="accessibility" autoScale />
             <Text tagName="p">Red</Text>
           </RadioSimple>
           ,
-          <RadioSimple value="blue" key="1">
+          <RadioSimple aria-label="Some label" value="blue" key="1">
             <Icon name="search" autoScale />
             <Text tagName="p">Blue</Text>
           </RadioSimple>
           ,
-          <RadioSimple value="yellow" key="2">
+          <RadioSimple aria-label="Some label" value="yellow" key="2">
             <Icon name="accessories" autoScale />
             <Text tagName="p">Yellow</Text>
           </RadioSimple>
@@ -386,7 +422,7 @@ describe('<RadioSimpleGroup />', () => {
       const onChange = jest.fn();
 
       render(
-        <RadioSimpleGroup onChange={onChange} defaultValue="red">
+        <RadioSimpleGroup aria-label="Some label" onChange={onChange} defaultValue="red">
           {children}
         </RadioSimpleGroup>
       );
@@ -426,7 +462,11 @@ describe('<RadioSimpleGroup />', () => {
 
       const onChange = jest.fn();
 
-      render(<RadioSimpleGroup onChange={onChange}>{children}</RadioSimpleGroup>);
+      render(
+        <RadioSimpleGroup aria-label="Some label" onChange={onChange}>
+          {children}
+        </RadioSimpleGroup>
+      );
 
       const optionRed = screen.getByLabelText('Red');
       const optionBlue = screen.getByLabelText('Blue');

--- a/src/components/RadioSimpleGroup/RadioSimpleGroup.unit.test.tsx.snap
+++ b/src/components/RadioSimpleGroup/RadioSimpleGroup.unit.test.tsx.snap
@@ -35,6 +35,7 @@ exports[`<RadioSimpleGroup /> snapshot should match snapshot 1`] = `
         style="border: 0px; clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
       >
         <input
+          aria-label="Some label"
           name="test-ID"
           tabindex="0"
           type="radio"
@@ -57,6 +58,7 @@ exports[`<RadioSimpleGroup /> snapshot should match snapshot 1`] = `
         style="border: 0px; clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
       >
         <input
+          aria-label="Some label"
           name="test-ID"
           tabindex="0"
           type="radio"
@@ -79,6 +81,7 @@ exports[`<RadioSimpleGroup /> snapshot should match snapshot 1`] = `
         style="border: 0px; clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
       >
         <input
+          aria-label="Some label"
           name="test-ID"
           tabindex="0"
           type="radio"
@@ -98,6 +101,7 @@ exports[`<RadioSimpleGroup /> snapshot should match snapshot 1`] = `
 exports[`<RadioSimpleGroup /> snapshot should match snapshot with child thats selected 1`] = `
 <DocumentFragment>
   <div
+    aria-label="Some label"
     aria-orientation="vertical"
     class="md-radio-simple-group-wrapper"
     data-disabled="false"
@@ -114,6 +118,7 @@ exports[`<RadioSimpleGroup /> snapshot should match snapshot with child thats se
         style="border: 0px; clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
       >
         <input
+          aria-label="Some label"
           checked=""
           name="test-ID"
           tabindex="0"
@@ -137,6 +142,7 @@ exports[`<RadioSimpleGroup /> snapshot should match snapshot with child thats se
         style="border: 0px; clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
       >
         <input
+          aria-label="Some label"
           name="test-ID"
           tabindex="0"
           type="radio"
@@ -159,6 +165,7 @@ exports[`<RadioSimpleGroup /> snapshot should match snapshot with child thats se
         style="border: 0px; clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
       >
         <input
+          aria-label="Some label"
           name="test-ID"
           tabindex="0"
           type="radio"
@@ -178,6 +185,7 @@ exports[`<RadioSimpleGroup /> snapshot should match snapshot with child thats se
 exports[`<RadioSimpleGroup /> snapshot should match snapshot with children 1`] = `
 <DocumentFragment>
   <div
+    aria-label="Some label"
     aria-orientation="vertical"
     class="md-radio-simple-group-wrapper"
     data-disabled="false"
@@ -194,6 +202,7 @@ exports[`<RadioSimpleGroup /> snapshot should match snapshot with children 1`] =
         style="border: 0px; clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
       >
         <input
+          aria-label="Some label"
           name="test-ID"
           tabindex="0"
           type="radio"
@@ -216,6 +225,7 @@ exports[`<RadioSimpleGroup /> snapshot should match snapshot with children 1`] =
         style="border: 0px; clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
       >
         <input
+          aria-label="Some label"
           name="test-ID"
           tabindex="0"
           type="radio"
@@ -238,6 +248,7 @@ exports[`<RadioSimpleGroup /> snapshot should match snapshot with children 1`] =
         style="border: 0px; clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
       >
         <input
+          aria-label="Some label"
           name="test-ID"
           tabindex="0"
           type="radio"
@@ -258,6 +269,7 @@ exports[`<RadioSimpleGroup /> snapshot should match snapshot with children with 
 <DocumentFragment>
   <div
     aria-disabled="true"
+    aria-label="Some label"
     aria-orientation="vertical"
     class="md-radio-simple-group-wrapper"
     data-disabled="true"
@@ -274,6 +286,7 @@ exports[`<RadioSimpleGroup /> snapshot should match snapshot with children with 
         style="border: 0px; clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
       >
         <input
+          aria-label="Some label"
           disabled=""
           name="test-ID"
           type="radio"
@@ -296,6 +309,7 @@ exports[`<RadioSimpleGroup /> snapshot should match snapshot with children with 
         style="border: 0px; clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
       >
         <input
+          aria-label="Some label"
           disabled=""
           name="test-ID"
           type="radio"
@@ -318,6 +332,7 @@ exports[`<RadioSimpleGroup /> snapshot should match snapshot with children with 
         style="border: 0px; clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
       >
         <input
+          aria-label="Some label"
           disabled=""
           name="test-ID"
           type="radio"
@@ -337,6 +352,7 @@ exports[`<RadioSimpleGroup /> snapshot should match snapshot with children with 
 exports[`<RadioSimpleGroup /> snapshot should match snapshot with children with read only 1`] = `
 <DocumentFragment>
   <div
+    aria-label="Some label"
     aria-orientation="vertical"
     aria-readonly="true"
     class="md-radio-simple-group-wrapper"
@@ -354,6 +370,7 @@ exports[`<RadioSimpleGroup /> snapshot should match snapshot with children with 
         style="border: 0px; clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
       >
         <input
+          aria-label="Some label"
           aria-readonly="true"
           name="test-ID"
           tabindex="0"
@@ -377,6 +394,7 @@ exports[`<RadioSimpleGroup /> snapshot should match snapshot with children with 
         style="border: 0px; clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
       >
         <input
+          aria-label="Some label"
           aria-readonly="true"
           name="test-ID"
           tabindex="0"
@@ -400,6 +418,7 @@ exports[`<RadioSimpleGroup /> snapshot should match snapshot with children with 
         style="border: 0px; clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
       >
         <input
+          aria-label="Some label"
           aria-readonly="true"
           name="test-ID"
           tabindex="0"
@@ -420,6 +439,7 @@ exports[`<RadioSimpleGroup /> snapshot should match snapshot with children with 
 exports[`<RadioSimpleGroup /> snapshot should match snapshot with className 1`] = `
 <DocumentFragment>
   <div
+    aria-label="Some label"
     aria-orientation="vertical"
     class="example-className md-radio-simple-group-wrapper"
     data-disabled="false"
@@ -436,6 +456,7 @@ exports[`<RadioSimpleGroup /> snapshot should match snapshot with className 1`] 
         style="border: 0px; clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
       >
         <input
+          aria-label="Some label"
           name="test-ID"
           tabindex="0"
           type="radio"
@@ -458,6 +479,7 @@ exports[`<RadioSimpleGroup /> snapshot should match snapshot with className 1`] 
         style="border: 0px; clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
       >
         <input
+          aria-label="Some label"
           name="test-ID"
           tabindex="0"
           type="radio"
@@ -480,6 +502,7 @@ exports[`<RadioSimpleGroup /> snapshot should match snapshot with className 1`] 
         style="border: 0px; clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
       >
         <input
+          aria-label="Some label"
           name="test-ID"
           tabindex="0"
           type="radio"
@@ -500,6 +523,7 @@ exports[`<RadioSimpleGroup /> snapshot should match snapshot with description 1`
 <DocumentFragment>
   <div
     aria-describedby="radio-simple-group-description-example-id"
+    aria-label="Some label"
     aria-orientation="vertical"
     class="md-radio-simple-group-wrapper"
     data-disabled="false"
@@ -523,6 +547,7 @@ exports[`<RadioSimpleGroup /> snapshot should match snapshot with description 1`
         style="border: 0px; clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
       >
         <input
+          aria-label="Some label"
           name="test-ID"
           tabindex="0"
           type="radio"
@@ -545,6 +570,7 @@ exports[`<RadioSimpleGroup /> snapshot should match snapshot with description 1`
         style="border: 0px; clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
       >
         <input
+          aria-label="Some label"
           name="test-ID"
           tabindex="0"
           type="radio"
@@ -567,6 +593,7 @@ exports[`<RadioSimpleGroup /> snapshot should match snapshot with description 1`
         style="border: 0px; clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
       >
         <input
+          aria-label="Some label"
           name="test-ID"
           tabindex="0"
           type="radio"
@@ -586,6 +613,7 @@ exports[`<RadioSimpleGroup /> snapshot should match snapshot with description 1`
 exports[`<RadioSimpleGroup /> snapshot should match snapshot with id 1`] = `
 <DocumentFragment>
   <div
+    aria-label="Some label"
     aria-orientation="vertical"
     class="md-radio-simple-group-wrapper"
     data-disabled="false"
@@ -602,6 +630,7 @@ exports[`<RadioSimpleGroup /> snapshot should match snapshot with id 1`] = `
         style="border: 0px; clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
       >
         <input
+          aria-label="Some label"
           name="test-ID"
           tabindex="0"
           type="radio"
@@ -624,6 +653,7 @@ exports[`<RadioSimpleGroup /> snapshot should match snapshot with id 1`] = `
         style="border: 0px; clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
       >
         <input
+          aria-label="Some label"
           name="test-ID"
           tabindex="0"
           type="radio"
@@ -646,6 +676,7 @@ exports[`<RadioSimpleGroup /> snapshot should match snapshot with id 1`] = `
         style="border: 0px; clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
       >
         <input
+          aria-label="Some label"
           name="test-ID"
           tabindex="0"
           type="radio"
@@ -665,6 +696,7 @@ exports[`<RadioSimpleGroup /> snapshot should match snapshot with id 1`] = `
 exports[`<RadioSimpleGroup /> snapshot should match snapshot with style 1`] = `
 <DocumentFragment>
   <div
+    aria-label="Some label"
     aria-orientation="vertical"
     class="md-radio-simple-group-wrapper"
     data-disabled="false"
@@ -682,6 +714,7 @@ exports[`<RadioSimpleGroup /> snapshot should match snapshot with style 1`] = `
         style="border: 0px; clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
       >
         <input
+          aria-label="Some label"
           name="test-ID"
           tabindex="0"
           type="radio"
@@ -704,6 +737,7 @@ exports[`<RadioSimpleGroup /> snapshot should match snapshot with style 1`] = `
         style="border: 0px; clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
       >
         <input
+          aria-label="Some label"
           name="test-ID"
           tabindex="0"
           type="radio"
@@ -726,6 +760,7 @@ exports[`<RadioSimpleGroup /> snapshot should match snapshot with style 1`] = `
         style="border: 0px; clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
       >
         <input
+          aria-label="Some label"
           name="test-ID"
           tabindex="0"
           type="radio"


### PR DESCRIPTION
Make aria-label(ledby) required on RadioSimple and RadioSimpleGroup.

On RadioSimpleGroup, if a label prop is passed, useRadioGroup automatically links it to the group with aria-labelledby. No need to link them manually.