### PR TITLE
feat(list): Non numeric item indexes

### DIFF
--- a/src/components/List/List.constants.ts
+++ b/src/components/List/List.constants.ts
@@ -4,7 +4,7 @@ const CLASS_PREFIX = 'md-list';
 
 const DEFAULTS = {
   ORIENTATION: 'vertical' as ListOrientation,
-  INITIAL_FOCUS: 0,
+  INITIAL_FOCUS_NOT_SET: null,
 };
 
 const STYLE = {

--- a/src/components/List/List.stories.tsx
+++ b/src/components/List/List.stories.tsx
@@ -35,7 +35,7 @@ import Badge from '../Badge';
 import Menu from '../Menu';
 import { Item } from '@react-stately/collections';
 import { AriaToolbar, AriaToolbarItem, ListItemBaseSection, MenuTrigger, SearchInput } from '..';
-import { omit } from 'lodash';
+import { omit, times } from 'lodash';
 import { ListRefObject } from './List.types';
 
 const TEST_LIST_SIZE = 30;
@@ -670,6 +670,30 @@ const DynamicListWithInitialFocus4 = Template<unknown>(DynamicListWithInitialFoc
   {}
 );
 
+const DynamicListGoesToZeroSizeWrapper = () => {
+  const [showItems, setShowItems] = useState(3);
+
+  useEffect(() => {
+    const handle = setInterval(() => {
+      setShowItems((old) => (old + 1) % 4);
+    }, 3000);
+
+    return () => clearInterval(handle);
+  });
+
+  return (
+    <List listSize={showItems}>
+      {times(showItems, (index) => (
+        <ListItemBase itemIndex={index} key={index}>
+          <ListItemBaseSection position="fill">Item {index}</ListItemBaseSection>
+        </ListItemBase>
+      ))}
+    </List>
+  );
+};
+
+const DynamicListGoesToZeroSize = Template<unknown>(DynamicListGoesToZeroSizeWrapper).bind({});
+
 const SingleItemListWrapper = () => {
   return (
     <List listSize={1}>
@@ -841,4 +865,5 @@ export {
   ListWithTextSelect,
   ListWithNonDefaultSetNextFocus,
   ListWithNonDefaultSetNextFocusVariableLength,
+  DynamicListGoesToZeroSize,
 };

--- a/src/components/List/List.stories.tsx
+++ b/src/components/List/List.stories.tsx
@@ -1,14 +1,6 @@
 /* eslint-disable react/no-multi-comp */
 /* eslint-disable react/display-name */
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  Dispatch,
-  SetStateAction,
-} from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { MultiTemplate, Template } from '../../storybook/helper.stories.templates';
 import { DocumentationPage } from '../../storybook/helper.stories.docs';
 import StyleDocs from '../../storybook/docs.stories.style.mdx';

--- a/src/components/List/List.stories.tsx
+++ b/src/components/List/List.stories.tsx
@@ -627,6 +627,49 @@ const DynamicListWithInitialFocus3 = Template<unknown>(DynamicListWithInitialFoc
   {}
 );
 
+const DynamicListWithInitialFocusWrapper4 = () => {
+  const [showMiddle, setShowMiddle] = useState(false);
+
+  useEffect(() => {
+    const handle = setInterval(() => {
+      setShowMiddle((old) => !old);
+    }, 3000);
+
+    return () => clearInterval(handle);
+  });
+
+  let offset = 0;
+  if (showMiddle) {
+    offset = 1;
+  }
+
+  return (
+    <List listSize={showMiddle ? 5 : 4}>
+      <ListItemBase itemIndex={0} key={0}>
+        Item 0
+      </ListItemBase>
+      <ListItemBase itemIndex={1} key={1}>
+        Item 1
+      </ListItemBase>
+      {showMiddle && (
+        <ListItemBase itemIndex={2} key={2}>
+          Item 2
+        </ListItemBase>
+      )}
+      <ListItemBase itemIndex={2 + offset} key={3}>
+        Item 3
+      </ListItemBase>
+      <ListItemBase itemIndex={3 + offset} key={4}>
+        Item 4
+      </ListItemBase>
+    </List>
+  );
+};
+
+const DynamicListWithInitialFocus4 = Template<unknown>(DynamicListWithInitialFocusWrapper4).bind(
+  {}
+);
+
 const SingleItemListWrapper = () => {
   return (
     <List listSize={1}>
@@ -793,6 +836,7 @@ export {
   DynamicListWithInitialFocus,
   DynamicListWithInitialFocus2,
   DynamicListWithInitialFocus3,
+  DynamicListWithInitialFocus4,
   SingleItemList,
   ListWithTextSelect,
   ListWithNonDefaultSetNextFocus,

--- a/src/components/List/List.stories.tsx
+++ b/src/components/List/List.stories.tsx
@@ -724,59 +724,6 @@ const ListWithTextSelectWrapper = () => {
 
 const ListWithTextSelect = Template<unknown>(ListWithTextSelectWrapper).bind({});
 
-const ListWithNonDefaultSetNextFocusWrapper = () => {
-  const itemIndexes: any[] = ['a', 'b', 'c'];
-
-  const setNextFocus = useCallback(
-    (
-      isBackward: boolean,
-      listSize: number,
-      currentFocus: number | string,
-      noLoop: boolean,
-      setFocus: Dispatch<SetStateAction<number>>
-    ) => {
-      const currentIndex = itemIndexes.indexOf(currentFocus);
-
-      let nextIndex: number;
-
-      if (isBackward) {
-        nextIndex = (listSize + currentIndex - 1) % listSize;
-
-        if (noLoop && nextIndex > currentIndex) {
-          return;
-        }
-      } else {
-        nextIndex = (listSize + currentIndex + 1) % listSize;
-
-        if (noLoop && nextIndex < currentIndex) {
-          return;
-        }
-      }
-
-      setFocus(itemIndexes[nextIndex]);
-    },
-    [itemIndexes]
-  );
-
-  return (
-    <List shouldFocusOnPress allItemIndexes={itemIndexes} setNextFocus={setNextFocus} listSize={3}>
-      <ListItemBase allowTextSelection itemIndex={itemIndexes[0]} key={0}>
-        Item 0
-      </ListItemBase>
-      <ListItemBase allowTextSelection itemIndex={itemIndexes[1]} key={1}>
-        Item 1
-      </ListItemBase>
-      <ListItemBase allowTextSelection itemIndex={itemIndexes[2]} key={2}>
-        Item 2
-      </ListItemBase>
-    </List>
-  );
-};
-
-const ListWithNonDefaultSetNextFocus = Template<unknown>(
-  ListWithNonDefaultSetNextFocusWrapper
-).bind({});
-
 const ListWithNonDefaultSetNextFocusVariableLengthWrapper = () => {
   const [itemIndices, setItemIndices] = useState<string[]>(['a', 'b', 'c']);
 
@@ -796,39 +743,8 @@ const ListWithNonDefaultSetNextFocusVariableLengthWrapper = () => {
     };
   }, []);
 
-  const setNextFocus = useCallback(
-    (
-      isBackward: boolean,
-      listSize: number,
-      currentFocus: number | string,
-      noLoop: boolean,
-      setFocus: Dispatch<SetStateAction<number | string>>
-    ) => {
-      const currentIndex = itemIndices.indexOf(currentFocus as string);
-
-      let nextIndex: number;
-
-      if (isBackward) {
-        nextIndex = (listSize + currentIndex - 1) % listSize;
-
-        if (noLoop && nextIndex > currentIndex) {
-          return;
-        }
-      } else {
-        nextIndex = (listSize + currentIndex + 1) % listSize;
-
-        if (noLoop && nextIndex < currentIndex) {
-          return;
-        }
-      }
-
-      setFocus(itemIndices[nextIndex]);
-    },
-    [itemIndices]
-  );
-
   return (
-    <List shouldFocusOnPress setNextFocus={setNextFocus} listSize={3} allItemIndexes={itemIndices}>
+    <List shouldFocusOnPress listSize={3} allItemIndexes={itemIndices}>
       {itemIndices.map((index) => {
         return (
           <ListItemBase allowTextSelection itemIndex={index} key={index}>
@@ -863,7 +779,6 @@ export {
   DynamicListWithInitialFocus4,
   SingleItemList,
   ListWithTextSelect,
-  ListWithNonDefaultSetNextFocus,
   ListWithNonDefaultSetNextFocusVariableLength,
   DynamicListGoesToZeroSize,
 };

--- a/src/components/List/List.stories.tsx
+++ b/src/components/List/List.stories.tsx
@@ -1,6 +1,14 @@
 /* eslint-disable react/no-multi-comp */
 /* eslint-disable react/display-name */
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  Dispatch,
+  SetStateAction,
+} from 'react';
 import { MultiTemplate, Template } from '../../storybook/helper.stories.templates';
 import { DocumentationPage } from '../../storybook/helper.stories.docs';
 import StyleDocs from '../../storybook/docs.stories.style.mdx';
@@ -649,6 +657,59 @@ const ListWithTextSelectWrapper = () => {
 
 const ListWithTextSelect = Template<unknown>(ListWithTextSelectWrapper).bind({});
 
+const ListWithNonDefaultSetNextFocusWrapper = () => {
+  const itemIndices: any[] = ['a', 'b', 'c'];
+
+  const setNextFocus = useCallback(
+    (
+      isBackward: boolean,
+      listSize: number,
+      currentFocus: number | string,
+      noLoop: boolean,
+      setFocus: Dispatch<SetStateAction<number>>
+    ) => {
+      const currentIndex = itemIndices.indexOf(currentFocus);
+
+      let nextIndex: number;
+
+      if (isBackward) {
+        nextIndex = (listSize + currentIndex - 1) % listSize;
+
+        if (noLoop && nextIndex > currentIndex) {
+          return;
+        }
+      } else {
+        nextIndex = (listSize + currentIndex + 1) % listSize;
+
+        if (noLoop && nextIndex < currentIndex) {
+          return;
+        }
+      }
+
+      setFocus(itemIndices[nextIndex]);
+    },
+    [itemIndices]
+  );
+
+  return (
+    <List shouldFocusOnPress setNextFocus={setNextFocus} listSize={3}>
+      <ListItemBase allowTextSelection itemIndex={itemIndices[0]} key={0}>
+        Item 0
+      </ListItemBase>
+      <ListItemBase allowTextSelection itemIndex={itemIndices[1]} key={1}>
+        Item 1
+      </ListItemBase>
+      <ListItemBase allowTextSelection itemIndex={itemIndices[2]} key={2}>
+        Item 2
+      </ListItemBase>
+    </List>
+  );
+};
+
+const ListWithNonDefaultSetNextFocus = Template<unknown>(
+  ListWithNonDefaultSetNextFocusWrapper
+).bind({});
+
 export {
   Example,
   Common,
@@ -667,4 +728,5 @@ export {
   DynamicListWithInitialFocus3,
   SingleItemList,
   ListWithTextSelect,
+  ListWithNonDefaultSetNextFocus,
 };

--- a/src/components/List/List.stories.tsx
+++ b/src/components/List/List.stories.tsx
@@ -710,6 +710,73 @@ const ListWithNonDefaultSetNextFocus = Template<unknown>(
   ListWithNonDefaultSetNextFocusWrapper
 ).bind({});
 
+const ListWithNonDefaultSetNextFocusVariableLengthWrapper = () => {
+  const [itemIndices, setItemIndices] = useState<string[]>(['a', 'b', 'c']);
+
+  useEffect(() => {
+    const handle = setInterval(() => {
+      setItemIndices((old) => {
+        if (old.length === 2) {
+          return [...old, 'c'];
+        } else {
+          return old.slice(0, 2);
+        }
+      });
+    }, 3000);
+
+    return () => {
+      clearTimeout(handle);
+    };
+  }, []);
+
+  const setNextFocus = useCallback(
+    (
+      isBackward: boolean,
+      listSize: number,
+      currentFocus: number | string,
+      noLoop: boolean,
+      setFocus: Dispatch<SetStateAction<number | string>>
+    ) => {
+      const currentIndex = itemIndices.indexOf(currentFocus as string);
+
+      let nextIndex: number;
+
+      if (isBackward) {
+        nextIndex = (listSize + currentIndex - 1) % listSize;
+
+        if (noLoop && nextIndex > currentIndex) {
+          return;
+        }
+      } else {
+        nextIndex = (listSize + currentIndex + 1) % listSize;
+
+        if (noLoop && nextIndex < currentIndex) {
+          return;
+        }
+      }
+
+      setFocus(itemIndices[nextIndex]);
+    },
+    [itemIndices]
+  );
+
+  return (
+    <List shouldFocusOnPress setNextFocus={setNextFocus} listSize={3} allItemIndexes={itemIndices}>
+      {itemIndices.map((index) => {
+        return (
+          <ListItemBase allowTextSelection itemIndex={index} key={index}>
+            <ListItemBaseSection position="fill">Item {index}</ListItemBaseSection>
+          </ListItemBase>
+        );
+      })}
+    </List>
+  );
+};
+
+const ListWithNonDefaultSetNextFocusVariableLength = Template<unknown>(
+  ListWithNonDefaultSetNextFocusVariableLengthWrapper
+).bind({});
+
 export {
   Example,
   Common,
@@ -729,4 +796,5 @@ export {
   SingleItemList,
   ListWithTextSelect,
   ListWithNonDefaultSetNextFocus,
+  ListWithNonDefaultSetNextFocusVariableLength,
 };

--- a/src/components/List/List.stories.tsx
+++ b/src/components/List/List.stories.tsx
@@ -658,7 +658,7 @@ const ListWithTextSelectWrapper = () => {
 const ListWithTextSelect = Template<unknown>(ListWithTextSelectWrapper).bind({});
 
 const ListWithNonDefaultSetNextFocusWrapper = () => {
-  const itemIndices: any[] = ['a', 'b', 'c'];
+  const itemIndexes: any[] = ['a', 'b', 'c'];
 
   const setNextFocus = useCallback(
     (
@@ -668,7 +668,7 @@ const ListWithNonDefaultSetNextFocusWrapper = () => {
       noLoop: boolean,
       setFocus: Dispatch<SetStateAction<number>>
     ) => {
-      const currentIndex = itemIndices.indexOf(currentFocus);
+      const currentIndex = itemIndexes.indexOf(currentFocus);
 
       let nextIndex: number;
 
@@ -686,20 +686,20 @@ const ListWithNonDefaultSetNextFocusWrapper = () => {
         }
       }
 
-      setFocus(itemIndices[nextIndex]);
+      setFocus(itemIndexes[nextIndex]);
     },
-    [itemIndices]
+    [itemIndexes]
   );
 
   return (
-    <List shouldFocusOnPress setNextFocus={setNextFocus} listSize={3}>
-      <ListItemBase allowTextSelection itemIndex={itemIndices[0]} key={0}>
+    <List shouldFocusOnPress allItemIndexes={itemIndexes} setNextFocus={setNextFocus} listSize={3}>
+      <ListItemBase allowTextSelection itemIndex={itemIndexes[0]} key={0}>
         Item 0
       </ListItemBase>
-      <ListItemBase allowTextSelection itemIndex={itemIndices[1]} key={1}>
+      <ListItemBase allowTextSelection itemIndex={itemIndexes[1]} key={1}>
         Item 1
       </ListItemBase>
-      <ListItemBase allowTextSelection itemIndex={itemIndices[2]} key={2}>
+      <ListItemBase allowTextSelection itemIndex={itemIndexes[2]} key={2}>
         Item 2
       </ListItemBase>
     </List>

--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -21,6 +21,7 @@ const List = forwardRef((props: Props, ref: RefObject<ListRefObject>) => {
     noLoop,
     orientation = DEFAULTS.ORIENTATION,
     initialFocus = DEFAULTS.INITIAL_FOCUS,
+    setNextFocus,
     ...rest
   } = props;
 
@@ -29,6 +30,7 @@ const List = forwardRef((props: Props, ref: RefObject<ListRefObject>) => {
     orientation,
     noLoop,
     initialFocus,
+    setNextFocus,
     contextProps: { shouldFocusOnPress, shouldItemFocusBeInset },
   });
 

--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -10,6 +10,7 @@ import { mergeProps } from '@react-aria/utils';
 
 const List = forwardRef((props: Props, ref: RefObject<ListRefObject>) => {
   const {
+    allItemIndexes,
     className,
     id,
     style,
@@ -20,13 +21,24 @@ const List = forwardRef((props: Props, ref: RefObject<ListRefObject>) => {
     shouldItemFocusBeInset,
     noLoop,
     orientation = DEFAULTS.ORIENTATION,
-    initialFocus = DEFAULTS.INITIAL_FOCUS,
+    initialFocus: propInitialFocus = DEFAULTS.INITIAL_FOCUS_NOT_SET,
     setNextFocus,
     ...rest
   } = props;
 
+  let initialFocus = propInitialFocus;
+
+  if (initialFocus === DEFAULTS.INITIAL_FOCUS_NOT_SET) {
+    if (allItemIndexes) {
+      initialFocus = allItemIndexes[0];
+    } else {
+      initialFocus = 0;
+    }
+  }
+
   const { keyboardProps, getContext, focusWithinProps } = useOrientationBasedKeyboardNavigation({
     listSize,
+    allItemIndexes,
     orientation,
     noLoop,
     initialFocus,

--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -7,6 +7,7 @@ import './List.style.scss';
 import { ListContext } from './List.utils';
 import useOrientationBasedKeyboardNavigation from '../../hooks/useOrientationBasedKeyboardNavigation';
 import { mergeProps } from '@react-aria/utils';
+import { ListItemBaseIndex } from '../ListItemBase/ListItemBase.types';
 
 const List = forwardRef((props: Props, ref: RefObject<ListRefObject>) => {
   const {
@@ -51,7 +52,7 @@ const List = forwardRef((props: Props, ref: RefObject<ListRefObject>) => {
   // Expose imperative methods
   useImperativeHandle(ref, () => ({
     listRef,
-    focusOnIndex: (index: number) => getContext()?.setCurrentFocus(index),
+    focusOnIndex: (index: ListItemBaseIndex) => getContext()?.setCurrentFocus(index),
     getCurrentFocusIndex: () => getContext()?.currentFocus,
   }));
 

--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -23,7 +23,6 @@ const List = forwardRef((props: Props, ref: RefObject<ListRefObject>) => {
     noLoop,
     orientation = DEFAULTS.ORIENTATION,
     initialFocus: propInitialFocus = DEFAULTS.INITIAL_FOCUS_NOT_SET,
-    setNextFocus,
     ...rest
   } = props;
 
@@ -43,7 +42,6 @@ const List = forwardRef((props: Props, ref: RefObject<ListRefObject>) => {
     orientation,
     noLoop,
     initialFocus,
-    setNextFocus,
     contextProps: { shouldFocusOnPress, shouldItemFocusBeInset },
   });
 

--- a/src/components/List/List.types.ts
+++ b/src/components/List/List.types.ts
@@ -1,4 +1,5 @@
 import { AriaRole, CSSProperties, Dispatch, ReactNode, SetStateAction } from 'react';
+import { ListItemBaseIndex } from '../ListItemBase/ListItemBase.types';
 
 export type ListOrientation = 'horizontal' | 'vertical';
 
@@ -64,7 +65,7 @@ export interface Props {
   /**
    * The index of the item that should be focused initially
    */
-  initialFocus?: number | string;
+  initialFocus?: ListItemBaseIndex;
 
   /**
    * Optional function to control the focus behavior when up/down keys are pressed
@@ -72,17 +73,22 @@ export interface Props {
   setNextFocus?: (
     isBackward: boolean,
     listSize: number,
-    currentFocus: number | string,
+    currentFocus: ListItemBaseIndex,
     noLoop: boolean,
-    setFocus: Dispatch<SetStateAction<number | string>>
+    setFocus: Dispatch<SetStateAction<ListItemBaseIndex>>
   ) => void;
+
+  /**
+   * The full list of item indexes to be displayed. This is necessary for non-numeric item indexes
+   */
+  allItemIndexes?: ListItemBaseIndex[];
 }
 
 export interface ListContextValue {
-  currentFocus?: number | string;
+  currentFocus?: ListItemBaseIndex;
   shouldFocusOnPress?: boolean;
   shouldItemFocusBeInset?: boolean;
-  setCurrentFocus?: Dispatch<SetStateAction<number | string>>;
+  setCurrentFocus?: Dispatch<SetStateAction<ListItemBaseIndex>>;
   listSize?: number;
   noLoop?: boolean;
   updateFocusBlocked?: boolean;
@@ -92,5 +98,5 @@ export interface ListContextValue {
 export interface ListRefObject {
   listRef: React.RefObject<HTMLUListElement>;
   focusOnIndex: (index: number) => void;
-  getCurrentFocusIndex: () => number | string;
+  getCurrentFocusIndex: () => ListItemBaseIndex;
 }

--- a/src/components/List/List.types.ts
+++ b/src/components/List/List.types.ts
@@ -64,14 +64,25 @@ export interface Props {
   /**
    * The index of the item that should be focused initially
    */
-  initialFocus?: number;
+  initialFocus?: number | string;
+
+  /**
+   * Optional function to control the focus behavior when up/down keys are pressed
+   */
+  setNextFocus?: (
+    isBackward: boolean,
+    listSize: number,
+    currentFocus: number | string,
+    noLoop: boolean,
+    setFocus: Dispatch<SetStateAction<number | string>>
+  ) => void;
 }
 
 export interface ListContextValue {
-  currentFocus?: number;
+  currentFocus?: number | string;
   shouldFocusOnPress?: boolean;
   shouldItemFocusBeInset?: boolean;
-  setCurrentFocus?: Dispatch<SetStateAction<number>>;
+  setCurrentFocus?: Dispatch<SetStateAction<number | string>>;
   listSize?: number;
   noLoop?: boolean;
   updateFocusBlocked?: boolean;
@@ -81,5 +92,5 @@ export interface ListContextValue {
 export interface ListRefObject {
   listRef: React.RefObject<HTMLUListElement>;
   focusOnIndex: (index: number) => void;
-  getCurrentFocusIndex: () => number;
+  getCurrentFocusIndex: () => number | string;
 }

--- a/src/components/List/List.types.ts
+++ b/src/components/List/List.types.ts
@@ -68,18 +68,6 @@ export interface Props {
   initialFocus?: ListItemBaseIndex;
 
   /**
-   * Optional function to control the focus behavior when up/down keys are pressed
-   */
-  setNextFocus?: (
-    isBackward: boolean,
-    listSize: number,
-    currentFocus: ListItemBaseIndex,
-    noLoop: boolean,
-    setFocus: Dispatch<SetStateAction<ListItemBaseIndex>>,
-    allItemIndexes?: ListItemBaseIndex[]
-  ) => void;
-
-  /**
    * The full list of item indexes to be displayed. This is necessary for non-numeric item indexes
    */
   allItemIndexes?: ListItemBaseIndex[];

--- a/src/components/List/List.types.ts
+++ b/src/components/List/List.types.ts
@@ -75,7 +75,8 @@ export interface Props {
     listSize: number,
     currentFocus: ListItemBaseIndex,
     noLoop: boolean,
-    setFocus: Dispatch<SetStateAction<ListItemBaseIndex>>
+    setFocus: Dispatch<SetStateAction<ListItemBaseIndex>>,
+    allItemIndexes?: ListItemBaseIndex[]
   ) => void;
 
   /**
@@ -97,6 +98,6 @@ export interface ListContextValue {
 }
 export interface ListRefObject {
   listRef: React.RefObject<HTMLUListElement>;
-  focusOnIndex: (index: number) => void;
+  focusOnIndex: (index: ListItemBaseIndex) => void;
   getCurrentFocusIndex: () => ListItemBaseIndex;
 }

--- a/src/components/List/List.unit.test.tsx
+++ b/src/components/List/List.unit.test.tsx
@@ -985,53 +985,16 @@ describe('<List />', () => {
     );
 
     it.each([
-      { indexes: [0, 1, 2], useItemIndexes: true, expectedNextFocus: 'list-item-0' },
+      { indexes: [0, 1, 2], useItemIndexes: true, expectedNextFocus: 'list-item-1' },
       { indexes: [0, 1, 2], useItemIndexes: false },
-      { indexes: ['a', 'b', 'c'], useItemIndexes: true, expectedNextFocus: 'list-item-0' },
-      {
-        indexes: ['a', 'b', 'c'],
-        useItemIndexes: true,
-        expectedNextFocus: 'list-item-1',
-        setNextFocus: (isBackward, listSize, currentFocus, noLoop, setFocus, allItemIndexes) => {
-          if (isBackward === null) {
-            // ['a', 'b', 'c'] represents the full list as it was when the list was first rendered
-            // becasue isBackward is null, we know the currentFocus is not in the current allItemIndexes
-            const originalAllItemIndexes = ['a', 'b', 'c'];
-
-            const currentIndex = ['a', 'b', 'c'].indexOf(currentFocus);
-
-            // get the positions of allItemIndex in the original list
-            const allItemIndexesPositions = allItemIndexes.map((itemIndex) =>
-              originalAllItemIndexes.indexOf(itemIndex)
-            );
-
-            // find the difference between these positions and the current index
-            const differences = allItemIndexesPositions.map((position) =>
-              Math.abs(position - currentIndex)
-            );
-
-            // pick the smallest difference as the new index. If there is more than one, prefer the last one
-            const nextIndex = allItemIndexes[differences.lastIndexOf(Math.min(...differences))];
-
-            setFocus(nextIndex);
-
-            return;
-          }
-
-          defaultSetNextFocus(isBackward, listSize, currentFocus, noLoop, setFocus, allItemIndexes);
-        },
-      },
+      { indexes: ['a', 'b', 'c'], useItemIndexes: true, expectedNextFocus: 'list-item-1' },
     ])(
       'should retain focus when the last item has focus and is removed from list',
-      async ({ indexes, useItemIndexes, expectedNextFocus, setNextFocus }) => {
+      async ({ indexes, useItemIndexes, expectedNextFocus }) => {
         const user = userEvent.setup();
 
         const { getByTestId, rerender } = render(
-          <List
-            allItemIndexes={useItemIndexes ? indexes : undefined}
-            listSize={3}
-            setNextFocus={setNextFocus ? setNextFocus : undefined}
-          >
+          <List allItemIndexes={useItemIndexes ? indexes : undefined} listSize={3}>
             <ListItemBase data-testid="list-item-0" key="0" itemIndex={indexes[0]}>
               0
             </ListItemBase>
@@ -1057,11 +1020,7 @@ describe('<List />', () => {
         expect(getByTestId('list-item-2')).toHaveFocus();
 
         rerender(
-          <List
-            allItemIndexes={useItemIndexes ? indexes.slice(0, 2) : undefined}
-            listSize={2}
-            setNextFocus={setNextFocus ? setNextFocus : undefined}
-          >
+          <List allItemIndexes={useItemIndexes ? indexes.slice(0, 2) : undefined} listSize={2}>
             <ListItemBase data-testid="list-item-0" key="0" itemIndex={indexes[0]}>
               0
             </ListItemBase>

--- a/src/components/List/List.unit.test.tsx
+++ b/src/components/List/List.unit.test.tsx
@@ -755,231 +755,278 @@ describe('<List />', () => {
       expect(document.body).toHaveFocus();
     });
 
-    it('should retain focus when the first item is removed from list', async () => {
-      const user = userEvent.setup();
+    it.each([
+      { indexes: [0, 1, 2], useItemIndexes: true },
+      { indexes: [0, 1, 2], useItemIndexes: false },
+      { indexes: ['a', 'b', 'c'], useItemIndexes: true },
+    ])(
+      'should retain focus when the first item is removed from list',
+      async ({ indexes, useItemIndexes }) => {
+        const user = userEvent.setup();
 
-      const { getByTestId, rerender } = render(
-        <List listSize={3}>
-          <ListItemBase data-testid="list-item-0" key="0" itemIndex={0}>
-            0
-          </ListItemBase>
-          <ListItemBase id="test" data-testid="list-item-1" key="1" itemIndex={1}>
-            1
-          </ListItemBase>
-          <ListItemBase data-testid="list-item-2" key="2" itemIndex={2}>
-            2
-          </ListItemBase>
-        </List>
-      );
+        const { getByTestId, rerender } = render(
+          <List allItemIndexes={useItemIndexes ? indexes : undefined} listSize={3}>
+            <ListItemBase data-testid="list-item-0" key="0" itemIndex={indexes[0]}>
+              0
+            </ListItemBase>
+            <ListItemBase id="test" data-testid="list-item-1" key="1" itemIndex={indexes[1]}>
+              1
+            </ListItemBase>
+            <ListItemBase data-testid="list-item-2" key="2" itemIndex={indexes[2]}>
+              2
+            </ListItemBase>
+          </List>
+        );
 
-      expect(document.body).toHaveFocus();
+        expect(document.body).toHaveFocus();
 
-      await user.tab();
+        await user.tab();
 
-      expect(getByTestId('list-item-0')).toHaveFocus();
+        expect(getByTestId('list-item-0')).toHaveFocus();
 
-      rerender(
-        <List listSize={2}>
-          <ListItemBase id="test" data-testid="list-item-1" key="1" itemIndex={0}>
-            1
-          </ListItemBase>
-          <ListItemBase data-testid="list-item-2" key="2" itemIndex={1}>
-            2
-          </ListItemBase>
-        </List>
-      );
+        indexes.shift();
 
-      expect(getByTestId('list-item-1')).toHaveFocus();
-    });
+        if (!useItemIndexes) {
+          indexes = indexes.map((i: any) => i - 1);
+        }
 
-    it('should retain focus when the an item before the focused item is removed from list', async () => {
-      const user = userEvent.setup();
+        rerender(
+          <List allItemIndexes={useItemIndexes ? [...indexes] : undefined} listSize={2}>
+            <ListItemBase id="test" data-testid="list-item-1" key="1" itemIndex={indexes[0]}>
+              1
+            </ListItemBase>
+            <ListItemBase data-testid="list-item-2" key="2" itemIndex={indexes[1]}>
+              2
+            </ListItemBase>
+          </List>
+        );
 
-      const { getByTestId, rerender } = render(
-        <List listSize={3}>
-          <ListItemBase data-testid="list-item-0" key="0" itemIndex={0}>
-            0
-          </ListItemBase>
-          <ListItemBase id="test" data-testid="list-item-1" key="1" itemIndex={1}>
-            1
-          </ListItemBase>
-          <ListItemBase data-testid="list-item-2" key="2" itemIndex={2}>
-            2
-          </ListItemBase>
-        </List>
-      );
+        expect(getByTestId('list-item-1')).toHaveFocus();
+      }
+    );
 
-      expect(document.body).toHaveFocus();
+    it.each([
+      { indexes: [0, 1, 2], useItemIndexes: true },
+      { indexes: [0, 1, 2], useItemIndexes: false },
+      { indexes: ['a', 'b', 'c'], useItemIndexes: true },
+    ])(
+      'should retain focus when the an item before the focused item is removed from list',
+      async ({ indexes, useItemIndexes }) => {
+        const user = userEvent.setup();
 
-      await user.tab();
+        const { getByTestId, rerender } = render(
+          <List allItemIndexes={useItemIndexes ? indexes : undefined} listSize={3}>
+            <ListItemBase data-testid="list-item-0" key="0" itemIndex={indexes[0]}>
+              0
+            </ListItemBase>
+            <ListItemBase id="test" data-testid="list-item-1" key="1" itemIndex={indexes[1]}>
+              1
+            </ListItemBase>
+            <ListItemBase data-testid="list-item-2" key="2" itemIndex={indexes[2]}>
+              2
+            </ListItemBase>
+          </List>
+        );
 
-      expect(getByTestId('list-item-0')).toHaveFocus();
+        expect(document.body).toHaveFocus();
 
-      await user.keyboard('{ArrowDown}');
+        await user.tab();
 
-      expect(getByTestId('list-item-1')).toHaveFocus();
+        expect(getByTestId('list-item-0')).toHaveFocus();
 
-      rerender(
-        <List listSize={2}>
-          <ListItemBase id="test" data-testid="list-item-1" key="1" itemIndex={0}>
-            1
-          </ListItemBase>
-          <ListItemBase data-testid="list-item-2" key="2" itemIndex={1}>
-            2
-          </ListItemBase>
-        </List>
-      );
+        await user.keyboard('{ArrowDown}');
 
-      expect(getByTestId('list-item-1')).toHaveFocus();
-    });
+        expect(getByTestId('list-item-1')).toHaveFocus();
 
-    it('should retain focus when the last item has focus and is removed from list', async () => {
-      const user = userEvent.setup();
+        rerender(
+          <List allItemIndexes={useItemIndexes ? indexes.slice(1, 3) : undefined} listSize={2}>
+            <ListItemBase id="test" data-testid="list-item-1" key="1" itemIndex={indexes[1]}>
+              1
+            </ListItemBase>
+            <ListItemBase data-testid="list-item-2" key="2" itemIndex={indexes[2]}>
+              2
+            </ListItemBase>
+          </List>
+        );
 
-      const { getByTestId, rerender } = render(
-        <List listSize={3}>
-          <ListItemBase data-testid="list-item-0" key="0" itemIndex={0}>
-            0
-          </ListItemBase>
-          <ListItemBase data-testid="list-item-1" key="1" itemIndex={1}>
-            1
-          </ListItemBase>
-          <ListItemBase data-testid="list-item-2" key="2" itemIndex={2}>
-            2
-          </ListItemBase>
-        </List>
-      );
+        expect(getByTestId('list-item-1')).toHaveFocus();
+      }
+    );
 
-      await user.tab();
+    it.each([
+      { indexes: [0, 1, 2], useItemIndexes: true, expectedNextFocus: 'list-item-0' },
+      { indexes: [0, 1, 2], useItemIndexes: false },
+      { indexes: ['a', 'b', 'c'], useItemIndexes: true, expectedNextFocus: 'list-item-0' },
+    ])(
+      'should retain focus when the last item has focus and is removed from list',
+      async ({ indexes, useItemIndexes, expectedNextFocus }) => {
+        const user = userEvent.setup();
 
-      expect(getByTestId('list-item-0')).toHaveFocus();
+        const { getByTestId, rerender } = render(
+          <List allItemIndexes={useItemIndexes ? indexes : undefined} listSize={3}>
+            <ListItemBase data-testid="list-item-0" key="0" itemIndex={indexes[0]}>
+              0
+            </ListItemBase>
+            <ListItemBase data-testid="list-item-1" key="1" itemIndex={indexes[1]}>
+              1
+            </ListItemBase>
+            <ListItemBase data-testid="list-item-2" key="2" itemIndex={indexes[2]}>
+              2
+            </ListItemBase>
+          </List>
+        );
 
-      await user.keyboard('{ArrowDown}');
+        await user.tab();
 
-      expect(getByTestId('list-item-1')).toHaveFocus();
+        expect(getByTestId('list-item-0')).toHaveFocus();
 
-      await user.keyboard('{ArrowDown}');
+        await user.keyboard('{ArrowDown}');
 
-      expect(getByTestId('list-item-2')).toHaveFocus();
+        expect(getByTestId('list-item-1')).toHaveFocus();
 
-      rerender(
-        <List listSize={2}>
-          <ListItemBase data-testid="list-item-0" key="0" itemIndex={0}>
-            0
-          </ListItemBase>
-          <ListItemBase data-testid="list-item-1" key="1" itemIndex={1}>
-            1
-          </ListItemBase>
-        </List>
-      );
+        await user.keyboard('{ArrowDown}');
 
-      expect(getByTestId('list-item-1')).toHaveFocus();
-    });
+        expect(getByTestId('list-item-2')).toHaveFocus();
 
-    it('should not autofocus when the last item is removed from the list', async () => {
-      const { rerender } = render(
-        <List listSize={3}>
-          <ListItemBase data-testid="list-item-0" key="0" itemIndex={0}>
-            0
-          </ListItemBase>
-          <ListItemBase data-testid="list-item-1" key="1" itemIndex={1}>
-            1
-          </ListItemBase>
-          <ListItemBase data-testid="list-item-2" key="2" itemIndex={2}>
-            2
-          </ListItemBase>
-        </List>
-      );
+        rerender(
+          <List allItemIndexes={useItemIndexes ? indexes.slice(0, 2) : undefined} listSize={2}>
+            <ListItemBase data-testid="list-item-0" key="0" itemIndex={indexes[0]}>
+              0
+            </ListItemBase>
+            <ListItemBase data-testid="list-item-1" key="1" itemIndex={indexes[1]}>
+              1
+            </ListItemBase>
+          </List>
+        );
 
-      expect(document.body).toHaveFocus();
+        expect(getByTestId(expectedNextFocus ?? 'list-item-1')).toHaveFocus();
+      }
+    );
 
-      rerender(
-        <List listSize={2}>
-          <ListItemBase data-testid="list-item-0" key="0" itemIndex={0}>
-            0
-          </ListItemBase>
-          <ListItemBase data-testid="list-item-1" key="1" itemIndex={1}>
-            1
-          </ListItemBase>
-        </List>
-      );
+    it.each([
+      { indexes: [0, 1, 2], useItemIndexes: true },
+      { indexes: [0, 1, 2], useItemIndexes: false },
+      { indexes: ['a', 'b', 'c'], useItemIndexes: true },
+    ])(
+      'should not autofocus when the last item is removed from the list',
+      async ({ indexes, useItemIndexes }) => {
+        const { rerender } = render(
+          <List allItemIndexes={useItemIndexes ? indexes : undefined} listSize={3}>
+            <ListItemBase data-testid="list-item-0" key="0" itemIndex={indexes[0]}>
+              0
+            </ListItemBase>
+            <ListItemBase data-testid="list-item-1" key="1" itemIndex={indexes[1]}>
+              1
+            </ListItemBase>
+            <ListItemBase data-testid="list-item-2" key="2" itemIndex={indexes[2]}>
+              2
+            </ListItemBase>
+          </List>
+        );
 
-      expect(document.body).toHaveFocus();
-    });
+        expect(document.body).toHaveFocus();
 
-    it('should retain focus when a middle focused item is removed from list', async () => {
-      const user = userEvent.setup();
+        rerender(
+          <List allItemIndexes={useItemIndexes ? indexes : undefined} listSize={2}>
+            <ListItemBase data-testid="list-item-0" key="0" itemIndex={indexes[0]}>
+              0
+            </ListItemBase>
+            <ListItemBase data-testid="list-item-1" key="1" itemIndex={indexes[1]}>
+              1
+            </ListItemBase>
+          </List>
+        );
 
-      const { getByTestId, rerender } = render(
-        <List listSize={3}>
-          <ListItemBase data-testid="list-item-0" key="0" itemIndex={0}>
-            0
-          </ListItemBase>
-          <ListItemBase data-testid="list-item-1" key="1" itemIndex={1}>
-            1
-          </ListItemBase>
-          <ListItemBase data-testid="list-item-2" key="2" itemIndex={2}>
-            2
-          </ListItemBase>
-        </List>
-      );
+        expect(document.body).toHaveFocus();
+      }
+    );
 
-      await user.tab();
+    it.each([
+      { indexes: [0, 1, 2], useItemIndexes: true },
+      { indexes: [0, 1, 2], useItemIndexes: false },
+      { indexes: ['a', 'b', 'c'], useItemIndexes: true },
+    ])(
+      'should retain focus when a middle focused item is removed from list',
+      async ({ indexes, useItemIndexes }) => {
+        const user = userEvent.setup();
 
-      expect(getByTestId('list-item-0')).toHaveFocus();
+        const { getByTestId, rerender } = render(
+          <List allItemIndexes={useItemIndexes ? indexes : undefined} listSize={3}>
+            <ListItemBase data-testid="list-item-0" key="0" itemIndex={indexes[0]}>
+              0
+            </ListItemBase>
+            <ListItemBase data-testid="list-item-1" key="1" itemIndex={indexes[1]}>
+              1
+            </ListItemBase>
+            <ListItemBase data-testid="list-item-2" key="2" itemIndex={indexes[2]}>
+              2
+            </ListItemBase>
+          </List>
+        );
 
-      await user.keyboard('{ArrowDown}');
+        await user.tab();
 
-      expect(getByTestId('list-item-1')).toHaveFocus();
+        expect(getByTestId('list-item-0')).toHaveFocus();
 
-      rerender(
-        <List listSize={2}>
-          <ListItemBase data-testid="list-item-0" key="0" itemIndex={0}>
-            0
-          </ListItemBase>
-          <ListItemBase data-testid="list-item-2" key="2" itemIndex={1}>
-            2
-          </ListItemBase>
-        </List>
-      );
+        await user.keyboard('{ArrowDown}');
 
-      expect(getByTestId('list-item-2')).toHaveFocus();
-    });
+        expect(getByTestId('list-item-1')).toHaveFocus();
 
-    it('should focus as expected when more items are added before tabbing to the list', async () => {
-      const user = userEvent.setup();
+        rerender(
+          <List allItemIndexes={indexes} listSize={2}>
+            <ListItemBase data-testid="list-item-0" key="0" itemIndex={indexes[0]}>
+              0
+            </ListItemBase>
+            <ListItemBase data-testid="list-item-2" key="2" itemIndex={indexes[1]}>
+              2
+            </ListItemBase>
+          </List>
+        );
 
-      const { getByTestId, rerender } = render(
-        <List listSize={2}>
-          <ListItemBase data-testid="list-item-1" key="1" itemIndex={1}>
-            1
-          </ListItemBase>
-          <ListItemBase data-testid="list-item-2" key="2" itemIndex={2}>
-            2
-          </ListItemBase>
-        </List>
-      );
+        expect(getByTestId('list-item-2')).toHaveFocus();
+      }
+    );
 
-      expect(document.body).toHaveFocus();
+    it.each([
+      { indexes: [0, 1, 2], useItemIndexes: false },
+      { indexes: ['a', 'b', 'c'], useItemIndexes: true },
+    ])(
+      'should focus as expected when more items are added before tabbing to the list',
+      async ({ indexes, useItemIndexes }) => {
+        const user = userEvent.setup();
 
-      rerender(
-        <List listSize={3}>
-          <ListItemBase data-testid="list-item-0" key="0" itemIndex={0}>
-            0
-          </ListItemBase>
-          <ListItemBase data-testid="list-item-1" key="1" itemIndex={1}>
-            1
-          </ListItemBase>
-          <ListItemBase data-testid="list-item-2" key="2" itemIndex={1}>
-            2
-          </ListItemBase>
-        </List>
-      );
+        const { getByTestId, rerender } = render(
+          <List allItemIndexes={useItemIndexes ? indexes : undefined} listSize={2}>
+            <ListItemBase data-testid="list-item-1" key="1" itemIndex={indexes[1]}>
+              1
+            </ListItemBase>
+            <ListItemBase data-testid="list-item-2" key="2" itemIndex={indexes[2]}>
+              2
+            </ListItemBase>
+          </List>
+        );
 
-      await user.tab();
+        expect(document.body).toHaveFocus();
 
-      expect(getByTestId('list-item-0')).toHaveFocus();
-    });
+        rerender(
+          <List allItemIndexes={useItemIndexes ? indexes : undefined} listSize={3}>
+            <ListItemBase data-testid="list-item-0" key="0" itemIndex={indexes[0]}>
+              0
+            </ListItemBase>
+            <ListItemBase data-testid="list-item-1" key="1" itemIndex={indexes[1]}>
+              1
+            </ListItemBase>
+            <ListItemBase data-testid="list-item-2" key="2" itemIndex={indexes[2]}>
+              2
+            </ListItemBase>
+          </List>
+        );
+
+        await user.tab();
+
+        expect(getByTestId('list-item-0')).toHaveFocus();
+      }
+    );
 
     it('should handle text selection', async () => {
       const user = userEvent.setup();

--- a/src/components/List/List.unit.test.tsx
+++ b/src/components/List/List.unit.test.tsx
@@ -16,7 +16,6 @@ import ButtonPill from '../ButtonPill';
 import Menu from '../Menu';
 import { Item } from '@react-stately/collections';
 import { ListRefObject } from './List.types';
-import { setNextFocus as defaultSetNextFocus } from './List.utils';
 
 describe('<List />', () => {
   const commonProps = {

--- a/src/components/List/List.unit.test.tsx
+++ b/src/components/List/List.unit.test.tsx
@@ -927,7 +927,7 @@ describe('<List />', () => {
           <List allItemIndexes={useItemIndexes ? initialIndexes : undefined} listSize={3}>
             <ListItemBase
               data-testid="list-item-0"
-              key={indexesEnd[0]}
+              key={initialIndexes[0]}
               itemIndex={initialIndexes[0]}
             >
               0
@@ -935,14 +935,14 @@ describe('<List />', () => {
             <ListItemBase
               id="test"
               data-testid="list-item-1"
-              key={indexesEnd[1]}
+              key={initialIndexes[1]}
               itemIndex={initialIndexes[1]}
             >
               1
             </ListItemBase>
             <ListItemBase
               data-testid="list-item-2"
-              key={indexesEnd[2]}
+              key={initialIndexes[2]}
               itemIndex={initialIndexes[2]}
             >
               2
@@ -965,12 +965,16 @@ describe('<List />', () => {
             <ListItemBase
               id="test"
               data-testid="list-item-1"
-              key={indexesEnd[0]}
+              key={initialIndexes[1]}
               itemIndex={indexesEnd[0]}
             >
               1
             </ListItemBase>
-            <ListItemBase data-testid="list-item-2" key={indexesEnd[1]} itemIndex={indexesEnd[1]}>
+            <ListItemBase
+              data-testid="list-item-2"
+              key={initialIndexes[2]}
+              itemIndex={indexesEnd[1]}
+            >
               2
             </ListItemBase>
           </List>

--- a/src/components/List/List.unit.test.tsx
+++ b/src/components/List/List.unit.test.tsx
@@ -16,6 +16,7 @@ import ButtonPill from '../ButtonPill';
 import Menu from '../Menu';
 import { Item } from '@react-stately/collections';
 import { ListRefObject } from './List.types';
+import { setNextFocus as defaultSetNextFocus } from './List.utils';
 
 describe('<List />', () => {
   const commonProps = {
@@ -224,51 +225,58 @@ describe('<List />', () => {
       expect(keyDownHandler).toHaveBeenCalled();
     });
 
-    it('should handle up/down arrow keys correctly for vertical lists', async () => {
-      expect.assertions(8);
-      const user = userEvent.setup();
+    it.each([
+      { indexes: [0, 1, 2], useItemIndexes: true },
+      { indexes: [0, 1, 2], useItemIndexes: false },
+      { indexes: ['a', 'b', 'c'], useItemIndexes: true },
+    ])(
+      'should handle up/down arrow keys correctly for vertical lists',
+      async ({ useItemIndexes, indexes }) => {
+        expect.assertions(8);
+        const user = userEvent.setup();
 
-      const { getAllByRole } = render(
-        <List listSize={3}>
-          <ListItemBase key="0" itemIndex={0}>
-            ListItemBase 1
-          </ListItemBase>
-          <ListItemBase key="1" itemIndex={1}>
-            ListItemBase 2
-          </ListItemBase>
-          <ListItemBase key="2" itemIndex={2}>
-            ListItemBase 3
-          </ListItemBase>
-        </List>
-      );
+        const { getAllByRole } = render(
+          <List allItemIndexes={useItemIndexes ? indexes : undefined} listSize={3}>
+            <ListItemBase key="0" itemIndex={indexes[0]}>
+              ListItemBase 1
+            </ListItemBase>
+            <ListItemBase key="1" itemIndex={indexes[1]}>
+              ListItemBase 2
+            </ListItemBase>
+            <ListItemBase key="2" itemIndex={indexes[2]}>
+              ListItemBase 3
+            </ListItemBase>
+          </List>
+        );
 
-      const listItems = getAllByRole('listitem');
+        const listItems = getAllByRole('listitem');
 
-      await user.tab();
+        await user.tab();
 
-      expect(listItems[0]).toHaveFocus();
+        expect(listItems[0]).toHaveFocus();
 
-      await user.keyboard('{ArrowDown}');
-      expect(listItems[1]).toHaveFocus();
+        await user.keyboard('{ArrowDown}');
+        expect(listItems[1]).toHaveFocus();
 
-      await user.keyboard('{ArrowDown}');
-      expect(listItems[2]).toHaveFocus();
+        await user.keyboard('{ArrowDown}');
+        expect(listItems[2]).toHaveFocus();
 
-      await user.keyboard('{ArrowDown}');
-      expect(listItems[0]).toHaveFocus();
+        await user.keyboard('{ArrowDown}');
+        expect(listItems[0]).toHaveFocus();
 
-      await user.keyboard('{ArrowUp}');
-      expect(listItems[2]).toHaveFocus();
+        await user.keyboard('{ArrowUp}');
+        expect(listItems[2]).toHaveFocus();
 
-      await user.keyboard('{ArrowUp}');
-      expect(listItems[1]).toHaveFocus();
+        await user.keyboard('{ArrowUp}');
+        expect(listItems[1]).toHaveFocus();
 
-      await user.keyboard('{ArrowUp}');
-      expect(listItems[0]).toHaveFocus();
+        await user.keyboard('{ArrowUp}');
+        expect(listItems[0]).toHaveFocus();
 
-      await user.keyboard('{ArrowUp}');
-      expect(listItems[2]).toHaveFocus();
-    });
+        await user.keyboard('{ArrowUp}');
+        expect(listItems[2]).toHaveFocus();
+      }
+    );
 
     it('is vertically oriented by default', async () => {
       expect.assertions(3);
@@ -301,42 +309,54 @@ describe('<List />', () => {
       expect(listItems[0]).toHaveFocus();
     });
 
-    it('should handle up/down arrow keys correctly - no loop for vertical lists', async () => {
-      expect.assertions(5);
-      const user = userEvent.setup();
+    it.each([
+      { indexes: [0, 1, 2], useItemIndexes: true },
+      { indexes: [0, 1, 2], useItemIndexes: false },
+      { indexes: ['a', 'b', 'c'], useItemIndexes: true },
+    ])(
+      'should handle up/down arrow keys correctly - no loop for vertical lists',
+      async ({ useItemIndexes, indexes }) => {
+        expect.assertions(5);
+        const user = userEvent.setup();
 
-      const { getAllByRole } = render(
-        <List listSize={3} noLoop orientation="vertical">
-          <ListItemBase key="0" itemIndex={0}>
-            ListItemBase 1
-          </ListItemBase>
-          <ListItemBase key="1" itemIndex={1}>
-            ListItemBase 2
-          </ListItemBase>
-          <ListItemBase key="2" itemIndex={2}>
-            ListItemBase 3
-          </ListItemBase>
-        </List>
-      );
+        const { getAllByRole } = render(
+          <List
+            allItemIndexes={useItemIndexes ? indexes : undefined}
+            listSize={3}
+            noLoop
+            orientation="vertical"
+          >
+            <ListItemBase key="0" itemIndex={indexes[0]}>
+              ListItemBase 1
+            </ListItemBase>
+            <ListItemBase key="1" itemIndex={indexes[1]}>
+              ListItemBase 2
+            </ListItemBase>
+            <ListItemBase key="2" itemIndex={indexes[2]}>
+              ListItemBase 3
+            </ListItemBase>
+          </List>
+        );
 
-      const listItems = getAllByRole('listitem');
+        const listItems = getAllByRole('listitem');
 
-      await user.tab();
+        await user.tab();
 
-      expect(listItems[0]).toHaveFocus();
+        expect(listItems[0]).toHaveFocus();
 
-      await user.keyboard('{ArrowUp}');
-      expect(listItems[0]).toHaveFocus();
+        await user.keyboard('{ArrowUp}');
+        expect(listItems[0]).toHaveFocus();
 
-      await user.keyboard('{ArrowDown}');
-      expect(listItems[1]).toHaveFocus();
+        await user.keyboard('{ArrowDown}');
+        expect(listItems[1]).toHaveFocus();
 
-      await user.keyboard('{ArrowDown}');
-      expect(listItems[2]).toHaveFocus();
+        await user.keyboard('{ArrowDown}');
+        expect(listItems[2]).toHaveFocus();
 
-      await user.keyboard('{ArrowDown}');
-      expect(listItems[2]).toHaveFocus();
-    });
+        await user.keyboard('{ArrowDown}');
+        expect(listItems[2]).toHaveFocus();
+      }
+    );
 
     it('should handle left/right arrow keys correctly for horizontal lists', async () => {
       expect.assertions(8);
@@ -561,88 +581,107 @@ describe('<List />', () => {
       expect(document.body).toHaveFocus();
     });
 
-    it('should focus programmatically on the specified index', async () => {
-      expect.assertions(4);
-      const user = userEvent.setup();
+    it.each([
+      { indexes: [0, 1, 2], useItemIndexes: true },
+      { indexes: [0, 1, 2], useItemIndexes: false },
+      { indexes: ['a', 'b', 'c'], useItemIndexes: true },
+    ])(
+      'should focus programmatically on the specified index',
+      async ({ useItemIndexes, indexes }) => {
+        expect.assertions(4);
+        const user = userEvent.setup();
 
-      const ProgrammaticList = () => {
-        const listRef = useRef<ListRefObject>(null);
+        const ProgrammaticList = () => {
+          const listRef = useRef<ListRefObject>(null);
 
-        return (
-          <>
-            <button
-              onClick={() => {
-                listRef.current.focusOnIndex(0);
-              }}
-            >
-              focus on 0
-            </button>
-            <button
-              onClick={() => {
-                listRef.current.focusOnIndex(1);
-              }}
-            >
-              focus on 1
-            </button>
-            <button
-              onClick={() => {
-                listRef.current.focusOnIndex(2);
-              }}
-            >
-              focus on 2
-            </button>
-            <List listSize={3} ref={listRef}>
-              <ListItemBase key="0" itemIndex={0}>
-                <p>list item 1</p>
-              </ListItemBase>
-              <ListItemBase key="1" itemIndex={1}>
-                <p>list item 2</p>
-              </ListItemBase>
-              <ListItemBase key="2" itemIndex={2}>
-                <p>list item 3</p>
-              </ListItemBase>
-            </List>
-          </>
-        );
-      };
+          return (
+            <>
+              <button
+                onClick={() => {
+                  listRef.current.focusOnIndex(indexes[0]);
+                }}
+              >
+                focus on 0
+              </button>
+              <button
+                onClick={() => {
+                  listRef.current.focusOnIndex(indexes[1]);
+                }}
+              >
+                focus on 1
+              </button>
+              <button
+                onClick={() => {
+                  listRef.current.focusOnIndex(indexes[2]);
+                }}
+              >
+                focus on 2
+              </button>
+              <List
+                allItemIndexes={useItemIndexes ? indexes : undefined}
+                listSize={3}
+                ref={listRef}
+              >
+                <ListItemBase key="0" itemIndex={indexes[0]}>
+                  <p>list item 1</p>
+                </ListItemBase>
+                <ListItemBase key="1" itemIndex={indexes[1]}>
+                  <p>list item 2</p>
+                </ListItemBase>
+                <ListItemBase key="2" itemIndex={indexes[2]}>
+                  <p>list item 3</p>
+                </ListItemBase>
+              </List>
+            </>
+          );
+        };
 
-      const { getAllByRole } = render(<ProgrammaticList />);
+        const { getAllByRole } = render(<ProgrammaticList />);
 
-      const listItems = getAllByRole('listitem');
-      const buttons = getAllByRole('button');
+        const listItems = getAllByRole('listitem');
+        const buttons = getAllByRole('button');
 
-      // tab past the buttons
-      await user.tab();
-      await user.tab();
-      await user.tab();
-      await user.tab();
+        // tab past the buttons
+        await user.tab();
+        await user.tab();
+        await user.tab();
+        await user.tab();
 
-      expect(listItems[0]).toHaveFocus();
+        expect(listItems[0]).toHaveFocus();
 
-      await user.click(buttons[1]);
-      expect(listItems[1]).toHaveFocus();
+        await user.click(buttons[1]);
+        expect(listItems[1]).toHaveFocus();
 
-      await user.click(buttons[2]);
+        await user.click(buttons[2]);
 
-      expect(listItems[2]).toHaveFocus();
+        expect(listItems[2]).toHaveFocus();
 
-      await user.click(buttons[0]);
+        await user.click(buttons[0]);
 
-      expect(listItems[0]).toHaveFocus();
-    });
+        expect(listItems[0]).toHaveFocus();
+      }
+    );
 
-    it('should focus the item with initialFocus', async () => {
+    it.each([
+      { indexes: [0, 1, 2], useItemIndexes: true },
+      { indexes: [0, 1, 2], useItemIndexes: false },
+      { indexes: ['a', 'b', 'c'], useItemIndexes: true },
+    ])('should focus the item with initialFocus', async ({ useItemIndexes, indexes }) => {
       const user = userEvent.setup();
 
       const { getByTestId, rerender } = render(
-        <List listSize={3} initialFocus={1}>
-          <ListItemBase data-testid="list-item-0" key="0" itemIndex={0}>
+        <List
+          listSize={3}
+          allItemIndexes={useItemIndexes ? indexes : undefined}
+          initialFocus={indexes[1]}
+        >
+          <ListItemBase data-testid="list-item-0" key="0" itemIndex={indexes[0]}>
             0
           </ListItemBase>
-          <ListItemBase data-testid="list-item-1" key="1" itemIndex={1}>
+          <ListItemBase data-testid="list-item-1" key="1" itemIndex={indexes[1]}>
             1
           </ListItemBase>
-          <ListItemBase data-testid="list-item-2" key="2" itemIndex={2}>
+          <ListItemBase data-testid="list-item-2" key="2" itemIndex={indexes[2]}>
             2
           </ListItemBase>
         </List>
@@ -658,17 +697,21 @@ describe('<List />', () => {
       // focus should not change the current focused position
 
       rerender(
-        <List listSize={3} initialFocus={1}>
-          <ListItemBase data-testid="list-item-0" key="0" itemIndex={0}>
+        <List
+          listSize={3}
+          allItemIndexes={useItemIndexes ? indexes : undefined}
+          initialFocus={indexes[1]}
+        >
+          <ListItemBase data-testid="list-item-0" key="0" itemIndex={indexes[0]}>
             0
           </ListItemBase>
-          <ListItemBase data-testid="list-item-1" key="1" itemIndex={1}>
+          <ListItemBase data-testid="list-item-1" key="1" itemIndex={indexes[1]}>
             1
           </ListItemBase>
-          <ListItemBase data-testid="list-item-2" key="2" itemIndex={2}>
+          <ListItemBase data-testid="list-item-2" key="2" itemIndex={indexes[2]}>
             2
           </ListItemBase>
-          <ListItemBase data-testid="list-item-3" key="3" itemIndex={3}>
+          <ListItemBase data-testid="list-item-3" key="3" itemIndex={indexes[3]}>
             3
           </ListItemBase>
         </List>
@@ -681,79 +724,101 @@ describe('<List />', () => {
       expect(getByTestId('list-item-2')).toHaveFocus();
     });
 
-    it('should focus the item with initialFocus when updated', async () => {
-      const user = userEvent.setup();
+    it.each([
+      { indexes: [0, 1, 2], useItemIndexes: true },
+      { indexes: [0, 1, 2], useItemIndexes: false },
+      { indexes: ['a', 'b', 'c'], useItemIndexes: true },
+    ])(
+      'should focus the item with initialFocus when updated',
+      async ({ useItemIndexes, indexes }) => {
+        const user = userEvent.setup();
 
-      const { getByTestId, rerender } = render(
-        <List listSize={3} initialFocus={1}>
-          <ListItemBase data-testid="list-item-0" key="0" itemIndex={0}>
-            0
-          </ListItemBase>
-          <ListItemBase data-testid="list-item-1" key="1" itemIndex={1}>
-            1
-          </ListItemBase>
-          <ListItemBase data-testid="list-item-2" key="2" itemIndex={2}>
-            2
-          </ListItemBase>
-        </List>
-      );
+        const { getByTestId, rerender } = render(
+          <List
+            allItemIndexes={useItemIndexes ? indexes : undefined}
+            listSize={3}
+            initialFocus={indexes[1]}
+          >
+            <ListItemBase data-testid="list-item-0" key="0" itemIndex={indexes[0]}>
+              0
+            </ListItemBase>
+            <ListItemBase data-testid="list-item-1" key="1" itemIndex={indexes[1]}>
+              1
+            </ListItemBase>
+            <ListItemBase data-testid="list-item-2" key="2" itemIndex={indexes[2]}>
+              2
+            </ListItemBase>
+          </List>
+        );
 
-      expect(document.body).toHaveFocus();
+        expect(document.body).toHaveFocus();
 
-      rerender(
-        <List listSize={4} initialFocus={2}>
-          <ListItemBase data-testid="list-item-0" key="0" itemIndex={0}>
-            0
-          </ListItemBase>
-          <ListItemBase data-testid="list-item-1" key="1" itemIndex={1}>
-            1
-          </ListItemBase>
-          <ListItemBase data-testid="list-item-2" key="2" itemIndex={2}>
-            2
-          </ListItemBase>
-          <ListItemBase data-testid="list-item-3" key="3" itemIndex={3}>
-            3
-          </ListItemBase>
-        </List>
-      );
+        rerender(
+          <List
+            allItemIndexes={useItemIndexes ? indexes : undefined}
+            listSize={4}
+            initialFocus={indexes[2]}
+          >
+            <ListItemBase data-testid="list-item-0" key="0" itemIndex={indexes[0]}>
+              0
+            </ListItemBase>
+            <ListItemBase data-testid="list-item-1" key="1" itemIndex={indexes[1]}>
+              1
+            </ListItemBase>
+            <ListItemBase data-testid="list-item-2" key="2" itemIndex={indexes[2]}>
+              2
+            </ListItemBase>
+            <ListItemBase data-testid="list-item-3" key="3" itemIndex={indexes[3]}>
+              3
+            </ListItemBase>
+          </List>
+        );
 
-      expect(document.body).toHaveFocus();
+        expect(document.body).toHaveFocus();
 
-      await user.tab();
+        await user.tab();
 
-      expect(getByTestId('list-item-2')).toHaveFocus();
-    });
+        expect(getByTestId('list-item-2')).toHaveFocus();
+      }
+    );
 
-    it('should not autofocus when a new item is added to the list', async () => {
-      const { rerender } = render(
-        <List listSize={2}>
-          <ListItemBase data-testid="list-item-1" key="1" itemIndex={0}>
-            1
-          </ListItemBase>
-          <ListItemBase data-testid="list-item-2" key="2" itemIndex={1}>
-            2
-          </ListItemBase>
-        </List>
-      );
+    it.each([
+      { indexes: [0, 1, 2], useItemIndexes: true },
+      { indexes: [0, 1, 2], useItemIndexes: false },
+      { indexes: ['a', 'b', 'c'], useItemIndexes: true },
+    ])(
+      'should not autofocus when a new item is added to the list',
+      async ({ useItemIndexes, indexes }) => {
+        const { rerender } = render(
+          <List allItemIndexes={useItemIndexes ? indexes : undefined} listSize={2}>
+            <ListItemBase data-testid="list-item-1" key="1" itemIndex={indexes[0]}>
+              1
+            </ListItemBase>
+            <ListItemBase data-testid="list-item-2" key="2" itemIndex={indexes[1]}>
+              2
+            </ListItemBase>
+          </List>
+        );
 
-      expect(document.body).toHaveFocus();
+        expect(document.body).toHaveFocus();
 
-      rerender(
-        <List listSize={3}>
-          <ListItemBase data-testid="list-item-0" key="0" itemIndex={0}>
-            0
-          </ListItemBase>
-          <ListItemBase data-testid="list-item-1" key="1" itemIndex={1}>
-            1
-          </ListItemBase>
-          <ListItemBase data-testid="list-item-2" key="2" itemIndex={2}>
-            2
-          </ListItemBase>
-        </List>
-      );
+        rerender(
+          <List allItemIndexes={useItemIndexes ? indexes : undefined} listSize={3}>
+            <ListItemBase data-testid="list-item-0" key="0" itemIndex={indexes[0]}>
+              0
+            </ListItemBase>
+            <ListItemBase data-testid="list-item-1" key="1" itemIndex={indexes[1]}>
+              1
+            </ListItemBase>
+            <ListItemBase data-testid="list-item-2" key="2" itemIndex={indexes[2]}>
+              2
+            </ListItemBase>
+          </List>
+        );
 
-      expect(document.body).toHaveFocus();
-    });
+        expect(document.body).toHaveFocus();
+      }
+    );
 
     it.each([
       { indexes: [0, 1, 2], useItemIndexes: true },
@@ -857,13 +922,50 @@ describe('<List />', () => {
       { indexes: [0, 1, 2], useItemIndexes: true, expectedNextFocus: 'list-item-0' },
       { indexes: [0, 1, 2], useItemIndexes: false },
       { indexes: ['a', 'b', 'c'], useItemIndexes: true, expectedNextFocus: 'list-item-0' },
+      {
+        indexes: ['a', 'b', 'c'],
+        useItemIndexes: true,
+        expectedNextFocus: 'list-item-1',
+        setNextFocus: (isBackward, listSize, currentFocus, noLoop, setFocus, allItemIndexes) => {
+          if (isBackward === null) {
+            // ['a', 'b', 'c'] represents the full list as it was when the list was first rendered
+            // becasue isBackward is null, we know the currentFocus is not in the current allItemIndexes
+            const originalAllItemIndexes = ['a', 'b', 'c'];
+
+            const currentIndex = ['a', 'b', 'c'].indexOf(currentFocus);
+
+            // get the positions of allItemIndex in the original list
+            const allItemIndexesPositions = allItemIndexes.map((itemIndex) =>
+              originalAllItemIndexes.indexOf(itemIndex)
+            );
+
+            // find the difference between these positions and the current index
+            const differences = allItemIndexesPositions.map((position) =>
+              Math.abs(position - currentIndex)
+            );
+
+            // pick the smallest difference as the new index. If there is more than one, prefer the last one
+            const nextIndex = allItemIndexes[differences.lastIndexOf(Math.min(...differences))];
+
+            setFocus(nextIndex);
+
+            return;
+          }
+
+          defaultSetNextFocus(isBackward, listSize, currentFocus, noLoop, setFocus, allItemIndexes);
+        },
+      },
     ])(
       'should retain focus when the last item has focus and is removed from list',
-      async ({ indexes, useItemIndexes, expectedNextFocus }) => {
+      async ({ indexes, useItemIndexes, expectedNextFocus, setNextFocus }) => {
         const user = userEvent.setup();
 
         const { getByTestId, rerender } = render(
-          <List allItemIndexes={useItemIndexes ? indexes : undefined} listSize={3}>
+          <List
+            allItemIndexes={useItemIndexes ? indexes : undefined}
+            listSize={3}
+            setNextFocus={setNextFocus ? setNextFocus : undefined}
+          >
             <ListItemBase data-testid="list-item-0" key="0" itemIndex={indexes[0]}>
               0
             </ListItemBase>
@@ -889,7 +991,11 @@ describe('<List />', () => {
         expect(getByTestId('list-item-2')).toHaveFocus();
 
         rerender(
-          <List allItemIndexes={useItemIndexes ? indexes.slice(0, 2) : undefined} listSize={2}>
+          <List
+            allItemIndexes={useItemIndexes ? indexes.slice(0, 2) : undefined}
+            listSize={2}
+            setNextFocus={setNextFocus ? setNextFocus : undefined}
+          >
             <ListItemBase data-testid="list-item-0" key="0" itemIndex={indexes[0]}>
               0
             </ListItemBase>

--- a/src/components/List/List.unit.test.tsx
+++ b/src/components/List/List.unit.test.tsx
@@ -1201,6 +1201,43 @@ describe('<List />', () => {
       }
     );
 
+    it('should handle the list size going to zero and then back again', async () => {
+      const user = userEvent.setup();
+
+      const { getByTestId, rerender } = render(
+        <List listSize={2}>
+          <ListItemBase data-testid="list-item-0" key="0" itemIndex={0}>
+            0
+          </ListItemBase>
+          <ListItemBase data-testid="list-item-1" key="1" itemIndex={1}>
+            1
+          </ListItemBase>
+        </List>
+      );
+
+      await user.tab();
+
+      expect(getByTestId('list-item-0')).toHaveFocus();
+
+      await user.keyboard('{ArrowDown}');
+
+      expect(getByTestId('list-item-1')).toHaveFocus();
+
+      rerender(<List listSize={0} />);
+
+      expect(document.body).toHaveFocus();
+
+      rerender(
+        <List listSize={1}>
+          <ListItemBase data-testid="list-item-0" key="0" itemIndex={0}>
+            0
+          </ListItemBase>
+        </List>
+      );
+
+      expect(getByTestId('list-item-0')).toHaveFocus();
+    });
+
     it('should handle text selection', async () => {
       const user = userEvent.setup();
 

--- a/src/components/List/List.unit.test.tsx
+++ b/src/components/List/List.unit.test.tsx
@@ -821,25 +821,69 @@ describe('<List />', () => {
     );
 
     it.each([
-      { indexes: [0, 1, 2], useItemIndexes: true },
-      { indexes: [0, 1, 2], useItemIndexes: false },
-      { indexes: ['a', 'b', 'c'], useItemIndexes: true },
+      {
+        initialData: [
+          { index: 0, label: 0 },
+          { index: 1, label: 1 },
+          { index: 2, label: 2 },
+          { index: 3, label: 3 },
+        ],
+        endData: [
+          { index: 0, label: 1 },
+          { index: 1, label: 2 },
+          { index: 2, label: 3 },
+        ],
+        useItemIndexes: true,
+      },
+
+      {
+        initialData: [
+          { index: 0, label: 0 },
+          { index: 1, label: 1 },
+          { index: 2, label: 2 },
+          { index: 3, label: 3 },
+        ],
+        endData: [
+          { index: 0, label: 1 },
+          { index: 1, label: 2 },
+          { index: 2, label: 3 },
+        ],
+        useItemIndexes: false,
+      },
+
+      {
+        initialData: [
+          { index: 'a', label: 0 },
+          { index: 'b', label: 1 },
+          { index: 'c', label: 2 },
+          { index: 'd', label: 3 },
+        ],
+        endData: [
+          { index: 'b', label: 1 },
+          { index: 'c', label: 2 },
+          { index: 'd', label: 3 },
+        ],
+        useItemIndexes: true,
+      },
     ])(
       'should retain focus when the first item is removed from list',
-      async ({ indexes, useItemIndexes }) => {
+      async ({ initialData, endData, useItemIndexes }) => {
         const user = userEvent.setup();
 
         const { getByTestId, rerender } = render(
-          <List allItemIndexes={useItemIndexes ? indexes : undefined} listSize={3}>
-            <ListItemBase data-testid="list-item-0" key="0" itemIndex={indexes[0]}>
-              0
-            </ListItemBase>
-            <ListItemBase id="test" data-testid="list-item-1" key="1" itemIndex={indexes[1]}>
-              1
-            </ListItemBase>
-            <ListItemBase data-testid="list-item-2" key="2" itemIndex={indexes[2]}>
-              2
-            </ListItemBase>
+          <List
+            allItemIndexes={useItemIndexes ? initialData.map((item) => item.index) : undefined}
+            listSize={3}
+          >
+            {initialData.map((item) => (
+              <ListItemBase
+                data-testid={`list-item-${item.label}`}
+                key={item.label}
+                itemIndex={item.index}
+              >
+                {item.label}
+              </ListItemBase>
+            ))}
           </List>
         );
 
@@ -849,20 +893,20 @@ describe('<List />', () => {
 
         expect(getByTestId('list-item-0')).toHaveFocus();
 
-        indexes.shift();
-
-        if (!useItemIndexes) {
-          indexes = indexes.map((i: any) => i - 1);
-        }
-
         rerender(
-          <List allItemIndexes={useItemIndexes ? [...indexes] : undefined} listSize={2}>
-            <ListItemBase id="test" data-testid="list-item-1" key="1" itemIndex={indexes[0]}>
-              1
-            </ListItemBase>
-            <ListItemBase data-testid="list-item-2" key="2" itemIndex={indexes[1]}>
-              2
-            </ListItemBase>
+          <List
+            allItemIndexes={useItemIndexes ? endData.map((item) => item.index) : undefined}
+            listSize={2}
+          >
+            {endData.map((item) => (
+              <ListItemBase
+                data-testid={`list-item-${item.label}`}
+                key={item.label}
+                itemIndex={item.index}
+              >
+                {item.label}
+              </ListItemBase>
+            ))}
           </List>
         );
 
@@ -871,23 +915,36 @@ describe('<List />', () => {
     );
 
     it.each([
-      { indexes: [0, 1, 2], useItemIndexes: true },
-      { indexes: [0, 1, 2], useItemIndexes: false },
-      { indexes: ['a', 'b', 'c'], useItemIndexes: true },
+      { initialIndexes: [0, 1, 2], indexesEnd: [1, 2], useItemIndexes: true },
+      { initialIndexes: [0, 1, 2], indexesEnd: [0, 1], useItemIndexes: false },
+      { initialIndexes: ['a', 'b', 'c'], indexesEnd: ['b', 'c'], useItemIndexes: true },
     ])(
       'should retain focus when the an item before the focused item is removed from list',
-      async ({ indexes, useItemIndexes }) => {
+      async ({ initialIndexes, indexesEnd, useItemIndexes }) => {
         const user = userEvent.setup();
 
         const { getByTestId, rerender } = render(
-          <List allItemIndexes={useItemIndexes ? indexes : undefined} listSize={3}>
-            <ListItemBase data-testid="list-item-0" key="0" itemIndex={indexes[0]}>
+          <List allItemIndexes={useItemIndexes ? initialIndexes : undefined} listSize={3}>
+            <ListItemBase
+              data-testid="list-item-0"
+              key={indexesEnd[0]}
+              itemIndex={initialIndexes[0]}
+            >
               0
             </ListItemBase>
-            <ListItemBase id="test" data-testid="list-item-1" key="1" itemIndex={indexes[1]}>
+            <ListItemBase
+              id="test"
+              data-testid="list-item-1"
+              key={indexesEnd[1]}
+              itemIndex={initialIndexes[1]}
+            >
               1
             </ListItemBase>
-            <ListItemBase data-testid="list-item-2" key="2" itemIndex={indexes[2]}>
+            <ListItemBase
+              data-testid="list-item-2"
+              key={indexesEnd[2]}
+              itemIndex={initialIndexes[2]}
+            >
               2
             </ListItemBase>
           </List>
@@ -904,11 +961,16 @@ describe('<List />', () => {
         expect(getByTestId('list-item-1')).toHaveFocus();
 
         rerender(
-          <List allItemIndexes={useItemIndexes ? indexes.slice(1, 3) : undefined} listSize={2}>
-            <ListItemBase id="test" data-testid="list-item-1" key="1" itemIndex={indexes[1]}>
+          <List allItemIndexes={useItemIndexes ? indexesEnd : undefined} listSize={2}>
+            <ListItemBase
+              id="test"
+              data-testid="list-item-1"
+              key={indexesEnd[0]}
+              itemIndex={indexesEnd[0]}
+            >
               1
             </ListItemBase>
-            <ListItemBase data-testid="list-item-2" key="2" itemIndex={indexes[2]}>
+            <ListItemBase data-testid="list-item-2" key={indexesEnd[1]} itemIndex={indexesEnd[1]}>
               2
             </ListItemBase>
           </List>
@@ -1095,6 +1157,7 @@ describe('<List />', () => {
 
     it.each([
       { indexes: [0, 1, 2], useItemIndexes: false },
+      { indexes: [0, 1, 2], useItemIndexes: true },
       { indexes: ['a', 'b', 'c'], useItemIndexes: true },
     ])(
       'should focus as expected when more items are added before tabbing to the list',

--- a/src/components/List/List.utils.tsx
+++ b/src/components/List/List.utils.tsx
@@ -59,3 +59,24 @@ export const setNextFocus = (
 
   setFocus(nextIndex);
 };
+
+export const onCurrentFocusNotFound = (
+  currentFocus: ListItemBaseIndex,
+  allItemIndexes: ListItemBaseIndex[],
+  previousAllItemIndexes: ListItemBaseIndex[],
+  setFocus: Dispatch<SetStateAction<ListItemBaseIndex>>
+): void => {
+  const previousIndexOfCurrentFocus = previousAllItemIndexes.indexOf(currentFocus);
+
+  const allItemIndexesPositions = allItemIndexes.map((itemIndex) =>
+    previousAllItemIndexes.indexOf(itemIndex)
+  );
+
+  const differences = allItemIndexesPositions.map((position) =>
+    Math.abs(position - previousIndexOfCurrentFocus)
+  );
+
+  const nextIndex = allItemIndexes[differences.lastIndexOf(Math.min(...differences))];
+
+  setFocus(nextIndex);
+};

--- a/src/components/List/List.utils.tsx
+++ b/src/components/List/List.utils.tsx
@@ -16,47 +16,35 @@ export const setNextFocus = (
   allItemIndexes: ListItemBaseIndex[]
 ): void => {
   let nextIndex: ListItemBaseIndex;
+  let currentIndex: number;
 
-  // Default behaviour with numeric index
   if (!allItemIndexes) {
     if (!isNumber(currentFocus)) {
       console.warn('Cannot handle non-numeric index without allItemIndexes');
       return;
     }
-
-    if (isBackward) {
-      nextIndex = (listSize + currentFocus - 1) % listSize;
-
-      if (noLoop && nextIndex > currentFocus) {
-        return;
-      }
-    } else {
-      nextIndex = (listSize + currentFocus + 1) % listSize;
-
-      if (noLoop && nextIndex < currentFocus) {
-        return;
-      }
-    }
+    currentIndex = currentFocus;
   } else {
-    // With allItemIndexes the current index is looked up in the full array
-    const currentIndex = allItemIndexes.indexOf(currentFocus);
-    if (isBackward) {
-      nextIndex = (listSize + currentIndex - 1) % listSize;
-
-      if (noLoop && nextIndex > currentIndex) {
-        return;
-      }
-    } else {
-      nextIndex = (listSize + currentIndex + 1) % listSize;
-
-      if (noLoop && nextIndex < currentIndex) {
-        return;
-      }
-    }
-
-    nextIndex = allItemIndexes[nextIndex];
+    currentIndex = allItemIndexes.indexOf(currentFocus);
   }
 
+  if (isBackward) {
+    nextIndex = (listSize + currentIndex - 1) % listSize;
+
+    if (noLoop && nextIndex > currentIndex) {
+      return;
+    }
+  } else {
+    nextIndex = (listSize + currentIndex + 1) % listSize;
+
+    if (noLoop && nextIndex < currentIndex) {
+      return;
+    }
+  }
+
+  if (allItemIndexes) {
+    nextIndex = allItemIndexes[nextIndex];
+  }
   setFocus(nextIndex);
 };
 

--- a/src/components/ListItemBase/ListItemBase.test.tsx
+++ b/src/components/ListItemBase/ListItemBase.test.tsx
@@ -486,6 +486,19 @@ describe('ListItemBase', () => {
       />
     );
     expect(getByTestId('list-item-1')).not.toHaveFocus();
+
+    rerender(
+      <Wrapper
+        value={{
+          listSize: 3,
+          shouldFocusOnPress: false,
+          shouldItemFocusBeInset: false,
+          currentFocus: 1,
+          setCurrentFocus: jest.fn(),
+        }}
+      />
+    );
+    expect(getByTestId('list-item-1')).not.toHaveFocus();
   });
 
   beforeEach(() => {

--- a/src/components/ListItemBase/ListItemBase.tsx
+++ b/src/components/ListItemBase/ListItemBase.tsx
@@ -23,7 +23,6 @@ import { useMutationObservable } from '../../hooks/useMutationObservable';
 import { usePrevious } from '../../hooks/usePrevious';
 import { getKeyboardFocusableElements } from '../../utils/navigation';
 import { useFocusAndFocusWithinState } from '../../hooks/useFocusState';
-import { isNumber } from 'lodash';
 
 type RefOrCallbackRef = RefObject<HTMLLIElement> | ((instance: HTMLLIElement) => void);
 

--- a/src/components/ListItemBase/ListItemBase.tsx
+++ b/src/components/ListItemBase/ListItemBase.tsx
@@ -184,25 +184,6 @@ const ListItemBase = (props: Props, providedRef: RefOrCallbackRef) => {
   const previousItemIndex = usePrevious(itemIndex);
   const lastCurrentFocus = usePrevious(currentFocus);
 
-  // When an item is added to the list, we need to reset the focus since the list size has changed
-  // and maybe the item index has changed as well
-  useLayoutEffect(() => {
-    if (
-      itemIndex !== previousItemIndex &&
-      currentFocus === previousItemIndex &&
-      listFocusedWithin
-    ) {
-      setCurrentFocus(itemIndex);
-    }
-  }, [
-    currentFocus,
-    itemIndex,
-    lastCurrentFocus,
-    listFocusedWithin,
-    previousItemIndex,
-    setCurrentFocus,
-  ]);
-
   // makes sure that whenever an item is pressed, the list focus state gets updated as well
   useEffect(() => {
     if (
@@ -260,21 +241,6 @@ const ListItemBase = (props: Props, providedRef: RefOrCallbackRef) => {
     previousItemIndex,
     ref,
   ]);
-
-  /**
-   * When the items inside the list context gets smaller (search/filter applied)
-   * we want to silently update the currentFocus back to the first element in
-   * case the index of the element focused before the list shrink is now outside
-   * the size of the new list size (shrinked size)
-   * Only works with numeric itemIndex
-   */
-  useLayoutEffect(() => {
-    if (!!listSize && isNumber(currentFocus) && currentFocus >= listSize) {
-      // set focus to last item
-      listContext.setCurrentFocus(listSize - 1);
-      updateTabIndexes();
-    }
-  }, [currentFocus, listContext, listSize, updateTabIndexes]);
 
   useEffect(() => {
     if (listContext && currentFocus === undefined) {

--- a/src/components/ListItemBase/ListItemBase.tsx
+++ b/src/components/ListItemBase/ListItemBase.tsx
@@ -183,6 +183,25 @@ const ListItemBase = (props: Props, providedRef: RefOrCallbackRef) => {
   const previousItemIndex = usePrevious(itemIndex);
   const lastCurrentFocus = usePrevious(currentFocus);
 
+  // When an item is added to the list, we need to reset the focus since the list size has changed
+  // and maybe the item index has changed as well
+  useLayoutEffect(() => {
+    if (
+      itemIndex !== previousItemIndex &&
+      currentFocus === previousItemIndex &&
+      listFocusedWithin
+    ) {
+      setCurrentFocus(itemIndex);
+    }
+  }, [
+    currentFocus,
+    itemIndex,
+    lastCurrentFocus,
+    listFocusedWithin,
+    previousItemIndex,
+    setCurrentFocus,
+  ]);
+
   // makes sure that whenever an item is pressed, the list focus state gets updated as well
   useEffect(() => {
     if (

--- a/src/components/ListItemBase/ListItemBase.tsx
+++ b/src/components/ListItemBase/ListItemBase.tsx
@@ -23,6 +23,7 @@ import { useMutationObservable } from '../../hooks/useMutationObservable';
 import { usePrevious } from '../../hooks/usePrevious';
 import { getKeyboardFocusableElements } from '../../utils/navigation';
 import { useFocusAndFocusWithinState } from '../../hooks/useFocusState';
+import { isNumber } from 'lodash';
 
 type RefOrCallbackRef = RefObject<HTMLLIElement> | ((instance: HTMLLIElement) => void);
 
@@ -265,9 +266,10 @@ const ListItemBase = (props: Props, providedRef: RefOrCallbackRef) => {
    * we want to silently update the currentFocus back to the first element in
    * case the index of the element focused before the list shrink is now outside
    * the size of the new list size (shrinked size)
+   * Only works with numeric itemIndex
    */
   useLayoutEffect(() => {
-    if (!!listSize && currentFocus >= listSize) {
+    if (!!listSize && isNumber(currentFocus) && currentFocus >= listSize) {
       // set focus to last item
       listContext.setCurrentFocus(listSize - 1);
       updateTabIndexes();

--- a/src/components/ListItemBase/ListItemBase.types.ts
+++ b/src/components/ListItemBase/ListItemBase.types.ts
@@ -4,6 +4,8 @@ import { FocusProps, FocusWithinProps } from '@react-aria/interactions';
 
 export type ListItemBaseSize = 32 | 40 | 50 | 70 | 'auto';
 
+export type ListItemBaseIndex = string | number;
+
 export interface Props
   extends PressEvents,
     Omit<FocusProps, 'isDisabled' | 'onFocusChange'>,
@@ -68,7 +70,7 @@ export interface Props
   /**
    * Indicates wether this item is currently focusable
    */
-  itemIndex?: number;
+  itemIndex?: ListItemBaseIndex;
 
   /**
    * Determines if the list item is interactive (usually used as a header when false)

--- a/src/hooks/useOrientationBasedKeyboardNavigation.test.ts
+++ b/src/hooks/useOrientationBasedKeyboardNavigation.test.ts
@@ -218,7 +218,19 @@ describe('useOrientationBasedKeyboardNavigation', () => {
         initialIndexes: ['a', 'b', 'c', 'd', 'e'],
         focusedIndex: 'e',
         finalIndexes: ['a', 'b', 'c', 'd'],
-        expectedNextFocus: 'a', // This is the unexpected result as it jumps back to the beginning of the list
+        expectedNextFocus: 'd',
+      },
+      {
+        initialIndexes: ['a', 'b', 'c', 'd', 'e'],
+        focusedIndex: 'e',
+        finalIndexes: ['a', 'b', 'c'],
+        expectedNextFocus: 'c',
+      },
+      {
+        initialIndexes: ['a', 'b', 'c', 'd', 'e', 'f'],
+        focusedIndex: 'c',
+        finalIndexes: ['a', 'b', 'e', 'f'],
+        expectedNextFocus: 'b',
       },
       {
         initialIndexes: ['a', 'b', 'c', 'd', 'e'],
@@ -287,6 +299,14 @@ describe('useOrientationBasedKeyboardNavigation', () => {
         focusedIndex: 'd',
         finalIndexes: ['a', 'b', 'c', 'd', 'e'],
         expectedNextFocus: 'd',
+      },
+
+      // swap all the items
+      {
+        initialIndexes: ['a', 'b', 'c', 'd', 'e'],
+        focusedIndex: 'c',
+        finalIndexes: ['g', 'h', 'i', 'j', 'k'],
+        expectedNextFocus: 'k',
       },
     ])(
       'should handle list size changing with non-numeric indexes',

--- a/src/hooks/useOrientationBasedKeyboardNavigation.test.ts
+++ b/src/hooks/useOrientationBasedKeyboardNavigation.test.ts
@@ -1,10 +1,9 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
-import { renderHook } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react-hooks';
 import useOrientationBasedKeyboardNavigation, {
   IUseOrientationBasedKeyboardNavigationProps,
 } from './useOrientationBasedKeyboardNavigation';
 import { KeyboardEvent } from 'react';
-import { act } from 'react-test-renderer';
 
 describe('useOrientationBasedKeyboardNavigation', () => {
   const defaultProps = {
@@ -116,5 +115,238 @@ describe('useOrientationBasedKeyboardNavigation', () => {
 
     ({ currentFocus } = result.current.getContext());
     expect(currentFocus).toStrictEqual(0);
+  });
+
+  describe('list size changes', () => {
+    it('should handle list size changing with numeric indexes - last item focused and removed', () => {
+      const { result, rerender } = renderHook(
+        (props: any) => useOrientationBasedKeyboardNavigation(props),
+        {
+          initialProps: { listSize: 3, orientation: 'vertical' },
+        }
+      );
+
+      expect(result.current.getContext()).toEqual({
+        allItemIndexes: undefined,
+        currentFocus: 0,
+        isFocusedWithin: false,
+        listSize: 3,
+        noLoop: undefined,
+        setCurrentFocus: expect.any(Function),
+        setUpdateFocusBlocked: expect.any(Function),
+        updateFocusBlocked: true,
+      });
+
+      act(() => {
+        result.current.getContext().setCurrentFocus(2);
+      });
+
+      expect(result.current.getContext()).toEqual({
+        allItemIndexes: undefined,
+        currentFocus: 2,
+        isFocusedWithin: false,
+        listSize: 3,
+        noLoop: undefined,
+        setCurrentFocus: expect.any(Function),
+        setUpdateFocusBlocked: expect.any(Function),
+        updateFocusBlocked: true,
+      });
+
+      act(() => {
+        rerender({ listSize: 2, orientation: 'vertical' });
+      });
+
+      expect(result.current.getContext()).toEqual({
+        allItemIndexes: undefined,
+        currentFocus: 1,
+        isFocusedWithin: false,
+        listSize: 2,
+        noLoop: undefined,
+        setCurrentFocus: expect.any(Function),
+        setUpdateFocusBlocked: expect.any(Function),
+        updateFocusBlocked: true,
+      });
+    });
+
+    it('should handle list size changing with numeric indexes - first item focused and removed', () => {
+      const { result, rerender } = renderHook(
+        (props: any) => useOrientationBasedKeyboardNavigation(props),
+        {
+          initialProps: { listSize: 3, orientation: 'vertical' },
+        }
+      );
+
+      expect(result.current.getContext()).toEqual({
+        allItemIndexes: undefined,
+        currentFocus: 0,
+        isFocusedWithin: false,
+        listSize: 3,
+        noLoop: undefined,
+        setCurrentFocus: expect.any(Function),
+        setUpdateFocusBlocked: expect.any(Function),
+        updateFocusBlocked: true,
+      });
+
+      act(() => {
+        rerender({ listSize: 2, orientation: 'vertical' });
+      });
+
+      expect(result.current.getContext()).toEqual({
+        allItemIndexes: undefined,
+        currentFocus: 0,
+        isFocusedWithin: false,
+        listSize: 2,
+        noLoop: undefined,
+        setCurrentFocus: expect.any(Function),
+        setUpdateFocusBlocked: expect.any(Function),
+        updateFocusBlocked: true,
+      });
+    });
+
+    it('should handle list size changing with non-numeric indexes - last item focused and removed', () => {
+      const { result, rerender } = renderHook(
+        (props: any) => useOrientationBasedKeyboardNavigation(props),
+        {
+          initialProps: { listSize: 3, orientation: 'vertical', allItemIndexes: ['a', 'b', 'c'] },
+        }
+      );
+
+      expect(result.current.getContext()).toEqual({
+        allItemIndexes: ['a', 'b', 'c'],
+        currentFocus: 'a',
+        isFocusedWithin: false,
+        listSize: 3,
+        noLoop: undefined,
+        setCurrentFocus: expect.any(Function),
+        setUpdateFocusBlocked: expect.any(Function),
+        updateFocusBlocked: true,
+      });
+
+      act(() => {
+        result.current.getContext().setCurrentFocus('c');
+      });
+
+      expect(result.current.getContext()).toEqual({
+        allItemIndexes: ['a', 'b', 'c'],
+        currentFocus: 'c',
+        isFocusedWithin: false,
+        listSize: 3,
+        noLoop: undefined,
+        setCurrentFocus: expect.any(Function),
+        setUpdateFocusBlocked: expect.any(Function),
+        updateFocusBlocked: true,
+      });
+
+      act(() => {
+        rerender({ listSize: 2, orientation: 'vertical', allItemIndexes: ['a', 'b'] });
+      });
+
+      // This result is perhaps unexpected, as the numeric case jumps to the previous item
+      // However without the previous version of allItemIndexes we can't determine the previous index
+      // So jumping to the first item in the list is the best we can do
+      expect(result.current.getContext()).toEqual({
+        allItemIndexes: ['a', 'b'],
+        currentFocus: 'a',
+        isFocusedWithin: false,
+        listSize: 2,
+        noLoop: undefined,
+        setCurrentFocus: expect.any(Function),
+        setUpdateFocusBlocked: expect.any(Function),
+        updateFocusBlocked: true,
+      });
+    });
+
+    it('should handle list size changing with non-numeric indexes - first item focused and removed', () => {
+      const { result, rerender } = renderHook(
+        (props: any) => useOrientationBasedKeyboardNavigation(props),
+        {
+          initialProps: { listSize: 3, orientation: 'vertical', allItemIndexes: ['a', 'b', 'c'] },
+        }
+      );
+
+      expect(result.current.getContext()).toEqual({
+        allItemIndexes: ['a', 'b', 'c'],
+        currentFocus: 'a',
+        isFocusedWithin: false,
+        listSize: 3,
+        noLoop: undefined,
+        setCurrentFocus: expect.any(Function),
+        setUpdateFocusBlocked: expect.any(Function),
+        updateFocusBlocked: true,
+      });
+
+      act(() => {
+        rerender({ listSize: 2, orientation: 'vertical', allItemIndexes: ['b', 'c'] });
+      });
+
+      expect(result.current.getContext()).toEqual({
+        allItemIndexes: ['b', 'c'],
+        currentFocus: 'b',
+        isFocusedWithin: false,
+        listSize: 2,
+        noLoop: undefined,
+        setCurrentFocus: expect.any(Function),
+        setUpdateFocusBlocked: expect.any(Function),
+        updateFocusBlocked: true,
+      });
+    });
+
+    it('should gracefully handle non-numeric item indexes without allItemIndexes', () => {
+      const { result, rerender } = renderHook(
+        (props: any) => useOrientationBasedKeyboardNavigation(props),
+        {
+          initialProps: { listSize: 3, orientation: 'vertical' },
+        }
+      );
+
+      jest.spyOn(console, 'warn');
+
+      expect(result.current.getContext()).toEqual({
+        allItemIndexes: undefined,
+        currentFocus: 0,
+        isFocusedWithin: false,
+        listSize: 3,
+        noLoop: undefined,
+        setCurrentFocus: expect.any(Function),
+        setUpdateFocusBlocked: expect.any(Function),
+        updateFocusBlocked: true,
+      });
+
+      act(() => {
+        result.current.getContext().setCurrentFocus('c');
+      });
+
+      expect(result.current.getContext()).toEqual({
+        currentFocus: 'c',
+        isFocusedWithin: false,
+        listSize: 3,
+        noLoop: undefined,
+        setCurrentFocus: expect.any(Function),
+        setUpdateFocusBlocked: expect.any(Function),
+        updateFocusBlocked: true,
+      });
+
+      act(() => {
+        rerender({ listSize: 2, orientation: 'vertical' });
+      });
+
+      // We can't handle non-numeric indexes without allItemIndexes
+      // So the current focus remains unchanged
+      expect(result.current.getContext()).toEqual({
+        allItemIndexes: undefined,
+        currentFocus: 'c',
+        isFocusedWithin: false,
+        listSize: 2,
+        noLoop: undefined,
+        setCurrentFocus: expect.any(Function),
+        setUpdateFocusBlocked: expect.any(Function),
+        updateFocusBlocked: true,
+      });
+
+      expect(console.warn).toHaveBeenCalledWith(
+        'Unable to handle non-numeric index without allItemIndexes',
+        'c'
+      );
+    });
   });
 });

--- a/src/hooks/useOrientationBasedKeyboardNavigation.test.ts
+++ b/src/hooks/useOrientationBasedKeyboardNavigation.test.ts
@@ -119,6 +119,7 @@ describe('useOrientationBasedKeyboardNavigation', () => {
 
   describe('list size changes', () => {
     it.each([
+      // removing items
       { focusedIndex: 0, expectedNextFocus: 0, newListSize: 4 },
       { focusedIndex: 1, expectedNextFocus: 1, newListSize: 4 },
       { focusedIndex: 2, expectedNextFocus: 2, newListSize: 4 },
@@ -127,6 +128,13 @@ describe('useOrientationBasedKeyboardNavigation', () => {
       { focusedIndex: 4, expectedNextFocus: 2, newListSize: 3 },
       { focusedIndex: 4, expectedNextFocus: 1, newListSize: 2 },
       { focusedIndex: 4, expectedNextFocus: 0, newListSize: 1 },
+
+      // adding items
+      { focusedIndex: 0, expectedNextFocus: 0, newListSize: 6 },
+      { focusedIndex: 1, expectedNextFocus: 1, newListSize: 6 },
+      { focusedIndex: 2, expectedNextFocus: 2, newListSize: 6 },
+      { focusedIndex: 3, expectedNextFocus: 3, newListSize: 6 },
+      { focusedIndex: 4, expectedNextFocus: 4, newListSize: 6 },
     ])(
       'should handle list size changing with numeric indexes - non-focused item removed',
       ({ focusedIndex, expectedNextFocus, newListSize }) => {

--- a/src/hooks/useOrientationBasedKeyboardNavigation.test.ts
+++ b/src/hooks/useOrientationBasedKeyboardNavigation.test.ts
@@ -118,178 +118,228 @@ describe('useOrientationBasedKeyboardNavigation', () => {
   });
 
   describe('list size changes', () => {
-    it('should handle list size changing with numeric indexes - last item focused and removed', () => {
-      const { result, rerender } = renderHook(
-        (props: any) => useOrientationBasedKeyboardNavigation(props),
-        {
-          initialProps: { listSize: 3, orientation: 'vertical' },
-        }
-      );
+    it.each([
+      { focusedIndex: 0, expectedNextFocus: 0, newListSize: 4 },
+      { focusedIndex: 1, expectedNextFocus: 1, newListSize: 4 },
+      { focusedIndex: 2, expectedNextFocus: 2, newListSize: 4 },
+      { focusedIndex: 3, expectedNextFocus: 3, newListSize: 4 },
+      { focusedIndex: 4, expectedNextFocus: 3, newListSize: 4 },
+      { focusedIndex: 4, expectedNextFocus: 2, newListSize: 3 },
+      { focusedIndex: 4, expectedNextFocus: 1, newListSize: 2 },
+      { focusedIndex: 4, expectedNextFocus: 0, newListSize: 1 },
+    ])(
+      'should handle list size changing with numeric indexes - non-focused item removed',
+      ({ focusedIndex, expectedNextFocus, newListSize }) => {
+        const { result, rerender } = renderHook(
+          (props: any) => useOrientationBasedKeyboardNavigation(props),
+          {
+            initialProps: { listSize: 5, orientation: 'vertical' },
+          }
+        );
 
-      expect(result.current.getContext()).toEqual({
-        allItemIndexes: undefined,
-        currentFocus: 0,
-        isFocusedWithin: false,
-        listSize: 3,
-        noLoop: undefined,
-        setCurrentFocus: expect.any(Function),
-        setUpdateFocusBlocked: expect.any(Function),
-        updateFocusBlocked: true,
-      });
+        expect(result.current.getContext()).toEqual({
+          allItemIndexes: undefined,
+          currentFocus: 0,
+          isFocusedWithin: false,
+          listSize: 5,
+          noLoop: undefined,
+          setCurrentFocus: expect.any(Function),
+          setUpdateFocusBlocked: expect.any(Function),
+          updateFocusBlocked: true,
+        });
 
-      act(() => {
-        result.current.getContext().setCurrentFocus(2);
-      });
+        act(() => {
+          result.current.getContext().setCurrentFocus(focusedIndex);
+        });
 
-      expect(result.current.getContext()).toEqual({
-        allItemIndexes: undefined,
-        currentFocus: 2,
-        isFocusedWithin: false,
-        listSize: 3,
-        noLoop: undefined,
-        setCurrentFocus: expect.any(Function),
-        setUpdateFocusBlocked: expect.any(Function),
-        updateFocusBlocked: true,
-      });
+        expect(result.current.getContext()).toEqual({
+          allItemIndexes: undefined,
+          currentFocus: focusedIndex,
+          isFocusedWithin: false,
+          listSize: 5,
+          noLoop: undefined,
+          setCurrentFocus: expect.any(Function),
+          setUpdateFocusBlocked: expect.any(Function),
+          updateFocusBlocked: true,
+        });
 
-      act(() => {
-        rerender({ listSize: 2, orientation: 'vertical' });
-      });
+        act(() => {
+          rerender({ listSize: newListSize, orientation: 'vertical' });
+        });
 
-      expect(result.current.getContext()).toEqual({
-        allItemIndexes: undefined,
-        currentFocus: 1,
-        isFocusedWithin: false,
-        listSize: 2,
-        noLoop: undefined,
-        setCurrentFocus: expect.any(Function),
-        setUpdateFocusBlocked: expect.any(Function),
-        updateFocusBlocked: true,
-      });
-    });
+        expect(result.current.getContext()).toEqual({
+          allItemIndexes: undefined,
+          currentFocus: expectedNextFocus,
+          isFocusedWithin: false,
+          listSize: newListSize,
+          noLoop: undefined,
+          setCurrentFocus: expect.any(Function),
+          setUpdateFocusBlocked: expect.any(Function),
+          updateFocusBlocked: true,
+        });
+      }
+    );
 
-    it('should handle list size changing with numeric indexes - first item focused and removed', () => {
-      const { result, rerender } = renderHook(
-        (props: any) => useOrientationBasedKeyboardNavigation(props),
-        {
-          initialProps: { listSize: 3, orientation: 'vertical' },
-        }
-      );
+    it.each([
+      // removing items
+      {
+        initialIndexes: ['a', 'b', 'c', 'd', 'e'],
+        focusedIndex: 'a',
+        finalIndexes: ['a', 'b', 'c', 'd'],
+        expectedNextFocus: 'a',
+      },
+      {
+        initialIndexes: ['a', 'b', 'c', 'd', 'e'],
+        focusedIndex: 'b',
+        finalIndexes: ['a', 'b', 'c', 'd'],
+        expectedNextFocus: 'b',
+      },
+      {
+        initialIndexes: ['a', 'b', 'c', 'd', 'e'],
+        focusedIndex: 'c',
+        finalIndexes: ['a', 'b', 'c', 'd'],
+        expectedNextFocus: 'c',
+      },
+      {
+        initialIndexes: ['a', 'b', 'c', 'd', 'e'],
+        focusedIndex: 'd',
+        finalIndexes: ['a', 'b', 'c', 'd'],
+        expectedNextFocus: 'd',
+      },
+      {
+        initialIndexes: ['a', 'b', 'c', 'd', 'e'],
+        focusedIndex: 'e',
+        finalIndexes: ['a', 'b', 'c', 'd'],
+        expectedNextFocus: 'a', // This is the unexpected result as it jumps back to the beginning of the list
+      },
+      {
+        initialIndexes: ['a', 'b', 'c', 'd', 'e'],
+        focusedIndex: 'a',
+        finalIndexes: ['b', 'c', 'd', 'e'],
+        expectedNextFocus: 'b',
+      },
+      {
+        initialIndexes: ['a', 'b', 'c', 'd', 'e'],
+        focusedIndex: 'b',
+        finalIndexes: ['b', 'c', 'd', 'e'],
+        expectedNextFocus: 'b',
+      },
+      {
+        initialIndexes: ['a', 'b', 'c', 'd', 'e'],
+        focusedIndex: 'c',
+        finalIndexes: ['b', 'c', 'd', 'e'],
+        expectedNextFocus: 'c',
+      },
+      {
+        initialIndexes: ['a', 'b', 'c', 'd', 'e'],
+        focusedIndex: 'd',
+        finalIndexes: ['b', 'c', 'd', 'e'],
+        expectedNextFocus: 'd',
+      },
+      {
+        initialIndexes: ['a', 'b', 'c', 'd', 'e'],
+        focusedIndex: 'e',
+        finalIndexes: ['b', 'c', 'd', 'e'],
+        expectedNextFocus: 'e',
+      },
 
-      expect(result.current.getContext()).toEqual({
-        allItemIndexes: undefined,
-        currentFocus: 0,
-        isFocusedWithin: false,
-        listSize: 3,
-        noLoop: undefined,
-        setCurrentFocus: expect.any(Function),
-        setUpdateFocusBlocked: expect.any(Function),
-        updateFocusBlocked: true,
-      });
+      // adding items
+      {
+        initialIndexes: ['a', 'b', 'c', 'd'],
+        focusedIndex: 'a',
+        finalIndexes: ['a', 'b', 'c', 'd', 'e'],
+        expectedNextFocus: 'a',
+      },
+      {
+        initialIndexes: ['a', 'b', 'c', 'd'],
+        focusedIndex: 'b',
+        finalIndexes: ['a', 'b', 'c', 'd', 'e'],
+        expectedNextFocus: 'b',
+      },
+      {
+        initialIndexes: ['a', 'b', 'c', 'd'],
+        focusedIndex: 'c',
+        finalIndexes: ['a', 'b', 'c', 'd', 'e'],
+        expectedNextFocus: 'c',
+      },
+      {
+        initialIndexes: ['a', 'b', 'c', 'd'],
+        focusedIndex: 'd',
+        finalIndexes: ['a', 'b', 'c', 'd', 'e'],
+        expectedNextFocus: 'd',
+      },
+      {
+        initialIndexes: ['a', 'b', 'd', 'e'],
+        focusedIndex: 'b',
+        finalIndexes: ['a', 'b', 'c', 'd', 'e'],
+        expectedNextFocus: 'b',
+      },
+      {
+        initialIndexes: ['a', 'b', 'd', 'e'],
+        focusedIndex: 'd',
+        finalIndexes: ['a', 'b', 'c', 'd', 'e'],
+        expectedNextFocus: 'd',
+      },
+    ])(
+      'should handle list size changing with non-numeric indexes',
+      ({ initialIndexes, focusedIndex, finalIndexes, expectedNextFocus }) => {
+        const { result, rerender } = renderHook(
+          (props: any) => useOrientationBasedKeyboardNavigation(props),
+          {
+            initialProps: {
+              listSize: initialIndexes.length,
+              orientation: 'vertical',
+              allItemIndexes: initialIndexes,
+            },
+          }
+        );
 
-      act(() => {
-        rerender({ listSize: 2, orientation: 'vertical' });
-      });
+        expect(result.current.getContext()).toEqual({
+          allItemIndexes: initialIndexes,
+          currentFocus: initialIndexes[0],
+          isFocusedWithin: false,
+          listSize: initialIndexes.length,
+          noLoop: undefined,
+          setCurrentFocus: expect.any(Function),
+          setUpdateFocusBlocked: expect.any(Function),
+          updateFocusBlocked: true,
+        });
 
-      expect(result.current.getContext()).toEqual({
-        allItemIndexes: undefined,
-        currentFocus: 0,
-        isFocusedWithin: false,
-        listSize: 2,
-        noLoop: undefined,
-        setCurrentFocus: expect.any(Function),
-        setUpdateFocusBlocked: expect.any(Function),
-        updateFocusBlocked: true,
-      });
-    });
+        act(() => {
+          result.current.getContext().setCurrentFocus(focusedIndex);
+        });
 
-    it('should handle list size changing with non-numeric indexes - last item focused and removed', () => {
-      const { result, rerender } = renderHook(
-        (props: any) => useOrientationBasedKeyboardNavigation(props),
-        {
-          initialProps: { listSize: 3, orientation: 'vertical', allItemIndexes: ['a', 'b', 'c'] },
-        }
-      );
+        expect(result.current.getContext()).toEqual({
+          allItemIndexes: initialIndexes,
+          currentFocus: focusedIndex,
+          isFocusedWithin: false,
+          listSize: initialIndexes.length,
+          noLoop: undefined,
+          setCurrentFocus: expect.any(Function),
+          setUpdateFocusBlocked: expect.any(Function),
+          updateFocusBlocked: true,
+        });
 
-      expect(result.current.getContext()).toEqual({
-        allItemIndexes: ['a', 'b', 'c'],
-        currentFocus: 'a',
-        isFocusedWithin: false,
-        listSize: 3,
-        noLoop: undefined,
-        setCurrentFocus: expect.any(Function),
-        setUpdateFocusBlocked: expect.any(Function),
-        updateFocusBlocked: true,
-      });
+        act(() => {
+          rerender({
+            listSize: finalIndexes.length,
+            orientation: 'vertical',
+            allItemIndexes: finalIndexes,
+          });
+        });
 
-      act(() => {
-        result.current.getContext().setCurrentFocus('c');
-      });
-
-      expect(result.current.getContext()).toEqual({
-        allItemIndexes: ['a', 'b', 'c'],
-        currentFocus: 'c',
-        isFocusedWithin: false,
-        listSize: 3,
-        noLoop: undefined,
-        setCurrentFocus: expect.any(Function),
-        setUpdateFocusBlocked: expect.any(Function),
-        updateFocusBlocked: true,
-      });
-
-      act(() => {
-        rerender({ listSize: 2, orientation: 'vertical', allItemIndexes: ['a', 'b'] });
-      });
-
-      // This result is perhaps unexpected, as the numeric case jumps to the previous item
-      // However without the previous version of allItemIndexes we can't determine the previous index
-      // So jumping to the first item in the list is the best we can do
-      expect(result.current.getContext()).toEqual({
-        allItemIndexes: ['a', 'b'],
-        currentFocus: 'a',
-        isFocusedWithin: false,
-        listSize: 2,
-        noLoop: undefined,
-        setCurrentFocus: expect.any(Function),
-        setUpdateFocusBlocked: expect.any(Function),
-        updateFocusBlocked: true,
-      });
-    });
-
-    it('should handle list size changing with non-numeric indexes - first item focused and removed', () => {
-      const { result, rerender } = renderHook(
-        (props: any) => useOrientationBasedKeyboardNavigation(props),
-        {
-          initialProps: { listSize: 3, orientation: 'vertical', allItemIndexes: ['a', 'b', 'c'] },
-        }
-      );
-
-      expect(result.current.getContext()).toEqual({
-        allItemIndexes: ['a', 'b', 'c'],
-        currentFocus: 'a',
-        isFocusedWithin: false,
-        listSize: 3,
-        noLoop: undefined,
-        setCurrentFocus: expect.any(Function),
-        setUpdateFocusBlocked: expect.any(Function),
-        updateFocusBlocked: true,
-      });
-
-      act(() => {
-        rerender({ listSize: 2, orientation: 'vertical', allItemIndexes: ['b', 'c'] });
-      });
-
-      expect(result.current.getContext()).toEqual({
-        allItemIndexes: ['b', 'c'],
-        currentFocus: 'b',
-        isFocusedWithin: false,
-        listSize: 2,
-        noLoop: undefined,
-        setCurrentFocus: expect.any(Function),
-        setUpdateFocusBlocked: expect.any(Function),
-        updateFocusBlocked: true,
-      });
-    });
+        expect(result.current.getContext()).toEqual({
+          allItemIndexes: finalIndexes,
+          currentFocus: expectedNextFocus,
+          isFocusedWithin: false,
+          listSize: finalIndexes.length,
+          noLoop: undefined,
+          setCurrentFocus: expect.any(Function),
+          setUpdateFocusBlocked: expect.any(Function),
+          updateFocusBlocked: true,
+        });
+      }
+    );
 
     it('should gracefully handle non-numeric item indexes without allItemIndexes', () => {
       const { result, rerender } = renderHook(

--- a/src/hooks/useOrientationBasedKeyboardNavigation.ts
+++ b/src/hooks/useOrientationBasedKeyboardNavigation.ts
@@ -114,7 +114,7 @@ const useOrientationBasedKeyboardNavigation = (
       return;
     }
 
-    if (!allItemIndexes.includes(currentFocus) && currentFocus !== -1) {
+    if (currentFocus !== -1 && !allItemIndexes.includes(currentFocus)) {
       const context = getContext();
 
       setNextFocus(

--- a/src/hooks/useOrientationBasedKeyboardNavigation.ts
+++ b/src/hooks/useOrientationBasedKeyboardNavigation.ts
@@ -11,7 +11,7 @@ import { useKeyboard } from '@react-aria/interactions';
 import { setNextFocus as defaultSetNextFocus } from '../components/List/List.utils';
 import { ListOrientation } from '../components/List/List.types';
 import { useFocusWithinState } from './useFocusState';
-import { initial, isNumber } from 'lodash';
+import { isNumber } from 'lodash';
 import { ListItemBaseIndex } from '../components/ListItemBase/ListItemBase.types';
 
 type IUseOrientationBasedKeyboardNavigationReturn = {

--- a/src/hooks/useOrientationBasedKeyboardNavigation.ts
+++ b/src/hooks/useOrientationBasedKeyboardNavigation.ts
@@ -40,7 +40,8 @@ export type IUseOrientationBasedKeyboardNavigationProps = {
     listSize: number,
     currentFocus: ListItemBaseIndex,
     noLoop: boolean,
-    setFocus: Dispatch<SetStateAction<ListItemBaseIndex>>
+    setFocus: Dispatch<SetStateAction<ListItemBaseIndex>>,
+    allItemIndexes: ListItemBaseIndex[]
   ) => void;
   contextProps?: {
     shouldFocusOnPress?: boolean;

--- a/src/hooks/useOrientationBasedKeyboardNavigation.ts
+++ b/src/hooks/useOrientationBasedKeyboardNavigation.ts
@@ -12,7 +12,7 @@ import { setNextFocus as defaultSetNextFocus } from '../components/List/List.uti
 import { ListOrientation } from '../components/List/List.types';
 import { useFocusWithinState } from './useFocusState';
 import { isNumber } from 'lodash';
-import { ListItemBaseIndex } from 'src/components/ListItemBase/ListItemBase.types';
+import { ListItemBaseIndex } from '../components/ListItemBase/ListItemBase.types';
 
 type IUseOrientationBasedKeyboardNavigationReturn = {
   keyboardProps: HTMLAttributes<HTMLElement>;
@@ -31,7 +31,7 @@ type IUseOrientationBasedKeyboardNavigationReturn = {
 
 export type IUseOrientationBasedKeyboardNavigationProps = {
   listSize: number;
-  allItemIndexes: ListItemBaseIndex[];
+  allItemIndexes?: ListItemBaseIndex[];
   orientation: ListOrientation;
   noLoop?: boolean;
   initialFocus?: ListItemBaseIndex;

--- a/src/hooks/useOrientationBasedKeyboardNavigation.ts
+++ b/src/hooks/useOrientationBasedKeyboardNavigation.ts
@@ -11,7 +11,7 @@ import { useKeyboard } from '@react-aria/interactions';
 import { setNextFocus as defaultSetNextFocus } from '../components/List/List.utils';
 import { ListOrientation } from '../components/List/List.types';
 import { useFocusWithinState } from './useFocusState';
-import { isNumber } from 'lodash';
+import { initial, isNumber } from 'lodash';
 import { ListItemBaseIndex } from '../components/ListItemBase/ListItemBase.types';
 
 type IUseOrientationBasedKeyboardNavigationReturn = {
@@ -108,7 +108,13 @@ const useOrientationBasedKeyboardNavigation = (
       }
 
       if (currentFocus >= listSize) {
-        setCurrentFocus(listSize - 1);
+        const newFocus = listSize - 1;
+
+        if (newFocus >= 0) {
+          setCurrentFocus(newFocus);
+        } else {
+          setCurrentFocus(initialFocus);
+        }
       }
 
       return;
@@ -126,7 +132,7 @@ const useOrientationBasedKeyboardNavigation = (
         context.allItemIndexes
       );
     }
-  }, [allItemIndexes, currentFocus, getContext, listSize, setNextFocus]);
+  }, [allItemIndexes, currentFocus, getContext, initialFocus, listSize, setNextFocus]);
 
   const { keyboardProps } = useKeyboard({
     onKeyDown: (evt) => {

--- a/src/hooks/useOrientationBasedKeyboardNavigation.ts
+++ b/src/hooks/useOrientationBasedKeyboardNavigation.ts
@@ -126,7 +126,7 @@ const useOrientationBasedKeyboardNavigation = (
         context.allItemIndexes
       );
     }
-  }, [allItemIndexes, currentFocus, getContext, listSize, noLoop, setNextFocus]);
+  }, [allItemIndexes, currentFocus, getContext, listSize, setNextFocus]);
 
   const { keyboardProps } = useKeyboard({
     onKeyDown: (evt) => {

--- a/src/hooks/useOrientationBasedKeyboardNavigation.ts
+++ b/src/hooks/useOrientationBasedKeyboardNavigation.ts
@@ -7,7 +7,7 @@ import {
   useState,
 } from 'react';
 import { useKeyboard } from '@react-aria/interactions';
-import { setNextFocus } from '../components/List/List.utils';
+import { setNextFocus as defaultSetNextFocus } from '../components/List/List.utils';
 import { ListOrientation } from '../components/List/List.types';
 import { useFocusWithinState } from './useFocusState';
 
@@ -16,8 +16,8 @@ type IUseOrientationBasedKeyboardNavigationReturn = {
   focusWithinProps: HTMLAttributes<HTMLElement>;
   getContext: () => {
     listSize: number;
-    currentFocus: number;
-    setCurrentFocus: Dispatch<SetStateAction<number>>;
+    currentFocus: number | string;
+    setCurrentFocus: Dispatch<SetStateAction<number | string>>;
     shouldFocusOnPress?: boolean;
     shouldItemFocusBeInset?: boolean;
     noLoop?: boolean;
@@ -30,7 +30,14 @@ export type IUseOrientationBasedKeyboardNavigationProps = {
   listSize: number;
   orientation: ListOrientation;
   noLoop?: boolean;
-  initialFocus?: number;
+  initialFocus?: number | string;
+  setNextFocus?: (
+    isBackward: boolean,
+    listSize: number,
+    currentFocus: number | string,
+    noLoop: boolean,
+    setFocus: Dispatch<SetStateAction<number | string>>
+  ) => void;
   contextProps?: {
     shouldFocusOnPress?: boolean;
     shouldItemFocusBeInset?: boolean;
@@ -40,8 +47,15 @@ export type IUseOrientationBasedKeyboardNavigationProps = {
 const useOrientationBasedKeyboardNavigation = (
   props: IUseOrientationBasedKeyboardNavigationProps
 ): IUseOrientationBasedKeyboardNavigationReturn => {
-  const { listSize, orientation, noLoop, contextProps, initialFocus = 0 } = props;
-  const [currentFocus, setCurrentFocus] = useState<number>(-1);
+  const {
+    listSize,
+    orientation,
+    noLoop,
+    contextProps,
+    initialFocus = 0,
+    setNextFocus = defaultSetNextFocus,
+  } = props;
+  const [currentFocus, setCurrentFocus] = useState<number | string>(-1);
   const [updateFocusBlocked, setUpdateFocusBlocked] = useState<boolean>(true);
 
   const { isFocusedWithin, focusWithinProps } = useFocusWithinState({});

--- a/src/hooks/useOrientationBasedKeyboardNavigation.ts
+++ b/src/hooks/useOrientationBasedKeyboardNavigation.ts
@@ -13,7 +13,6 @@ import { ListOrientation } from '../components/List/List.types';
 import { useFocusWithinState } from './useFocusState';
 import { isNumber } from 'lodash';
 import { ListItemBaseIndex } from '../components/ListItemBase/ListItemBase.types';
-import { usePrevious } from './usePrevious';
 
 type IUseOrientationBasedKeyboardNavigationReturn = {
   keyboardProps: HTMLAttributes<HTMLElement>;
@@ -100,22 +99,13 @@ const useOrientationBasedKeyboardNavigation = (
     ]
   );
 
-  const previousListSize = usePrevious(listSize);
-
   useEffect(() => {
     if (!allItemIndexes) {
       if (isNumber(currentFocus)) {
-        if (
-          previousListSize &&
-          listSize !== previousListSize &&
-          currentFocus !== -1 &&
-          isFocusedWithin
-        ) {
-          const listSizeDifference = listSize - previousListSize;
-
-          const newFocus = currentFocus + listSizeDifference;
-
-          setCurrentFocus(newFocus);
+        if (listSize && currentFocus !== -1) {
+          if (currentFocus >= listSize) {
+            setCurrentFocus(listSize - 1);
+          }
         }
       } else if (!(isNumber(currentFocus) && currentFocus === -1)) {
         console.warn('Unable to handle non-numeric index without allItemIndexes', currentFocus);
@@ -134,16 +124,7 @@ const useOrientationBasedKeyboardNavigation = (
         context.allItemIndexes
       );
     }
-  }, [
-    allItemIndexes,
-    currentFocus,
-    getContext,
-    isFocusedWithin,
-    listSize,
-    noLoop,
-    previousListSize,
-    setNextFocus,
-  ]);
+  }, [allItemIndexes, currentFocus, getContext, listSize, noLoop, setNextFocus]);
 
   const { keyboardProps } = useKeyboard({
     onKeyDown: (evt) => {

--- a/src/hooks/useOrientationBasedKeyboardNavigation.ts
+++ b/src/hooks/useOrientationBasedKeyboardNavigation.ts
@@ -13,6 +13,7 @@ import { ListOrientation } from '../components/List/List.types';
 import { useFocusWithinState } from './useFocusState';
 import { isNumber } from 'lodash';
 import { ListItemBaseIndex } from '../components/ListItemBase/ListItemBase.types';
+import { usePrevious } from './usePrevious';
 
 type IUseOrientationBasedKeyboardNavigationReturn = {
   keyboardProps: HTMLAttributes<HTMLElement>;
@@ -99,11 +100,22 @@ const useOrientationBasedKeyboardNavigation = (
     ]
   );
 
+  const previousListSize = usePrevious(listSize);
+
   useEffect(() => {
     if (!allItemIndexes) {
       if (isNumber(currentFocus)) {
-        if (currentFocus >= listSize) {
-          setCurrentFocus(listSize - 1);
+        if (
+          previousListSize &&
+          listSize !== previousListSize &&
+          currentFocus !== -1 &&
+          isFocusedWithin
+        ) {
+          const listSizeDifference = listSize - previousListSize;
+
+          const newFocus = currentFocus + listSizeDifference;
+
+          setCurrentFocus(newFocus);
         }
       } else if (!(isNumber(currentFocus) && currentFocus === -1)) {
         console.warn('Unable to handle non-numeric index without allItemIndexes', currentFocus);
@@ -122,7 +134,16 @@ const useOrientationBasedKeyboardNavigation = (
         context.allItemIndexes
       );
     }
-  }, [allItemIndexes, currentFocus, getContext, listSize, setNextFocus]);
+  }, [
+    allItemIndexes,
+    currentFocus,
+    getContext,
+    isFocusedWithin,
+    listSize,
+    noLoop,
+    previousListSize,
+    setNextFocus,
+  ]);
 
   const { keyboardProps } = useKeyboard({
     onKeyDown: (evt) => {

--- a/src/hooks/useOrientationBasedKeyboardNavigation.ts
+++ b/src/hooks/useOrientationBasedKeyboardNavigation.ts
@@ -101,18 +101,20 @@ const useOrientationBasedKeyboardNavigation = (
 
   useEffect(() => {
     if (!allItemIndexes) {
-      if (isNumber(currentFocus)) {
-        if (listSize && currentFocus !== -1) {
-          if (currentFocus >= listSize) {
-            setCurrentFocus(listSize - 1);
-          }
-        }
-      } else if (!(isNumber(currentFocus) && currentFocus === -1)) {
+      if (!isNumber(currentFocus)) {
         console.warn('Unable to handle non-numeric index without allItemIndexes', currentFocus);
+
+        return;
       }
+
+      if (currentFocus >= listSize) {
+        setCurrentFocus(listSize - 1);
+      }
+
       return;
     }
-    if (allItemIndexes.indexOf(currentFocus) < 0 && currentFocus !== -1) {
+
+    if (!allItemIndexes.includes(currentFocus) && currentFocus !== -1) {
       const context = getContext();
 
       setNextFocus(


### PR DESCRIPTION
# Description

Allow non-numeric item indexes in the list. This is helpful for rendering parts of a list where each item has a unique id e.g. in virtual scrolling.

Default behavior with numeric indexes is preserved. With non-numeric indexes, a new prop allItemIndexes is required in order to find the appropriate next/previous item when navigating with the keyboard.

The default behavior when removing the last item from the list if it has focus is different with numeric and non-numeric. With non-numeric it will jump to the beginning of the list instead of the next last item. For more complex behaviors, setNextFocus is overwritable, allowing different focusing behavior when something is removed from the list.
