### PR TITLE
fix: allow mdc-buttons in aria toolbar to work

### DIFF
--- a/src/components/AriaToolbar/AriaToolbar.stories.tsx
+++ b/src/components/AriaToolbar/AriaToolbar.stories.tsx
@@ -8,6 +8,7 @@ import ButtonCircle from '../ButtonCircle';
 import ButtonPill from '../ButtonPill';
 import ButtonSimple from '../ButtonSimple';
 import Popover from '../Popover';
+import ButtonCircleToggle from '../ButtonCircleToggle';
 
 import argTypes from './AriaToolbar.stories.args';
 import { Props } from './AriaToolbar.types';
@@ -237,4 +238,63 @@ RenderedAsButtonGroup.args = {
   ],
 };
 
-export { Horizontal, Vertical, WithinPopover, IncludesPopoverAndTooltips, RenderedAsButtonGroup };
+const WithButtonCircleToggles = () => {
+  return (
+    <>
+      <AriaToolbar
+        orientation="vertical"
+        aria-controls="textInput"
+        aria-label="toolbar 1"
+        style={{ display: 'flex', rowGap: '0.5rem', flexDirection: 'column' }}
+        ariaToolbarItemsSize={3}
+      >
+        <AriaToolbarItem itemIndex={0}>
+          <ButtonCircleToggle onChange={onPressHandler}>1</ButtonCircleToggle>
+        </AriaToolbarItem>
+
+        <AriaToolbarItem itemIndex={1}>
+          <ButtonCircleToggle onChange={onPressHandler}>2</ButtonCircleToggle>
+        </AriaToolbarItem>
+
+        <AriaToolbarItem itemIndex={2}>
+          <ButtonCircleToggle onChange={onPressHandler}>3</ButtonCircleToggle>
+        </AriaToolbarItem>
+      </AriaToolbar>
+      <AriaToolbar
+        orientation="vertical"
+        aria-controls="textInput"
+        aria-label="toolbar 2"
+        style={{
+          display: 'flex',
+          rowGap: '0.5rem',
+          flexDirection: 'column',
+          marginTop: '1rem',
+          marginBottom: '1rem',
+        }}
+        ariaToolbarItemsSize={3}
+      >
+        <AriaToolbarItem itemIndex={0}>
+          <ButtonCircleToggle onChange={onPressHandler}>1</ButtonCircleToggle>
+        </AriaToolbarItem>
+
+        <AriaToolbarItem itemIndex={1}>
+          <ButtonCircleToggle onChange={onPressHandler}>2</ButtonCircleToggle>
+        </AriaToolbarItem>
+
+        <AriaToolbarItem itemIndex={2}>
+          <ButtonCircleToggle onChange={onPressHandler}>3</ButtonCircleToggle>
+        </AriaToolbarItem>
+      </AriaToolbar>
+      <input type="text" id="textInput" aria-label="A text input" />
+    </>
+  );
+};
+
+export {
+  Horizontal,
+  Vertical,
+  WithinPopover,
+  IncludesPopoverAndTooltips,
+  RenderedAsButtonGroup,
+  WithButtonCircleToggles,
+};

--- a/src/components/AriaToolbarItem/AriaToolbarItem.tsx
+++ b/src/components/AriaToolbarItem/AriaToolbarItem.tsx
@@ -1,8 +1,7 @@
+/* eslint-disable react/display-name */
 import { Props } from './AriaToolbarItem.types';
 
 import React, { forwardRef, useCallback } from 'react';
-
-import { useKeyboard } from '@react-aria/interactions';
 import { useAriaToolbarContext } from '../AriaToolbar/AriaToolbar.utils';
 import { useProvidedRef } from '../../utils/useProvidedRef';
 import { defaults } from 'lodash';
@@ -14,16 +13,12 @@ const AriaToolbarItem = forwardRef<HTMLButtonElement, Props>((props, providedRef
 
   const ref = useProvidedRef<HTMLButtonElement>(providedRef, null);
 
-  const { keyboardProps } = useKeyboard({
-    onKeyDown: (e) => {
+  const onKeyDown = useCallback(
+    (e) => {
       if (!ariaToolbarContext) return;
 
       const { orientation, setCurrentFocus, ariaToolbarItemsSize, currentFocus, onTabPress } =
         ariaToolbarContext;
-
-      // for the escape key (and other key presses), continue propagation to let Popovers / Modals know that
-      // they should close
-      e.continuePropagation();
 
       switch (e.key) {
         case orientation === 'horizontal' ? 'ArrowLeft' : 'ArrowUp':
@@ -45,7 +40,8 @@ const AriaToolbarItem = forwardRef<HTMLButtonElement, Props>((props, providedRef
           break;
       }
     },
-  });
+    [ariaToolbarContext]
+  );
 
   const getPropsForChildren = useCallback(
     (child, index) => {
@@ -69,13 +65,13 @@ const AriaToolbarItem = forwardRef<HTMLButtonElement, Props>((props, providedRef
             child.props?.onPress?.();
           },
           useNativeKeyDown: true,
-          ...keyboardProps,
+          onKeyDown,
         },
         children?.props, // specified props of children should take precedent over drilled props from parent
         rest
       );
     },
-    [ariaToolbarContext?.currentFocus, rest, children]
+    [ariaToolbarContext, onKeyDown, children.props, rest, ref]
   );
 
   return React.cloneElement(children, getPropsForChildren(children, itemIndex));

--- a/src/utils/navigation.test.ts
+++ b/src/utils/navigation.test.ts
@@ -29,10 +29,11 @@ describe('navigation', () => {
       <button aria-hidden='true' id='12'></button>
       <button aria-hidden='false' id='13'></button>
       <button disabled id='14'></button>
+      <mdc-button id='15'></mdc-button>
     `)
       ).map((n) => n.id);
 
-      expect(ids).toEqual(['2', '3', '4', '5', '6', '7', '8', '13']);
+      expect(ids).toEqual(['2', '3', '4', '5', '6', '7', '8', '13', '15']);
     });
 
     it('should return with focusable tags for any elements which can be focused', () => {

--- a/src/utils/navigation.ts
+++ b/src/utils/navigation.ts
@@ -1,5 +1,6 @@
 export const PRESERVE_TABINDEX_CLASSNAME = 'md-nav-preserve-tabindex';
-const FOCUSABLE_ELEMENT_SELECTORS = 'a[href], button, input, textarea, select, details, [tabindex]';
+const FOCUSABLE_ELEMENT_SELECTORS =
+  'a[href], button, mdc-button, input, textarea, select, details, [tabindex]';
 const PRESERVE_TABINDEX_SELECTORS = `[data-preserve-tabindex],.${PRESERVE_TABINDEX_CLASSNAME}`;
 
 type Options = {


### PR DESCRIPTION
# Description

Aria Toolbar currently does not work with ButtonCircleToggle & ButtonPillToggle, due to mdc-button being used.
To fix that, the following measurements have been taken:
- Added mdc-button to allowed tagnames in navigation.ts util
- Removed useKeyboard react-aria hook and replaced it with normal onKeydown handler to make all types of buttons work (React-Aria buttons and non React-Aria buttons).
- Tested with consuming client if everything still works as expected.
