### PR TITLE
fix: use result of onShow callback in TooltipPopoverCombo

### DIFF
--- a/src/components/TooltipPopoverCombo/TooltipPopoverCombo.tsx
+++ b/src/components/TooltipPopoverCombo/TooltipPopoverCombo.tsx
@@ -31,32 +31,37 @@ const TooltipPopoverCombo: FC<Props> = (props: TooltipPopoverComboProps) => {
 
   const handleOnShowPopover = useCallback(
     (instance: PopoverInstance | undefined) => {
-      otherPopoverProps?.onShow?.(instance);
-      setIsPopoverOpen(true);
+      const result = otherPopoverProps?.onShow?.(instance);
+      if (result !== false) setIsPopoverOpen(true);
+      return result;
     },
     [otherPopoverProps]
   );
 
   const handleOnHidePopover = useCallback(
     (instance: PopoverInstance | undefined) => {
-      otherPopoverProps?.onHide?.(instance);
-      setIsPopoverOpen(false);
+      const result = otherPopoverProps?.onHide?.(instance);
+      if (result !== false) setIsPopoverOpen(false);
+      return result;
     },
     [otherPopoverProps]
   );
 
   const handleOnHideTooltip = useCallback(
     (instance: PopoverInstance | undefined) => {
-      otherTooltipProps?.onHide?.(instance);
-      setIsTooltipOpen(false);
+      const result = otherTooltipProps?.onHide?.(instance);
+      if (result !== false) setIsTooltipOpen(false);
+
+      return result;
     },
     [otherTooltipProps]
   );
 
   const handleOnShowTooltip = useCallback(
     (instance: PopoverInstance | undefined) => {
-      otherTooltipProps?.onShow?.(instance);
-      setIsTooltipOpen(true);
+      const result = otherTooltipProps?.onShow?.(instance);
+      if (result !== false) setIsTooltipOpen(true);
+      return result;
     },
     [otherTooltipProps]
   );

--- a/src/components/TooltipPopoverCombo/TooltipPopoverCombo.unit.test.tsx
+++ b/src/components/TooltipPopoverCombo/TooltipPopoverCombo.unit.test.tsx
@@ -307,5 +307,54 @@ describe('<TooltipPopoverCombo />', () => {
         expect(screen.queryByText('Example popover content button')).not.toBeInTheDocument();
       });
     });
+
+    it('should not show tooltip or popover when onShow callback return false', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <TooltipPopoverCombo
+          triggerComponent={triggerComponent}
+          tooltipContent={tooltipContent}
+          popoverContent={popoverContent}
+          otherTooltipProps={{ onShow: () => false }}
+          otherPopoverProps={{ onShow: () => false }}
+        />
+      );
+      await user.hover(screen.getByText('Example button'));
+
+      await waitFor(() => expect(screen.queryByRole('tooltip')).not.toBeInTheDocument());
+
+      await user.click(screen.getByText('Example button'));
+
+      await waitFor(() =>
+        expect(screen.queryByText('Example popover content button')).not.toBeInTheDocument()
+      );
+    });
+
+    it('should not hide tooltip or popover when onHide callback return false', async () => {
+      const user = userEvent.setup();
+
+      const { container } = render(
+        <TooltipPopoverCombo
+          triggerComponent={triggerComponent}
+          tooltipContent={tooltipContent}
+          popoverContent={popoverContent}
+          otherTooltipProps={{ onHide: () => false }}
+          otherPopoverProps={{ onHide: () => false }}
+        />
+      );
+      await user.hover(screen.getByText('Example button'));
+      await user.unhover(screen.getByText('Example button'));
+
+      await waitFor(() => expect(screen.queryByRole('tooltip')).toBeInTheDocument());
+
+      await user.click(screen.getByText('Example button'));
+      const backdrop = container.querySelector(`.${POPOVER_STYLE.backdrop}`);
+      await user.click(backdrop);
+
+      await waitFor(() =>
+        expect(screen.queryByText('Example popover content button')).toBeInTheDocument()
+      );
+    });
   });
 });


### PR DESCRIPTION
# Description

Passing the result of the custom (popover and tooltip) onShow result to tippy as expected.

# Links

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-623004
