### PR TITLE
fix: bump-momentum-design-fix-icon-a11y-issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "@momentum-design/animations": "^0.0.4",
-    "@momentum-design/components": "0.27.3",
+    "@momentum-design/components": "0.33.2",
     "@momentum-design/fonts": "0.0.8",
     "@momentum-design/icons": "0.10.0",
     "@momentum-design/tokens": "0.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2299,6 +2299,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@floating-ui/core@npm:^1.6.0":
+  version: 1.6.9
+  resolution: "@floating-ui/core@npm:1.6.9"
+  dependencies:
+    "@floating-ui/utils": ^0.2.9
+  checksum: 21cbcac72a40172399570dedf0eb96e4f24b0d829980160e8d14edf08c2955ac6feffb7b94e1530c78fb7944635e52669c9257ad08570e0295efead3b5a9af91
+  languageName: node
+  linkType: hard
+
+"@floating-ui/dom@npm:^1.6.12":
+  version: 1.6.13
+  resolution: "@floating-ui/dom@npm:1.6.13"
+  dependencies:
+    "@floating-ui/core": ^1.6.0
+    "@floating-ui/utils": ^0.2.9
+  checksum: eabab9d860d3b5beab1c2d6936287efc4d9ab352de99062380589ef62870d59e8730397489c34a96657e128498001b5672330c4a9da0159fe8b2401ac59fe314
+  languageName: node
+  linkType: hard
+
+"@floating-ui/utils@npm:^0.2.9":
+  version: 0.2.9
+  resolution: "@floating-ui/utils@npm:0.2.9"
+  checksum: d518b80cec5a323e54a069a1dd99a20f8221a4853ed98ac16c75275a0cc22f75de4f8ac5b121b4f8990bd45da7ad1fb015b9a1e4bac27bb1cd62444af84e9784
+  languageName: node
+  linkType: hard
+
 "@formatjs/ecma402-abstract@npm:1.9.5":
   version: 1.9.5
   resolution: "@formatjs/ecma402-abstract@npm:1.9.5"
@@ -2876,10 +2902,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@momentum-design/components@npm:0.27.3":
-  version: 0.27.3
-  resolution: "@momentum-design/components@npm:0.27.3"
+"@momentum-design/components@npm:0.33.2":
+  version: 0.33.2
+  resolution: "@momentum-design/components@npm:0.33.2"
   dependencies:
+    "@floating-ui/dom": ^1.6.12
     "@lit/context": ^1.1.2
     "@lit/react": ^1.0.5
     "@momentum-design/fonts": "*"
@@ -2888,7 +2915,7 @@ __metadata:
     "@tanstack/lit-virtual": ^3.11.3
     lit: ^3.2.0
     uuid: ^11.0.5
-  checksum: 7ae448142896cf89d8904e0a3d47ecb9f1e56582c4e0927945898064e50534fd34e92b6c48f047da99eb235a85406a8df9c3cac4b3e97a983b5ae0bab395c51a
+  checksum: f1e4ccff59c3d95b22326da21fe3b767fc9fed54ced89dea817ac4eaec59a3f750e83ff9f0e6993740b900ee6cbcf9af72af4f1fa0b2963edc67aef413049157
   languageName: node
   linkType: hard
 
@@ -2957,7 +2984,7 @@ __metadata:
     "@commitlint/config-conventional": ^12.0.1
     "@hot-loader/react-dom": ~16.8.0
     "@momentum-design/animations": ^0.0.4
-    "@momentum-design/components": 0.27.3
+    "@momentum-design/components": 0.33.2
     "@momentum-design/fonts": 0.0.8
     "@momentum-design/icons": 0.10.0
     "@momentum-design/tokens": 0.3.2


### PR DESCRIPTION
# Description

- Bumping momentum-design to latest version to get fix for icon a11y issue (not setting role="img" when setting aria-labelledby)

# Links

https://github.com/momentum-design/momentum-design/pull/1152
