### PR TITLE
fix(device notifications): fall back to default announcer if announcerIdentity not registered

### DIFF
--- a/src/components/NotificationSystem/NotificationSystem.utils.ts
+++ b/src/components/NotificationSystem/NotificationSystem.utils.ts
@@ -46,13 +46,20 @@ export const notify = (content: ToastContent, options: NotifyOptionsType): Id =>
     attention,
     onClose,
     role,
-    announcerIdentity,
+    announcerIdentity: announcerIdentityFromOptions,
   } = options;
   if (screenReaderAnnouncement) {
-    ScreenReaderAnnouncer.announce(
-      { body: screenReaderAnnouncement },
-      announcerIdentity || notificationSystemId
-    );
+    let announcerIdentity = notificationSystemId;
+    if (announcerIdentityFromOptions) {
+      if (ScreenReaderAnnouncer.isRegistered(announcerIdentityFromOptions)) {
+        announcerIdentity = announcerIdentityFromOptions;
+      } else {
+        console.warn(
+          `ScreenReaderAnnouncer with identity ${announcerIdentityFromOptions} is not registered, falling back to ${notificationSystemId}`
+        );
+      }
+    }
+    ScreenReaderAnnouncer.announce({ body: screenReaderAnnouncement }, announcerIdentity);
   }
   return toast(content, {
     toastId: toastId,
@@ -74,14 +81,21 @@ export const update = (toastId: Id, options: UpdateOptionsType): void => {
     notificationSystemId,
     attention,
     screenReaderAnnouncement,
-    announcerIdentity,
+    announcerIdentity: announcerIdentityFromOptions,
     ...updateOptions
   } = options;
   if (screenReaderAnnouncement) {
-    ScreenReaderAnnouncer.announce(
-      { body: screenReaderAnnouncement },
-      announcerIdentity || notificationSystemId
-    );
+    let announcerIdentity = notificationSystemId;
+    if (announcerIdentityFromOptions) {
+      if (ScreenReaderAnnouncer.isRegistered(announcerIdentityFromOptions)) {
+        announcerIdentity = announcerIdentityFromOptions;
+      } else {
+        console.warn(
+          `ScreenReaderAnnouncer with identity ${announcerIdentityFromOptions} is not registered, falling back to ${notificationSystemId}`
+        );
+      }
+    }
+    ScreenReaderAnnouncer.announce({ body: screenReaderAnnouncement }, announcerIdentity);
   }
   toast.update(toastId, {
     ...updateOptions,

--- a/src/components/ScreenReaderAnnouncer/ScreenReaderAnnouncer.tsx
+++ b/src/components/ScreenReaderAnnouncer/ScreenReaderAnnouncer.tsx
@@ -11,6 +11,7 @@ import {
   AnnouncerProps,
   CompoundProps,
   ScreenReaderAnnouncerAnnounce,
+  ScreenReaderAnnouncerIsRegistered,
 } from './ScreenReaderAnnouncer.types';
 
 const registry: Record<string, { announce: Announce }> = {};
@@ -36,6 +37,9 @@ const register = (identity: string, announce: Announce) => {
 const deregister = (identity: string) => {
   delete registry[identity];
 };
+
+const isRegistered: ScreenReaderAnnouncerIsRegistered = (announcerIdentity) =>
+  !!registry[announcerIdentity];
 
 /**
  * Announce a message via a screen reader.
@@ -146,3 +150,4 @@ const ScreenReaderAnnouncer: FC<AnnouncerProps> & CompoundProps = ({
 export default ScreenReaderAnnouncer;
 
 ScreenReaderAnnouncer.announce = announce;
+ScreenReaderAnnouncer.isRegistered = isRegistered;

--- a/src/components/ScreenReaderAnnouncer/ScreenReaderAnnouncer.types.ts
+++ b/src/components/ScreenReaderAnnouncer/ScreenReaderAnnouncer.types.ts
@@ -3,6 +3,7 @@ import { ReactNode } from 'react';
 type Level = 'assertive' | 'polite';
 export interface CompoundProps {
   announce: ScreenReaderAnnouncerAnnounce;
+  isRegistered: ScreenReaderAnnouncerIsRegistered;
 }
 
 type AnnounceOptions = {
@@ -29,6 +30,7 @@ type AnnounceOptions = {
   timeout?: number;
 };
 type ScreenReaderAnnouncerAnnounce = (options: AnnounceOptions, announcerIdentity?: string) => void;
+type ScreenReaderAnnouncerIsRegistered = (announcerIdentity: string) => boolean;
 type Announce = (options: AnnounceOptions) => void;
 type Clear = (options: { messageIdentity: string }) => void;
 type Message = {
@@ -50,6 +52,7 @@ type AnnouncerProps = { identity?: string };
 
 export type {
   ScreenReaderAnnouncerAnnounce,
+  ScreenReaderAnnouncerIsRegistered,
   Level,
   AnnounceOptions,
   Announce,

--- a/src/components/ScreenReaderAnnouncer/ScreenReaderAnnouncer.unit.test.tsx
+++ b/src/components/ScreenReaderAnnouncer/ScreenReaderAnnouncer.unit.test.tsx
@@ -404,5 +404,17 @@ describe('<ScreenReaderAnnouncer />', () => {
       // This would error if the announcement timer was not cleared
       advanceTimers(delay);
     });
+
+    it('isRegistered returns correctly', () => {
+      setup();
+
+      if (announcerIdentity) {
+        expect(ScreenReaderAnnouncer.isRegistered(announcerIdentity)).toBe(true);
+        expect(ScreenReaderAnnouncer.isRegistered('default')).toBe(false);
+      } else {
+        expect(ScreenReaderAnnouncer.isRegistered('custom-identity')).toBe(false);
+        expect(ScreenReaderAnnouncer.isRegistered('default')).toBe(true);
+      }
+    });
   });
 });

--- a/src/components/ScreenReaderAnnouncer/ScreenReaderAnnouncer.unit.test.tsx.snap
+++ b/src/components/ScreenReaderAnnouncer/ScreenReaderAnnouncer.unit.test.tsx.snap
@@ -1500,6 +1500,16 @@ exports[`<ScreenReaderAnnouncer /> Announcer identity: custom-identity errors wh
 </div>
 `;
 
+exports[`<ScreenReaderAnnouncer /> Announcer identity: custom-identity isRegistered returns correctly 1`] = `
+<div>
+  <div
+    class="md-screen-reader-announcer-wrapper"
+    data-testid="screen-reader-announcer"
+    style="clip-path: inset(50%); height: 1px; overflow: hidden; position: absolute; width: 1px; white-space: nowrap;"
+  />
+</div>
+`;
+
 exports[`<ScreenReaderAnnouncer /> Announcer identity: undefined announces react node with default configuration 1`] = `
 <div>
   <div
@@ -2991,6 +3001,16 @@ exports[`<ScreenReaderAnnouncer /> Announcer identity: undefined errors when ann
 `;
 
 exports[`<ScreenReaderAnnouncer /> Announcer identity: undefined errors when registering a duplicate announcer 1`] = `
+<div>
+  <div
+    class="md-screen-reader-announcer-wrapper"
+    data-testid="screen-reader-announcer"
+    style="clip-path: inset(50%); height: 1px; overflow: hidden; position: absolute; width: 1px; white-space: nowrap;"
+  />
+</div>
+`;
+
+exports[`<ScreenReaderAnnouncer /> Announcer identity: undefined isRegistered returns correctly 1`] = `
 <div>
   <div
     class="md-screen-reader-announcer-wrapper"


### PR DESCRIPTION
# Description

- Add isRegistered function to ScreenReaderAnnouncer
- NotificationSystem falls back to its default announcer if announcerIdentity isn't registered, with a warning, to avoid losing notifications to timing issues.
 
# Links

jira: https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-635490
original momentum PR: https://github.com/momentum-design/momentum-react-v2/pull/773
accompanying cantina PR: https://sqbu-github.cisco.com/WebExSquared/webex-web-client/pull/7881
