### PR TITLE
fix(device notifications): allow individual notifications to use a specific screenreader announcer

### DIFF
--- a/src/components/NotificationSystem/NotificationSystem.types.ts
+++ b/src/components/NotificationSystem/NotificationSystem.types.ts
@@ -26,6 +26,10 @@ type CustomOptions = {
    * No announcement will be made if this is not provided.
    */
   screenReaderAnnouncement?: string;
+  /**
+   * Screen reader announcer to use for this message (overrides notification system default)
+   */
+  announcerIdentity?: string;
 };
 
 export type UpdateOptionsType = UpdateOptions & CustomOptions;

--- a/src/components/NotificationSystem/NotificationSystem.utils.ts
+++ b/src/components/NotificationSystem/NotificationSystem.utils.ts
@@ -39,10 +39,20 @@ export const calculateAutoClose = (options: NotifyOptionsType): number | false =
  * @returns the toastId of the triggered notification
  */
 export const notify = (content: ToastContent, options: NotifyOptionsType): Id => {
-  const { notificationSystemId, screenReaderAnnouncement, toastId, attention, onClose, role } =
-    options;
+  const {
+    notificationSystemId,
+    screenReaderAnnouncement,
+    toastId,
+    attention,
+    onClose,
+    role,
+    announcerIdentity,
+  } = options;
   if (screenReaderAnnouncement) {
-    ScreenReaderAnnouncer.announce({ body: screenReaderAnnouncement }, notificationSystemId);
+    ScreenReaderAnnouncer.announce(
+      { body: screenReaderAnnouncement },
+      announcerIdentity || notificationSystemId
+    );
   }
   return toast(content, {
     toastId: toastId,
@@ -60,9 +70,18 @@ export const notify = (content: ToastContent, options: NotifyOptionsType): Id =>
  * @param options several options to pass in (for details check type)
  */
 export const update = (toastId: Id, options: UpdateOptionsType): void => {
-  const { notificationSystemId, attention, screenReaderAnnouncement, ...updateOptions } = options;
+  const {
+    notificationSystemId,
+    attention,
+    screenReaderAnnouncement,
+    announcerIdentity,
+    ...updateOptions
+  } = options;
   if (screenReaderAnnouncement) {
-    ScreenReaderAnnouncer.announce({ body: screenReaderAnnouncement }, notificationSystemId);
+    ScreenReaderAnnouncer.announce(
+      { body: screenReaderAnnouncement },
+      announcerIdentity || notificationSystemId
+    );
   }
   toast.update(toastId, {
     ...updateOptions,


### PR DESCRIPTION
# Description
allow individual notifications to use a specific screenreader announcer e.g. when a modal dialog is open.

# Links
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-635490
