### PR TITLE
fix(MeetingRowContent): use grid layout to adapt different length

### DIFF
--- a/src/components/MeetingListItem/MeetingListItem.stories.tsx
+++ b/src/components/MeetingListItem/MeetingListItem.stories.tsx
@@ -307,12 +307,21 @@ Colors.parameters = {
     {
       buttonGroup: (
         <ButtonGroup spaced>
-          <ButtonHyperlink>Link</ButtonHyperlink>
+          <ButtonHyperlink>
+            Link for Lorem Ipsum is simply dummy text of the printing and typesetting industry.
+            Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an
+            unknown printer took a galley of type and scrambled it to make a type specimen book. It
+            has survived not only five centuries, but also the leap
+          </ButtonHyperlink>
         </ButtonGroup>
       ),
       children: (
         <Text type="body-primary" tagName="p">
           {MeetingMarker.AcceptedActive}
+          What is Lorem Ipsum? Lorem Ipsum is simply dummy text of the printing and typesetting
+          industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s,
+          when an unknown printer took a galley of type and scrambled it to make a type specimen
+          book. It has survived not only five centuries, but also the leap
         </Text>
       ),
       color: MeetingMarker.AcceptedActive,
@@ -327,6 +336,10 @@ Colors.parameters = {
       children: (
         <Text type="body-primary" tagName="p">
           {MeetingMarker.AcceptedInactive}
+          What is Lorem Ipsum? Lorem Ipsum is simply dummy text of the printing and typesetting
+          industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s,
+          when an unknown printer took a galley of type and scrambled it to make a type specimen
+          book. It has survived not only five centuries, but also the leap
         </Text>
       ),
       color: MeetingMarker.AcceptedInactive,
@@ -335,7 +348,12 @@ Colors.parameters = {
     {
       buttonGroup: (
         <ButtonGroup spaced>
-          <ButtonHyperlink>Link</ButtonHyperlink>
+          <ButtonHyperlink>
+            Link for Lorem Ipsum is simply dummy text of the printing and typesetting industry.
+            Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an
+            unknown printer took a galley of type and scrambled it to make a type specimen book. It
+            has survived not only five centuries, but also the leap
+          </ButtonHyperlink>
         </ButtonGroup>
       ),
       children: (

--- a/src/components/MeetingRowContent/MeetingRowContent.style.scss
+++ b/src/components/MeetingRowContent/MeetingRowContent.style.scss
@@ -79,6 +79,36 @@
   }
 }
 
+.md-meeting-list-item-wrapper {
+  display: grid;
+  grid-template-columns: 2rem auto auto;
+  grid-column-gap: 0.75rem;
+  justify-content: unset;
+
+  div[data-position='middle'] {
+    > * {
+      width: 100%;
+    }
+  }
+
+  div[data-position='end'] {
+    width: 100% !important;
+    justify-content: end;
+    justify-self: end;
+
+    .md-button-group-wrapper {
+      width: auto;
+      justify-content: end;
+    }
+
+    a {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+  }
+}
+
 .md-meeting-row-content-end-section {
   .md-button-group-wrapper > .md-icon-wrapper > svg {
     path {

--- a/src/components/MeetingRowContent/MeetingRowContent.style.scss
+++ b/src/components/MeetingRowContent/MeetingRowContent.style.scss
@@ -81,23 +81,26 @@
 
 .md-meeting-list-item-wrapper {
   display: grid;
-  grid-template-columns: 2rem auto auto;
-  grid-column-gap: 0.75rem;
+  grid-template-columns: max-content minmax(0, 3fr) minmax(0, 2fr);
   justify-content: unset;
 
   div[data-position='middle'] {
-    > * {
-      width: 100%;
-    }
+    width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   div[data-position='end'] {
-    width: 100% !important;
+    width: 100%;
+    display: flex;
     justify-content: end;
     justify-self: end;
+    flex-direction: column;
+    align-items: flex-end;
 
     .md-button-group-wrapper {
-      width: auto;
+      width: 100%;
       justify-content: end;
     }
 

--- a/src/components/MeetingRowContent/MeetingRowContent.style.scss
+++ b/src/components/MeetingRowContent/MeetingRowContent.style.scss
@@ -85,10 +85,13 @@
   justify-content: unset;
 
   div[data-position='middle'] {
-    width: 100%;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+
+    > * {
+      width: 100%;
+    }
   }
 
   div[data-position='end'] {
@@ -99,7 +102,7 @@
     flex-direction: column;
     align-items: flex-end;
 
-    .md-button-group-wrapper {
+    > * {
       width: 100%;
       justify-content: end;
     }


### PR DESCRIPTION
# Description
when the text in calendar list is too long, it will overlap.
*The full description of the changes made in this request.*
add grid layout to meeting-list-item to adapt different length
# Links
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-600759