### PR TITLE
fix: use aria-label for checkbox/radio if defined instead of label

### DIFF
--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -77,7 +77,7 @@ const Checkbox = (props: Props, providedRef: RefObject<HTMLInputElement>) => {
           <input
             {...inputProps}
             {...focusProps}
-            aria-label={label || inputProps?.['aria-label']}
+            aria-label={inputProps?.['aria-label'] || label}
             ref={ref}
           />
         </VisuallyHidden>

--- a/src/components/Checkbox/Checkbox.unit.test.tsx
+++ b/src/components/Checkbox/Checkbox.unit.test.tsx
@@ -162,25 +162,25 @@ describe('<Checkbox />', () => {
       expect(element.getAttribute('data-disabled')).toBe(disabled.toString());
     });
 
-    it('should use label prop for aria-label when provided', async () => {
+    it('should use aria-label prop for aria-label when provided', async () => {
       expect.assertions(1);
 
-      const label = 'test label';
+      const ariaLabel = 'Checkbox';
 
-      const wrapper = await mountAndWait(<Checkbox aria-label="Checkbox" label={label} />);
-      const element = wrapper.find('input').getDOMNode();
-
-      expect(element.getAttribute('aria-label')).toBe(label);
-    });
-
-    it('should use aria-label prop when label prop not provided', async () => {
-      expect.assertions(1);
-
-      const ariaLabel = 'test aria label';
-      const wrapper = await mountAndWait(<Checkbox aria-label={ariaLabel} />);
+      const wrapper = await mountAndWait(<Checkbox aria-label={ariaLabel} label={'test label'} />);
       const element = wrapper.find('input').getDOMNode();
 
       expect(element.getAttribute('aria-label')).toBe(ariaLabel);
+    });
+
+    it('should use label prop when aria-label prop not provided', async () => {
+      expect.assertions(1);
+
+      const label = 'test aria label';
+      const wrapper = await mountAndWait(<Checkbox label={label} />);
+      const element = wrapper.find('input').getDOMNode();
+
+      expect(element.getAttribute('aria-label')).toBe(label);
     });
 
     it('should not add a description when description if not provided', async () => {

--- a/src/components/Checkbox/Checkbox.unit.test.tsx.snap
+++ b/src/components/Checkbox/Checkbox.unit.test.tsx.snap
@@ -361,7 +361,7 @@ exports[`<Checkbox /> snapshot should match snapshot with labelled checkbox 1`] 
         >
           <input
             aria-checked={false}
-            aria-label="Example text"
+            aria-label="Checkbox"
             checked={false}
             disabled={false}
             onBlur={[Function]}
@@ -425,7 +425,7 @@ exports[`<Checkbox /> snapshot should match snapshot with labelled checkbox and 
           <input
             aria-checked={false}
             aria-describedby="checkbox-description-test-ID"
-            aria-label="Example text"
+            aria-label="Checkbox"
             checked={false}
             disabled={false}
             onBlur={[Function]}

--- a/src/components/RadioGroup/Radio.tsx
+++ b/src/components/RadioGroup/Radio.tsx
@@ -20,7 +20,7 @@ const Radio: FC<RadioProps> = (props: RadioProps) => {
   const radioId = useId(id);
 
   const radioProps = {
-    'aria-label': label,
+    'aria-label': props['aria-label'] || label,
     ...props,
     ...(description
       ? {

--- a/src/components/RadioGroup/RadioGroup.unit.test.tsx
+++ b/src/components/RadioGroup/RadioGroup.unit.test.tsx
@@ -104,6 +104,7 @@ describe('<RadioGroup />', () => {
             {
               label: 'Option 1',
               value: 'option1',
+              'aria-label': 'Test Group Option 1',
             },
           ]}
         />
@@ -448,6 +449,28 @@ describe('<RadioGroup />', () => {
       const radio = screen.getByText('Option 1');
 
       expect(radio.id).toBe(id);
+    });
+
+    it('should have child aria-label when aria-label is provided to child', () => {
+      expect.assertions(1);
+
+      const ariaLabel = 'Test Group Option 1';
+
+      render(
+        <RadioGroup
+          label="Test Radio Group"
+          options={[
+            {
+              label: 'Option 1',
+              value: 'option1',
+              'aria-label': ariaLabel,
+            },
+          ]}
+        />
+      );
+      const radio = screen.getByRole('radio');
+
+      expect(radio.getAttribute('aria-label')).toBe(ariaLabel);
     });
 
     it('should have child style when style is provided to child', () => {

--- a/src/components/RadioGroup/RadioGroup.unit.test.tsx.snap
+++ b/src/components/RadioGroup/RadioGroup.unit.test.tsx.snap
@@ -148,7 +148,7 @@ exports[`<RadioGroup /> snapshot should match snapshot with child 1`] = `
         class="md-radio-label"
       >
         <input
-          aria-label="Option 1"
+          aria-label="Test Group Option 1"
           class="md-radio-button"
           name="test-ID"
           tabindex="0"


### PR DESCRIPTION
# Description

Update CheckboxNext and Radio to use the aria-label provided instead of always using the label
