### PR TITLE
feat: create TooltipMenuTriggerCombo component

### DIFF
--- a/src/components/MenuTrigger/MenuTrigger.stories.tsx
+++ b/src/components/MenuTrigger/MenuTrigger.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { MultiTemplate, Template } from '../../storybook/helper.stories.templates';
 import { DocumentationPage } from '../../storybook/helper.stories.docs';
 import StyleDocs from '../../storybook/docs.stories.style.mdx';
@@ -16,6 +16,7 @@ import Avatar from '../Avatar';
 import { PresenceType } from '../Avatar/Avatar.types';
 import { action } from '@storybook/addon-actions';
 import ContentSeparator from '../ContentSeparator';
+import { StoryObj } from '@storybook/react';
 
 export default {
   title: 'Momentum UI/MenuTrigger',
@@ -290,4 +291,31 @@ CloseOnSelect.parameters = {
   ],
 };
 
-export { Example, Common, CloseOnSelect };
+const WithOpenChangeHandler: StoryObj<typeof MenuTrigger> = {
+  // eslint-disable-next-line react/display-name
+  render: () => {
+    const [isOpen, setIsOpen] = useState(false);
+
+    return (
+      <MenuTrigger
+        triggerComponent={
+          <ButtonCircle>
+            <Icon name={isOpen ? 'arrow-up' : 'arrow-down'} weight="bold" autoScale={100} />
+          </ButtonCircle>
+        }
+        onOpenChange={setIsOpen}
+      >
+        <Menu selectionMode="single" key="2">
+          <Item key="one">This is a longer text and should trim nicely...</Item>
+          <Item key="two">Two</Item>
+          <Item key="three">Three</Item>
+          <Item key="four">Four</Item>
+          <Item key="five">Five</Item>
+          <Item key="six">Six</Item>
+        </Menu>
+      </MenuTrigger>
+    );
+  },
+};
+
+export { Example, Common, CloseOnSelect, WithOpenChangeHandler };

--- a/src/components/MenuTrigger/MenuTrigger.tsx
+++ b/src/components/MenuTrigger/MenuTrigger.tsx
@@ -86,13 +86,13 @@ const MenuTrigger = forwardRef(
      */
     useEffect(() => {
       if (popoverInstance) {
-        if (isOpen) {
+        if (state.isOpen) {
           popoverInstance.show();
         } else {
           popoverInstance.hide();
         }
       }
-    }, [isOpen, popoverInstance]);
+    }, [popoverInstance, state.isOpen]);
 
     /**
      * Add manual keyboard accessibility because our Popover component
@@ -109,9 +109,6 @@ const MenuTrigger = forwardRef(
     // delete color prop which is passed down and used in the ModalContainer
     // because it conflicts with the HTML color property
     delete keyboardProps.color;
-    // delete the onKeyDown provided by Aria because Popover component will add
-    // appropriate keyboard accessibility instead.
-    delete menuTriggerProps.onKeyDown;
 
     return (
       <Popover
@@ -120,7 +117,7 @@ const MenuTrigger = forwardRef(
           ref: buttonRef,
         })}
         className={classnames(className, STYLE.wrapper)}
-        trigger="click"
+        trigger="manual"
         id={id}
         role="generic"
         style={style}
@@ -161,5 +158,7 @@ const MenuTrigger = forwardRef(
     );
   }
 );
+
+MenuTrigger.displayName = 'MenuTrigger';
 
 export default MenuTrigger;

--- a/src/components/MenuTrigger/MenuTrigger.tsx
+++ b/src/components/MenuTrigger/MenuTrigger.tsx
@@ -32,7 +32,6 @@ const MenuTrigger = forwardRef(
       style,
       closeOnSelect,
       children,
-      isOpen,
       delay,
       variant = DEFAULTS.VARIANT,
       color = DEFAULTS.COLOR,

--- a/src/components/MenuTrigger/MenuTrigger.unit.test.tsx.snap
+++ b/src/components/MenuTrigger/MenuTrigger.unit.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot 1`] = `
-<ForwardRef
+<MenuTrigger
   aria-label="Menu Trigger Component "
   isOpen={true}
   triggerComponent={
@@ -22,13 +22,14 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot 1`] = `
     role="generic"
     setInstance={[Function]}
     showArrow={false}
-    trigger="click"
+    trigger="manual"
     triggerComponent={
       <ButtonPill
         aria-controls="test-ID"
         aria-expanded={true}
         aria-haspopup={true}
         id="test-ID"
+        onKeyDown={[Function]}
         onPress={[Function]}
         onPressStart={[Function]}
       >
@@ -40,7 +41,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot 1`] = `
     <LazyTippy
       animation={false}
       appendTo="parent"
-      hideOnClick={true}
+      hideOnClick={false}
       interactive={true}
       offset={
         Array [
@@ -84,12 +85,12 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot 1`] = `
       }
       render={[Function]}
       setInstance={[Function]}
-      trigger="click"
+      trigger="manual"
     >
       <ForwardRef(TippyWrapper)
         animation={false}
         appendTo="parent"
-        hideOnClick={true}
+        hideOnClick={false}
         interactive={true}
         offset={
           Array [
@@ -141,12 +142,12 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot 1`] = `
           }
         }
         render={[Function]}
-        trigger="click"
+        trigger="manual"
       >
         <Tippy
           animation={false}
           appendTo="parent"
-          hideOnClick={true}
+          hideOnClick={false}
           interactive={true}
           offset={
             Array [
@@ -198,13 +199,14 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot 1`] = `
             }
           }
           render={[Function]}
-          trigger="click"
+          trigger="manual"
         >
           <ButtonPill
             aria-controls="test-ID"
             aria-expanded={true}
             aria-haspopup={true}
             id="test-ID"
+            onKeyDown={[Function]}
             onPress={[Function]}
             onPressStart={[Function]}
             useNativeKeyDown={true}
@@ -225,6 +227,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot 1`] = `
               data-shallow-disabled={false}
               data-size={40}
               id="test-ID"
+              onKeyDown={[Function]}
               onPress={[Function]}
               onPressStart={[Function]}
               useNativeKeyDown={true}
@@ -253,6 +256,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot 1`] = `
                     onClick={[Function]}
                     onDragStart={[Function]}
                     onFocus={[Function]}
+                    onKeyDown={[Function]}
                     onKeyUp={[Function]}
                     onMouseDown={[Function]}
                     onMouseEnter={[Function]}
@@ -2208,11 +2212,11 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot 1`] = `
       </ForwardRef(TippyWrapper)>
     </LazyTippy>
   </Popover>
-</ForwardRef>
+</MenuTrigger>
 `;
 
 exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with className 1`] = `
-<ForwardRef
+<MenuTrigger
   aria-label="Menu Trigger Component "
   className="example-class"
   isOpen={true}
@@ -2234,13 +2238,14 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with className 
     role="generic"
     setInstance={[Function]}
     showArrow={false}
-    trigger="click"
+    trigger="manual"
     triggerComponent={
       <ButtonPill
         aria-controls="test-ID"
         aria-expanded={true}
         aria-haspopup={true}
         id="test-ID"
+        onKeyDown={[Function]}
         onPress={[Function]}
         onPressStart={[Function]}
       >
@@ -2252,7 +2257,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with className 
     <LazyTippy
       animation={false}
       appendTo="parent"
-      hideOnClick={true}
+      hideOnClick={false}
       interactive={true}
       offset={
         Array [
@@ -2296,12 +2301,12 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with className 
       }
       render={[Function]}
       setInstance={[Function]}
-      trigger="click"
+      trigger="manual"
     >
       <ForwardRef(TippyWrapper)
         animation={false}
         appendTo="parent"
-        hideOnClick={true}
+        hideOnClick={false}
         interactive={true}
         offset={
           Array [
@@ -2353,12 +2358,12 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with className 
           }
         }
         render={[Function]}
-        trigger="click"
+        trigger="manual"
       >
         <Tippy
           animation={false}
           appendTo="parent"
-          hideOnClick={true}
+          hideOnClick={false}
           interactive={true}
           offset={
             Array [
@@ -2410,13 +2415,14 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with className 
             }
           }
           render={[Function]}
-          trigger="click"
+          trigger="manual"
         >
           <ButtonPill
             aria-controls="test-ID"
             aria-expanded={true}
             aria-haspopup={true}
             id="test-ID"
+            onKeyDown={[Function]}
             onPress={[Function]}
             onPressStart={[Function]}
             useNativeKeyDown={true}
@@ -2437,6 +2443,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with className 
               data-shallow-disabled={false}
               data-size={40}
               id="test-ID"
+              onKeyDown={[Function]}
               onPress={[Function]}
               onPressStart={[Function]}
               useNativeKeyDown={true}
@@ -2465,6 +2472,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with className 
                     onClick={[Function]}
                     onDragStart={[Function]}
                     onFocus={[Function]}
+                    onKeyDown={[Function]}
                     onKeyUp={[Function]}
                     onMouseDown={[Function]}
                     onMouseEnter={[Function]}
@@ -4420,11 +4428,11 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with className 
       </ForwardRef(TippyWrapper)>
     </LazyTippy>
   </Popover>
-</ForwardRef>
+</MenuTrigger>
 `;
 
 exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with color 1`] = `
-<ForwardRef
+<MenuTrigger
   aria-label="Menu Trigger Component "
   color="secondary"
   isOpen={true}
@@ -4446,13 +4454,14 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with color 1`] 
     role="generic"
     setInstance={[Function]}
     showArrow={false}
-    trigger="click"
+    trigger="manual"
     triggerComponent={
       <ButtonPill
         aria-controls="test-ID"
         aria-expanded={true}
         aria-haspopup={true}
         id="test-ID"
+        onKeyDown={[Function]}
         onPress={[Function]}
         onPressStart={[Function]}
       >
@@ -4464,7 +4473,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with color 1`] 
     <LazyTippy
       animation={false}
       appendTo="parent"
-      hideOnClick={true}
+      hideOnClick={false}
       interactive={true}
       offset={
         Array [
@@ -4508,12 +4517,12 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with color 1`] 
       }
       render={[Function]}
       setInstance={[Function]}
-      trigger="click"
+      trigger="manual"
     >
       <ForwardRef(TippyWrapper)
         animation={false}
         appendTo="parent"
-        hideOnClick={true}
+        hideOnClick={false}
         interactive={true}
         offset={
           Array [
@@ -4565,12 +4574,12 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with color 1`] 
           }
         }
         render={[Function]}
-        trigger="click"
+        trigger="manual"
       >
         <Tippy
           animation={false}
           appendTo="parent"
-          hideOnClick={true}
+          hideOnClick={false}
           interactive={true}
           offset={
             Array [
@@ -4622,13 +4631,14 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with color 1`] 
             }
           }
           render={[Function]}
-          trigger="click"
+          trigger="manual"
         >
           <ButtonPill
             aria-controls="test-ID"
             aria-expanded={true}
             aria-haspopup={true}
             id="test-ID"
+            onKeyDown={[Function]}
             onPress={[Function]}
             onPressStart={[Function]}
             useNativeKeyDown={true}
@@ -4649,6 +4659,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with color 1`] 
               data-shallow-disabled={false}
               data-size={40}
               id="test-ID"
+              onKeyDown={[Function]}
               onPress={[Function]}
               onPressStart={[Function]}
               useNativeKeyDown={true}
@@ -4677,6 +4688,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with color 1`] 
                     onClick={[Function]}
                     onDragStart={[Function]}
                     onFocus={[Function]}
+                    onKeyDown={[Function]}
                     onKeyUp={[Function]}
                     onMouseDown={[Function]}
                     onMouseEnter={[Function]}
@@ -6632,11 +6644,11 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with color 1`] 
       </ForwardRef(TippyWrapper)>
     </LazyTippy>
   </Popover>
-</ForwardRef>
+</MenuTrigger>
 `;
 
 exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with id 1`] = `
-<ForwardRef
+<MenuTrigger
   aria-label="Menu Trigger Component "
   id="example-id"
   isOpen={true}
@@ -6659,13 +6671,14 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with id 1`] = `
     role="generic"
     setInstance={[Function]}
     showArrow={false}
-    trigger="click"
+    trigger="manual"
     triggerComponent={
       <ButtonPill
         aria-controls="test-ID"
         aria-expanded={true}
         aria-haspopup={true}
         id="test-ID"
+        onKeyDown={[Function]}
         onPress={[Function]}
         onPressStart={[Function]}
       >
@@ -6677,7 +6690,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with id 1`] = `
     <LazyTippy
       animation={false}
       appendTo="parent"
-      hideOnClick={true}
+      hideOnClick={false}
       interactive={true}
       offset={
         Array [
@@ -6721,12 +6734,12 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with id 1`] = `
       }
       render={[Function]}
       setInstance={[Function]}
-      trigger="click"
+      trigger="manual"
     >
       <ForwardRef(TippyWrapper)
         animation={false}
         appendTo="parent"
-        hideOnClick={true}
+        hideOnClick={false}
         interactive={true}
         offset={
           Array [
@@ -6778,12 +6791,12 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with id 1`] = `
           }
         }
         render={[Function]}
-        trigger="click"
+        trigger="manual"
       >
         <Tippy
           animation={false}
           appendTo="parent"
-          hideOnClick={true}
+          hideOnClick={false}
           interactive={true}
           offset={
             Array [
@@ -6835,13 +6848,14 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with id 1`] = `
             }
           }
           render={[Function]}
-          trigger="click"
+          trigger="manual"
         >
           <ButtonPill
             aria-controls="test-ID"
             aria-expanded={true}
             aria-haspopup={true}
             id="test-ID"
+            onKeyDown={[Function]}
             onPress={[Function]}
             onPressStart={[Function]}
             useNativeKeyDown={true}
@@ -6862,6 +6876,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with id 1`] = `
               data-shallow-disabled={false}
               data-size={40}
               id="test-ID"
+              onKeyDown={[Function]}
               onPress={[Function]}
               onPressStart={[Function]}
               useNativeKeyDown={true}
@@ -6890,6 +6905,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with id 1`] = `
                     onClick={[Function]}
                     onDragStart={[Function]}
                     onFocus={[Function]}
+                    onKeyDown={[Function]}
                     onKeyUp={[Function]}
                     onMouseDown={[Function]}
                     onMouseEnter={[Function]}
@@ -8848,11 +8864,11 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with id 1`] = `
       </ForwardRef(TippyWrapper)>
     </LazyTippy>
   </Popover>
-</ForwardRef>
+</MenuTrigger>
 `;
 
 exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with placement 1`] = `
-<ForwardRef
+<MenuTrigger
   aria-label="Menu Trigger Component "
   isOpen={true}
   placement="top"
@@ -8874,13 +8890,14 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with placement 
     role="generic"
     setInstance={[Function]}
     showArrow={false}
-    trigger="click"
+    trigger="manual"
     triggerComponent={
       <ButtonPill
         aria-controls="test-ID"
         aria-expanded={true}
         aria-haspopup={true}
         id="test-ID"
+        onKeyDown={[Function]}
         onPress={[Function]}
         onPressStart={[Function]}
       >
@@ -8892,7 +8909,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with placement 
     <LazyTippy
       animation={false}
       appendTo="parent"
-      hideOnClick={true}
+      hideOnClick={false}
       interactive={true}
       offset={
         Array [
@@ -8936,12 +8953,12 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with placement 
       }
       render={[Function]}
       setInstance={[Function]}
-      trigger="click"
+      trigger="manual"
     >
       <ForwardRef(TippyWrapper)
         animation={false}
         appendTo="parent"
-        hideOnClick={true}
+        hideOnClick={false}
         interactive={true}
         offset={
           Array [
@@ -8993,12 +9010,12 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with placement 
           }
         }
         render={[Function]}
-        trigger="click"
+        trigger="manual"
       >
         <Tippy
           animation={false}
           appendTo="parent"
-          hideOnClick={true}
+          hideOnClick={false}
           interactive={true}
           offset={
             Array [
@@ -9050,13 +9067,14 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with placement 
             }
           }
           render={[Function]}
-          trigger="click"
+          trigger="manual"
         >
           <ButtonPill
             aria-controls="test-ID"
             aria-expanded={true}
             aria-haspopup={true}
             id="test-ID"
+            onKeyDown={[Function]}
             onPress={[Function]}
             onPressStart={[Function]}
             useNativeKeyDown={true}
@@ -9077,6 +9095,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with placement 
               data-shallow-disabled={false}
               data-size={40}
               id="test-ID"
+              onKeyDown={[Function]}
               onPress={[Function]}
               onPressStart={[Function]}
               useNativeKeyDown={true}
@@ -9105,6 +9124,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with placement 
                     onClick={[Function]}
                     onDragStart={[Function]}
                     onFocus={[Function]}
+                    onKeyDown={[Function]}
                     onKeyUp={[Function]}
                     onMouseDown={[Function]}
                     onMouseEnter={[Function]}
@@ -11060,11 +11080,11 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with placement 
       </ForwardRef(TippyWrapper)>
     </LazyTippy>
   </Popover>
-</ForwardRef>
+</MenuTrigger>
 `;
 
 exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with showArrow 1`] = `
-<ForwardRef
+<MenuTrigger
   aria-label="Menu Trigger Component "
   isOpen={true}
   showArrow={true}
@@ -11086,13 +11106,14 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with showArrow 
     role="generic"
     setInstance={[Function]}
     showArrow={true}
-    trigger="click"
+    trigger="manual"
     triggerComponent={
       <ButtonPill
         aria-controls="test-ID"
         aria-expanded={true}
         aria-haspopup={true}
         id="test-ID"
+        onKeyDown={[Function]}
         onPress={[Function]}
         onPressStart={[Function]}
       >
@@ -11104,7 +11125,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with showArrow 
     <LazyTippy
       animation={false}
       appendTo="parent"
-      hideOnClick={true}
+      hideOnClick={false}
       interactive={true}
       offset={
         Array [
@@ -11148,12 +11169,12 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with showArrow 
       }
       render={[Function]}
       setInstance={[Function]}
-      trigger="click"
+      trigger="manual"
     >
       <ForwardRef(TippyWrapper)
         animation={false}
         appendTo="parent"
-        hideOnClick={true}
+        hideOnClick={false}
         interactive={true}
         offset={
           Array [
@@ -11205,12 +11226,12 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with showArrow 
           }
         }
         render={[Function]}
-        trigger="click"
+        trigger="manual"
       >
         <Tippy
           animation={false}
           appendTo="parent"
-          hideOnClick={true}
+          hideOnClick={false}
           interactive={true}
           offset={
             Array [
@@ -11262,13 +11283,14 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with showArrow 
             }
           }
           render={[Function]}
-          trigger="click"
+          trigger="manual"
         >
           <ButtonPill
             aria-controls="test-ID"
             aria-expanded={true}
             aria-haspopup={true}
             id="test-ID"
+            onKeyDown={[Function]}
             onPress={[Function]}
             onPressStart={[Function]}
             useNativeKeyDown={true}
@@ -11289,6 +11311,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with showArrow 
               data-shallow-disabled={false}
               data-size={40}
               id="test-ID"
+              onKeyDown={[Function]}
               onPress={[Function]}
               onPressStart={[Function]}
               useNativeKeyDown={true}
@@ -11317,6 +11340,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with showArrow 
                     onClick={[Function]}
                     onDragStart={[Function]}
                     onFocus={[Function]}
+                    onKeyDown={[Function]}
                     onKeyUp={[Function]}
                     onMouseDown={[Function]}
                     onMouseEnter={[Function]}
@@ -13338,11 +13362,11 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with showArrow 
       </ForwardRef(TippyWrapper)>
     </LazyTippy>
   </Popover>
-</ForwardRef>
+</MenuTrigger>
 `;
 
 exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with style 1`] = `
-<ForwardRef
+<MenuTrigger
   aria-label="Menu Trigger Component "
   isOpen={true}
   style={
@@ -13373,13 +13397,14 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with style 1`] 
         "color": "pink",
       }
     }
-    trigger="click"
+    trigger="manual"
     triggerComponent={
       <ButtonPill
         aria-controls="test-ID"
         aria-expanded={true}
         aria-haspopup={true}
         id="test-ID"
+        onKeyDown={[Function]}
         onPress={[Function]}
         onPressStart={[Function]}
       >
@@ -13391,7 +13416,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with style 1`] 
     <LazyTippy
       animation={false}
       appendTo="parent"
-      hideOnClick={true}
+      hideOnClick={false}
       interactive={true}
       offset={
         Array [
@@ -13435,12 +13460,12 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with style 1`] 
       }
       render={[Function]}
       setInstance={[Function]}
-      trigger="click"
+      trigger="manual"
     >
       <ForwardRef(TippyWrapper)
         animation={false}
         appendTo="parent"
-        hideOnClick={true}
+        hideOnClick={false}
         interactive={true}
         offset={
           Array [
@@ -13492,12 +13517,12 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with style 1`] 
           }
         }
         render={[Function]}
-        trigger="click"
+        trigger="manual"
       >
         <Tippy
           animation={false}
           appendTo="parent"
-          hideOnClick={true}
+          hideOnClick={false}
           interactive={true}
           offset={
             Array [
@@ -13549,13 +13574,14 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with style 1`] 
             }
           }
           render={[Function]}
-          trigger="click"
+          trigger="manual"
         >
           <ButtonPill
             aria-controls="test-ID"
             aria-expanded={true}
             aria-haspopup={true}
             id="test-ID"
+            onKeyDown={[Function]}
             onPress={[Function]}
             onPressStart={[Function]}
             useNativeKeyDown={true}
@@ -13576,6 +13602,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with style 1`] 
               data-shallow-disabled={false}
               data-size={40}
               id="test-ID"
+              onKeyDown={[Function]}
               onPress={[Function]}
               onPressStart={[Function]}
               useNativeKeyDown={true}
@@ -13604,6 +13631,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with style 1`] 
                     onClick={[Function]}
                     onDragStart={[Function]}
                     onFocus={[Function]}
+                    onKeyDown={[Function]}
                     onKeyUp={[Function]}
                     onMouseDown={[Function]}
                     onMouseEnter={[Function]}
@@ -15570,11 +15598,11 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with style 1`] 
       </ForwardRef(TippyWrapper)>
     </LazyTippy>
   </Popover>
-</ForwardRef>
+</MenuTrigger>
 `;
 
 exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with variant 1`] = `
-<ForwardRef
+<MenuTrigger
   aria-label="Menu Trigger Component "
   isOpen={true}
   triggerComponent={
@@ -15596,13 +15624,14 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with variant 1`
     role="generic"
     setInstance={[Function]}
     showArrow={false}
-    trigger="click"
+    trigger="manual"
     triggerComponent={
       <ButtonPill
         aria-controls="test-ID"
         aria-expanded={true}
         aria-haspopup={true}
         id="test-ID"
+        onKeyDown={[Function]}
         onPress={[Function]}
         onPressStart={[Function]}
       >
@@ -15614,7 +15643,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with variant 1`
     <LazyTippy
       animation={false}
       appendTo="parent"
-      hideOnClick={true}
+      hideOnClick={false}
       interactive={true}
       offset={
         Array [
@@ -15658,12 +15687,12 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with variant 1`
       }
       render={[Function]}
       setInstance={[Function]}
-      trigger="click"
+      trigger="manual"
     >
       <ForwardRef(TippyWrapper)
         animation={false}
         appendTo="parent"
-        hideOnClick={true}
+        hideOnClick={false}
         interactive={true}
         offset={
           Array [
@@ -15715,12 +15744,12 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with variant 1`
           }
         }
         render={[Function]}
-        trigger="click"
+        trigger="manual"
       >
         <Tippy
           animation={false}
           appendTo="parent"
-          hideOnClick={true}
+          hideOnClick={false}
           interactive={true}
           offset={
             Array [
@@ -15772,13 +15801,14 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with variant 1`
             }
           }
           render={[Function]}
-          trigger="click"
+          trigger="manual"
         >
           <ButtonPill
             aria-controls="test-ID"
             aria-expanded={true}
             aria-haspopup={true}
             id="test-ID"
+            onKeyDown={[Function]}
             onPress={[Function]}
             onPressStart={[Function]}
             useNativeKeyDown={true}
@@ -15799,6 +15829,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with variant 1`
               data-shallow-disabled={false}
               data-size={40}
               id="test-ID"
+              onKeyDown={[Function]}
               onPress={[Function]}
               onPressStart={[Function]}
               useNativeKeyDown={true}
@@ -15827,6 +15858,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with variant 1`
                     onClick={[Function]}
                     onDragStart={[Function]}
                     onFocus={[Function]}
+                    onKeyDown={[Function]}
                     onKeyUp={[Function]}
                     onMouseDown={[Function]}
                     onMouseEnter={[Function]}
@@ -17782,11 +17814,11 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with variant 1`
       </ForwardRef(TippyWrapper)>
     </LazyTippy>
   </Popover>
-</ForwardRef>
+</MenuTrigger>
 `;
 
 exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with zIndex 1`] = `
-<ForwardRef
+<MenuTrigger
   aria-label="Menu Trigger Component "
   isOpen={true}
   triggerComponent={
@@ -17808,13 +17840,14 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with zIndex 1`]
     role="generic"
     setInstance={[Function]}
     showArrow={false}
-    trigger="click"
+    trigger="manual"
     triggerComponent={
       <ButtonPill
         aria-controls="test-ID"
         aria-expanded={true}
         aria-haspopup={true}
         id="test-ID"
+        onKeyDown={[Function]}
         onPress={[Function]}
         onPressStart={[Function]}
       >
@@ -17827,7 +17860,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with zIndex 1`]
     <LazyTippy
       animation={false}
       appendTo="parent"
-      hideOnClick={true}
+      hideOnClick={false}
       interactive={true}
       offset={
         Array [
@@ -17871,13 +17904,13 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with zIndex 1`]
       }
       render={[Function]}
       setInstance={[Function]}
-      trigger="click"
+      trigger="manual"
       zIndex={9998}
     >
       <ForwardRef(TippyWrapper)
         animation={false}
         appendTo="parent"
-        hideOnClick={true}
+        hideOnClick={false}
         interactive={true}
         offset={
           Array [
@@ -17929,13 +17962,13 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with zIndex 1`]
           }
         }
         render={[Function]}
-        trigger="click"
+        trigger="manual"
         zIndex={9998}
       >
         <Tippy
           animation={false}
           appendTo="parent"
-          hideOnClick={true}
+          hideOnClick={false}
           interactive={true}
           offset={
             Array [
@@ -17987,7 +18020,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with zIndex 1`]
             }
           }
           render={[Function]}
-          trigger="click"
+          trigger="manual"
           zIndex={9998}
         >
           <ButtonPill
@@ -17995,6 +18028,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with zIndex 1`]
             aria-expanded={true}
             aria-haspopup={true}
             id="test-ID"
+            onKeyDown={[Function]}
             onPress={[Function]}
             onPressStart={[Function]}
             useNativeKeyDown={true}
@@ -18015,6 +18049,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with zIndex 1`]
               data-shallow-disabled={false}
               data-size={40}
               id="test-ID"
+              onKeyDown={[Function]}
               onPress={[Function]}
               onPressStart={[Function]}
               useNativeKeyDown={true}
@@ -18043,6 +18078,7 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with zIndex 1`]
                     onClick={[Function]}
                     onDragStart={[Function]}
                     onFocus={[Function]}
+                    onKeyDown={[Function]}
                     onKeyUp={[Function]}
                     onMouseDown={[Function]}
                     onMouseEnter={[Function]}
@@ -19998,5 +20034,5 @@ exports[`<MenuTrigger /> - Enzyme snapshot should match snapshot with zIndex 1`]
       </ForwardRef(TippyWrapper)>
     </LazyTippy>
   </Popover>
-</ForwardRef>
+</MenuTrigger>
 `;

--- a/src/components/SpaceRowContent/SpaceRowContent.unit.test.tsx.snap
+++ b/src/components/SpaceRowContent/SpaceRowContent.unit.test.tsx.snap
@@ -1021,7 +1021,7 @@ exports[`<SpaceRowContent /> snapshot should match snapshot with menuItems 1`] =
       className="md-space-row-content-menu-trigger-wrapper"
       data-position="end"
     >
-      <ForwardRef
+      <MenuTrigger
         triggerComponent={
           <ButtonCircle
             aria-label="Menu trigger label"
@@ -1049,7 +1049,7 @@ exports[`<SpaceRowContent /> snapshot should match snapshot with menuItems 1`] =
           role="generic"
           setInstance={[Function]}
           showArrow={false}
-          trigger="click"
+          trigger="manual"
           triggerComponent={
             <ButtonCircle
               aria-controls={null}
@@ -1059,6 +1059,7 @@ exports[`<SpaceRowContent /> snapshot should match snapshot with menuItems 1`] =
               data-testid="menu-trigger-button"
               ghost={true}
               id="test-ID"
+              onKeyDown={[Function]}
               onPress={[Function]}
               onPressStart={[Function]}
               size={28}
@@ -1075,7 +1076,7 @@ exports[`<SpaceRowContent /> snapshot should match snapshot with menuItems 1`] =
           <LazyTippy
             animation={false}
             appendTo="parent"
-            hideOnClick={true}
+            hideOnClick={false}
             interactive={true}
             offset={
               Array [
@@ -1119,12 +1120,12 @@ exports[`<SpaceRowContent /> snapshot should match snapshot with menuItems 1`] =
             }
             render={[Function]}
             setInstance={[Function]}
-            trigger="click"
+            trigger="manual"
           >
             <ForwardRef(TippyWrapper)
               animation={false}
               appendTo="parent"
-              hideOnClick={true}
+              hideOnClick={false}
               interactive={true}
               offset={
                 Array [
@@ -1176,12 +1177,12 @@ exports[`<SpaceRowContent /> snapshot should match snapshot with menuItems 1`] =
                 }
               }
               render={[Function]}
-              trigger="click"
+              trigger="manual"
             >
               <Tippy
                 animation={false}
                 appendTo="parent"
-                hideOnClick={true}
+                hideOnClick={false}
                 interactive={true}
                 offset={
                   Array [
@@ -1233,7 +1234,7 @@ exports[`<SpaceRowContent /> snapshot should match snapshot with menuItems 1`] =
                   }
                 }
                 render={[Function]}
-                trigger="click"
+                trigger="manual"
               >
                 <ButtonCircle
                   aria-controls={null}
@@ -1243,6 +1244,7 @@ exports[`<SpaceRowContent /> snapshot should match snapshot with menuItems 1`] =
                   data-testid="menu-trigger-button"
                   ghost={true}
                   id="test-ID"
+                  onKeyDown={[Function]}
                   onPress={[Function]}
                   onPressStart={[Function]}
                   size={28}
@@ -1265,6 +1267,7 @@ exports[`<SpaceRowContent /> snapshot should match snapshot with menuItems 1`] =
                     data-size={28}
                     data-testid="menu-trigger-button"
                     id="test-ID"
+                    onKeyDown={[Function]}
                     onPress={[Function]}
                     onPressStart={[Function]}
                     useNativeKeyDown={true}
@@ -1294,6 +1297,7 @@ exports[`<SpaceRowContent /> snapshot should match snapshot with menuItems 1`] =
                           onClick={[Function]}
                           onDragStart={[Function]}
                           onFocus={[Function]}
+                          onKeyDown={[Function]}
                           onKeyUp={[Function]}
                           onMouseDown={[Function]}
                           onMouseEnter={[Function]}
@@ -1349,7 +1353,7 @@ exports[`<SpaceRowContent /> snapshot should match snapshot with menuItems 1`] =
             </ForwardRef(TippyWrapper)>
           </LazyTippy>
         </Popover>
-      </ForwardRef>
+      </MenuTrigger>
     </div>
   </ListItemBaseSection>
 </SpaceRowContent>

--- a/src/components/TooltipMenuTriggerCombo/TooltipMenuTriggerCombo.stories.docs.mdx
+++ b/src/components/TooltipMenuTriggerCombo/TooltipMenuTriggerCombo.stories.docs.mdx
@@ -1,1 +1,4 @@
 The `<TooltipMenuTriggerCombo />` component.
+
+This component allows you to have both a MenuTrigger and a Tooltip on the same trigger element. The
+Menu and Tooltip will not be shown at the same time to avoid any unintentional overlapping content.

--- a/src/components/TooltipMenuTriggerCombo/TooltipMenuTriggerCombo.stories.docs.mdx
+++ b/src/components/TooltipMenuTriggerCombo/TooltipMenuTriggerCombo.stories.docs.mdx
@@ -1,0 +1,1 @@
+The `<TooltipMenuTriggerCombo />` component.

--- a/src/components/TooltipMenuTriggerCombo/TooltipMenuTriggerCombo.stories.tsx
+++ b/src/components/TooltipMenuTriggerCombo/TooltipMenuTriggerCombo.stories.tsx
@@ -59,7 +59,7 @@ const ExampleStory = ({ isPill }: { isPill: boolean }) => {
   );
 };
 
-const Example: StoryObj<typeof TooltipMenuTriggerCombo> = {
+const Example: StoryObj = {
   // eslint-disable-next-line react/display-name
   render: () => (
     <>
@@ -69,4 +69,27 @@ const Example: StoryObj<typeof TooltipMenuTriggerCombo> = {
   ),
 };
 
-export { Example };
+const WithDescriptionTooltip: StoryObj = {
+  // eslint-disable-next-line react/display-name
+  render: () => (
+    <TooltipMenuTriggerCombo
+      menuContent={
+        <Menu selectionMode="single" key="2">
+          <Item key="one">This is a longer text and should trim nicely...</Item>
+          <Item key="two">Two</Item>
+          <Item key="three">Three</Item>
+          <Item key="four">Four</Item>
+          <Item key="five">Five</Item>
+          <Item key="six">Six</Item>
+        </Menu>
+      }
+      tooltipContent={'This is a description'}
+      tooltipProps={{
+        type: 'description',
+      }}
+      triggerComponent={<ButtonPill>Open Menu</ButtonPill>}
+    />
+  ),
+};
+
+export { Example, WithDescriptionTooltip };

--- a/src/components/TooltipMenuTriggerCombo/TooltipMenuTriggerCombo.stories.tsx
+++ b/src/components/TooltipMenuTriggerCombo/TooltipMenuTriggerCombo.stories.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import { DocumentationPage } from '../../storybook/helper.stories.docs';
-import StyleDocs from '../../storybook/docs.stories.style.mdx';
 
 import TooltipMenuTriggerCombo from './';
 import Documentation from './TooltipMenuTriggerCombo.stories.docs.mdx';
@@ -17,7 +16,7 @@ export default {
   parameters: {
     expanded: true,
     docs: {
-      page: DocumentationPage(Documentation, StyleDocs),
+      page: DocumentationPage(Documentation),
     },
   },
 };
@@ -25,14 +24,7 @@ export default {
 const ExampleStory = ({ isPill }: { isPill: boolean }) => {
   const [isOpen, setIsOpen] = useState(false);
 
-  const icon = (
-    <Icon
-      name={isOpen ? 'arrow-up' : 'arrow-down'}
-      weight="bold"
-      autoScale={100}
-      style={{ border: '1px solid black' }}
-    />
-  );
+  const icon = <Icon name={isOpen ? 'arrow-up' : 'arrow-down'} weight="bold" autoScale={100} />;
 
   return (
     <TooltipMenuTriggerCombo
@@ -68,6 +60,7 @@ const ExampleStory = ({ isPill }: { isPill: boolean }) => {
 };
 
 const Example: StoryObj<typeof TooltipMenuTriggerCombo> = {
+  // eslint-disable-next-line react/display-name
   render: () => (
     <>
       <ExampleStory isPill={true} />

--- a/src/components/TooltipMenuTriggerCombo/TooltipMenuTriggerCombo.stories.tsx
+++ b/src/components/TooltipMenuTriggerCombo/TooltipMenuTriggerCombo.stories.tsx
@@ -1,0 +1,79 @@
+import React, { useState } from 'react';
+import { DocumentationPage } from '../../storybook/helper.stories.docs';
+import StyleDocs from '../../storybook/docs.stories.style.mdx';
+
+import TooltipMenuTriggerCombo from './';
+import Documentation from './TooltipMenuTriggerCombo.stories.docs.mdx';
+import Menu from '../Menu';
+import { Item } from '@react-stately/collections';
+import Icon from '../Icon';
+import ButtonPill from '../ButtonPill';
+import { StoryObj } from '@storybook/react';
+import ButtonCircle from '../ButtonCircle';
+
+export default {
+  title: 'Momentum UI/TooltipMenuTriggerCombo',
+  component: TooltipMenuTriggerCombo,
+  parameters: {
+    expanded: true,
+    docs: {
+      page: DocumentationPage(Documentation, StyleDocs),
+    },
+  },
+};
+
+const ExampleStory = ({ isPill }: { isPill: boolean }) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const icon = (
+    <Icon
+      name={isOpen ? 'arrow-up' : 'arrow-down'}
+      weight="bold"
+      autoScale={100}
+      style={{ border: '1px solid black' }}
+    />
+  );
+
+  return (
+    <TooltipMenuTriggerCombo
+      menuContent={
+        <Menu selectionMode="single" key="2">
+          <Item key="one">This is a longer text and should trim nicely...</Item>
+          <Item key="two">Two</Item>
+          <Item key="three">Three</Item>
+          <Item key="four">Four</Item>
+          <Item key="five">Five</Item>
+          <Item key="six">Six</Item>
+        </Menu>
+      }
+      menuTriggerProps={{
+        closeOnSelect: true,
+        onOpenChange: setIsOpen,
+      }}
+      tooltipContent={<>Tooltip</>}
+      tooltipProps={{
+        type: 'label',
+      }}
+      triggerComponent={
+        isPill ? (
+          <ButtonPill>
+            <div>Menu</div> {icon}
+          </ButtonPill>
+        ) : (
+          <ButtonCircle>{icon}</ButtonCircle>
+        )
+      }
+    />
+  );
+};
+
+const Example: StoryObj<typeof TooltipMenuTriggerCombo> = {
+  render: () => (
+    <>
+      <ExampleStory isPill={true} />
+      <ExampleStory isPill={false} />
+    </>
+  ),
+};
+
+export { Example };

--- a/src/components/TooltipMenuTriggerCombo/TooltipMenuTriggerCombo.style.scss
+++ b/src/components/TooltipMenuTriggerCombo/TooltipMenuTriggerCombo.style.scss
@@ -1,2 +1,0 @@
-.md-tooltip-menu-trigger-combo-wrapper {
-}

--- a/src/components/TooltipMenuTriggerCombo/TooltipMenuTriggerCombo.style.scss
+++ b/src/components/TooltipMenuTriggerCombo/TooltipMenuTriggerCombo.style.scss
@@ -1,0 +1,2 @@
+.md-tooltip-menu-trigger-combo-wrapper {
+}

--- a/src/components/TooltipMenuTriggerCombo/TooltipMenuTriggerCombo.tsx
+++ b/src/components/TooltipMenuTriggerCombo/TooltipMenuTriggerCombo.tsx
@@ -1,7 +1,6 @@
 import React, { FC, useCallback, useEffect, useState } from 'react';
 
 import { Props } from './TooltipMenuTriggerCombo.types';
-import './TooltipMenuTriggerCombo.style.scss';
 import MenuTrigger from '../MenuTrigger';
 import TooltipWrapper from './TooltipWrapper';
 import { PopoverInstance } from '../Popover';
@@ -13,7 +12,7 @@ const TooltipMenuTriggerCombo: FC<Props> = (props: Props) => {
   const { menuContent, menuTriggerProps, tooltipContent, tooltipProps, triggerComponent } = props;
 
   const [tooltipInstance, setTooltipInstance] = useState<PopoverInstance>();
-  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isTooltipOpen, setIsTooltipOpen] = useState(false);
 
   const setMergedTooltipInstances = useCallback(
@@ -27,7 +26,7 @@ const TooltipMenuTriggerCombo: FC<Props> = (props: Props) => {
   const handleMenuOpenChange = useCallback(
     (isOpen: boolean) => {
       menuTriggerProps?.onOpenChange?.(isOpen);
-      setIsPopoverOpen(isOpen);
+      setIsMenuOpen(isOpen);
     },
     [menuTriggerProps]
   );
@@ -50,10 +49,10 @@ const TooltipMenuTriggerCombo: FC<Props> = (props: Props) => {
 
   // if the tooltip and popover are both open at the same time we close the tooltip to avoid them overlapping
   useEffect(() => {
-    if (isPopoverOpen && isTooltipOpen) {
+    if (isMenuOpen && isTooltipOpen) {
       tooltipInstance?.hide();
     }
-  }, [isPopoverOpen, isTooltipOpen, tooltipInstance]);
+  }, [isMenuOpen, isTooltipOpen, tooltipInstance]);
 
   return (
     <MenuTrigger
@@ -62,6 +61,7 @@ const TooltipMenuTriggerCombo: FC<Props> = (props: Props) => {
       triggerComponent={
         <TooltipWrapper
           _tooltipProps={{
+            type: 'label',
             ...tooltipProps,
             onHide: handleOnHideTooltip,
             onShow: handleOnShowTooltip,

--- a/src/components/TooltipMenuTriggerCombo/TooltipMenuTriggerCombo.tsx
+++ b/src/components/TooltipMenuTriggerCombo/TooltipMenuTriggerCombo.tsx
@@ -1,0 +1,80 @@
+import React, { FC, useCallback, useEffect, useState } from 'react';
+
+import { Props } from './TooltipMenuTriggerCombo.types';
+import './TooltipMenuTriggerCombo.style.scss';
+import MenuTrigger from '../MenuTrigger';
+import TooltipWrapper from './TooltipWrapper';
+import { PopoverInstance } from '../Popover';
+
+/**
+ * The TooltipMenuTriggerCombo component.
+ */
+const TooltipMenuTriggerCombo: FC<Props> = (props: Props) => {
+  const { menuContent, menuTriggerProps, tooltipContent, tooltipProps, triggerComponent } = props;
+
+  const [tooltipInstance, setTooltipInstance] = useState<PopoverInstance>();
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const [isTooltipOpen, setIsTooltipOpen] = useState(false);
+
+  const setMergedTooltipInstances = useCallback(
+    (popoverInstance: PopoverInstance | undefined) => {
+      tooltipProps?.setInstance?.(popoverInstance);
+      setTooltipInstance(popoverInstance);
+    },
+    [tooltipProps]
+  );
+
+  const handleMenuOpenChange = useCallback(
+    (isOpen: boolean) => {
+      menuTriggerProps?.onOpenChange?.(isOpen);
+      setIsPopoverOpen(isOpen);
+    },
+    [menuTriggerProps]
+  );
+
+  const handleOnHideTooltip = useCallback(
+    (instance: PopoverInstance | undefined) => {
+      tooltipProps?.onHide?.(instance);
+      setIsTooltipOpen(false);
+    },
+    [tooltipProps]
+  );
+
+  const handleOnShowTooltip = useCallback(
+    (instance: PopoverInstance | undefined) => {
+      tooltipProps?.onShow?.(instance);
+      setIsTooltipOpen(true);
+    },
+    [tooltipProps]
+  );
+
+  // if the tooltip and popover are both open at the same time we close the tooltip to avoid them overlapping
+  useEffect(() => {
+    if (isPopoverOpen && isTooltipOpen) {
+      tooltipInstance?.hide();
+    }
+  }, [isPopoverOpen, isTooltipOpen, tooltipInstance]);
+
+  return (
+    <MenuTrigger
+      {...menuTriggerProps}
+      onOpenChange={handleMenuOpenChange}
+      triggerComponent={
+        <TooltipWrapper
+          _tooltipProps={{
+            ...tooltipProps,
+            onHide: handleOnHideTooltip,
+            onShow: handleOnShowTooltip,
+            setInstance: setMergedTooltipInstances,
+            children: tooltipContent,
+          }}
+          _triggerComponent={triggerComponent}
+        />
+      }
+    >
+      {menuContent}
+    </MenuTrigger>
+  );
+};
+
+export default TooltipMenuTriggerCombo;

--- a/src/components/TooltipMenuTriggerCombo/TooltipMenuTriggerCombo.types.ts
+++ b/src/components/TooltipMenuTriggerCombo/TooltipMenuTriggerCombo.types.ts
@@ -1,0 +1,11 @@
+import { ReactElement } from 'react';
+import { MenuTriggerProps } from '../MenuTrigger';
+import { TooltipProps } from '../Tooltip';
+
+export interface Props {
+  menuTriggerProps: Omit<MenuTriggerProps, 'children' | 'triggerComponent'>;
+  menuContent: MenuTriggerProps['children'];
+  tooltipProps: Omit<TooltipProps, 'children' | 'triggerComponent'>;
+  tooltipContent: TooltipProps['children'];
+  triggerComponent: ReactElement;
+}

--- a/src/components/TooltipMenuTriggerCombo/TooltipMenuTriggerCombo.types.ts
+++ b/src/components/TooltipMenuTriggerCombo/TooltipMenuTriggerCombo.types.ts
@@ -3,9 +3,9 @@ import { MenuTriggerProps } from '../MenuTrigger';
 import { TooltipProps } from '../Tooltip';
 
 export interface Props {
-  menuTriggerProps: Omit<MenuTriggerProps, 'children' | 'triggerComponent'>;
+  menuTriggerProps?: Omit<MenuTriggerProps, 'children' | 'triggerComponent'>;
   menuContent: MenuTriggerProps['children'];
-  tooltipProps: Omit<TooltipProps, 'children' | 'triggerComponent'>;
+  tooltipProps?: Partial<Omit<TooltipProps, 'children' | 'triggerComponent'>>;
   tooltipContent: TooltipProps['children'];
   triggerComponent: ReactElement;
 }

--- a/src/components/TooltipMenuTriggerCombo/TooltipMenuTriggerCombo.unit.test.tsx
+++ b/src/components/TooltipMenuTriggerCombo/TooltipMenuTriggerCombo.unit.test.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import TooltipMenuTriggerCombo, { TOOLTIP_MENU_TRIGGER_COMBO_CONSTANTS as CONSTANTS } from './';
+
+describe('<TooltipMenuTriggerCombo />', () => {
+  describe('snapshot', () => {
+    it('should match snapshot', () => {
+      expect.assertions(1);
+
+      const container = mount(<TooltipMenuTriggerCombo />);
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match snapshot with className', () => {
+      expect.assertions(1);
+
+      const className = 'example-class';
+
+      const container = mount(<TooltipMenuTriggerCombo className={className} />);
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match snapshot with id', () => {
+      expect.assertions(1);
+
+      const id = 'example-id';
+
+      const container = mount(<TooltipMenuTriggerCombo id={id} />);
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should match snapshot with style', () => {
+      expect.assertions(1);
+
+      const style = { color: 'pink' };
+
+      const container = mount(<TooltipMenuTriggerCombo style={style} />);
+
+      expect(container).toMatchSnapshot();
+    });
+
+    /* ...additional snapshot tests... */
+  });
+
+  describe('attributes', () => {
+    it('should have its wrapper class', () => {
+      expect.assertions(1);
+
+      const element = mount(<TooltipMenuTriggerCombo />)
+        .find(TooltipMenuTriggerCombo)
+        .getDOMNode();
+
+      expect(element.classList.contains(CONSTANTS.STYLE.wrapper)).toBe(true);
+    });
+
+    it('should have provided class when className is provided', () => {
+      expect.assertions(1);
+
+      const className = 'example-class';
+
+      const element = mount(<TooltipMenuTriggerCombo className={className} />)
+        .find(TooltipMenuTriggerCombo)
+        .getDOMNode();
+
+      expect(element.classList.contains(className)).toBe(true);
+    });
+
+    it('should have provided id when id is provided', () => {
+      expect.assertions(1);
+
+      const id = 'example-id';
+
+      const element = mount(<TooltipMenuTriggerCombo id={id} />)
+        .find(TooltipMenuTriggerCombo)
+        .getDOMNode();
+
+      expect(element.id).toBe(id);
+    });
+
+    it('should have provided style when style is provided', () => {
+      expect.assertions(1);
+
+      const style = { color: 'pink' };
+      const styleString = 'color: pink;';
+
+      const element = mount(<TooltipMenuTriggerCombo style={style} />)
+        .find(TooltipMenuTriggerCombo)
+        .getDOMNode();
+
+      expect(element.getAttribute('style')).toBe(styleString);
+    });
+
+    /* ...additional attribute tests... */
+  });
+
+  describe('actions', () => {
+    /* ...action tests... */
+  });
+});

--- a/src/components/TooltipMenuTriggerCombo/TooltipMenuTriggerCombo.unit.test.tsx
+++ b/src/components/TooltipMenuTriggerCombo/TooltipMenuTriggerCombo.unit.test.tsx
@@ -1,103 +1,359 @@
-import React from 'react';
 import { mount } from 'enzyme';
+import React from 'react';
 
-import TooltipMenuTriggerCombo, { TOOLTIP_MENU_TRIGGER_COMBO_CONSTANTS as CONSTANTS } from './';
+import { Item } from '@react-stately/collections';
+import '@testing-library/jest-dom';
+import { getByText, queryByText, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ButtonPill from '../ButtonPill';
+import Menu from '../Menu';
+import MenuTrigger from '../MenuTrigger';
+import { STYLE as POPOVER_STYLE } from '../Popover/Popover.constants';
+import Text from '../Text';
+import Tooltip from '../Tooltip';
+import TooltipMenuTriggerCombo from './';
+
+jest.mock('uuid', () => ({
+  v4: () => '1',
+}));
 
 describe('<TooltipMenuTriggerCombo />', () => {
+  const menu = (
+    <Menu selectionMode="single" key="2">
+      <Item key="one">One</Item>
+      <Item key="two">Two</Item>
+      <Item key="three">Three</Item>
+    </Menu>
+  );
+  const tooltipContent = <Text tagName="p">Tooltip</Text>;
+  const triggerComponent = <ButtonPill>Trigger component</ButtonPill>;
+
   describe('snapshot', () => {
     it('should match snapshot', () => {
       expect.assertions(1);
 
-      const container = mount(<TooltipMenuTriggerCombo />);
+      const container = mount(
+        <TooltipMenuTriggerCombo
+          menuContent={menu}
+          tooltipProps={{
+            type: 'label',
+          }}
+          tooltipContent={tooltipContent}
+          triggerComponent={triggerComponent}
+        />
+      );
 
       expect(container).toMatchSnapshot();
     });
 
-    it('should match snapshot with className', () => {
+    it('should match snapshot with menuTriggerProps', () => {
       expect.assertions(1);
 
-      const className = 'example-class';
-
-      const container = mount(<TooltipMenuTriggerCombo className={className} />);
+      const container = mount(
+        <TooltipMenuTriggerCombo
+          menuTriggerProps={{
+            closeOnSelect: false,
+          }}
+          menuContent={menu}
+          tooltipProps={{
+            type: 'label',
+          }}
+          tooltipContent={tooltipContent}
+          triggerComponent={triggerComponent}
+        />
+      );
 
       expect(container).toMatchSnapshot();
     });
 
-    it('should match snapshot with id', () => {
+    it('should match snapshot with tooltipProps', () => {
       expect.assertions(1);
 
-      const id = 'example-id';
-
-      const container = mount(<TooltipMenuTriggerCombo id={id} />);
+      const container = mount(
+        <TooltipMenuTriggerCombo
+          menuTriggerProps={{
+            closeOnSelect: false,
+          }}
+          menuContent={menu}
+          tooltipProps={{
+            type: 'label',
+            placement: 'bottom',
+          }}
+          tooltipContent={tooltipContent}
+          triggerComponent={triggerComponent}
+        />
+      );
 
       expect(container).toMatchSnapshot();
     });
 
-    it('should match snapshot with style', () => {
+    it('should match snapshot with tooltipProps.type = "description"', () => {
       expect.assertions(1);
 
-      const style = { color: 'pink' };
-
-      const container = mount(<TooltipMenuTriggerCombo style={style} />);
+      const container = mount(
+        <TooltipMenuTriggerCombo
+          menuContent={menu}
+          tooltipProps={{
+            type: 'description',
+            placement: 'bottom',
+          }}
+          tooltipContent={tooltipContent}
+          triggerComponent={triggerComponent}
+        />
+      );
 
       expect(container).toMatchSnapshot();
     });
-
-    /* ...additional snapshot tests... */
   });
 
   describe('attributes', () => {
-    it('should have its wrapper class', () => {
-      expect.assertions(1);
+    it('should have popover with correct props', () => {
+      expect.assertions(4);
 
-      const element = mount(<TooltipMenuTriggerCombo />)
-        .find(TooltipMenuTriggerCombo)
-        .getDOMNode();
+      const comboElement = mount(
+        <TooltipMenuTriggerCombo
+          triggerComponent={triggerComponent}
+          tooltipContent={tooltipContent}
+          menuContent={menu}
+        />
+      ).find(TooltipMenuTriggerCombo);
 
-      expect(element.classList.contains(CONSTANTS.STYLE.wrapper)).toBe(true);
+      const menuTrigger = comboElement.find(MenuTrigger);
+
+      expect(menuTrigger.props()).toStrictEqual({
+        children: menu,
+        onOpenChange: expect.any(Function),
+        triggerComponent: expect.anything(),
+      });
+
+      const tooltip = comboElement.find(Tooltip);
+
+      expect(tooltip.props()).toStrictEqual({
+        children: tooltipContent,
+        onHide: expect.any(Function),
+        onShow: expect.any(Function),
+        setInstance: expect.any(Function),
+        triggerComponent: expect.any(Object),
+        type: 'label',
+      });
+
+      expect(tooltip.prop('triggerComponent').type).toEqual(triggerComponent.type);
+      expect(tooltip.prop('triggerComponent').props).toEqual({
+        ...triggerComponent.props,
+        'aria-controls': null,
+        'aria-expanded': false,
+        'aria-haspopup': true,
+        id: 'test-ID',
+        onKeyDown: expect.any(Function),
+        onPress: expect.any(Function),
+        onPressStart: expect.any(Function),
+      });
     });
 
-    it('should have provided class when className is provided', () => {
-      expect.assertions(1);
+    it('should have provided tooltipProps on Tooltip when provided', () => {
+      expect.assertions(4);
 
-      const className = 'example-class';
+      const comboElement = mount(
+        <TooltipMenuTriggerCombo
+          triggerComponent={triggerComponent}
+          tooltipProps={{
+            placement: 'top',
+          }}
+          tooltipContent={tooltipContent}
+          menuContent={menu}
+        />
+      ).find(TooltipMenuTriggerCombo);
 
-      const element = mount(<TooltipMenuTriggerCombo className={className} />)
-        .find(TooltipMenuTriggerCombo)
-        .getDOMNode();
+      const menuTrigger = comboElement.find(MenuTrigger);
 
-      expect(element.classList.contains(className)).toBe(true);
+      expect(menuTrigger.props()).toStrictEqual({
+        children: menu,
+        onOpenChange: expect.any(Function),
+        triggerComponent: expect.anything(),
+      });
+
+      const tooltip = comboElement.find(Tooltip);
+
+      expect(tooltip.props()).toStrictEqual({
+        children: tooltipContent,
+        placement: 'top',
+        onHide: expect.any(Function),
+        onShow: expect.any(Function),
+        setInstance: expect.any(Function),
+        triggerComponent: expect.any(Object),
+        type: 'label',
+      });
+
+      expect(tooltip.prop('triggerComponent').type).toEqual(triggerComponent.type);
+      expect(tooltip.prop('triggerComponent').props).toEqual({
+        ...triggerComponent.props,
+        'aria-controls': null,
+        'aria-expanded': false,
+        'aria-haspopup': true,
+        id: 'test-ID',
+        onKeyDown: expect.any(Function),
+        onPress: expect.any(Function),
+        onPressStart: expect.any(Function),
+      });
     });
-
-    it('should have provided id when id is provided', () => {
-      expect.assertions(1);
-
-      const id = 'example-id';
-
-      const element = mount(<TooltipMenuTriggerCombo id={id} />)
-        .find(TooltipMenuTriggerCombo)
-        .getDOMNode();
-
-      expect(element.id).toBe(id);
-    });
-
-    it('should have provided style when style is provided', () => {
-      expect.assertions(1);
-
-      const style = { color: 'pink' };
-      const styleString = 'color: pink;';
-
-      const element = mount(<TooltipMenuTriggerCombo style={style} />)
-        .find(TooltipMenuTriggerCombo)
-        .getDOMNode();
-
-      expect(element.getAttribute('style')).toBe(styleString);
-    });
-
-    /* ...additional attribute tests... */
   });
 
   describe('actions', () => {
-    /* ...action tests... */
+    it.each([
+      ['mouse', false],
+      ['keyboard', true],
+    ])('passes through the event callbacks (with %s)', async (_, withKeyboard) => {
+      const user = userEvent.setup();
+
+      const handleOpenChange = jest.fn();
+      const handleTooltipOpen = jest.fn();
+      const handleTooltipHide = jest.fn();
+      const handleSetTooltipInstance = jest.fn();
+
+      render(
+        <TooltipMenuTriggerCombo
+          triggerComponent={triggerComponent}
+          tooltipProps={{
+            setInstance: handleSetTooltipInstance,
+            onShow: handleTooltipOpen,
+            onHide: handleTooltipHide,
+          }}
+          tooltipContent={tooltipContent}
+          menuTriggerProps={{
+            onOpenChange: handleOpenChange,
+          }}
+          menuContent={menu}
+        />
+      );
+
+      expect(handleSetTooltipInstance).toHaveBeenCalled();
+
+      // Open Tooltip
+      if (withKeyboard) {
+        await user.tab();
+      } else {
+        await user.hover(screen.getByRole('button'));
+      }
+      expect(handleTooltipOpen).toHaveBeenCalled();
+
+      // Open Menu & Close Tooltip
+      if (withKeyboard) {
+        await user.keyboard('{Enter}');
+      } else {
+        await user.click(screen.getByRole('button'));
+      }
+      expect(handleTooltipHide).toHaveBeenCalled();
+      expect(handleOpenChange).toHaveBeenCalledWith(true);
+      handleOpenChange.mockReset();
+
+      // Close Menu
+      await user.keyboard('{Escape}');
+      expect(handleOpenChange).toHaveBeenCalledWith(false);
+    });
+
+    it('should hide tooltip when opening menu when navigating with keyboard', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <TooltipMenuTriggerCombo
+          triggerComponent={triggerComponent}
+          tooltipContent={tooltipContent}
+          menuContent={menu}
+        />
+      );
+
+      // press tab
+      await user.tab();
+
+      // trigger button should be focused, tooltip should be shown & menu hidden
+      expect(screen.getByRole('button')).toHaveFocus();
+
+      let tooltip = screen.getByRole('tooltip', { hidden: true });
+      await waitFor(() => {
+        expect(getByText(tooltip, 'Tooltip')).toBeInTheDocument();
+        expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+      });
+
+      // press enter
+      await user.keyboard('{Enter}');
+
+      const menuItems = screen.getAllByRole('menuitemradio');
+
+      // first menu item should be focused, menu should be shown & tooltip hidden
+      expect(menuItems[0]).toHaveFocus();
+      await waitFor(() => {
+        expect(queryByText(tooltip, 'Tooltip')).not.toBeInTheDocument();
+      });
+
+      // focus lock inside popover should work
+      await user.tab();
+      expect(menuItems[0]).toHaveFocus();
+      await user.tab({ shift: true });
+      expect(menuItems[0]).toHaveFocus();
+
+      // press Escape
+      await user.keyboard('{Escape}');
+
+      // trigger button should be focused once again, tooltip should be shown & menu hidden
+      expect(screen.getByRole('button')).toHaveFocus();
+      tooltip = screen.getByRole('tooltip', { hidden: true });
+      await waitFor(() => {
+        expect(getByText(tooltip, 'Tooltip')).toBeInTheDocument();
+        expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+      });
+
+      // press Escape 2nd time
+      await user.keyboard('{Escape}');
+
+      // trigger button should be focused still, tooltip & menu both hidden
+      expect(screen.getByRole('button')).toHaveFocus();
+      await waitFor(() => {
+        expect(queryByText(tooltip, 'Tooltip')).not.toBeInTheDocument();
+        expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+      });
+    });
+
+    it('should hide tooltip when opening popover when navigating with mouse', async () => {
+      const user = userEvent.setup();
+
+      const { container } = render(
+        <TooltipMenuTriggerCombo
+          triggerComponent={triggerComponent}
+          tooltipContent={tooltipContent}
+          menuContent={menu}
+        />
+      );
+
+      // user hovers over Example button
+      await user.hover(screen.getByText('Trigger component'));
+
+      // tooltip should be shown but menu remains hidden
+
+      const tooltip = screen.getByRole('tooltip', { hidden: true });
+      await waitFor(() => {
+        expect(getByText(tooltip, 'Tooltip')).toBeInTheDocument();
+        expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+      });
+
+      // user clicks on Example button
+      await user.click(screen.getByText('Trigger component'));
+
+      // tooltip should be hidden and menu shown
+      await waitFor(() => {
+        expect(queryByText(tooltip, 'Tooltip')).not.toBeInTheDocument();
+        expect(screen.getByRole('menu')).toBeInTheDocument();
+      });
+
+      // user then clicks off the menu to close it
+      const backdrop = container.querySelector(`.${POPOVER_STYLE.backdrop}`);
+
+      await user.click(backdrop);
+
+      // tooltip & menu both hidden
+      await waitFor(() => {
+        expect(queryByText(tooltip, 'Tooltip')).not.toBeInTheDocument();
+        expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+      });
+    });
   });
 });

--- a/src/components/TooltipMenuTriggerCombo/TooltipMenuTriggerCombo.unit.test.tsx.snap
+++ b/src/components/TooltipMenuTriggerCombo/TooltipMenuTriggerCombo.unit.test.tsx.snap
@@ -1,0 +1,2619 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<TooltipMenuTriggerCombo /> snapshot should match snapshot 1`] = `
+<TooltipMenuTriggerCombo
+  menuContent={
+    <_Menu
+      selectionMode="single"
+    >
+      <$de85adf0b38f4f13e9cffd2f21$var$Item>
+        One
+      </$de85adf0b38f4f13e9cffd2f21$var$Item>
+      <$de85adf0b38f4f13e9cffd2f21$var$Item>
+        Two
+      </$de85adf0b38f4f13e9cffd2f21$var$Item>
+      <$de85adf0b38f4f13e9cffd2f21$var$Item>
+        Three
+      </$de85adf0b38f4f13e9cffd2f21$var$Item>
+    </_Menu>
+  }
+  tooltipContent={
+    <Text
+      tagName="p"
+    >
+      Tooltip
+    </Text>
+  }
+  tooltipProps={
+    Object {
+      "type": "label",
+    }
+  }
+  triggerComponent={
+    <ButtonPill>
+      Trigger component
+    </ButtonPill>
+  }
+>
+  <MenuTrigger
+    onOpenChange={[Function]}
+    triggerComponent={
+      <TooltipWrapper
+        _tooltipProps={
+          Object {
+            "children": <Text
+              tagName="p"
+            >
+              Tooltip
+            </Text>,
+            "onHide": [Function],
+            "onShow": [Function],
+            "setInstance": [Function],
+            "type": "label",
+          }
+        }
+        _triggerComponent={
+          <ButtonPill>
+            Trigger component
+          </ButtonPill>
+        }
+      />
+    }
+  >
+    <Popover
+      autoFocus={false}
+      className="md-menu-trigger-wrapper"
+      color="primary"
+      hideOnEsc={false}
+      interactive={true}
+      onClickOutside={[Function]}
+      onKeyDown={[Function]}
+      placement="bottom-start"
+      role="generic"
+      setInstance={[Function]}
+      showArrow={false}
+      trigger="manual"
+      triggerComponent={
+        <TooltipWrapper
+          _tooltipProps={
+            Object {
+              "children": <Text
+                tagName="p"
+              >
+                Tooltip
+              </Text>,
+              "onHide": [Function],
+              "onShow": [Function],
+              "setInstance": [Function],
+              "type": "label",
+            }
+          }
+          _triggerComponent={
+            <ButtonPill>
+              Trigger component
+            </ButtonPill>
+          }
+          aria-controls={null}
+          aria-expanded={false}
+          aria-haspopup={true}
+          id="test-ID"
+          onKeyDown={[Function]}
+          onPress={[Function]}
+          onPressStart={[Function]}
+        />
+      }
+      variant="medium"
+    >
+      <LazyTippy
+        animation={false}
+        appendTo="parent"
+        hideOnClick={false}
+        interactive={true}
+        offset={
+          Array [
+            0,
+            5,
+          ]
+        }
+        onClickOutside={[Function]}
+        onHidden={[Function]}
+        placement="bottom-start"
+        plugins={
+          Array [
+            Object {
+              "fn": [Function],
+              "name": "addBackdropPlugin",
+            },
+          ]
+        }
+        popperOptions={
+          Object {
+            "modifiers": Array [
+              Object {
+                "enabled": false,
+                "name": "arrow",
+                "options": Object {
+                  "element": "#arrow1",
+                  "padding": 5,
+                },
+              },
+              Object {
+                "name": "preventOverflow",
+                "options": Object {
+                  "altAxis": true,
+                  "boundariesElement": "scrollParent",
+                  "padding": 8,
+                },
+              },
+            ],
+            "strategy": "absolute",
+          }
+        }
+        render={[Function]}
+        setInstance={[Function]}
+        trigger="manual"
+      >
+        <ForwardRef(TippyWrapper)
+          animation={false}
+          appendTo="parent"
+          hideOnClick={false}
+          interactive={true}
+          offset={
+            Array [
+              0,
+              5,
+            ]
+          }
+          onClickOutside={[Function]}
+          onHidden={[Function]}
+          placement="bottom-start"
+          plugins={
+            Array [
+              Object {
+                "fn": [Function],
+              },
+              Object {
+                "fn": [Function],
+              },
+              Object {
+                "fn": [Function],
+              },
+              Object {
+                "fn": [Function],
+                "name": "addBackdropPlugin",
+              },
+            ]
+          }
+          popperOptions={
+            Object {
+              "modifiers": Array [
+                Object {
+                  "enabled": false,
+                  "name": "arrow",
+                  "options": Object {
+                    "element": "#arrow1",
+                    "padding": 5,
+                  },
+                },
+                Object {
+                  "name": "preventOverflow",
+                  "options": Object {
+                    "altAxis": true,
+                    "boundariesElement": "scrollParent",
+                    "padding": 8,
+                  },
+                },
+              ],
+              "strategy": "absolute",
+            }
+          }
+          render={[Function]}
+          trigger="manual"
+        >
+          <Tippy
+            animation={false}
+            appendTo="parent"
+            hideOnClick={false}
+            interactive={true}
+            offset={
+              Array [
+                0,
+                5,
+              ]
+            }
+            onClickOutside={[Function]}
+            onHidden={[Function]}
+            placement="bottom-start"
+            plugins={
+              Array [
+                Object {
+                  "fn": [Function],
+                },
+                Object {
+                  "fn": [Function],
+                },
+                Object {
+                  "fn": [Function],
+                },
+                Object {
+                  "fn": [Function],
+                  "name": "addBackdropPlugin",
+                },
+              ]
+            }
+            popperOptions={
+              Object {
+                "modifiers": Array [
+                  Object {
+                    "enabled": false,
+                    "name": "arrow",
+                    "options": Object {
+                      "element": "#arrow1",
+                      "padding": 5,
+                    },
+                  },
+                  Object {
+                    "name": "preventOverflow",
+                    "options": Object {
+                      "altAxis": true,
+                      "boundariesElement": "scrollParent",
+                      "padding": 8,
+                    },
+                  },
+                ],
+                "strategy": "absolute",
+              }
+            }
+            render={[Function]}
+            trigger="manual"
+          >
+            <TooltipWrapper
+              _tooltipProps={
+                Object {
+                  "children": <Text
+                    tagName="p"
+                  >
+                    Tooltip
+                  </Text>,
+                  "onHide": [Function],
+                  "onShow": [Function],
+                  "setInstance": [Function],
+                  "type": "label",
+                }
+              }
+              _triggerComponent={
+                <ButtonPill>
+                  Trigger component
+                </ButtonPill>
+              }
+              aria-controls={null}
+              aria-expanded={false}
+              aria-haspopup={true}
+              id="test-ID"
+              onKeyDown={[Function]}
+              onPress={[Function]}
+              onPressStart={[Function]}
+            >
+              <Tooltip
+                onHide={[Function]}
+                onShow={[Function]}
+                setInstance={[Function]}
+                triggerComponent={
+                  <ButtonPill
+                    aria-controls={null}
+                    aria-expanded={false}
+                    aria-haspopup={true}
+                    id="test-ID"
+                    onKeyDown={[Function]}
+                    onPress={[Function]}
+                    onPressStart={[Function]}
+                  >
+                    Trigger component
+                  </ButtonPill>
+                }
+                type="label"
+              >
+                <Popover
+                  addBackdrop={false}
+                  aria-hidden={false}
+                  boundary="scrollParent"
+                  color="primary"
+                  interactive={false}
+                  offsetDistance={5}
+                  offsetSkidding={0}
+                  onHide={[Function]}
+                  onShow={[Function]}
+                  placement="auto"
+                  role="tooltip"
+                  setInstance={[Function]}
+                  showArrow={true}
+                  strategy="absolute"
+                  trigger="mouseenter focus"
+                  triggerComponent={
+                    <ButtonPill
+                      aria-controls={null}
+                      aria-expanded={false}
+                      aria-haspopup={true}
+                      aria-labelledby="test-ID"
+                      id="test-ID"
+                      onKeyDown={[Function]}
+                      onPress={[Function]}
+                      onPressStart={[Function]}
+                    >
+                      Trigger component
+                    </ButtonPill>
+                  }
+                  variant="small"
+                >
+                  <LazyTippy
+                    animation={false}
+                    appendTo="parent"
+                    hideOnClick={true}
+                    interactive={false}
+                    offset={
+                      Array [
+                        0,
+                        17,
+                      ]
+                    }
+                    onHidden={[Function]}
+                    onHide={[Function]}
+                    onShow={[Function]}
+                    placement="auto"
+                    plugins={
+                      Array [
+                        Object {
+                          "defaultValue": true,
+                          "fn": [Function],
+                          "name": "hideOnEsc",
+                        },
+                      ]
+                    }
+                    popperOptions={
+                      Object {
+                        "modifiers": Array [
+                          Object {
+                            "enabled": true,
+                            "name": "arrow",
+                            "options": Object {
+                              "element": "#arrow1",
+                              "padding": 5,
+                            },
+                          },
+                          Object {
+                            "name": "preventOverflow",
+                            "options": Object {
+                              "altAxis": true,
+                              "boundariesElement": "scrollParent",
+                              "padding": 8,
+                            },
+                          },
+                        ],
+                        "strategy": "absolute",
+                      }
+                    }
+                    render={[Function]}
+                    setInstance={[Function]}
+                    trigger="mouseenter focus"
+                  >
+                    <ForwardRef(TippyWrapper)
+                      animation={false}
+                      appendTo="parent"
+                      hideOnClick={true}
+                      interactive={false}
+                      offset={
+                        Array [
+                          0,
+                          17,
+                        ]
+                      }
+                      onHidden={[Function]}
+                      onHide={[Function]}
+                      onShow={[Function]}
+                      placement="auto"
+                      plugins={
+                        Array [
+                          Object {
+                            "fn": [Function],
+                          },
+                          Object {
+                            "fn": [Function],
+                          },
+                          Object {
+                            "fn": [Function],
+                          },
+                          Object {
+                            "defaultValue": true,
+                            "fn": [Function],
+                            "name": "hideOnEsc",
+                          },
+                        ]
+                      }
+                      popperOptions={
+                        Object {
+                          "modifiers": Array [
+                            Object {
+                              "enabled": true,
+                              "name": "arrow",
+                              "options": Object {
+                                "element": "#arrow1",
+                                "padding": 5,
+                              },
+                            },
+                            Object {
+                              "name": "preventOverflow",
+                              "options": Object {
+                                "altAxis": true,
+                                "boundariesElement": "scrollParent",
+                                "padding": 8,
+                              },
+                            },
+                          ],
+                          "strategy": "absolute",
+                        }
+                      }
+                      render={[Function]}
+                      trigger="mouseenter focus"
+                    >
+                      <Tippy
+                        animation={false}
+                        appendTo="parent"
+                        hideOnClick={true}
+                        interactive={false}
+                        offset={
+                          Array [
+                            0,
+                            17,
+                          ]
+                        }
+                        onHidden={[Function]}
+                        onHide={[Function]}
+                        onShow={[Function]}
+                        placement="auto"
+                        plugins={
+                          Array [
+                            Object {
+                              "fn": [Function],
+                            },
+                            Object {
+                              "fn": [Function],
+                            },
+                            Object {
+                              "fn": [Function],
+                            },
+                            Object {
+                              "defaultValue": true,
+                              "fn": [Function],
+                              "name": "hideOnEsc",
+                            },
+                          ]
+                        }
+                        popperOptions={
+                          Object {
+                            "modifiers": Array [
+                              Object {
+                                "enabled": true,
+                                "name": "arrow",
+                                "options": Object {
+                                  "element": "#arrow1",
+                                  "padding": 5,
+                                },
+                              },
+                              Object {
+                                "name": "preventOverflow",
+                                "options": Object {
+                                  "altAxis": true,
+                                  "boundariesElement": "scrollParent",
+                                  "padding": 8,
+                                },
+                              },
+                            ],
+                            "strategy": "absolute",
+                          }
+                        }
+                        render={[Function]}
+                        trigger="mouseenter focus"
+                      >
+                        <ButtonPill
+                          aria-controls={null}
+                          aria-expanded={false}
+                          aria-haspopup={true}
+                          aria-labelledby="test-ID"
+                          id="test-ID"
+                          onKeyDown={[Function]}
+                          onPress={[Function]}
+                          onPressStart={[Function]}
+                          useNativeKeyDown={true}
+                        >
+                          <ButtonSimple
+                            aria-controls={null}
+                            aria-disabled={false}
+                            aria-expanded={false}
+                            aria-haspopup={true}
+                            aria-labelledby="test-ID"
+                            className="md-button-pill-wrapper"
+                            data-color="primary"
+                            data-disabled={false}
+                            data-disabled-outline={false}
+                            data-ghost={false}
+                            data-grown={false}
+                            data-inverted={false}
+                            data-outline={false}
+                            data-shallow-disabled={false}
+                            data-size={40}
+                            id="test-ID"
+                            onKeyDown={[Function]}
+                            onPress={[Function]}
+                            onPressStart={[Function]}
+                            useNativeKeyDown={true}
+                          >
+                            <FocusRing>
+                              <FocusRing
+                                focusClass="md-focus-ring-wrapper children"
+                                focusRingClass="md-focus-ring-wrapper children"
+                              >
+                                <button
+                                  aria-controls={null}
+                                  aria-expanded={false}
+                                  aria-haspopup={true}
+                                  aria-labelledby="test-ID"
+                                  className="md-button-pill-wrapper md-button-simple-wrapper"
+                                  data-color="primary"
+                                  data-disabled={false}
+                                  data-disabled-outline={false}
+                                  data-ghost={false}
+                                  data-grown={false}
+                                  data-inverted={false}
+                                  data-outline={false}
+                                  data-shallow-disabled={false}
+                                  data-size={40}
+                                  id="test-ID"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onDragStart={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onKeyUp={[Function]}
+                                  onMouseDown={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  onMouseUp={[Function]}
+                                  onTouchCancel={[Function]}
+                                  onTouchEnd={[Function]}
+                                  onTouchMove={[Function]}
+                                  onTouchStart={[Function]}
+                                  type="button"
+                                >
+                                  <span>
+                                    Trigger component
+                                  </span>
+                                </button>
+                              </FocusRing>
+                            </FocusRing>
+                          </ButtonSimple>
+                        </ButtonPill>
+                        <Portal
+                          containerInfo={
+                            <div
+                              data-tippy-root=""
+                              id="tippy-1"
+                              style="pointer-events: none; z-index: 9999;"
+                            >
+                              
+                            </div>
+                          }
+                        />
+                      </Tippy>
+                    </ForwardRef(TippyWrapper)>
+                  </LazyTippy>
+                </Popover>
+                <div
+                  className="md-tooltip-label"
+                  id="test-ID"
+                >
+                  <Text
+                    tagName="p"
+                  >
+                    <Text
+                      className="md-text-wrapper"
+                      tagname="p"
+                      type="body-large-regular"
+                    >
+                      <mdc-text
+                        class="md-text-wrapper"
+                        suppressHydrationWarning={true}
+                      >
+                        Tooltip
+                      </mdc-text>
+                    </Text>
+                  </Text>
+                </div>
+              </Tooltip>
+            </TooltipWrapper>
+            <Portal
+              containerInfo={
+                <div
+                  data-tippy-root=""
+                  id="tippy-2"
+                  style="z-index: 9999;"
+                >
+                  
+                </div>
+              }
+            />
+          </Tippy>
+        </ForwardRef(TippyWrapper)>
+      </LazyTippy>
+    </Popover>
+  </MenuTrigger>
+</TooltipMenuTriggerCombo>
+`;
+
+exports[`<TooltipMenuTriggerCombo /> snapshot should match snapshot with menuTriggerProps 1`] = `
+<TooltipMenuTriggerCombo
+  menuContent={
+    <_Menu
+      selectionMode="single"
+    >
+      <$de85adf0b38f4f13e9cffd2f21$var$Item>
+        One
+      </$de85adf0b38f4f13e9cffd2f21$var$Item>
+      <$de85adf0b38f4f13e9cffd2f21$var$Item>
+        Two
+      </$de85adf0b38f4f13e9cffd2f21$var$Item>
+      <$de85adf0b38f4f13e9cffd2f21$var$Item>
+        Three
+      </$de85adf0b38f4f13e9cffd2f21$var$Item>
+    </_Menu>
+  }
+  menuTriggerProps={
+    Object {
+      "closeOnSelect": false,
+    }
+  }
+  tooltipContent={
+    <Text
+      tagName="p"
+    >
+      Tooltip
+    </Text>
+  }
+  tooltipProps={
+    Object {
+      "type": "label",
+    }
+  }
+  triggerComponent={
+    <ButtonPill>
+      Trigger component
+    </ButtonPill>
+  }
+>
+  <MenuTrigger
+    closeOnSelect={false}
+    onOpenChange={[Function]}
+    triggerComponent={
+      <TooltipWrapper
+        _tooltipProps={
+          Object {
+            "children": <Text
+              tagName="p"
+            >
+              Tooltip
+            </Text>,
+            "onHide": [Function],
+            "onShow": [Function],
+            "setInstance": [Function],
+            "type": "label",
+          }
+        }
+        _triggerComponent={
+          <ButtonPill>
+            Trigger component
+          </ButtonPill>
+        }
+      />
+    }
+  >
+    <Popover
+      autoFocus={false}
+      className="md-menu-trigger-wrapper"
+      color="primary"
+      hideOnEsc={false}
+      interactive={true}
+      onClickOutside={[Function]}
+      onKeyDown={[Function]}
+      placement="bottom-start"
+      role="generic"
+      setInstance={[Function]}
+      showArrow={false}
+      trigger="manual"
+      triggerComponent={
+        <TooltipWrapper
+          _tooltipProps={
+            Object {
+              "children": <Text
+                tagName="p"
+              >
+                Tooltip
+              </Text>,
+              "onHide": [Function],
+              "onShow": [Function],
+              "setInstance": [Function],
+              "type": "label",
+            }
+          }
+          _triggerComponent={
+            <ButtonPill>
+              Trigger component
+            </ButtonPill>
+          }
+          aria-controls={null}
+          aria-expanded={false}
+          aria-haspopup={true}
+          id="test-ID"
+          onKeyDown={[Function]}
+          onPress={[Function]}
+          onPressStart={[Function]}
+        />
+      }
+      variant="medium"
+    >
+      <LazyTippy
+        animation={false}
+        appendTo="parent"
+        hideOnClick={false}
+        interactive={true}
+        offset={
+          Array [
+            0,
+            5,
+          ]
+        }
+        onClickOutside={[Function]}
+        onHidden={[Function]}
+        placement="bottom-start"
+        plugins={
+          Array [
+            Object {
+              "fn": [Function],
+              "name": "addBackdropPlugin",
+            },
+          ]
+        }
+        popperOptions={
+          Object {
+            "modifiers": Array [
+              Object {
+                "enabled": false,
+                "name": "arrow",
+                "options": Object {
+                  "element": "#arrow1",
+                  "padding": 5,
+                },
+              },
+              Object {
+                "name": "preventOverflow",
+                "options": Object {
+                  "altAxis": true,
+                  "boundariesElement": "scrollParent",
+                  "padding": 8,
+                },
+              },
+            ],
+            "strategy": "absolute",
+          }
+        }
+        render={[Function]}
+        setInstance={[Function]}
+        trigger="manual"
+      >
+        <ForwardRef(TippyWrapper)
+          animation={false}
+          appendTo="parent"
+          hideOnClick={false}
+          interactive={true}
+          offset={
+            Array [
+              0,
+              5,
+            ]
+          }
+          onClickOutside={[Function]}
+          onHidden={[Function]}
+          placement="bottom-start"
+          plugins={
+            Array [
+              Object {
+                "fn": [Function],
+              },
+              Object {
+                "fn": [Function],
+              },
+              Object {
+                "fn": [Function],
+              },
+              Object {
+                "fn": [Function],
+                "name": "addBackdropPlugin",
+              },
+            ]
+          }
+          popperOptions={
+            Object {
+              "modifiers": Array [
+                Object {
+                  "enabled": false,
+                  "name": "arrow",
+                  "options": Object {
+                    "element": "#arrow1",
+                    "padding": 5,
+                  },
+                },
+                Object {
+                  "name": "preventOverflow",
+                  "options": Object {
+                    "altAxis": true,
+                    "boundariesElement": "scrollParent",
+                    "padding": 8,
+                  },
+                },
+              ],
+              "strategy": "absolute",
+            }
+          }
+          render={[Function]}
+          trigger="manual"
+        >
+          <Tippy
+            animation={false}
+            appendTo="parent"
+            hideOnClick={false}
+            interactive={true}
+            offset={
+              Array [
+                0,
+                5,
+              ]
+            }
+            onClickOutside={[Function]}
+            onHidden={[Function]}
+            placement="bottom-start"
+            plugins={
+              Array [
+                Object {
+                  "fn": [Function],
+                },
+                Object {
+                  "fn": [Function],
+                },
+                Object {
+                  "fn": [Function],
+                },
+                Object {
+                  "fn": [Function],
+                  "name": "addBackdropPlugin",
+                },
+              ]
+            }
+            popperOptions={
+              Object {
+                "modifiers": Array [
+                  Object {
+                    "enabled": false,
+                    "name": "arrow",
+                    "options": Object {
+                      "element": "#arrow1",
+                      "padding": 5,
+                    },
+                  },
+                  Object {
+                    "name": "preventOverflow",
+                    "options": Object {
+                      "altAxis": true,
+                      "boundariesElement": "scrollParent",
+                      "padding": 8,
+                    },
+                  },
+                ],
+                "strategy": "absolute",
+              }
+            }
+            render={[Function]}
+            trigger="manual"
+          >
+            <TooltipWrapper
+              _tooltipProps={
+                Object {
+                  "children": <Text
+                    tagName="p"
+                  >
+                    Tooltip
+                  </Text>,
+                  "onHide": [Function],
+                  "onShow": [Function],
+                  "setInstance": [Function],
+                  "type": "label",
+                }
+              }
+              _triggerComponent={
+                <ButtonPill>
+                  Trigger component
+                </ButtonPill>
+              }
+              aria-controls={null}
+              aria-expanded={false}
+              aria-haspopup={true}
+              id="test-ID"
+              onKeyDown={[Function]}
+              onPress={[Function]}
+              onPressStart={[Function]}
+            >
+              <Tooltip
+                onHide={[Function]}
+                onShow={[Function]}
+                setInstance={[Function]}
+                triggerComponent={
+                  <ButtonPill
+                    aria-controls={null}
+                    aria-expanded={false}
+                    aria-haspopup={true}
+                    id="test-ID"
+                    onKeyDown={[Function]}
+                    onPress={[Function]}
+                    onPressStart={[Function]}
+                  >
+                    Trigger component
+                  </ButtonPill>
+                }
+                type="label"
+              >
+                <Popover
+                  addBackdrop={false}
+                  aria-hidden={false}
+                  boundary="scrollParent"
+                  color="primary"
+                  interactive={false}
+                  offsetDistance={5}
+                  offsetSkidding={0}
+                  onHide={[Function]}
+                  onShow={[Function]}
+                  placement="auto"
+                  role="tooltip"
+                  setInstance={[Function]}
+                  showArrow={true}
+                  strategy="absolute"
+                  trigger="mouseenter focus"
+                  triggerComponent={
+                    <ButtonPill
+                      aria-controls={null}
+                      aria-expanded={false}
+                      aria-haspopup={true}
+                      aria-labelledby="test-ID"
+                      id="test-ID"
+                      onKeyDown={[Function]}
+                      onPress={[Function]}
+                      onPressStart={[Function]}
+                    >
+                      Trigger component
+                    </ButtonPill>
+                  }
+                  variant="small"
+                >
+                  <LazyTippy
+                    animation={false}
+                    appendTo="parent"
+                    hideOnClick={true}
+                    interactive={false}
+                    offset={
+                      Array [
+                        0,
+                        17,
+                      ]
+                    }
+                    onHidden={[Function]}
+                    onHide={[Function]}
+                    onShow={[Function]}
+                    placement="auto"
+                    plugins={
+                      Array [
+                        Object {
+                          "defaultValue": true,
+                          "fn": [Function],
+                          "name": "hideOnEsc",
+                        },
+                      ]
+                    }
+                    popperOptions={
+                      Object {
+                        "modifiers": Array [
+                          Object {
+                            "enabled": true,
+                            "name": "arrow",
+                            "options": Object {
+                              "element": "#arrow1",
+                              "padding": 5,
+                            },
+                          },
+                          Object {
+                            "name": "preventOverflow",
+                            "options": Object {
+                              "altAxis": true,
+                              "boundariesElement": "scrollParent",
+                              "padding": 8,
+                            },
+                          },
+                        ],
+                        "strategy": "absolute",
+                      }
+                    }
+                    render={[Function]}
+                    setInstance={[Function]}
+                    trigger="mouseenter focus"
+                  >
+                    <ForwardRef(TippyWrapper)
+                      animation={false}
+                      appendTo="parent"
+                      hideOnClick={true}
+                      interactive={false}
+                      offset={
+                        Array [
+                          0,
+                          17,
+                        ]
+                      }
+                      onHidden={[Function]}
+                      onHide={[Function]}
+                      onShow={[Function]}
+                      placement="auto"
+                      plugins={
+                        Array [
+                          Object {
+                            "fn": [Function],
+                          },
+                          Object {
+                            "fn": [Function],
+                          },
+                          Object {
+                            "fn": [Function],
+                          },
+                          Object {
+                            "defaultValue": true,
+                            "fn": [Function],
+                            "name": "hideOnEsc",
+                          },
+                        ]
+                      }
+                      popperOptions={
+                        Object {
+                          "modifiers": Array [
+                            Object {
+                              "enabled": true,
+                              "name": "arrow",
+                              "options": Object {
+                                "element": "#arrow1",
+                                "padding": 5,
+                              },
+                            },
+                            Object {
+                              "name": "preventOverflow",
+                              "options": Object {
+                                "altAxis": true,
+                                "boundariesElement": "scrollParent",
+                                "padding": 8,
+                              },
+                            },
+                          ],
+                          "strategy": "absolute",
+                        }
+                      }
+                      render={[Function]}
+                      trigger="mouseenter focus"
+                    >
+                      <Tippy
+                        animation={false}
+                        appendTo="parent"
+                        hideOnClick={true}
+                        interactive={false}
+                        offset={
+                          Array [
+                            0,
+                            17,
+                          ]
+                        }
+                        onHidden={[Function]}
+                        onHide={[Function]}
+                        onShow={[Function]}
+                        placement="auto"
+                        plugins={
+                          Array [
+                            Object {
+                              "fn": [Function],
+                            },
+                            Object {
+                              "fn": [Function],
+                            },
+                            Object {
+                              "fn": [Function],
+                            },
+                            Object {
+                              "defaultValue": true,
+                              "fn": [Function],
+                              "name": "hideOnEsc",
+                            },
+                          ]
+                        }
+                        popperOptions={
+                          Object {
+                            "modifiers": Array [
+                              Object {
+                                "enabled": true,
+                                "name": "arrow",
+                                "options": Object {
+                                  "element": "#arrow1",
+                                  "padding": 5,
+                                },
+                              },
+                              Object {
+                                "name": "preventOverflow",
+                                "options": Object {
+                                  "altAxis": true,
+                                  "boundariesElement": "scrollParent",
+                                  "padding": 8,
+                                },
+                              },
+                            ],
+                            "strategy": "absolute",
+                          }
+                        }
+                        render={[Function]}
+                        trigger="mouseenter focus"
+                      >
+                        <ButtonPill
+                          aria-controls={null}
+                          aria-expanded={false}
+                          aria-haspopup={true}
+                          aria-labelledby="test-ID"
+                          id="test-ID"
+                          onKeyDown={[Function]}
+                          onPress={[Function]}
+                          onPressStart={[Function]}
+                          useNativeKeyDown={true}
+                        >
+                          <ButtonSimple
+                            aria-controls={null}
+                            aria-disabled={false}
+                            aria-expanded={false}
+                            aria-haspopup={true}
+                            aria-labelledby="test-ID"
+                            className="md-button-pill-wrapper"
+                            data-color="primary"
+                            data-disabled={false}
+                            data-disabled-outline={false}
+                            data-ghost={false}
+                            data-grown={false}
+                            data-inverted={false}
+                            data-outline={false}
+                            data-shallow-disabled={false}
+                            data-size={40}
+                            id="test-ID"
+                            onKeyDown={[Function]}
+                            onPress={[Function]}
+                            onPressStart={[Function]}
+                            useNativeKeyDown={true}
+                          >
+                            <FocusRing>
+                              <FocusRing
+                                focusClass="md-focus-ring-wrapper children"
+                                focusRingClass="md-focus-ring-wrapper children"
+                              >
+                                <button
+                                  aria-controls={null}
+                                  aria-expanded={false}
+                                  aria-haspopup={true}
+                                  aria-labelledby="test-ID"
+                                  className="md-button-pill-wrapper md-button-simple-wrapper"
+                                  data-color="primary"
+                                  data-disabled={false}
+                                  data-disabled-outline={false}
+                                  data-ghost={false}
+                                  data-grown={false}
+                                  data-inverted={false}
+                                  data-outline={false}
+                                  data-shallow-disabled={false}
+                                  data-size={40}
+                                  id="test-ID"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onDragStart={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onKeyUp={[Function]}
+                                  onMouseDown={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  onMouseUp={[Function]}
+                                  onTouchCancel={[Function]}
+                                  onTouchEnd={[Function]}
+                                  onTouchMove={[Function]}
+                                  onTouchStart={[Function]}
+                                  type="button"
+                                >
+                                  <span>
+                                    Trigger component
+                                  </span>
+                                </button>
+                              </FocusRing>
+                            </FocusRing>
+                          </ButtonSimple>
+                        </ButtonPill>
+                        <Portal
+                          containerInfo={
+                            <div
+                              data-tippy-root=""
+                              id="tippy-3"
+                              style="pointer-events: none; z-index: 9999;"
+                            >
+                              
+                            </div>
+                          }
+                        />
+                      </Tippy>
+                    </ForwardRef(TippyWrapper)>
+                  </LazyTippy>
+                </Popover>
+                <div
+                  className="md-tooltip-label"
+                  id="test-ID"
+                >
+                  <Text
+                    tagName="p"
+                  >
+                    <Text
+                      className="md-text-wrapper"
+                      tagname="p"
+                      type="body-large-regular"
+                    >
+                      <mdc-text
+                        class="md-text-wrapper"
+                        suppressHydrationWarning={true}
+                      >
+                        Tooltip
+                      </mdc-text>
+                    </Text>
+                  </Text>
+                </div>
+              </Tooltip>
+            </TooltipWrapper>
+            <Portal
+              containerInfo={
+                <div
+                  data-tippy-root=""
+                  id="tippy-4"
+                  style="z-index: 9999;"
+                >
+                  
+                </div>
+              }
+            />
+          </Tippy>
+        </ForwardRef(TippyWrapper)>
+      </LazyTippy>
+    </Popover>
+  </MenuTrigger>
+</TooltipMenuTriggerCombo>
+`;
+
+exports[`<TooltipMenuTriggerCombo /> snapshot should match snapshot with tooltipProps 1`] = `
+<TooltipMenuTriggerCombo
+  menuContent={
+    <_Menu
+      selectionMode="single"
+    >
+      <$de85adf0b38f4f13e9cffd2f21$var$Item>
+        One
+      </$de85adf0b38f4f13e9cffd2f21$var$Item>
+      <$de85adf0b38f4f13e9cffd2f21$var$Item>
+        Two
+      </$de85adf0b38f4f13e9cffd2f21$var$Item>
+      <$de85adf0b38f4f13e9cffd2f21$var$Item>
+        Three
+      </$de85adf0b38f4f13e9cffd2f21$var$Item>
+    </_Menu>
+  }
+  menuTriggerProps={
+    Object {
+      "closeOnSelect": false,
+    }
+  }
+  tooltipContent={
+    <Text
+      tagName="p"
+    >
+      Tooltip
+    </Text>
+  }
+  tooltipProps={
+    Object {
+      "placement": "bottom",
+      "type": "label",
+    }
+  }
+  triggerComponent={
+    <ButtonPill>
+      Trigger component
+    </ButtonPill>
+  }
+>
+  <MenuTrigger
+    closeOnSelect={false}
+    onOpenChange={[Function]}
+    triggerComponent={
+      <TooltipWrapper
+        _tooltipProps={
+          Object {
+            "children": <Text
+              tagName="p"
+            >
+              Tooltip
+            </Text>,
+            "onHide": [Function],
+            "onShow": [Function],
+            "placement": "bottom",
+            "setInstance": [Function],
+            "type": "label",
+          }
+        }
+        _triggerComponent={
+          <ButtonPill>
+            Trigger component
+          </ButtonPill>
+        }
+      />
+    }
+  >
+    <Popover
+      autoFocus={false}
+      className="md-menu-trigger-wrapper"
+      color="primary"
+      hideOnEsc={false}
+      interactive={true}
+      onClickOutside={[Function]}
+      onKeyDown={[Function]}
+      placement="bottom-start"
+      role="generic"
+      setInstance={[Function]}
+      showArrow={false}
+      trigger="manual"
+      triggerComponent={
+        <TooltipWrapper
+          _tooltipProps={
+            Object {
+              "children": <Text
+                tagName="p"
+              >
+                Tooltip
+              </Text>,
+              "onHide": [Function],
+              "onShow": [Function],
+              "placement": "bottom",
+              "setInstance": [Function],
+              "type": "label",
+            }
+          }
+          _triggerComponent={
+            <ButtonPill>
+              Trigger component
+            </ButtonPill>
+          }
+          aria-controls={null}
+          aria-expanded={false}
+          aria-haspopup={true}
+          id="test-ID"
+          onKeyDown={[Function]}
+          onPress={[Function]}
+          onPressStart={[Function]}
+        />
+      }
+      variant="medium"
+    >
+      <LazyTippy
+        animation={false}
+        appendTo="parent"
+        hideOnClick={false}
+        interactive={true}
+        offset={
+          Array [
+            0,
+            5,
+          ]
+        }
+        onClickOutside={[Function]}
+        onHidden={[Function]}
+        placement="bottom-start"
+        plugins={
+          Array [
+            Object {
+              "fn": [Function],
+              "name": "addBackdropPlugin",
+            },
+          ]
+        }
+        popperOptions={
+          Object {
+            "modifiers": Array [
+              Object {
+                "enabled": false,
+                "name": "arrow",
+                "options": Object {
+                  "element": "#arrow1",
+                  "padding": 5,
+                },
+              },
+              Object {
+                "name": "preventOverflow",
+                "options": Object {
+                  "altAxis": true,
+                  "boundariesElement": "scrollParent",
+                  "padding": 8,
+                },
+              },
+            ],
+            "strategy": "absolute",
+          }
+        }
+        render={[Function]}
+        setInstance={[Function]}
+        trigger="manual"
+      >
+        <ForwardRef(TippyWrapper)
+          animation={false}
+          appendTo="parent"
+          hideOnClick={false}
+          interactive={true}
+          offset={
+            Array [
+              0,
+              5,
+            ]
+          }
+          onClickOutside={[Function]}
+          onHidden={[Function]}
+          placement="bottom-start"
+          plugins={
+            Array [
+              Object {
+                "fn": [Function],
+              },
+              Object {
+                "fn": [Function],
+              },
+              Object {
+                "fn": [Function],
+              },
+              Object {
+                "fn": [Function],
+                "name": "addBackdropPlugin",
+              },
+            ]
+          }
+          popperOptions={
+            Object {
+              "modifiers": Array [
+                Object {
+                  "enabled": false,
+                  "name": "arrow",
+                  "options": Object {
+                    "element": "#arrow1",
+                    "padding": 5,
+                  },
+                },
+                Object {
+                  "name": "preventOverflow",
+                  "options": Object {
+                    "altAxis": true,
+                    "boundariesElement": "scrollParent",
+                    "padding": 8,
+                  },
+                },
+              ],
+              "strategy": "absolute",
+            }
+          }
+          render={[Function]}
+          trigger="manual"
+        >
+          <Tippy
+            animation={false}
+            appendTo="parent"
+            hideOnClick={false}
+            interactive={true}
+            offset={
+              Array [
+                0,
+                5,
+              ]
+            }
+            onClickOutside={[Function]}
+            onHidden={[Function]}
+            placement="bottom-start"
+            plugins={
+              Array [
+                Object {
+                  "fn": [Function],
+                },
+                Object {
+                  "fn": [Function],
+                },
+                Object {
+                  "fn": [Function],
+                },
+                Object {
+                  "fn": [Function],
+                  "name": "addBackdropPlugin",
+                },
+              ]
+            }
+            popperOptions={
+              Object {
+                "modifiers": Array [
+                  Object {
+                    "enabled": false,
+                    "name": "arrow",
+                    "options": Object {
+                      "element": "#arrow1",
+                      "padding": 5,
+                    },
+                  },
+                  Object {
+                    "name": "preventOverflow",
+                    "options": Object {
+                      "altAxis": true,
+                      "boundariesElement": "scrollParent",
+                      "padding": 8,
+                    },
+                  },
+                ],
+                "strategy": "absolute",
+              }
+            }
+            render={[Function]}
+            trigger="manual"
+          >
+            <TooltipWrapper
+              _tooltipProps={
+                Object {
+                  "children": <Text
+                    tagName="p"
+                  >
+                    Tooltip
+                  </Text>,
+                  "onHide": [Function],
+                  "onShow": [Function],
+                  "placement": "bottom",
+                  "setInstance": [Function],
+                  "type": "label",
+                }
+              }
+              _triggerComponent={
+                <ButtonPill>
+                  Trigger component
+                </ButtonPill>
+              }
+              aria-controls={null}
+              aria-expanded={false}
+              aria-haspopup={true}
+              id="test-ID"
+              onKeyDown={[Function]}
+              onPress={[Function]}
+              onPressStart={[Function]}
+            >
+              <Tooltip
+                onHide={[Function]}
+                onShow={[Function]}
+                placement="bottom"
+                setInstance={[Function]}
+                triggerComponent={
+                  <ButtonPill
+                    aria-controls={null}
+                    aria-expanded={false}
+                    aria-haspopup={true}
+                    id="test-ID"
+                    onKeyDown={[Function]}
+                    onPress={[Function]}
+                    onPressStart={[Function]}
+                  >
+                    Trigger component
+                  </ButtonPill>
+                }
+                type="label"
+              >
+                <Popover
+                  addBackdrop={false}
+                  aria-hidden={false}
+                  boundary="scrollParent"
+                  color="primary"
+                  interactive={false}
+                  offsetDistance={5}
+                  offsetSkidding={0}
+                  onHide={[Function]}
+                  onShow={[Function]}
+                  placement="bottom"
+                  role="tooltip"
+                  setInstance={[Function]}
+                  showArrow={true}
+                  strategy="absolute"
+                  trigger="mouseenter focus"
+                  triggerComponent={
+                    <ButtonPill
+                      aria-controls={null}
+                      aria-expanded={false}
+                      aria-haspopup={true}
+                      aria-labelledby="test-ID"
+                      id="test-ID"
+                      onKeyDown={[Function]}
+                      onPress={[Function]}
+                      onPressStart={[Function]}
+                    >
+                      Trigger component
+                    </ButtonPill>
+                  }
+                  variant="small"
+                >
+                  <LazyTippy
+                    animation={false}
+                    appendTo="parent"
+                    hideOnClick={true}
+                    interactive={false}
+                    offset={
+                      Array [
+                        0,
+                        17,
+                      ]
+                    }
+                    onHidden={[Function]}
+                    onHide={[Function]}
+                    onShow={[Function]}
+                    placement="bottom"
+                    plugins={
+                      Array [
+                        Object {
+                          "defaultValue": true,
+                          "fn": [Function],
+                          "name": "hideOnEsc",
+                        },
+                      ]
+                    }
+                    popperOptions={
+                      Object {
+                        "modifiers": Array [
+                          Object {
+                            "enabled": true,
+                            "name": "arrow",
+                            "options": Object {
+                              "element": "#arrow1",
+                              "padding": 5,
+                            },
+                          },
+                          Object {
+                            "name": "preventOverflow",
+                            "options": Object {
+                              "altAxis": true,
+                              "boundariesElement": "scrollParent",
+                              "padding": 8,
+                            },
+                          },
+                        ],
+                        "strategy": "absolute",
+                      }
+                    }
+                    render={[Function]}
+                    setInstance={[Function]}
+                    trigger="mouseenter focus"
+                  >
+                    <ForwardRef(TippyWrapper)
+                      animation={false}
+                      appendTo="parent"
+                      hideOnClick={true}
+                      interactive={false}
+                      offset={
+                        Array [
+                          0,
+                          17,
+                        ]
+                      }
+                      onHidden={[Function]}
+                      onHide={[Function]}
+                      onShow={[Function]}
+                      placement="bottom"
+                      plugins={
+                        Array [
+                          Object {
+                            "fn": [Function],
+                          },
+                          Object {
+                            "fn": [Function],
+                          },
+                          Object {
+                            "fn": [Function],
+                          },
+                          Object {
+                            "defaultValue": true,
+                            "fn": [Function],
+                            "name": "hideOnEsc",
+                          },
+                        ]
+                      }
+                      popperOptions={
+                        Object {
+                          "modifiers": Array [
+                            Object {
+                              "enabled": true,
+                              "name": "arrow",
+                              "options": Object {
+                                "element": "#arrow1",
+                                "padding": 5,
+                              },
+                            },
+                            Object {
+                              "name": "preventOverflow",
+                              "options": Object {
+                                "altAxis": true,
+                                "boundariesElement": "scrollParent",
+                                "padding": 8,
+                              },
+                            },
+                          ],
+                          "strategy": "absolute",
+                        }
+                      }
+                      render={[Function]}
+                      trigger="mouseenter focus"
+                    >
+                      <Tippy
+                        animation={false}
+                        appendTo="parent"
+                        hideOnClick={true}
+                        interactive={false}
+                        offset={
+                          Array [
+                            0,
+                            17,
+                          ]
+                        }
+                        onHidden={[Function]}
+                        onHide={[Function]}
+                        onShow={[Function]}
+                        placement="bottom"
+                        plugins={
+                          Array [
+                            Object {
+                              "fn": [Function],
+                            },
+                            Object {
+                              "fn": [Function],
+                            },
+                            Object {
+                              "fn": [Function],
+                            },
+                            Object {
+                              "defaultValue": true,
+                              "fn": [Function],
+                              "name": "hideOnEsc",
+                            },
+                          ]
+                        }
+                        popperOptions={
+                          Object {
+                            "modifiers": Array [
+                              Object {
+                                "enabled": true,
+                                "name": "arrow",
+                                "options": Object {
+                                  "element": "#arrow1",
+                                  "padding": 5,
+                                },
+                              },
+                              Object {
+                                "name": "preventOverflow",
+                                "options": Object {
+                                  "altAxis": true,
+                                  "boundariesElement": "scrollParent",
+                                  "padding": 8,
+                                },
+                              },
+                            ],
+                            "strategy": "absolute",
+                          }
+                        }
+                        render={[Function]}
+                        trigger="mouseenter focus"
+                      >
+                        <ButtonPill
+                          aria-controls={null}
+                          aria-expanded={false}
+                          aria-haspopup={true}
+                          aria-labelledby="test-ID"
+                          id="test-ID"
+                          onKeyDown={[Function]}
+                          onPress={[Function]}
+                          onPressStart={[Function]}
+                          useNativeKeyDown={true}
+                        >
+                          <ButtonSimple
+                            aria-controls={null}
+                            aria-disabled={false}
+                            aria-expanded={false}
+                            aria-haspopup={true}
+                            aria-labelledby="test-ID"
+                            className="md-button-pill-wrapper"
+                            data-color="primary"
+                            data-disabled={false}
+                            data-disabled-outline={false}
+                            data-ghost={false}
+                            data-grown={false}
+                            data-inverted={false}
+                            data-outline={false}
+                            data-shallow-disabled={false}
+                            data-size={40}
+                            id="test-ID"
+                            onKeyDown={[Function]}
+                            onPress={[Function]}
+                            onPressStart={[Function]}
+                            useNativeKeyDown={true}
+                          >
+                            <FocusRing>
+                              <FocusRing
+                                focusClass="md-focus-ring-wrapper children"
+                                focusRingClass="md-focus-ring-wrapper children"
+                              >
+                                <button
+                                  aria-controls={null}
+                                  aria-expanded={false}
+                                  aria-haspopup={true}
+                                  aria-labelledby="test-ID"
+                                  className="md-button-pill-wrapper md-button-simple-wrapper"
+                                  data-color="primary"
+                                  data-disabled={false}
+                                  data-disabled-outline={false}
+                                  data-ghost={false}
+                                  data-grown={false}
+                                  data-inverted={false}
+                                  data-outline={false}
+                                  data-shallow-disabled={false}
+                                  data-size={40}
+                                  id="test-ID"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onDragStart={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onKeyUp={[Function]}
+                                  onMouseDown={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  onMouseUp={[Function]}
+                                  onTouchCancel={[Function]}
+                                  onTouchEnd={[Function]}
+                                  onTouchMove={[Function]}
+                                  onTouchStart={[Function]}
+                                  type="button"
+                                >
+                                  <span>
+                                    Trigger component
+                                  </span>
+                                </button>
+                              </FocusRing>
+                            </FocusRing>
+                          </ButtonSimple>
+                        </ButtonPill>
+                        <Portal
+                          containerInfo={
+                            <div
+                              data-tippy-root=""
+                              id="tippy-5"
+                              style="pointer-events: none; z-index: 9999;"
+                            >
+                              
+                            </div>
+                          }
+                        />
+                      </Tippy>
+                    </ForwardRef(TippyWrapper)>
+                  </LazyTippy>
+                </Popover>
+                <div
+                  className="md-tooltip-label"
+                  id="test-ID"
+                >
+                  <Text
+                    tagName="p"
+                  >
+                    <Text
+                      className="md-text-wrapper"
+                      tagname="p"
+                      type="body-large-regular"
+                    >
+                      <mdc-text
+                        class="md-text-wrapper"
+                        suppressHydrationWarning={true}
+                      >
+                        Tooltip
+                      </mdc-text>
+                    </Text>
+                  </Text>
+                </div>
+              </Tooltip>
+            </TooltipWrapper>
+            <Portal
+              containerInfo={
+                <div
+                  data-tippy-root=""
+                  id="tippy-6"
+                  style="z-index: 9999;"
+                >
+                  
+                </div>
+              }
+            />
+          </Tippy>
+        </ForwardRef(TippyWrapper)>
+      </LazyTippy>
+    </Popover>
+  </MenuTrigger>
+</TooltipMenuTriggerCombo>
+`;
+
+exports[`<TooltipMenuTriggerCombo /> snapshot should match snapshot with tooltipProps.type = "description" 1`] = `
+<TooltipMenuTriggerCombo
+  menuContent={
+    <_Menu
+      selectionMode="single"
+    >
+      <$de85adf0b38f4f13e9cffd2f21$var$Item>
+        One
+      </$de85adf0b38f4f13e9cffd2f21$var$Item>
+      <$de85adf0b38f4f13e9cffd2f21$var$Item>
+        Two
+      </$de85adf0b38f4f13e9cffd2f21$var$Item>
+      <$de85adf0b38f4f13e9cffd2f21$var$Item>
+        Three
+      </$de85adf0b38f4f13e9cffd2f21$var$Item>
+    </_Menu>
+  }
+  tooltipContent={
+    <Text
+      tagName="p"
+    >
+      Tooltip
+    </Text>
+  }
+  tooltipProps={
+    Object {
+      "placement": "bottom",
+      "type": "description",
+    }
+  }
+  triggerComponent={
+    <ButtonPill>
+      Trigger component
+    </ButtonPill>
+  }
+>
+  <MenuTrigger
+    onOpenChange={[Function]}
+    triggerComponent={
+      <TooltipWrapper
+        _tooltipProps={
+          Object {
+            "children": <Text
+              tagName="p"
+            >
+              Tooltip
+            </Text>,
+            "onHide": [Function],
+            "onShow": [Function],
+            "placement": "bottom",
+            "setInstance": [Function],
+            "type": "description",
+          }
+        }
+        _triggerComponent={
+          <ButtonPill>
+            Trigger component
+          </ButtonPill>
+        }
+      />
+    }
+  >
+    <Popover
+      autoFocus={false}
+      className="md-menu-trigger-wrapper"
+      color="primary"
+      hideOnEsc={false}
+      interactive={true}
+      onClickOutside={[Function]}
+      onKeyDown={[Function]}
+      placement="bottom-start"
+      role="generic"
+      setInstance={[Function]}
+      showArrow={false}
+      trigger="manual"
+      triggerComponent={
+        <TooltipWrapper
+          _tooltipProps={
+            Object {
+              "children": <Text
+                tagName="p"
+              >
+                Tooltip
+              </Text>,
+              "onHide": [Function],
+              "onShow": [Function],
+              "placement": "bottom",
+              "setInstance": [Function],
+              "type": "description",
+            }
+          }
+          _triggerComponent={
+            <ButtonPill>
+              Trigger component
+            </ButtonPill>
+          }
+          aria-controls={null}
+          aria-expanded={false}
+          aria-haspopup={true}
+          id="test-ID"
+          onKeyDown={[Function]}
+          onPress={[Function]}
+          onPressStart={[Function]}
+        />
+      }
+      variant="medium"
+    >
+      <LazyTippy
+        animation={false}
+        appendTo="parent"
+        hideOnClick={false}
+        interactive={true}
+        offset={
+          Array [
+            0,
+            5,
+          ]
+        }
+        onClickOutside={[Function]}
+        onHidden={[Function]}
+        placement="bottom-start"
+        plugins={
+          Array [
+            Object {
+              "fn": [Function],
+              "name": "addBackdropPlugin",
+            },
+          ]
+        }
+        popperOptions={
+          Object {
+            "modifiers": Array [
+              Object {
+                "enabled": false,
+                "name": "arrow",
+                "options": Object {
+                  "element": "#arrow1",
+                  "padding": 5,
+                },
+              },
+              Object {
+                "name": "preventOverflow",
+                "options": Object {
+                  "altAxis": true,
+                  "boundariesElement": "scrollParent",
+                  "padding": 8,
+                },
+              },
+            ],
+            "strategy": "absolute",
+          }
+        }
+        render={[Function]}
+        setInstance={[Function]}
+        trigger="manual"
+      >
+        <ForwardRef(TippyWrapper)
+          animation={false}
+          appendTo="parent"
+          hideOnClick={false}
+          interactive={true}
+          offset={
+            Array [
+              0,
+              5,
+            ]
+          }
+          onClickOutside={[Function]}
+          onHidden={[Function]}
+          placement="bottom-start"
+          plugins={
+            Array [
+              Object {
+                "fn": [Function],
+              },
+              Object {
+                "fn": [Function],
+              },
+              Object {
+                "fn": [Function],
+              },
+              Object {
+                "fn": [Function],
+                "name": "addBackdropPlugin",
+              },
+            ]
+          }
+          popperOptions={
+            Object {
+              "modifiers": Array [
+                Object {
+                  "enabled": false,
+                  "name": "arrow",
+                  "options": Object {
+                    "element": "#arrow1",
+                    "padding": 5,
+                  },
+                },
+                Object {
+                  "name": "preventOverflow",
+                  "options": Object {
+                    "altAxis": true,
+                    "boundariesElement": "scrollParent",
+                    "padding": 8,
+                  },
+                },
+              ],
+              "strategy": "absolute",
+            }
+          }
+          render={[Function]}
+          trigger="manual"
+        >
+          <Tippy
+            animation={false}
+            appendTo="parent"
+            hideOnClick={false}
+            interactive={true}
+            offset={
+              Array [
+                0,
+                5,
+              ]
+            }
+            onClickOutside={[Function]}
+            onHidden={[Function]}
+            placement="bottom-start"
+            plugins={
+              Array [
+                Object {
+                  "fn": [Function],
+                },
+                Object {
+                  "fn": [Function],
+                },
+                Object {
+                  "fn": [Function],
+                },
+                Object {
+                  "fn": [Function],
+                  "name": "addBackdropPlugin",
+                },
+              ]
+            }
+            popperOptions={
+              Object {
+                "modifiers": Array [
+                  Object {
+                    "enabled": false,
+                    "name": "arrow",
+                    "options": Object {
+                      "element": "#arrow1",
+                      "padding": 5,
+                    },
+                  },
+                  Object {
+                    "name": "preventOverflow",
+                    "options": Object {
+                      "altAxis": true,
+                      "boundariesElement": "scrollParent",
+                      "padding": 8,
+                    },
+                  },
+                ],
+                "strategy": "absolute",
+              }
+            }
+            render={[Function]}
+            trigger="manual"
+          >
+            <TooltipWrapper
+              _tooltipProps={
+                Object {
+                  "children": <Text
+                    tagName="p"
+                  >
+                    Tooltip
+                  </Text>,
+                  "onHide": [Function],
+                  "onShow": [Function],
+                  "placement": "bottom",
+                  "setInstance": [Function],
+                  "type": "description",
+                }
+              }
+              _triggerComponent={
+                <ButtonPill>
+                  Trigger component
+                </ButtonPill>
+              }
+              aria-controls={null}
+              aria-expanded={false}
+              aria-haspopup={true}
+              id="test-ID"
+              onKeyDown={[Function]}
+              onPress={[Function]}
+              onPressStart={[Function]}
+            >
+              <Tooltip
+                onHide={[Function]}
+                onShow={[Function]}
+                placement="bottom"
+                setInstance={[Function]}
+                triggerComponent={
+                  <ButtonPill
+                    aria-controls={null}
+                    aria-expanded={false}
+                    aria-haspopup={true}
+                    id="test-ID"
+                    onKeyDown={[Function]}
+                    onPress={[Function]}
+                    onPressStart={[Function]}
+                  >
+                    Trigger component
+                  </ButtonPill>
+                }
+                type="description"
+              >
+                <Popover
+                  addBackdrop={false}
+                  aria-hidden={true}
+                  boundary="scrollParent"
+                  color="primary"
+                  interactive={false}
+                  offsetDistance={5}
+                  offsetSkidding={0}
+                  onHide={[Function]}
+                  onShow={[Function]}
+                  placement="bottom"
+                  role="tooltip"
+                  setInstance={[Function]}
+                  showArrow={true}
+                  strategy="absolute"
+                  trigger="mouseenter focus"
+                  triggerComponent={
+                    <ButtonPill
+                      aria-controls={null}
+                      aria-describedby="test-ID"
+                      aria-expanded={false}
+                      aria-haspopup={true}
+                      id="test-ID"
+                      onKeyDown={[Function]}
+                      onPress={[Function]}
+                      onPressStart={[Function]}
+                    >
+                      Trigger component
+                    </ButtonPill>
+                  }
+                  variant="small"
+                >
+                  <LazyTippy
+                    animation={false}
+                    appendTo="parent"
+                    hideOnClick={true}
+                    interactive={false}
+                    offset={
+                      Array [
+                        0,
+                        17,
+                      ]
+                    }
+                    onHidden={[Function]}
+                    onHide={[Function]}
+                    onShow={[Function]}
+                    placement="bottom"
+                    plugins={
+                      Array [
+                        Object {
+                          "defaultValue": true,
+                          "fn": [Function],
+                          "name": "hideOnEsc",
+                        },
+                      ]
+                    }
+                    popperOptions={
+                      Object {
+                        "modifiers": Array [
+                          Object {
+                            "enabled": true,
+                            "name": "arrow",
+                            "options": Object {
+                              "element": "#arrow1",
+                              "padding": 5,
+                            },
+                          },
+                          Object {
+                            "name": "preventOverflow",
+                            "options": Object {
+                              "altAxis": true,
+                              "boundariesElement": "scrollParent",
+                              "padding": 8,
+                            },
+                          },
+                        ],
+                        "strategy": "absolute",
+                      }
+                    }
+                    render={[Function]}
+                    setInstance={[Function]}
+                    trigger="mouseenter focus"
+                  >
+                    <ForwardRef(TippyWrapper)
+                      animation={false}
+                      appendTo="parent"
+                      hideOnClick={true}
+                      interactive={false}
+                      offset={
+                        Array [
+                          0,
+                          17,
+                        ]
+                      }
+                      onHidden={[Function]}
+                      onHide={[Function]}
+                      onShow={[Function]}
+                      placement="bottom"
+                      plugins={
+                        Array [
+                          Object {
+                            "fn": [Function],
+                          },
+                          Object {
+                            "fn": [Function],
+                          },
+                          Object {
+                            "fn": [Function],
+                          },
+                          Object {
+                            "defaultValue": true,
+                            "fn": [Function],
+                            "name": "hideOnEsc",
+                          },
+                        ]
+                      }
+                      popperOptions={
+                        Object {
+                          "modifiers": Array [
+                            Object {
+                              "enabled": true,
+                              "name": "arrow",
+                              "options": Object {
+                                "element": "#arrow1",
+                                "padding": 5,
+                              },
+                            },
+                            Object {
+                              "name": "preventOverflow",
+                              "options": Object {
+                                "altAxis": true,
+                                "boundariesElement": "scrollParent",
+                                "padding": 8,
+                              },
+                            },
+                          ],
+                          "strategy": "absolute",
+                        }
+                      }
+                      render={[Function]}
+                      trigger="mouseenter focus"
+                    >
+                      <Tippy
+                        animation={false}
+                        appendTo="parent"
+                        hideOnClick={true}
+                        interactive={false}
+                        offset={
+                          Array [
+                            0,
+                            17,
+                          ]
+                        }
+                        onHidden={[Function]}
+                        onHide={[Function]}
+                        onShow={[Function]}
+                        placement="bottom"
+                        plugins={
+                          Array [
+                            Object {
+                              "fn": [Function],
+                            },
+                            Object {
+                              "fn": [Function],
+                            },
+                            Object {
+                              "fn": [Function],
+                            },
+                            Object {
+                              "defaultValue": true,
+                              "fn": [Function],
+                              "name": "hideOnEsc",
+                            },
+                          ]
+                        }
+                        popperOptions={
+                          Object {
+                            "modifiers": Array [
+                              Object {
+                                "enabled": true,
+                                "name": "arrow",
+                                "options": Object {
+                                  "element": "#arrow1",
+                                  "padding": 5,
+                                },
+                              },
+                              Object {
+                                "name": "preventOverflow",
+                                "options": Object {
+                                  "altAxis": true,
+                                  "boundariesElement": "scrollParent",
+                                  "padding": 8,
+                                },
+                              },
+                            ],
+                            "strategy": "absolute",
+                          }
+                        }
+                        render={[Function]}
+                        trigger="mouseenter focus"
+                      >
+                        <ButtonPill
+                          aria-controls={null}
+                          aria-describedby="test-ID"
+                          aria-expanded={false}
+                          aria-haspopup={true}
+                          id="test-ID"
+                          onKeyDown={[Function]}
+                          onPress={[Function]}
+                          onPressStart={[Function]}
+                          useNativeKeyDown={true}
+                        >
+                          <ButtonSimple
+                            aria-controls={null}
+                            aria-describedby="test-ID"
+                            aria-disabled={false}
+                            aria-expanded={false}
+                            aria-haspopup={true}
+                            className="md-button-pill-wrapper"
+                            data-color="primary"
+                            data-disabled={false}
+                            data-disabled-outline={false}
+                            data-ghost={false}
+                            data-grown={false}
+                            data-inverted={false}
+                            data-outline={false}
+                            data-shallow-disabled={false}
+                            data-size={40}
+                            id="test-ID"
+                            onKeyDown={[Function]}
+                            onPress={[Function]}
+                            onPressStart={[Function]}
+                            useNativeKeyDown={true}
+                          >
+                            <FocusRing>
+                              <FocusRing
+                                focusClass="md-focus-ring-wrapper children"
+                                focusRingClass="md-focus-ring-wrapper children"
+                              >
+                                <button
+                                  aria-controls={null}
+                                  aria-describedby="test-ID"
+                                  aria-expanded={false}
+                                  aria-haspopup={true}
+                                  className="md-button-pill-wrapper md-button-simple-wrapper"
+                                  data-color="primary"
+                                  data-disabled={false}
+                                  data-disabled-outline={false}
+                                  data-ghost={false}
+                                  data-grown={false}
+                                  data-inverted={false}
+                                  data-outline={false}
+                                  data-shallow-disabled={false}
+                                  data-size={40}
+                                  id="test-ID"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onDragStart={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onKeyUp={[Function]}
+                                  onMouseDown={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  onMouseUp={[Function]}
+                                  onTouchCancel={[Function]}
+                                  onTouchEnd={[Function]}
+                                  onTouchMove={[Function]}
+                                  onTouchStart={[Function]}
+                                  type="button"
+                                >
+                                  <span>
+                                    Trigger component
+                                  </span>
+                                </button>
+                              </FocusRing>
+                            </FocusRing>
+                          </ButtonSimple>
+                        </ButtonPill>
+                        <Portal
+                          containerInfo={
+                            <div
+                              data-tippy-root=""
+                              id="tippy-7"
+                              style="pointer-events: none; z-index: 9999;"
+                            >
+                              
+                            </div>
+                          }
+                        />
+                      </Tippy>
+                    </ForwardRef(TippyWrapper)>
+                  </LazyTippy>
+                </Popover>
+                <div
+                  className="md-tooltip-label"
+                  id="test-ID"
+                >
+                  <Text
+                    tagName="p"
+                  >
+                    <Text
+                      className="md-text-wrapper"
+                      tagname="p"
+                      type="body-large-regular"
+                    >
+                      <mdc-text
+                        class="md-text-wrapper"
+                        suppressHydrationWarning={true}
+                      >
+                        Tooltip
+                      </mdc-text>
+                    </Text>
+                  </Text>
+                </div>
+              </Tooltip>
+            </TooltipWrapper>
+            <Portal
+              containerInfo={
+                <div
+                  data-tippy-root=""
+                  id="tippy-8"
+                  style="z-index: 9999;"
+                >
+                  
+                </div>
+              }
+            />
+          </Tippy>
+        </ForwardRef(TippyWrapper)>
+      </LazyTippy>
+    </Popover>
+  </MenuTrigger>
+</TooltipMenuTriggerCombo>
+`;

--- a/src/components/TooltipMenuTriggerCombo/TooltipWrapper.tsx
+++ b/src/components/TooltipMenuTriggerCombo/TooltipWrapper.tsx
@@ -1,0 +1,23 @@
+import React, { FC, forwardRef } from 'react';
+
+import type { TooltipWrapperProps } from './TooltipWrapper.types';
+import Tooltip from '../Tooltip';
+
+/**
+ * The TooltipWrapper component.
+ *
+ * MenuTrigger passes additional properties to its `triggerComponent` (for example, useNativeKeyDown, onPress, onPressStart)
+ * Capture these props and pass them to the triggerComponent of the tooltip instead
+ */
+const TooltipWrapper: FC<TooltipWrapperProps> = forwardRef(
+  ({ _tooltipProps, _triggerComponent, ...props }: TooltipWrapperProps, ref) => (
+    <Tooltip
+      {..._tooltipProps}
+      triggerComponent={React.cloneElement(_triggerComponent, { ...props, ref })}
+    />
+  )
+);
+
+TooltipWrapper.displayName = 'TooltipWrapper';
+
+export default TooltipWrapper;

--- a/src/components/TooltipMenuTriggerCombo/TooltipWrapper.tsx
+++ b/src/components/TooltipMenuTriggerCombo/TooltipWrapper.tsx
@@ -6,7 +6,7 @@ import Tooltip from '../Tooltip';
 /**
  * The TooltipWrapper component.
  *
- * MenuTrigger passes additional properties to its `triggerComponent` (for example, useNativeKeyDown, onPress, onPressStart)
+ * MenuTrigger passes additional properties to its `triggerComponent` (for example, onPress, onPressStart)
  * Capture these props and pass them to the triggerComponent of the tooltip instead
  */
 const TooltipWrapper: FC<TooltipWrapperProps> = forwardRef(

--- a/src/components/TooltipMenuTriggerCombo/TooltipWrapper.types.ts
+++ b/src/components/TooltipMenuTriggerCombo/TooltipWrapper.types.ts
@@ -1,0 +1,7 @@
+import { ReactElement } from 'react';
+import { TooltipProps } from '../Tooltip';
+
+export type TooltipWrapperProps = {
+  _tooltipProps: Omit<TooltipProps, 'triggerComponent'>;
+  _triggerComponent: ReactElement;
+};

--- a/src/components/TooltipMenuTriggerCombo/TooltipWrapper.types.ts
+++ b/src/components/TooltipMenuTriggerCombo/TooltipWrapper.types.ts
@@ -4,4 +4,4 @@ import { TooltipProps } from '../Tooltip';
 export type TooltipWrapperProps = {
   _tooltipProps: Omit<TooltipProps, 'triggerComponent'>;
   _triggerComponent: ReactElement;
-};
+} & Record<string, unknown>;

--- a/src/components/TooltipMenuTriggerCombo/TooltipWrapper.unit.test.tsx
+++ b/src/components/TooltipMenuTriggerCombo/TooltipWrapper.unit.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import TooltipWrapper from './TooltipWrapper';
+import ButtonPill from '../ButtonPill';
+import Tooltip from '../Tooltip';
+
+describe('<TooltipWrapper />', () => {
+  it('moves the props around correctly', () => {
+    const onPressHandler = jest.fn();
+
+    const wrapper = mount(
+      <TooltipWrapper
+        _tooltipProps={{ type: 'label', children: 'Tooltip Content' }}
+        _triggerComponent={<ButtonPill aria-describedby="test">Trigger</ButtonPill>}
+        onPress={onPressHandler}
+      />
+    );
+
+    const tooltip = wrapper.find(Tooltip);
+    expect(tooltip.props()).toEqual({
+      type: 'label',
+      children: 'Tooltip Content',
+      triggerComponent: expect.any(Object),
+    });
+
+    const triggerComponent = tooltip.prop('triggerComponent');
+    expect(triggerComponent.type).toBe(ButtonPill);
+    expect(triggerComponent.props).toEqual({
+      children: 'Trigger',
+      'aria-describedby': 'test',
+      onPress: onPressHandler,
+    });
+  });
+});

--- a/src/components/TooltipMenuTriggerCombo/index.ts
+++ b/src/components/TooltipMenuTriggerCombo/index.ts
@@ -1,0 +1,6 @@
+import { default as TooltipMenuTriggerCombo } from './TooltipMenuTriggerCombo';
+import { Props } from './TooltipMenuTriggerCombo.types';
+
+export type TooltipMenuTriggerComboProps = Props;
+
+export default TooltipMenuTriggerCombo;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -77,6 +77,7 @@ export { default as RadioSimple } from './RadioSimple';
 export { default as RadioSimpleGroup } from './RadioSimpleGroup';
 export { default as ScreenReaderAnnouncer } from './ScreenReaderAnnouncer';
 export { default as Tooltip } from './Tooltip';
+export { default as TooltipMenuTriggerCombo } from './TooltipMenuTriggerCombo';
 export { default as TooltipPopoverCombo } from './TooltipPopoverCombo';
 export { default as Toggletip } from './Toggletip';
 export { default as Link } from './Link';

--- a/src/index.js
+++ b/src/index.js
@@ -190,6 +190,7 @@ export {
   RadioSimpleGroup,
   ScreenReaderAnnouncer,
   Tooltip as TooltipNext,
+  TooltipMenuTriggerCombo,
   TooltipPopoverCombo,
   Toggletip,
   Link as LinkNext,


### PR DESCRIPTION
# Description
This PR fixes 2 issues related to MenuTrigger:
1. onOpenChange doesn't fire and a11y properties don't update when the user activates the trigger component using the keyboard.
2. MenuTrigger with Tooltip as triggerComponent doesn't work correctly.

react-aria functionality doesn't fire when the trigger component is activated by the keyboard. This is causes the onOpenChange callback to not fire and a11y props (such as aria-expanded) to not update on the trigger component.

This PR makes the react-aria useMenuTriggerState control if the menu is open or not and makes the Popover trigger manually when the useMenuTriggerState.isOpen is updated. (like the Select component)
This causes a small breaking change if you are using Tooltips as the triggerComponent since tippy doesn't add the click event handler to the button anymore.

Additionally MenuTrigger doesn't provide all the props to the trigger component when using a Tooltip that it does normally when a button is provided directly. (for example aria-controls) This is because the properties don't get merged onto the Button but instead the Popover created by the Tooltip.

This PR creates a TooltipMenuTriggerCombo component, similar to TooltipPopoverCombo, which handles capturing the props given to the MenuTrigger triggerComponent and passes them to the button component instead.

# Links
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-615094
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-616381
