### PR TITLE
fix(contentSeparator): set Text or other component to put in the middle of the separator

### DIFF
--- a/src/components/ContentSeparator/ContentSeparator.style.scss
+++ b/src/components/ContentSeparator/ContentSeparator.style.scss
@@ -5,6 +5,7 @@
   flex-direction: row;
 
   &[data-gradient='true'] {
+    &:before,
     &:after {
       border-bottom: none;
       height: 1px;
@@ -12,6 +13,7 @@
     }
   }
 
+  &:before,
   &:after {
     content: '';
     flex: 1 1;


### PR DESCRIPTION

<img width="940" alt="image" src="https://github.com/user-attachments/assets/bba2567d-309a-402c-af32-fd4f122ac7bc" />

# Description
add :before in css to set Text or other component to put in the middle of the separator
