### PR TITLE
ci: update github workflow

### DIFF
--- a/.github/workflows/deploy-documentation.yml
+++ b/.github/workflows/deploy-documentation.yml
@@ -26,7 +26,7 @@ jobs:
         run: yarn
 
       - name: Cache Dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: node_modules/
           key: node-modules-${{ runner.os }}-${{ env.rid }}
@@ -45,7 +45,7 @@ jobs:
           node-version-file: '.nvmrc'
 
       - name: Uncache Dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: node_modules/
           key: node-modules-${{ runner.os }}-${{ env.rid }}
@@ -54,7 +54,7 @@ jobs:
         run: yarn ci:build
 
       - name: Cache Documentation
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: docs/
           key: docs-${{ runner.os }}-${{ env.rid }}
@@ -74,7 +74,7 @@ jobs:
           rm -rf ./docs
 
       - name: Uncache Documentation
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: docs/
           key: docs-${{ runner.os }}-${{ env.rid }}

--- a/.github/workflows/deploy-documentation.yml
+++ b/.github/workflows/deploy-documentation.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   initialize:
     name: Initialize
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Project
         uses: actions/checkout@v4
@@ -34,7 +34,7 @@ jobs:
   build-source:
     name: Build - Source
     needs: initialize
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Project
         uses: actions/checkout@v4
@@ -62,7 +62,7 @@ jobs:
   deploy-documentation:
     name: Deploy - Documentation
     needs: build-source
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Project
         uses: actions/checkout@v4

--- a/.github/workflows/deploy-package.yml
+++ b/.github/workflows/deploy-package.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   initialize:
     name: Initialize
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Project
         uses: actions/checkout@v4
@@ -34,7 +34,7 @@ jobs:
   deploy-package:
     name: Deploy - Package
     needs: initialize
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Project
         uses: actions/checkout@v4

--- a/.github/workflows/deploy-package.yml
+++ b/.github/workflows/deploy-package.yml
@@ -26,7 +26,7 @@ jobs:
         run: yarn
 
       - name: Cache Dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: node_modules/
           key: node-modules-${{ runner.os }}-${{ env.rid }}
@@ -45,7 +45,7 @@ jobs:
           node-version-file: '.nvmrc'
 
       - name: Uncache Dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: node_modules/
           key: node-modules-${{ runner.os }}-${{ env.rid }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Validate Dependencies
         id: validate-dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: node_modules/
           key: node-modules-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
@@ -62,7 +62,7 @@ jobs:
         run: yarn
 
       - name: Cache Dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         if: steps.validate-dependencies.outputs.cache-hit != 'true'
         with:
           path: node_modules/
@@ -84,7 +84,7 @@ jobs:
           node-version-file: '.nvmrc'
 
       - name: Uncache Dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: node_modules/
           key: node-modules-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
@@ -108,7 +108,7 @@ jobs:
           node-version-file: '.nvmrc'
 
       - name: Uncache Dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: node_modules/
           key: node-modules-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
@@ -135,7 +135,7 @@ jobs:
           node-version-file: '.nvmrc'
 
       - name: Uncache Dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: node_modules/
           key: node-modules-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
@@ -144,19 +144,19 @@ jobs:
         run: yarn ci:build
 
       - name: Cache Dist
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: dist/
           key: dist-${{ runner.os }}-${{ env.rid }}
 
       - name: Cache Docs
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: docs/
           key: docs-${{ runner.os }}-${{ env.rid }}
 
       - name: Cache Styles
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: scss/
           key: scss-${{ runner.os }}-${{ env.rid }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   check-validation:
     name: Check - Validation
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check Validation
         run: |
@@ -38,7 +38,7 @@ jobs:
   initialize:
     name: Initialize
     needs: check-validation
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Project
         uses: actions/checkout@v4
@@ -71,7 +71,7 @@ jobs:
   test-source:
     name: Test - Source
     needs: initialize
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Project
         uses: actions/checkout@v4
@@ -95,7 +95,7 @@ jobs:
   test-static:
     name: Test - static
     needs: initialize
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Project
         uses: actions/checkout@v4
@@ -122,7 +122,7 @@ jobs:
   build-source:
     name: Build - Source
     needs: initialize
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Project
         uses: actions/checkout@v4


### PR DESCRIPTION
update github actions

- ubuntu 20.04 -> latest - [Will be deprecated in 2025.04.01.](https://github.com/actions/runner-images/issues/11101)
- action/cache v2 -> v4 - [Deprecated in 2025.03.01](https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down)