### PR TITLE
fix: notificationsystem-font-issue

### DIFF
--- a/src/components/NotificationSystem/NotificationSystem.style.scss
+++ b/src/components/NotificationSystem/NotificationSystem.style.scss
@@ -121,6 +121,7 @@
   }
 
   .Toastify__toast {
+    font-family: inherit;
     padding: 0px;
     min-height: 0px;
     background: none;


### PR DESCRIPTION
# Description

When passing in a text content to the Notification, the Font was not set correctly, since toastify was setting it to sans-serif.
This is not an issue if toast content is passed in using the Text component, but there are cases where the Text component is not used. This will fix it.

