### PR TITLE
fix: buttoncircle issues

### DIFF
--- a/src/components/Accordion/Accordion.unit.test.tsx.snap
+++ b/src/components/Accordion/Accordion.unit.test.tsx.snap
@@ -57,7 +57,7 @@ exports[`<Accordion /> snapshot should match snapshot 1`] = `
                 onTouchStart={[Function]}
                 type="button"
               >
-                <Icon
+                <Mrv2Icon
                   name="arrow-down"
                   scale={12}
                 >
@@ -78,7 +78,7 @@ exports[`<Accordion /> snapshot should match snapshot 1`] = `
                       suppressHydrationWarning={true}
                     />
                   </Icon>
-                </Icon>
+                </Mrv2Icon>
                 <Text
                   tagName="small"
                   type="body-secondary"
@@ -169,7 +169,7 @@ exports[`<Accordion /> snapshot should match snapshot with className 1`] = `
                 onTouchStart={[Function]}
                 type="button"
               >
-                <Icon
+                <Mrv2Icon
                   name="arrow-down"
                   scale={12}
                 >
@@ -190,7 +190,7 @@ exports[`<Accordion /> snapshot should match snapshot with className 1`] = `
                       suppressHydrationWarning={true}
                     />
                   </Icon>
-                </Icon>
+                </Mrv2Icon>
                 <Text
                   tagName="small"
                   type="body-secondary"
@@ -281,7 +281,7 @@ exports[`<Accordion /> snapshot should match snapshot with headingRightContent 1
                 onTouchStart={[Function]}
                 type="button"
               >
-                <Icon
+                <Mrv2Icon
                   name="arrow-down"
                   scale={12}
                 >
@@ -302,7 +302,7 @@ exports[`<Accordion /> snapshot should match snapshot with headingRightContent 1
                       suppressHydrationWarning={true}
                     />
                   </Icon>
-                </Icon>
+                </Mrv2Icon>
                 <Text
                   tagName="small"
                   type="body-secondary"
@@ -393,7 +393,7 @@ exports[`<Accordion /> snapshot should match snapshot with id 1`] = `
                 onTouchStart={[Function]}
                 type="button"
               >
-                <Icon
+                <Mrv2Icon
                   name="arrow-down"
                   scale={12}
                 >
@@ -414,7 +414,7 @@ exports[`<Accordion /> snapshot should match snapshot with id 1`] = `
                       suppressHydrationWarning={true}
                     />
                   </Icon>
-                </Icon>
+                </Mrv2Icon>
                 <Text
                   tagName="small"
                   type="body-secondary"
@@ -514,7 +514,7 @@ exports[`<Accordion /> snapshot should match snapshot with style 1`] = `
                 onTouchStart={[Function]}
                 type="button"
               >
-                <Icon
+                <Mrv2Icon
                   name="arrow-down"
                   scale={12}
                 >
@@ -535,7 +535,7 @@ exports[`<Accordion /> snapshot should match snapshot with style 1`] = `
                       suppressHydrationWarning={true}
                     />
                   </Icon>
-                </Icon>
+                </Mrv2Icon>
                 <Text
                   tagName="small"
                   type="body-secondary"

--- a/src/components/Avatar/Avatar.unit.test.tsx.snap
+++ b/src/components/Avatar/Avatar.unit.test.tsx.snap
@@ -93,7 +93,7 @@ exports[`Avatar snapshot should match snapshot with failureBadge 1`] = `
         className="md-avatar-presence-icon-wrapper"
         data-shape={true}
       >
-        <Icon
+        <Mrv2Icon
           fillColor="var(--mds-color-theme-indicator-attention)"
           name="warning"
           scale={14}
@@ -124,7 +124,7 @@ exports[`Avatar snapshot should match snapshot with failureBadge 1`] = `
               suppressHydrationWarning={true}
             />
           </Icon>
-        </Icon>
+        </Mrv2Icon>
       </div>
     </Presence>
   </div>
@@ -143,7 +143,7 @@ exports[`Avatar snapshot should match snapshot with icon 1`] = `
     data-size={24}
     role="img"
   >
-    <Icon
+    <Mrv2Icon
       className="md-avatar-wrapper-children md-avatar-icon-wrapper"
       name="check"
       scale={16}
@@ -166,7 +166,7 @@ exports[`Avatar snapshot should match snapshot with icon 1`] = `
           suppressHydrationWarning={true}
         />
       </Icon>
-    </Icon>
+    </Mrv2Icon>
   </div>
 </Avatar>
 `;
@@ -186,7 +186,7 @@ exports[`Avatar snapshot should match snapshot with iconOnHover 1`] = `
     <div
       className="md-avatar-wrapper-children md-avatar-icon-on-hover-wrapper"
     >
-      <Icon
+      <Mrv2Icon
         className="md-avatar-wrapper-children md-avatar-icon-wrapper"
         name="check"
         scale={16}
@@ -209,7 +209,7 @@ exports[`Avatar snapshot should match snapshot with iconOnHover 1`] = `
             suppressHydrationWarning={true}
           />
         </Icon>
-      </Icon>
+      </Mrv2Icon>
     </div>
   </div>
 </Avatar>
@@ -476,7 +476,7 @@ exports[`Avatar snapshot should match snapshot with presence and presenceLabel 1
           className="md-avatar-presence-icon-wrapper"
           data-shape={true}
         >
-          <Icon
+          <Mrv2Icon
             fillColor="var(--mds-color-theme-indicator-stable)"
             name="unread"
             scale={14}
@@ -507,7 +507,7 @@ exports[`Avatar snapshot should match snapshot with presence and presenceLabel 1
                 suppressHydrationWarning={true}
               />
             </Icon>
-          </Icon>
+          </Mrv2Icon>
         </div>
       </Presence>
     </div>
@@ -548,7 +548,7 @@ exports[`Avatar snapshot should match snapshot with presence and presenceLabel 1
           className="md-avatar-presence-icon-wrapper"
           data-shape={false}
         >
-          <Icon
+          <Mrv2Icon
             fillColor="var(--mds-color-theme-indicator-unstable)"
             name="camera-presence"
             scale={14}
@@ -579,7 +579,7 @@ exports[`Avatar snapshot should match snapshot with presence and presenceLabel 1
                 suppressHydrationWarning={true}
               />
             </Icon>
-          </Icon>
+          </Mrv2Icon>
         </div>
       </Presence>
     </div>
@@ -620,7 +620,7 @@ exports[`Avatar snapshot should match snapshot with presence and presenceLabel 1
           className="md-avatar-presence-icon-wrapper"
           data-shape={false}
         >
-          <Icon
+          <Mrv2Icon
             fillColor="var(--mds-color-theme-indicator-unstable)"
             name="meetings-presence"
             scale={14}
@@ -651,7 +651,7 @@ exports[`Avatar snapshot should match snapshot with presence and presenceLabel 1
                 suppressHydrationWarning={true}
               />
             </Icon>
-          </Icon>
+          </Mrv2Icon>
         </div>
       </Presence>
     </div>
@@ -692,7 +692,7 @@ exports[`Avatar snapshot should match snapshot with presence and presenceLabel 1
           className="md-avatar-presence-icon-wrapper"
           data-shape={false}
         >
-          <Icon
+          <Mrv2Icon
             fillColor="var(--mds-color-theme-indicator-unstable)"
             name="handset"
             scale={14}
@@ -723,7 +723,7 @@ exports[`Avatar snapshot should match snapshot with presence and presenceLabel 1
                 suppressHydrationWarning={true}
               />
             </Icon>
-          </Icon>
+          </Mrv2Icon>
         </div>
       </Presence>
     </div>
@@ -764,7 +764,7 @@ exports[`Avatar snapshot should match snapshot with presence and presenceLabel 1
           className="md-avatar-presence-icon-wrapper"
           data-shape={true}
         >
-          <Icon
+          <Mrv2Icon
             fillColor="var(--mds-color-theme-indicator-attention)"
             name="dnd-presence"
             scale={14}
@@ -795,7 +795,7 @@ exports[`Avatar snapshot should match snapshot with presence and presenceLabel 1
                 suppressHydrationWarning={true}
               />
             </Icon>
-          </Icon>
+          </Mrv2Icon>
         </div>
       </Presence>
     </div>
@@ -836,7 +836,7 @@ exports[`Avatar snapshot should match snapshot with presence and presenceLabel 1
           className="md-avatar-presence-icon-wrapper"
           data-shape={false}
         >
-          <Icon
+          <Mrv2Icon
             fillColor="var(--mds-color-theme-indicator-attention)"
             name="share-screen"
             scale={14}
@@ -867,7 +867,7 @@ exports[`Avatar snapshot should match snapshot with presence and presenceLabel 1
                 suppressHydrationWarning={true}
               />
             </Icon>
-          </Icon>
+          </Mrv2Icon>
         </div>
       </Presence>
     </div>
@@ -908,7 +908,7 @@ exports[`Avatar snapshot should match snapshot with presence and presenceLabel 1
           className="md-avatar-presence-icon-wrapper"
           data-shape={true}
         >
-          <Icon
+          <Mrv2Icon
             fillColor="var(--mds-color-theme-indicator-locked)"
             name="quiet-hours-presence"
             scale={14}
@@ -939,7 +939,7 @@ exports[`Avatar snapshot should match snapshot with presence and presenceLabel 1
                 suppressHydrationWarning={true}
               />
             </Icon>
-          </Icon>
+          </Mrv2Icon>
         </div>
       </Presence>
     </div>
@@ -980,7 +980,7 @@ exports[`Avatar snapshot should match snapshot with presence and presenceLabel 1
           className="md-avatar-presence-icon-wrapper"
           data-shape={true}
         >
-          <Icon
+          <Mrv2Icon
             fillColor="var(--mds-color-theme-indicator-locked)"
             name="recents-presence"
             scale={14}
@@ -1011,7 +1011,7 @@ exports[`Avatar snapshot should match snapshot with presence and presenceLabel 1
                 suppressHydrationWarning={true}
               />
             </Icon>
-          </Icon>
+          </Mrv2Icon>
         </div>
       </Presence>
     </div>
@@ -1052,7 +1052,7 @@ exports[`Avatar snapshot should match snapshot with presence and presenceLabel 1
           className="md-avatar-presence-icon-wrapper"
           data-shape={true}
         >
-          <Icon
+          <Mrv2Icon
             fillColor="var(--mds-color-theme-indicator-locked)"
             name="pto-presence"
             scale={14}
@@ -1083,7 +1083,7 @@ exports[`Avatar snapshot should match snapshot with presence and presenceLabel 1
                 suppressHydrationWarning={true}
               />
             </Icon>
-          </Icon>
+          </Mrv2Icon>
         </div>
       </Presence>
     </div>
@@ -1124,7 +1124,7 @@ exports[`Avatar snapshot should match snapshot with presence and presenceLabel 1
           className="md-avatar-presence-icon-wrapper"
           data-shape={true}
         >
-          <Icon
+          <Mrv2Icon
             fillColor="var(--mds-color-theme-indicator-unstable)"
             name="busy-presence"
             scale={14}
@@ -1155,7 +1155,7 @@ exports[`Avatar snapshot should match snapshot with presence and presenceLabel 1
                 suppressHydrationWarning={true}
               />
             </Icon>
-          </Icon>
+          </Mrv2Icon>
         </div>
       </Presence>
     </div>
@@ -1196,7 +1196,7 @@ exports[`Avatar snapshot should match snapshot with presence and presenceLabel 1
           className="md-avatar-presence-icon-wrapper"
           data-shape={false}
         >
-          <Icon
+          <Mrv2Icon
             fillColor="var(--mds-color-theme-indicator-locked)"
             name="phone"
             scale={14}
@@ -1227,7 +1227,7 @@ exports[`Avatar snapshot should match snapshot with presence and presenceLabel 1
                 suppressHydrationWarning={true}
               />
             </Icon>
-          </Icon>
+          </Mrv2Icon>
         </div>
       </Presence>
     </div>
@@ -1268,7 +1268,7 @@ exports[`Avatar snapshot should match snapshot with presence and presenceLabel 1
           className="md-avatar-presence-icon-wrapper"
           data-shape={false}
         >
-          <Icon
+          <Mrv2Icon
             fillColor="var(--mds-color-theme-indicator-locked)"
             name="generic-device-video"
             scale={14}
@@ -1299,7 +1299,7 @@ exports[`Avatar snapshot should match snapshot with presence and presenceLabel 1
                 suppressHydrationWarning={true}
               />
             </Icon>
-          </Icon>
+          </Mrv2Icon>
         </div>
       </Presence>
     </div>
@@ -1340,7 +1340,7 @@ exports[`Avatar snapshot should match snapshot with presence and presenceLabel 1
           className="md-avatar-presence-icon-wrapper"
           data-shape={false}
         >
-          <Icon
+          <Mrv2Icon
             fillColor="var(--mds-color-theme-indicator-locked)"
             name="pause"
             scale={14}
@@ -1371,7 +1371,7 @@ exports[`Avatar snapshot should match snapshot with presence and presenceLabel 1
                 suppressHydrationWarning={true}
               />
             </Icon>
-          </Icon>
+          </Mrv2Icon>
         </div>
       </Presence>
     </div>

--- a/src/components/ButtonCircle/ButtonCircle.constants.ts
+++ b/src/components/ButtonCircle/ButtonCircle.constants.ts
@@ -8,6 +8,7 @@ const DEFAULTS = {
   OUTLINE: false,
   SIZE: 40,
   INVERTED: false,
+  STOP_PROPAGATION: true,
 } as const;
 
 const COLORS = {

--- a/src/components/ButtonCircle/ButtonCircle.tsx
+++ b/src/components/ButtonCircle/ButtonCircle.tsx
@@ -19,6 +19,7 @@ const ButtonCircle = forwardRef((props: Props, providedRef: RefObject<Button>) =
     ghost,
     outline,
     shallowDisabled,
+    stopPropagation = DEFAULTS.STOP_PROPAGATION,
     ...rest
   } = props;
 
@@ -51,7 +52,7 @@ const ButtonCircle = forwardRef((props: Props, providedRef: RefObject<Button>) =
   if (children && Children.count(children) === 1) {
     const Icon = children as ReactElement;
     // @ts-ignore
-    if (Icon.type?.name === 'Icon') {
+    if (Icon.type?.displayName === 'Mrv2Icon') {
       prefixIcon = [Icon.props.name, Icon.props.weight || 'regular'].join('-');
     }
   }
@@ -61,8 +62,10 @@ const ButtonCircle = forwardRef((props: Props, providedRef: RefObject<Button>) =
   // this can be removed once ListItemBase is refactored to use the new momentum-design listitem component
   const preventBubble = (event: any) => {
     // Prevent the event from bubbling up to the parent element
-    event.stopPropagation();
-    event.preventDefault();
+    if (stopPropagation) {
+      event.stopPropagation();
+      event.preventDefault();
+    }
   };
 
   const handleClick = (event: MouseEvent) => {

--- a/src/components/ButtonCircle/ButtonCircle.types.ts
+++ b/src/components/ButtonCircle/ButtonCircle.types.ts
@@ -16,10 +16,18 @@ export type Props = Omit<MdcButtonProps, 'active' | 'color'> & {
    * Whether or not this ButtonCircle has an outline/border.
    */
   outline?: boolean;
+
   /**
    * Child components of this ButtonCircle.
+   *
+   * @deprecated Use `prefix-icon` prop instead.
    */
   children?: ReactNode;
 
   shallowDisabled?: boolean;
+
+  /**
+   * Whether or not to stop the event from bubbling up.
+   */
+  stopPropagation?: boolean;
 };

--- a/src/components/ButtonCircle/ButtonCircle.unit.test.tsx
+++ b/src/components/ButtonCircle/ButtonCircle.unit.test.tsx
@@ -168,21 +168,21 @@ describe('<ButtonCircle />', () => {
   describe('actions', () => {
     it('should call onPress when clicked', async () => {
       const onPress = jest.fn();
-      await setup(<ButtonCircle onPress={onPress} />);
+      await setup(<ButtonCircle onPress={onPress} stopPropagation={false} />);
       await userEvent.click(screen.getByRole('button'));
       expect(onPress).toHaveBeenCalled();
     });
 
     it('should not call onPress when disabled', async () => {
       const onPress = jest.fn();
-      await setup(<ButtonCircle onPress={onPress} disabled />);
+      await setup(<ButtonCircle onPress={onPress} disabled stopPropagation={false} />);
       await userEvent.click(screen.getByRole('button'));
       expect(onPress).not.toHaveBeenCalled();
     });
 
     it('should call onPress when shallowDisabled', async () => {
       const onPress = jest.fn();
-      await setup(<ButtonCircle onPress={onPress} shallowDisabled />);
+      await setup(<ButtonCircle onPress={onPress} shallowDisabled stopPropagation={false} />);
       await userEvent.click(screen.getByRole('button'));
       expect(onPress).toHaveBeenCalled();
     });

--- a/src/components/ButtonControl/ButtonControl.unit.test.tsx.snap
+++ b/src/components/ButtonControl/ButtonControl.unit.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`<ButtonControl /> snapshot should match snapshot 1`] = `
           onTouchStart={[Function]}
           type="button"
         >
-          <Icon
+          <Mrv2Icon
             autoScale={true}
             name="cancel"
             weight="bold"
@@ -52,7 +52,7 @@ exports[`<ButtonControl /> snapshot should match snapshot 1`] = `
                 suppressHydrationWarning={true}
               />
             </Icon>
-          </Icon>
+          </Mrv2Icon>
         </button>
       </FocusRing>
     </FocusRing>
@@ -91,7 +91,7 @@ exports[`<ButtonControl /> snapshot should match snapshot with className 1`] = `
           onTouchStart={[Function]}
           type="button"
         >
-          <Icon
+          <Mrv2Icon
             autoScale={true}
             name="cancel"
             weight="bold"
@@ -113,7 +113,7 @@ exports[`<ButtonControl /> snapshot should match snapshot with className 1`] = `
                 suppressHydrationWarning={true}
               />
             </Icon>
-          </Icon>
+          </Mrv2Icon>
         </button>
       </FocusRing>
     </FocusRing>
@@ -154,7 +154,7 @@ exports[`<ButtonControl /> snapshot should match snapshot with id 1`] = `
           onTouchStart={[Function]}
           type="button"
         >
-          <Icon
+          <Mrv2Icon
             autoScale={true}
             name="cancel"
             weight="bold"
@@ -176,7 +176,7 @@ exports[`<ButtonControl /> snapshot should match snapshot with id 1`] = `
                 suppressHydrationWarning={true}
               />
             </Icon>
-          </Icon>
+          </Mrv2Icon>
         </button>
       </FocusRing>
     </FocusRing>
@@ -217,7 +217,7 @@ exports[`<ButtonControl /> snapshot should match snapshot with isCircular 1`] = 
           onTouchStart={[Function]}
           type="button"
         >
-          <Icon
+          <Mrv2Icon
             autoScale={true}
             name="cancel"
             weight="bold"
@@ -239,7 +239,7 @@ exports[`<ButtonControl /> snapshot should match snapshot with isCircular 1`] = 
                 suppressHydrationWarning={true}
               />
             </Icon>
-          </Icon>
+          </Mrv2Icon>
         </button>
       </FocusRing>
     </FocusRing>
@@ -285,7 +285,7 @@ exports[`<ButtonControl /> snapshot should match snapshot with isDisabled 1`] = 
           onTouchStart={[Function]}
           type="button"
         >
-          <Icon
+          <Mrv2Icon
             autoScale={true}
             name="cancel"
             weight="bold"
@@ -307,7 +307,7 @@ exports[`<ButtonControl /> snapshot should match snapshot with isDisabled 1`] = 
                 suppressHydrationWarning={true}
               />
             </Icon>
-          </Icon>
+          </Mrv2Icon>
         </button>
       </FocusRing>
     </FocusRing>
@@ -360,7 +360,7 @@ exports[`<ButtonControl /> snapshot should match snapshot with style 1`] = `
           }
           type="button"
         >
-          <Icon
+          <Mrv2Icon
             autoScale={true}
             name="cancel"
             weight="bold"
@@ -382,7 +382,7 @@ exports[`<ButtonControl /> snapshot should match snapshot with style 1`] = `
                 suppressHydrationWarning={true}
               />
             </Icon>
-          </Icon>
+          </Mrv2Icon>
         </button>
       </FocusRing>
     </FocusRing>

--- a/src/components/ButtonGroup/ButtonGroup.unit.test.tsx.snap
+++ b/src/components/ButtonGroup/ButtonGroup.unit.test.tsx.snap
@@ -72,11 +72,16 @@ exports[`<ButtonGroup /> snapshot should match snapshot 1`] = `
       <Button
         className="md-button-circle-wrapper"
         color="default"
+        onClick={[Function]}
+        onPointerDown={[Function]}
+        onPointerUp={[Function]}
         size={40}
         variant="primary"
       >
         <mdc-button
           class="md-button-circle-wrapper"
+          onPointerDown={[Function]}
+          onPointerUp={[Function]}
           suppressHydrationWarning={true}
         >
           A
@@ -161,11 +166,16 @@ exports[`<ButtonGroup /> snapshot should match snapshot when spaced 1`] = `
       <Button
         className="md-button-circle-wrapper"
         color="default"
+        onClick={[Function]}
+        onPointerDown={[Function]}
+        onPointerUp={[Function]}
         size={40}
         variant="primary"
       >
         <mdc-button
           class="md-button-circle-wrapper"
+          onPointerDown={[Function]}
+          onPointerUp={[Function]}
           suppressHydrationWarning={true}
         >
           A
@@ -251,11 +261,16 @@ exports[`<ButtonGroup /> snapshot should match snapshot with aria-label 1`] = `
       <Button
         className="md-button-circle-wrapper"
         color="default"
+        onClick={[Function]}
+        onPointerDown={[Function]}
+        onPointerUp={[Function]}
         size={40}
         variant="primary"
       >
         <mdc-button
           class="md-button-circle-wrapper"
+          onPointerDown={[Function]}
+          onPointerUp={[Function]}
           suppressHydrationWarning={true}
         >
           A
@@ -273,11 +288,16 @@ exports[`<ButtonGroup /> snapshot should match snapshot with className 1`] = `
   <Button
     className="md-button-circle-wrapper example-class"
     color="default"
+    onClick={[Function]}
+    onPointerDown={[Function]}
+    onPointerUp={[Function]}
     size={40}
     variant="primary"
   >
     <mdc-button
       class="md-button-circle-wrapper example-class"
+      onPointerDown={[Function]}
+      onPointerUp={[Function]}
       suppressHydrationWarning={true}
     />
   </Button>
@@ -292,11 +312,16 @@ exports[`<ButtonGroup /> snapshot should match snapshot with id 1`] = `
     className="md-button-circle-wrapper"
     color="default"
     id="example-id"
+    onClick={[Function]}
+    onPointerDown={[Function]}
+    onPointerUp={[Function]}
     size={40}
     variant="primary"
   >
     <mdc-button
       class="md-button-circle-wrapper"
+      onPointerDown={[Function]}
+      onPointerUp={[Function]}
       suppressHydrationWarning={true}
     />
   </Button>
@@ -377,11 +402,16 @@ exports[`<ButtonGroup /> snapshot should match snapshot with orientation = verti
       <Button
         className="md-button-circle-wrapper"
         color="default"
+        onClick={[Function]}
+        onPointerDown={[Function]}
+        onPointerUp={[Function]}
         size={40}
         variant="primary"
       >
         <mdc-button
           class="md-button-circle-wrapper"
+          onPointerDown={[Function]}
+          onPointerUp={[Function]}
           suppressHydrationWarning={true}
         >
           A
@@ -467,11 +497,16 @@ exports[`<ButtonGroup /> snapshot should match snapshot with role 1`] = `
       <Button
         className="md-button-circle-wrapper"
         color="default"
+        onClick={[Function]}
+        onPointerDown={[Function]}
+        onPointerUp={[Function]}
         size={40}
         variant="primary"
       >
         <mdc-button
           class="md-button-circle-wrapper"
+          onPointerDown={[Function]}
+          onPointerUp={[Function]}
           suppressHydrationWarning={true}
         >
           A
@@ -556,11 +591,16 @@ exports[`<ButtonGroup /> snapshot should match snapshot with round 1`] = `
       <Button
         className="md-button-circle-wrapper"
         color="default"
+        onClick={[Function]}
+        onPointerDown={[Function]}
+        onPointerUp={[Function]}
         size={40}
         variant="primary"
       >
         <mdc-button
           class="md-button-circle-wrapper"
+          onPointerDown={[Function]}
+          onPointerUp={[Function]}
           suppressHydrationWarning={true}
         >
           A
@@ -645,11 +685,16 @@ exports[`<ButtonGroup /> snapshot should match snapshot with separator 1`] = `
       <Button
         className="md-button-circle-wrapper"
         color="default"
+        onClick={[Function]}
+        onPointerDown={[Function]}
+        onPointerUp={[Function]}
         size={40}
         variant="primary"
       >
         <mdc-button
           class="md-button-circle-wrapper"
+          onPointerDown={[Function]}
+          onPointerUp={[Function]}
           suppressHydrationWarning={true}
         >
           A
@@ -671,6 +716,9 @@ exports[`<ButtonGroup /> snapshot should match snapshot with style 1`] = `
   <Button
     className="md-button-circle-wrapper"
     color="default"
+    onClick={[Function]}
+    onPointerDown={[Function]}
+    onPointerUp={[Function]}
     size={40}
     style={
       Object {
@@ -681,6 +729,8 @@ exports[`<ButtonGroup /> snapshot should match snapshot with style 1`] = `
   >
     <mdc-button
       class="md-button-circle-wrapper"
+      onPointerDown={[Function]}
+      onPointerUp={[Function]}
       style={
         Object {
           "color": "pink",

--- a/src/components/Checkbox/Checkbox.unit.test.tsx.snap
+++ b/src/components/Checkbox/Checkbox.unit.test.tsx.snap
@@ -300,7 +300,7 @@ exports[`<Checkbox /> snapshot should match snapshot with indeterminate checkbox
       <div
         className="md-checkbox-selected checkbox"
       >
-        <Icon
+        <Mrv2Icon
           className="md-checkbox-icon"
           name="minus"
           scale={12}
@@ -323,7 +323,7 @@ exports[`<Checkbox /> snapshot should match snapshot with indeterminate checkbox
               suppressHydrationWarning={true}
             />
           </Icon>
-        </Icon>
+        </Mrv2Icon>
       </div>
     </label>
   </div>
@@ -593,7 +593,7 @@ exports[`<Checkbox /> snapshot should match snapshot with selected checkbox 1`] 
       <div
         className="md-checkbox-selected checkbox"
       >
-        <Icon
+        <Mrv2Icon
           className="md-checkbox-icon"
           name="check"
           scale={12}
@@ -616,7 +616,7 @@ exports[`<Checkbox /> snapshot should match snapshot with selected checkbox 1`] 
               suppressHydrationWarning={true}
             />
           </Icon>
-        </Icon>
+        </Mrv2Icon>
       </div>
     </label>
   </div>

--- a/src/components/ComboBox/ComboBox.unit.test.tsx.snap
+++ b/src/components/ComboBox/ComboBox.unit.test.tsx.snap
@@ -163,7 +163,7 @@ exports[`ComboBox snapshot should match snapshot label 1`] = `
                 onTouchStart={[Function]}
                 type="button"
               >
-                <Icon
+                <Mrv2Icon
                   className="md-combo-box-arrow-icon"
                   name="arrow-down"
                   scale={12}
@@ -186,7 +186,7 @@ exports[`ComboBox snapshot should match snapshot label 1`] = `
                       suppressHydrationWarning={true}
                     />
                   </Icon>
-                </Icon>
+                </Mrv2Icon>
               </button>
             </FocusRing>
           </FocusRing>
@@ -355,7 +355,7 @@ exports[`ComboBox snapshot should match snapshot with className 1`] = `
                 onTouchStart={[Function]}
                 type="button"
               >
-                <Icon
+                <Mrv2Icon
                   className="md-combo-box-arrow-icon"
                   name="arrow-down"
                   scale={12}
@@ -378,7 +378,7 @@ exports[`ComboBox snapshot should match snapshot with className 1`] = `
                       suppressHydrationWarning={true}
                     />
                   </Icon>
-                </Icon>
+                </Mrv2Icon>
               </button>
             </FocusRing>
           </FocusRing>
@@ -547,7 +547,7 @@ exports[`ComboBox snapshot should match snapshot with noResultText 1`] = `
                 onTouchStart={[Function]}
                 type="button"
               >
-                <Icon
+                <Mrv2Icon
                   className="md-combo-box-arrow-icon"
                   name="arrow-down"
                   scale={12}
@@ -570,7 +570,7 @@ exports[`ComboBox snapshot should match snapshot with noResultText 1`] = `
                       suppressHydrationWarning={true}
                     />
                   </Icon>
-                </Icon>
+                </Mrv2Icon>
               </button>
             </FocusRing>
           </FocusRing>
@@ -739,7 +739,7 @@ exports[`ComboBox snapshot should match snapshot with placeholder 1`] = `
                 onTouchStart={[Function]}
                 type="button"
               >
-                <Icon
+                <Mrv2Icon
                   className="md-combo-box-arrow-icon"
                   name="arrow-down"
                   scale={12}
@@ -762,7 +762,7 @@ exports[`ComboBox snapshot should match snapshot with placeholder 1`] = `
                       suppressHydrationWarning={true}
                     />
                   </Icon>
-                </Icon>
+                </Mrv2Icon>
               </button>
             </FocusRing>
           </FocusRing>
@@ -936,7 +936,7 @@ exports[`ComboBox snapshot should match snapshot with style 1`] = `
                 onTouchStart={[Function]}
                 type="button"
               >
-                <Icon
+                <Mrv2Icon
                   className="md-combo-box-arrow-icon"
                   name="arrow-down"
                   scale={12}
@@ -959,7 +959,7 @@ exports[`ComboBox snapshot should match snapshot with style 1`] = `
                       suppressHydrationWarning={true}
                     />
                   </Icon>
-                </Icon>
+                </Mrv2Icon>
               </button>
             </FocusRing>
           </FocusRing>
@@ -1128,7 +1128,7 @@ exports[`ComboBox snapshot should match snapshot with width 1`] = `
                 onTouchStart={[Function]}
                 type="button"
               >
-                <Icon
+                <Mrv2Icon
                   className="md-combo-box-arrow-icon"
                   name="arrow-down"
                   scale={12}
@@ -1151,7 +1151,7 @@ exports[`ComboBox snapshot should match snapshot with width 1`] = `
                       suppressHydrationWarning={true}
                     />
                   </Icon>
-                </Icon>
+                </Mrv2Icon>
               </button>
             </FocusRing>
           </FocusRing>
@@ -1333,7 +1333,7 @@ exports[`ComboBox snapshot should match snapshot withSection 1`] = `
                 onTouchStart={[Function]}
                 type="button"
               >
-                <Icon
+                <Mrv2Icon
                   className="md-combo-box-arrow-icon"
                   name="arrow-down"
                   scale={12}
@@ -1356,7 +1356,7 @@ exports[`ComboBox snapshot should match snapshot withSection 1`] = `
                       suppressHydrationWarning={true}
                     />
                   </Icon>
-                </Icon>
+                </Mrv2Icon>
               </button>
             </FocusRing>
           </FocusRing>

--- a/src/components/GlobalSearchInput/GlobalSearchInput.unit.test.tsx.snap
+++ b/src/components/GlobalSearchInput/GlobalSearchInput.unit.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`<GlobalSearchInput /> snapshot should match snapshot 1`] = `
         htmlFor="test-ID"
       />
       <div>
-        <Icon
+        <Mrv2Icon
           className="md-global-search-input-search"
           fillColor="var(--mds-color-theme-text-primary-normal)"
           name="search"
@@ -47,7 +47,7 @@ exports[`<GlobalSearchInput /> snapshot should match snapshot 1`] = `
               suppressHydrationWarning={true}
             />
           </Icon>
-        </Icon>
+        </Mrv2Icon>
       </div>
       <div
         className="md-global-search-input-container"
@@ -114,7 +114,7 @@ exports[`<GlobalSearchInput /> snapshot should match snapshot when filters are s
         nonempty, nonempty:
       </label>
       <div>
-        <Icon
+        <Mrv2Icon
           className="md-global-search-input-search"
           fillColor="var(--mds-color-theme-text-primary-normal)"
           name="search"
@@ -146,7 +146,7 @@ exports[`<GlobalSearchInput /> snapshot should match snapshot when filters are s
               suppressHydrationWarning={true}
             />
           </Icon>
-        </Icon>
+        </Mrv2Icon>
       </div>
       <div
         className="md-global-search-input-container"
@@ -213,7 +213,7 @@ exports[`<GlobalSearchInput /> snapshot should match snapshot when filters are s
               onTouchStart={[Function]}
               type="button"
             >
-              <Icon
+              <Mrv2Icon
                 name="cancel"
                 scale={18}
               >
@@ -234,7 +234,7 @@ exports[`<GlobalSearchInput /> snapshot should match snapshot when filters are s
                     suppressHydrationWarning={true}
                   />
                 </Icon>
-              </Icon>
+              </Mrv2Icon>
             </button>
           </FocusRing>
         </FocusRing>
@@ -329,7 +329,7 @@ exports[`<GlobalSearchInput /> snapshot should match snapshot with className 1`]
         htmlFor="test-ID"
       />
       <div>
-        <Icon
+        <Mrv2Icon
           className="md-global-search-input-search"
           fillColor="var(--mds-color-theme-text-primary-normal)"
           name="search"
@@ -361,7 +361,7 @@ exports[`<GlobalSearchInput /> snapshot should match snapshot with className 1`]
               suppressHydrationWarning={true}
             />
           </Icon>
-        </Icon>
+        </Mrv2Icon>
       </div>
       <div
         className="md-global-search-input-container"
@@ -401,7 +401,7 @@ exports[`<GlobalSearchInput /> snapshot should match snapshot with id 1`] = `
         htmlFor="example-id"
       />
       <div>
-        <Icon
+        <Mrv2Icon
           className="md-global-search-input-search"
           fillColor="var(--mds-color-theme-text-primary-normal)"
           name="search"
@@ -433,7 +433,7 @@ exports[`<GlobalSearchInput /> snapshot should match snapshot with id 1`] = `
               suppressHydrationWarning={true}
             />
           </Icon>
-        </Icon>
+        </Mrv2Icon>
       </div>
       <div
         className="md-global-search-input-container"
@@ -481,7 +481,7 @@ exports[`<GlobalSearchInput /> snapshot should match snapshot with style 1`] = `
         htmlFor="test-ID"
       />
       <div>
-        <Icon
+        <Mrv2Icon
           className="md-global-search-input-search"
           fillColor="var(--mds-color-theme-text-primary-normal)"
           name="search"
@@ -513,7 +513,7 @@ exports[`<GlobalSearchInput /> snapshot should match snapshot with style 1`] = `
               suppressHydrationWarning={true}
             />
           </Icon>
-        </Icon>
+        </Mrv2Icon>
       </div>
       <div
         className="md-global-search-input-container"

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -71,4 +71,6 @@ const Icon: React.FC<Props> = (props: Props) => {
   );
 };
 
+Icon.displayName = 'Mrv2Icon';
+
 export default Icon;

--- a/src/components/Icon/Icon.unit.test.tsx.snap
+++ b/src/components/Icon/Icon.unit.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Icon /> snapshot should match snapshot 1`] = `
-<Icon
+<Mrv2Icon
   name="accessibility"
 >
   <Icon
@@ -19,11 +19,11 @@ exports[`<Icon /> snapshot should match snapshot 1`] = `
       suppressHydrationWarning={true}
     />
   </Icon>
-</Icon>
+</Mrv2Icon>
 `;
 
 exports[`<Icon /> snapshot should match snapshot with aria-label 1`] = `
-<Icon
+<Mrv2Icon
   aria-label="This participant is muted"
   name="draft-indicator"
   weight="bold"
@@ -45,11 +45,11 @@ exports[`<Icon /> snapshot should match snapshot with aria-label 1`] = `
       suppressHydrationWarning={true}
     />
   </Icon>
-</Icon>
+</Mrv2Icon>
 `;
 
 exports[`<Icon /> snapshot should match snapshot with ariaLabel 1`] = `
-<Icon
+<Mrv2Icon
   ariaLabel="This participant is muted"
   name="draft-indicator"
   weight="bold"
@@ -71,11 +71,11 @@ exports[`<Icon /> snapshot should match snapshot with ariaLabel 1`] = `
       suppressHydrationWarning={true}
     />
   </Icon>
-</Icon>
+</Mrv2Icon>
 `;
 
 exports[`<Icon /> snapshot should match snapshot with autoScale set to 'true' 1`] = `
-<Icon
+<Mrv2Icon
   autoScale={true}
   name="accessibility"
 >
@@ -96,11 +96,11 @@ exports[`<Icon /> snapshot should match snapshot with autoScale set to 'true' 1`
       suppressHydrationWarning={true}
     />
   </Icon>
-</Icon>
+</Mrv2Icon>
 `;
 
 exports[`<Icon /> snapshot should match snapshot with autoScale set to a percentage value 1`] = `
-<Icon
+<Mrv2Icon
   autoScale={150}
   name="accessibility"
 >
@@ -121,11 +121,11 @@ exports[`<Icon /> snapshot should match snapshot with autoScale set to a percent
       suppressHydrationWarning={true}
     />
   </Icon>
-</Icon>
+</Mrv2Icon>
 `;
 
 exports[`<Icon /> snapshot should match snapshot with className 1`] = `
-<Icon
+<Mrv2Icon
   className="example-class"
   name="accessibility"
 >
@@ -144,11 +144,11 @@ exports[`<Icon /> snapshot should match snapshot with className 1`] = `
       suppressHydrationWarning={true}
     />
   </Icon>
-</Icon>
+</Mrv2Icon>
 `;
 
 exports[`<Icon /> snapshot should match snapshot with fillColor 1`] = `
-<Icon
+<Mrv2Icon
   fillColor="red"
   name="accessibility"
 >
@@ -175,11 +175,11 @@ exports[`<Icon /> snapshot should match snapshot with fillColor 1`] = `
       suppressHydrationWarning={true}
     />
   </Icon>
-</Icon>
+</Mrv2Icon>
 `;
 
 exports[`<Icon /> snapshot should match snapshot with id 1`] = `
-<Icon
+<Mrv2Icon
   id="example-id"
   name="accessibility"
 >
@@ -199,11 +199,11 @@ exports[`<Icon /> snapshot should match snapshot with id 1`] = `
       suppressHydrationWarning={true}
     />
   </Icon>
-</Icon>
+</Mrv2Icon>
 `;
 
 exports[`<Icon /> snapshot should match snapshot with invalid name 1`] = `
-<Icon
+<Mrv2Icon
   name="invalid_icon_name"
 >
   <Icon
@@ -221,11 +221,11 @@ exports[`<Icon /> snapshot should match snapshot with invalid name 1`] = `
       suppressHydrationWarning={true}
     />
   </Icon>
-</Icon>
+</Mrv2Icon>
 `;
 
 exports[`<Icon /> snapshot should match snapshot with scale 1`] = `
-<Icon
+<Mrv2Icon
   name="accessibility"
   scale={16}
 >
@@ -246,11 +246,11 @@ exports[`<Icon /> snapshot should match snapshot with scale 1`] = `
       suppressHydrationWarning={true}
     />
   </Icon>
-</Icon>
+</Mrv2Icon>
 `;
 
 exports[`<Icon /> snapshot should match snapshot with small icons 1`] = `
-<Icon
+<Mrv2Icon
   name="info-badge"
   scale={14}
 >
@@ -271,11 +271,11 @@ exports[`<Icon /> snapshot should match snapshot with small icons 1`] = `
       suppressHydrationWarning={true}
     />
   </Icon>
-</Icon>
+</Mrv2Icon>
 `;
 
 exports[`<Icon /> snapshot should match snapshot with style 1`] = `
-<Icon
+<Mrv2Icon
   name="accessibility"
   style={
     Object {
@@ -306,11 +306,11 @@ exports[`<Icon /> snapshot should match snapshot with style 1`] = `
       suppressHydrationWarning={true}
     />
   </Icon>
-</Icon>
+</Mrv2Icon>
 `;
 
 exports[`<Icon /> snapshot should match snapshot with title 1`] = `
-<Icon
+<Mrv2Icon
   name="draft-indicator"
   title="You have a draft message"
   weight="bold"
@@ -332,11 +332,11 @@ exports[`<Icon /> snapshot should match snapshot with title 1`] = `
       suppressHydrationWarning={true}
     />
   </Icon>
-</Icon>
+</Mrv2Icon>
 `;
 
 exports[`<Icon /> snapshot should match snapshot with tooltip (children and placement) 1`] = `
-<Icon
+<Mrv2Icon
   name="accessibility"
   tooltipProps={
     Object {
@@ -590,11 +590,11 @@ exports[`<Icon /> snapshot should match snapshot with tooltip (children and plac
       Test
     </div>
   </Tooltip>
-</Icon>
+</Mrv2Icon>
 `;
 
 exports[`<Icon /> snapshot should match snapshot with tooltip (children) 1`] = `
-<Icon
+<Mrv2Icon
   name="accessibility"
   tooltipProps={
     Object {
@@ -847,11 +847,11 @@ exports[`<Icon /> snapshot should match snapshot with tooltip (children) 1`] = `
       Test
     </div>
   </Tooltip>
-</Icon>
+</Mrv2Icon>
 `;
 
 exports[`<Icon /> snapshot should match snapshot with weight 1`] = `
-<Icon
+<Mrv2Icon
   name="accessibility"
   weight="light"
 >
@@ -870,5 +870,5 @@ exports[`<Icon /> snapshot should match snapshot with weight 1`] = `
       suppressHydrationWarning={true}
     />
   </Icon>
-</Icon>
+</Mrv2Icon>
 `;

--- a/src/components/InputMessage/InputMessage.unit.test.tsx.snap
+++ b/src/components/InputMessage/InputMessage.unit.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`InputMessage snapshot should match snapshot 1`] = `
       <div
         className="md-input-message--icon"
       >
-        <Icon
+        <Mrv2Icon
           fillColor="var(--mds-color-theme-text-error-normal)"
           name="warning"
           scale={16}
@@ -46,7 +46,7 @@ exports[`InputMessage snapshot should match snapshot 1`] = `
               suppressHydrationWarning={true}
             />
           </Icon>
-        </Icon>
+        </Mrv2Icon>
       </div>
       <Text
         className="md-input-message--text"

--- a/src/components/ListItemBase/ListItemBase.stories.tsx
+++ b/src/components/ListItemBase/ListItemBase.stories.tsx
@@ -100,6 +100,25 @@ Common.parameters = {
       ),
     },
     {
+      label: 'With ButtonCircle',
+      onPress: action('onPressButtonListItemBase'),
+      children: (state) => (
+        <>
+          <ListItemBaseSection position="fill">Text</ListItemBaseSection>
+          <ListItemBaseSection position="end">
+            <ButtonCircle
+              disabled={state === 'Disable'}
+              color="join"
+              size={24}
+              onPress={action('onPressButtonCircle')}
+            >
+              <Icon name="placeholder" scale={16} />
+            </ButtonCircle>
+          </ListItemBaseSection>
+        </>
+      ),
+    },
+    {
       label: 'With 2 Icons',
       children: (
         <>

--- a/src/components/MeetingContainer/MeetingContainer.unit.test.tsx.snap
+++ b/src/components/MeetingContainer/MeetingContainer.unit.test.tsx.snap
@@ -572,11 +572,16 @@ exports[`<MeetingContainer /> snapshot should match snapshot with circle action 
                       <Button
                         className="md-button-circle-wrapper"
                         color="positive"
+                        onClick={[Function]}
+                        onPointerDown={[Function]}
+                        onPointerUp={[Function]}
                         size={28}
                         variant="secondary"
                       >
                         <mdc-button
                           class="md-button-circle-wrapper"
+                          onPointerDown={[Function]}
+                          onPointerUp={[Function]}
                           suppressHydrationWarning={true}
                         >
                           T
@@ -593,11 +598,16 @@ exports[`<MeetingContainer /> snapshot should match snapshot with circle action 
                       <Button
                         className="md-button-circle-wrapper"
                         color="positive"
+                        onClick={[Function]}
+                        onPointerDown={[Function]}
+                        onPointerUp={[Function]}
                         size={28}
                         variant="secondary"
                       >
                         <mdc-button
                           class="md-button-circle-wrapper"
+                          onPointerDown={[Function]}
+                          onPointerUp={[Function]}
                           suppressHydrationWarning={true}
                         >
                           T
@@ -614,11 +624,16 @@ exports[`<MeetingContainer /> snapshot should match snapshot with circle action 
                       <Button
                         className="md-button-circle-wrapper"
                         color="positive"
+                        onClick={[Function]}
+                        onPointerDown={[Function]}
+                        onPointerUp={[Function]}
                         size={28}
                         variant="secondary"
                       >
                         <mdc-button
                           class="md-button-circle-wrapper"
+                          onPointerDown={[Function]}
+                          onPointerUp={[Function]}
                           suppressHydrationWarning={true}
                         >
                           T

--- a/src/components/MeetingListItem/MeetingListItem.unit.test.tsx.snap
+++ b/src/components/MeetingListItem/MeetingListItem.unit.test.tsx.snap
@@ -423,7 +423,7 @@ exports[`<MeetingListItem /> snapshot should match snapshot with id 1`] = `
 exports[`<MeetingListItem /> snapshot should match snapshot with image 1`] = `
 <MeetingListItem
   image={
-    <Icon
+    <Mrv2Icon
       name="placeholder"
     />
   }
@@ -473,7 +473,7 @@ exports[`<MeetingListItem /> snapshot should match snapshot with image 1`] = `
           <MeetingRowContent
             color="Transparent"
             image={
-              <Icon
+              <Mrv2Icon
                 name="placeholder"
               />
             }
@@ -490,7 +490,7 @@ exports[`<MeetingListItem /> snapshot should match snapshot with image 1`] = `
                   className="md-meeting-row-content-border"
                   data-color="Transparent"
                 />
-                <Icon
+                <Mrv2Icon
                   name="placeholder"
                   scale={12}
                   strokeColor="none"
@@ -515,7 +515,7 @@ exports[`<MeetingListItem /> snapshot should match snapshot with image 1`] = `
                       suppressHydrationWarning={true}
                     />
                   </Icon>
-                </Icon>
+                </Mrv2Icon>
               </div>
             </ListItemBaseSection>
             <ListItemBaseSection

--- a/src/components/MeetingRowContent/MeetingRowContent.unit.test.tsx.snap
+++ b/src/components/MeetingRowContent/MeetingRowContent.unit.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`<MeetingRowContent /> snapshot should match snapshot with buttonGroup 1
       >
         17
       </div>
-      <Icon
+      <Mrv2Icon
         name="participant-list"
         scale={16}
       />
@@ -144,7 +144,7 @@ exports[`<MeetingRowContent /> snapshot should match snapshot with buttonGroup 1
           >
             17
           </div>
-          <Icon
+          <Mrv2Icon
             key="participants-icon"
             name="participant-list"
             scale={16}
@@ -166,7 +166,7 @@ exports[`<MeetingRowContent /> snapshot should match snapshot with buttonGroup 1
                 suppressHydrationWarning={true}
               />
             </Icon>
-          </Icon>
+          </Mrv2Icon>
           <ButtonPill
             color="join"
             key="join-button"

--- a/src/components/MenuItem/MenuItem.unit.test.tsx.snap
+++ b/src/components/MenuItem/MenuItem.unit.test.tsx.snap
@@ -344,7 +344,7 @@ exports[`<MenuItem /> snapshot should match snapshot 1`] = `
             <div
               data-position="end"
             >
-              <Icon
+              <Mrv2Icon
                 fillColor="var(--mds-color-theme-control-active-normal)"
                 name="check"
                 scale={16}
@@ -375,7 +375,7 @@ exports[`<MenuItem /> snapshot should match snapshot 1`] = `
                     suppressHydrationWarning={true}
                   />
                 </Icon>
-              </Icon>
+              </Mrv2Icon>
             </div>
           </ListItemBaseSection>
         </li>
@@ -718,7 +718,7 @@ exports[`<MenuItem /> snapshot should match snapshot with tickPosition 1`] = `
             <div
               data-position="start"
             >
-              <Icon
+              <Mrv2Icon
                 fillColor="var(--mds-color-theme-control-active-normal)"
                 name="check"
                 scale={16}
@@ -749,7 +749,7 @@ exports[`<MenuItem /> snapshot should match snapshot with tickPosition 1`] = `
                     suppressHydrationWarning={true}
                   />
                 </Icon>
-              </Icon>
+              </Mrv2Icon>
             </div>
           </ListItemBaseSection>
           <ListItemBaseSection

--- a/src/components/NavigationTab/NavigationTab.unit.test.tsx.snap
+++ b/src/components/NavigationTab/NavigationTab.unit.test.tsx.snap
@@ -256,7 +256,7 @@ exports[`<NavigationTab /> snapshot should match snapshot with icon 1`] = `
               onTouchStart={[Function]}
               type="button"
             >
-              <Icon
+              <Mrv2Icon
                 className="md-navigation-tab-icon"
                 name="contacts"
                 scale={24}
@@ -279,7 +279,7 @@ exports[`<NavigationTab /> snapshot should match snapshot with icon 1`] = `
                     suppressHydrationWarning={true}
                   />
                 </Icon>
-              </Icon>
+              </Mrv2Icon>
             </button>
           </FocusRing>
         </FocusRing>
@@ -578,7 +578,7 @@ exports[`<NavigationTab /> snapshot should match snapshot with size, label, icon
               onTouchStart={[Function]}
               type="button"
             >
-              <Icon
+              <Mrv2Icon
                 className="md-navigation-tab-icon"
                 name="contacts"
                 scale={24}
@@ -601,7 +601,7 @@ exports[`<NavigationTab /> snapshot should match snapshot with size, label, icon
                     suppressHydrationWarning={true}
                   />
                 </Icon>
-              </Icon>
+              </Mrv2Icon>
             </button>
           </FocusRing>
         </FocusRing>
@@ -656,7 +656,7 @@ exports[`<NavigationTab /> snapshot should match snapshot with size, label, icon
               onTouchStart={[Function]}
               type="button"
             >
-              <Icon
+              <Mrv2Icon
                 className="md-navigation-tab-icon"
                 name="contacts"
                 scale={24}
@@ -679,7 +679,7 @@ exports[`<NavigationTab /> snapshot should match snapshot with size, label, icon
                     suppressHydrationWarning={true}
                   />
                 </Icon>
-              </Icon>
+              </Mrv2Icon>
             </button>
           </FocusRing>
         </FocusRing>

--- a/src/components/OverlayAlert/OverlayAlert.unit.test.tsx.snap
+++ b/src/components/OverlayAlert/OverlayAlert.unit.test.tsx.snap
@@ -408,7 +408,7 @@ exports[`<OverlayAlert /> snapshot should match snapshot with controls 1`] = `
                           onTouchStart={[Function]}
                           type="button"
                         >
-                          <Icon
+                          <Mrv2Icon
                             autoScale={true}
                             name="cancel"
                             weight="bold"
@@ -430,7 +430,7 @@ exports[`<OverlayAlert /> snapshot should match snapshot with controls 1`] = `
                                 suppressHydrationWarning={true}
                               />
                             </Icon>
-                          </Icon>
+                          </Mrv2Icon>
                         </button>
                       </FocusRing>
                     </FocusRing>
@@ -1021,7 +1021,7 @@ exports[`<OverlayAlert /> snapshot should match snapshot with multiple controls 
                           onTouchStart={[Function]}
                           type="button"
                         >
-                          <Icon
+                          <Mrv2Icon
                             autoScale={true}
                             name="cancel"
                             weight="bold"
@@ -1043,7 +1043,7 @@ exports[`<OverlayAlert /> snapshot should match snapshot with multiple controls 
                                 suppressHydrationWarning={true}
                               />
                             </Icon>
-                          </Icon>
+                          </Mrv2Icon>
                         </button>
                       </FocusRing>
                     </FocusRing>
@@ -1080,7 +1080,7 @@ exports[`<OverlayAlert /> snapshot should match snapshot with multiple controls 
                           onTouchStart={[Function]}
                           type="button"
                         >
-                          <Icon
+                          <Mrv2Icon
                             autoScale={true}
                             fillColor="var(--mds-color-theme-text-warning-normal)"
                             name="favorite"
@@ -1111,7 +1111,7 @@ exports[`<OverlayAlert /> snapshot should match snapshot with multiple controls 
                                 suppressHydrationWarning={true}
                               />
                             </Icon>
-                          </Icon>
+                          </Mrv2Icon>
                         </button>
                       </FocusRing>
                     </FocusRing>
@@ -1148,7 +1148,7 @@ exports[`<OverlayAlert /> snapshot should match snapshot with multiple controls 
                           onTouchStart={[Function]}
                           type="button"
                         >
-                          <Icon
+                          <Mrv2Icon
                             autoScale={true}
                             name="arrow-up"
                             weight="bold"
@@ -1170,7 +1170,7 @@ exports[`<OverlayAlert /> snapshot should match snapshot with multiple controls 
                                 suppressHydrationWarning={true}
                               />
                             </Icon>
-                          </Icon>
+                          </Mrv2Icon>
                         </button>
                       </FocusRing>
                     </FocusRing>

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -200,6 +200,7 @@ const Popover = forwardRef((props: Props, ref: ForwardedRef<HTMLElement>) => {
           {closeButtonPlacement !== 'none' && (
             <ButtonCircle
               {...closeButtonProps}
+              stopPropagation={false}
               className={classNames(STYLE.closeButton, closeButtonProps?.className)}
               data-placement={closeButtonPlacement}
               size={20}

--- a/src/components/ReactionButton/ReactionButton.tsx
+++ b/src/components/ReactionButton/ReactionButton.tsx
@@ -22,6 +22,7 @@ const ReactionButton = forwardRef((props: Props, ref: RefObject<Button>) => {
       size={DEFAULTS.SIZE as ButtonCircleSize}
       style={style}
       variant="tertiary"
+      stopPropagation={false}
       {...otherProps}
     >
       {children}

--- a/src/components/ReactionButton/ReactionButton.unit.test.tsx.snap
+++ b/src/components/ReactionButton/ReactionButton.unit.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`<ReactionButton /> snapshot should match snapshot 1`] = `
     className="md-reaction-button-wrapper"
     data-reacted={false}
     size={32}
+    stopPropagation={false}
     variant="tertiary"
   >
     <Button
@@ -48,6 +49,7 @@ exports[`<ReactionButton /> snapshot should match snapshot with className 1`] = 
     className="example-class md-reaction-button-wrapper"
     data-reacted={false}
     size={32}
+    stopPropagation={false}
     variant="tertiary"
   >
     <Button
@@ -91,6 +93,7 @@ exports[`<ReactionButton /> snapshot should match snapshot with id 1`] = `
     data-reacted={false}
     id="example-id"
     size={32}
+    stopPropagation={false}
     variant="tertiary"
   >
     <Button
@@ -134,6 +137,7 @@ exports[`<ReactionButton /> snapshot should match snapshot with reacted 1`] = `
     className="md-reaction-button-wrapper"
     data-reacted={true}
     size={32}
+    stopPropagation={false}
     variant="tertiary"
   >
     <Button
@@ -180,6 +184,7 @@ exports[`<ReactionButton /> snapshot should match snapshot with style 1`] = `
     className="md-reaction-button-wrapper"
     data-reacted={false}
     size={32}
+    stopPropagation={false}
     style={
       Object {
         "color": "pink",

--- a/src/components/ReactionButton/ReactionButton.unit.test.tsx.snap
+++ b/src/components/ReactionButton/ReactionButton.unit.test.tsx.snap
@@ -12,12 +12,17 @@ exports[`<ReactionButton /> snapshot should match snapshot 1`] = `
       className="md-button-circle-wrapper md-reaction-button-wrapper"
       color="default"
       data-reacted={false}
+      onClick={[Function]}
+      onPointerDown={[Function]}
+      onPointerUp={[Function]}
       size={32}
       variant="tertiary"
     >
       <mdc-button
         class="md-button-circle-wrapper md-reaction-button-wrapper"
         data-reacted={false}
+        onPointerDown={[Function]}
+        onPointerUp={[Function]}
         suppressHydrationWarning={true}
       >
         <Reaction
@@ -49,12 +54,17 @@ exports[`<ReactionButton /> snapshot should match snapshot with className 1`] = 
       className="md-button-circle-wrapper example-class md-reaction-button-wrapper"
       color="default"
       data-reacted={false}
+      onClick={[Function]}
+      onPointerDown={[Function]}
+      onPointerUp={[Function]}
       size={32}
       variant="tertiary"
     >
       <mdc-button
         class="md-button-circle-wrapper example-class md-reaction-button-wrapper"
         data-reacted={false}
+        onPointerDown={[Function]}
+        onPointerUp={[Function]}
         suppressHydrationWarning={true}
       >
         <Reaction
@@ -88,12 +98,17 @@ exports[`<ReactionButton /> snapshot should match snapshot with id 1`] = `
       color="default"
       data-reacted={false}
       id="example-id"
+      onClick={[Function]}
+      onPointerDown={[Function]}
+      onPointerUp={[Function]}
       size={32}
       variant="tertiary"
     >
       <mdc-button
         class="md-button-circle-wrapper md-reaction-button-wrapper"
         data-reacted={false}
+        onPointerDown={[Function]}
+        onPointerUp={[Function]}
         suppressHydrationWarning={true}
       >
         <Reaction
@@ -125,12 +140,17 @@ exports[`<ReactionButton /> snapshot should match snapshot with reacted 1`] = `
       className="md-button-circle-wrapper md-reaction-button-wrapper"
       color="default"
       data-reacted={true}
+      onClick={[Function]}
+      onPointerDown={[Function]}
+      onPointerUp={[Function]}
       size={32}
       variant="tertiary"
     >
       <mdc-button
         class="md-button-circle-wrapper md-reaction-button-wrapper"
         data-reacted={true}
+        onPointerDown={[Function]}
+        onPointerUp={[Function]}
         suppressHydrationWarning={true}
       >
         <Reaction
@@ -171,6 +191,9 @@ exports[`<ReactionButton /> snapshot should match snapshot with style 1`] = `
       className="md-button-circle-wrapper md-reaction-button-wrapper"
       color="default"
       data-reacted={false}
+      onClick={[Function]}
+      onPointerDown={[Function]}
+      onPointerUp={[Function]}
       size={32}
       style={
         Object {
@@ -182,6 +205,8 @@ exports[`<ReactionButton /> snapshot should match snapshot with style 1`] = `
       <mdc-button
         class="md-button-circle-wrapper md-reaction-button-wrapper"
         data-reacted={false}
+        onPointerDown={[Function]}
+        onPointerUp={[Function]}
         style={
           Object {
             "color": "pink",

--- a/src/components/ReactionPicker/ReactionPicker.unit.test.tsx.snap
+++ b/src/components/ReactionPicker/ReactionPicker.unit.test.tsx.snap
@@ -55,6 +55,7 @@ exports[`<ReactionPicker /> snapshot should match snapshot with children 1`] = `
             onKeyDown={[Function]}
             onPress={[Function]}
             size={32}
+            stopPropagation={false}
             tabIndex={0}
             useNativeKeyDown={true}
             variant="tertiary"

--- a/src/components/ReactionPicker/ReactionPicker.unit.test.tsx.snap
+++ b/src/components/ReactionPicker/ReactionPicker.unit.test.tsx.snap
@@ -66,6 +66,8 @@ exports[`<ReactionPicker /> snapshot should match snapshot with children 1`] = `
               onClick={[Function]}
               onFocus={[Function]}
               onKeyDown={[Function]}
+              onPointerDown={[Function]}
+              onPointerUp={[Function]}
               size={32}
               tabIndex={0}
               useNativeKeyDown={true}
@@ -74,6 +76,8 @@ exports[`<ReactionPicker /> snapshot should match snapshot with children 1`] = `
               <mdc-button
                 class="md-button-circle-wrapper md-reaction-button-wrapper"
                 data-reacted={false}
+                onPointerDown={[Function]}
+                onPointerUp={[Function]}
                 suppressHydrationWarning={true}
                 useNativeKeyDown={true}
               />

--- a/src/components/SearchInput/SearchInput.unit.test.tsx.snap
+++ b/src/components/SearchInput/SearchInput.unit.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`<SearchInput /> snapshot should match snapshot 1`] = `
       onClick={[Function]}
     >
       <div>
-        <Icon
+        <Mrv2Icon
           className="md-search-input-search"
           name="search"
           scale={16}
@@ -36,7 +36,7 @@ exports[`<SearchInput /> snapshot should match snapshot 1`] = `
               suppressHydrationWarning={true}
             />
           </Icon>
-        </Icon>
+        </Mrv2Icon>
       </div>
       <div
         className="md-search-input-container"
@@ -126,7 +126,7 @@ exports[`<SearchInput /> snapshot should match snapshot when filters are set 1`]
       onClick={[Function]}
     >
       <div>
-        <Icon
+        <Mrv2Icon
           className="md-search-input-search"
           name="search"
           scale={16}
@@ -149,7 +149,7 @@ exports[`<SearchInput /> snapshot should match snapshot when filters are set 1`]
               suppressHydrationWarning={true}
             />
           </Icon>
-        </Icon>
+        </Mrv2Icon>
       </div>
       <div
         className="md-search-input-container"
@@ -199,7 +199,7 @@ exports[`<SearchInput /> snapshot should match snapshot when filters are set 1`]
               onTouchStart={[Function]}
               type="button"
             >
-              <Icon
+              <Mrv2Icon
                 name="cancel"
                 scale={16}
                 weight="bold"
@@ -221,7 +221,7 @@ exports[`<SearchInput /> snapshot should match snapshot when filters are set 1`]
                     suppressHydrationWarning={true}
                   />
                 </Icon>
-              </Icon>
+              </Mrv2Icon>
             </button>
           </FocusRing>
         </FocusRing>
@@ -272,7 +272,7 @@ exports[`<SearchInput /> snapshot should match snapshot when isCombobox is true 
       onClick={[Function]}
     >
       <div>
-        <Icon
+        <Mrv2Icon
           className="md-search-input-search"
           name="search"
           scale={16}
@@ -295,7 +295,7 @@ exports[`<SearchInput /> snapshot should match snapshot when isCombobox is true 
               suppressHydrationWarning={true}
             />
           </Icon>
-        </Icon>
+        </Mrv2Icon>
       </div>
       <div
         className="md-search-input-container"
@@ -454,7 +454,7 @@ exports[`<SearchInput /> snapshot should match snapshot with a label 1`] = `
       onClick={[Function]}
     >
       <div>
-        <Icon
+        <Mrv2Icon
           className="md-search-input-search"
           name="search"
           scale={16}
@@ -477,7 +477,7 @@ exports[`<SearchInput /> snapshot should match snapshot with a label 1`] = `
               suppressHydrationWarning={true}
             />
           </Icon>
-        </Icon>
+        </Mrv2Icon>
       </div>
       <div
         className="md-search-input-container"
@@ -541,7 +541,7 @@ exports[`<SearchInput /> snapshot should match snapshot with className 1`] = `
       onClick={[Function]}
     >
       <div>
-        <Icon
+        <Mrv2Icon
           className="md-search-input-search"
           name="search"
           scale={16}
@@ -564,7 +564,7 @@ exports[`<SearchInput /> snapshot should match snapshot with className 1`] = `
               suppressHydrationWarning={true}
             />
           </Icon>
-        </Icon>
+        </Mrv2Icon>
       </div>
       <div
         className="md-search-input-container"
@@ -628,7 +628,7 @@ exports[`<SearchInput /> snapshot should match snapshot with height 1`] = `
       onClick={[Function]}
     >
       <div>
-        <Icon
+        <Mrv2Icon
           className="md-search-input-search"
           name="search"
           scale={12}
@@ -651,7 +651,7 @@ exports[`<SearchInput /> snapshot should match snapshot with height 1`] = `
               suppressHydrationWarning={true}
             />
           </Icon>
-        </Icon>
+        </Mrv2Icon>
       </div>
       <div
         className="md-search-input-container"
@@ -715,7 +715,7 @@ exports[`<SearchInput /> snapshot should match snapshot with id 1`] = `
       onClick={[Function]}
     >
       <div>
-        <Icon
+        <Mrv2Icon
           className="md-search-input-search"
           name="search"
           scale={16}
@@ -738,7 +738,7 @@ exports[`<SearchInput /> snapshot should match snapshot with id 1`] = `
               suppressHydrationWarning={true}
             />
           </Icon>
-        </Icon>
+        </Mrv2Icon>
       </div>
       <div
         className="md-search-input-container"
@@ -811,7 +811,7 @@ exports[`<SearchInput /> snapshot should match snapshot with style 1`] = `
       }
     >
       <div>
-        <Icon
+        <Mrv2Icon
           className="md-search-input-search"
           name="search"
           scale={16}
@@ -834,7 +834,7 @@ exports[`<SearchInput /> snapshot should match snapshot with style 1`] = `
               suppressHydrationWarning={true}
             />
           </Icon>
-        </Icon>
+        </Mrv2Icon>
       </div>
       <div
         className="md-search-input-container"

--- a/src/components/Select/Select.unit.test.tsx.snap
+++ b/src/components/Select/Select.unit.test.tsx.snap
@@ -309,7 +309,7 @@ exports[`Select snapshot should match snapshot 1`] = `
             aria-hidden="true"
             className="md-select-icon-wrapper"
           >
-            <Icon
+            <Mrv2Icon
               name="arrow-down"
               scale={16}
               weight="bold"
@@ -517,7 +517,7 @@ exports[`Select snapshot should match snapshot 1`] = `
                 aria-hidden="true"
                 className="md-select-icon-wrapper"
               >
-                <Icon
+                <Mrv2Icon
                   name="arrow-down"
                   scale={16}
                   weight="bold"
@@ -539,7 +539,7 @@ exports[`Select snapshot should match snapshot 1`] = `
                       suppressHydrationWarning={true}
                     />
                   </Icon>
-                </Icon>
+                </Mrv2Icon>
               </span>
             </button>
             <Portal
@@ -870,7 +870,7 @@ exports[`Select snapshot should match snapshot before and after opening select d
             aria-hidden="true"
             className="md-select-icon-wrapper"
           >
-            <Icon
+            <Mrv2Icon
               name="arrow-down"
               scale={16}
               weight="bold"
@@ -1078,7 +1078,7 @@ exports[`Select snapshot should match snapshot before and after opening select d
                 aria-hidden="true"
                 className="md-select-icon-wrapper"
               >
-                <Icon
+                <Mrv2Icon
                   name="arrow-down"
                   scale={16}
                   weight="bold"
@@ -1100,7 +1100,7 @@ exports[`Select snapshot should match snapshot before and after opening select d
                       suppressHydrationWarning={true}
                     />
                   </Icon>
-                </Icon>
+                </Mrv2Icon>
               </span>
             </button>
             <Portal
@@ -1432,7 +1432,7 @@ exports[`Select snapshot should match snapshot before and after opening select d
             aria-hidden="true"
             className="md-select-icon-wrapper"
           >
-            <Icon
+            <Mrv2Icon
               name="arrow-up"
               scale={16}
               weight="bold"
@@ -1640,7 +1640,7 @@ exports[`Select snapshot should match snapshot before and after opening select d
                 aria-hidden="true"
                 className="md-select-icon-wrapper"
               >
-                <Icon
+                <Mrv2Icon
                   name="arrow-up"
                   scale={16}
                   weight="bold"
@@ -1662,7 +1662,7 @@ exports[`Select snapshot should match snapshot before and after opening select d
                       suppressHydrationWarning={true}
                     />
                   </Icon>
-                </Icon>
+                </Mrv2Icon>
               </span>
             </button>
             <Portal
@@ -2529,7 +2529,7 @@ exports[`Select snapshot should match snapshot with border 1`] = `
             aria-hidden="true"
             className="md-select-icon-wrapper"
           >
-            <Icon
+            <Mrv2Icon
               name="arrow-down"
               scale={16}
               weight="bold"
@@ -2737,7 +2737,7 @@ exports[`Select snapshot should match snapshot with border 1`] = `
                 aria-hidden="true"
                 className="md-select-icon-wrapper"
               >
-                <Icon
+                <Mrv2Icon
                   name="arrow-down"
                   scale={16}
                   weight="bold"
@@ -2759,7 +2759,7 @@ exports[`Select snapshot should match snapshot with border 1`] = `
                       suppressHydrationWarning={true}
                     />
                   </Icon>
-                </Icon>
+                </Mrv2Icon>
               </span>
             </button>
             <Portal
@@ -3091,7 +3091,7 @@ exports[`Select snapshot should match snapshot with className 1`] = `
             aria-hidden="true"
             className="md-select-icon-wrapper"
           >
-            <Icon
+            <Mrv2Icon
               name="arrow-down"
               scale={16}
               weight="bold"
@@ -3299,7 +3299,7 @@ exports[`Select snapshot should match snapshot with className 1`] = `
                 aria-hidden="true"
                 className="md-select-icon-wrapper"
               >
-                <Icon
+                <Mrv2Icon
                   name="arrow-down"
                   scale={16}
                   weight="bold"
@@ -3321,7 +3321,7 @@ exports[`Select snapshot should match snapshot with className 1`] = `
                       suppressHydrationWarning={true}
                     />
                   </Icon>
-                </Icon>
+                </Mrv2Icon>
               </span>
             </button>
             <Portal
@@ -3653,7 +3653,7 @@ exports[`Select snapshot should match snapshot with direction 1`] = `
             aria-hidden="true"
             className="md-select-icon-wrapper"
           >
-            <Icon
+            <Mrv2Icon
               name="arrow-down"
               scale={16}
               weight="bold"
@@ -3861,7 +3861,7 @@ exports[`Select snapshot should match snapshot with direction 1`] = `
                 aria-hidden="true"
                 className="md-select-icon-wrapper"
               >
-                <Icon
+                <Mrv2Icon
                   name="arrow-down"
                   scale={16}
                   weight="bold"
@@ -3883,7 +3883,7 @@ exports[`Select snapshot should match snapshot with direction 1`] = `
                       suppressHydrationWarning={true}
                     />
                   </Icon>
-                </Icon>
+                </Mrv2Icon>
               </span>
             </button>
             <Portal
@@ -4225,7 +4225,7 @@ exports[`Select snapshot should match snapshot with disabled option 1`] = `
             aria-hidden="true"
             className="md-select-icon-wrapper"
           >
-            <Icon
+            <Mrv2Icon
               name="arrow-up"
               scale={16}
               weight="bold"
@@ -4433,7 +4433,7 @@ exports[`Select snapshot should match snapshot with disabled option 1`] = `
                 aria-hidden="true"
                 className="md-select-icon-wrapper"
               >
-                <Icon
+                <Mrv2Icon
                   name="arrow-up"
                   scale={16}
                   weight="bold"
@@ -4455,7 +4455,7 @@ exports[`Select snapshot should match snapshot with disabled option 1`] = `
                       suppressHydrationWarning={true}
                     />
                   </Icon>
-                </Icon>
+                </Mrv2Icon>
               </span>
             </button>
             <Portal
@@ -5325,7 +5325,7 @@ exports[`Select snapshot should match snapshot with id 1`] = `
             aria-hidden="true"
             className="md-select-icon-wrapper"
           >
-            <Icon
+            <Mrv2Icon
               name="arrow-down"
               scale={16}
               weight="bold"
@@ -5533,7 +5533,7 @@ exports[`Select snapshot should match snapshot with id 1`] = `
                 aria-hidden="true"
                 className="md-select-icon-wrapper"
               >
-                <Icon
+                <Mrv2Icon
                   name="arrow-down"
                   scale={16}
                   weight="bold"
@@ -5555,7 +5555,7 @@ exports[`Select snapshot should match snapshot with id 1`] = `
                       suppressHydrationWarning={true}
                     />
                   </Icon>
-                </Icon>
+                </Mrv2Icon>
               </span>
             </button>
             <Portal
@@ -5662,7 +5662,7 @@ exports[`Select snapshot should match snapshot with isInForm = false 1`] = `
             aria-hidden="true"
             className="md-select-icon-wrapper"
           >
-            <Icon
+            <Mrv2Icon
               name="arrow-down"
               scale={16}
               weight="bold"
@@ -5869,7 +5869,7 @@ exports[`Select snapshot should match snapshot with isInForm = false 1`] = `
                 aria-hidden="true"
                 className="md-select-icon-wrapper"
               >
-                <Icon
+                <Mrv2Icon
                   name="arrow-down"
                   scale={16}
                   weight="bold"
@@ -5891,7 +5891,7 @@ exports[`Select snapshot should match snapshot with isInForm = false 1`] = `
                       suppressHydrationWarning={true}
                     />
                   </Icon>
-                </Icon>
+                </Mrv2Icon>
               </span>
             </button>
             <Portal
@@ -6224,7 +6224,7 @@ exports[`Select snapshot should match snapshot with listbox opened 1`] = `
             aria-hidden="true"
             className="md-select-icon-wrapper"
           >
-            <Icon
+            <Mrv2Icon
               name="arrow-up"
               scale={16}
               weight="bold"
@@ -6432,7 +6432,7 @@ exports[`Select snapshot should match snapshot with listbox opened 1`] = `
                 aria-hidden="true"
                 className="md-select-icon-wrapper"
               >
-                <Icon
+                <Mrv2Icon
                   name="arrow-up"
                   scale={16}
                   weight="bold"
@@ -6454,7 +6454,7 @@ exports[`Select snapshot should match snapshot with listbox opened 1`] = `
                       suppressHydrationWarning={true}
                     />
                   </Icon>
-                </Icon>
+                </Mrv2Icon>
               </span>
             </button>
             <Portal
@@ -7319,7 +7319,7 @@ exports[`Select snapshot should match snapshot with listboxMaxHeight 1`] = `
             aria-hidden="true"
             className="md-select-icon-wrapper"
           >
-            <Icon
+            <Mrv2Icon
               name="arrow-up"
               scale={16}
               weight="bold"
@@ -7526,7 +7526,7 @@ exports[`Select snapshot should match snapshot with listboxMaxHeight 1`] = `
                 aria-hidden="true"
                 className="md-select-icon-wrapper"
               >
-                <Icon
+                <Mrv2Icon
                   name="arrow-up"
                   scale={16}
                   weight="bold"
@@ -7548,7 +7548,7 @@ exports[`Select snapshot should match snapshot with listboxMaxHeight 1`] = `
                       suppressHydrationWarning={true}
                     />
                   </Icon>
-                </Icon>
+                </Mrv2Icon>
               </span>
             </button>
             <Portal
@@ -8413,7 +8413,7 @@ exports[`Select snapshot should match snapshot with listboxWidth 1`] = `
             aria-hidden="true"
             className="md-select-icon-wrapper"
           >
-            <Icon
+            <Mrv2Icon
               name="arrow-up"
               scale={16}
               weight="bold"
@@ -8620,7 +8620,7 @@ exports[`Select snapshot should match snapshot with listboxWidth 1`] = `
                 aria-hidden="true"
                 className="md-select-icon-wrapper"
               >
-                <Icon
+                <Mrv2Icon
                   name="arrow-up"
                   scale={16}
                   weight="bold"
@@ -8642,7 +8642,7 @@ exports[`Select snapshot should match snapshot with listboxWidth 1`] = `
                       suppressHydrationWarning={true}
                     />
                   </Icon>
-                </Icon>
+                </Mrv2Icon>
               </span>
             </button>
             <Portal
@@ -9513,7 +9513,7 @@ exports[`Select snapshot should match snapshot with placeholder 1`] = `
             aria-hidden="true"
             className="md-select-icon-wrapper"
           >
-            <Icon
+            <Mrv2Icon
               name="arrow-down"
               scale={16}
               weight="bold"
@@ -9723,7 +9723,7 @@ exports[`Select snapshot should match snapshot with placeholder 1`] = `
                 aria-hidden="true"
                 className="md-select-icon-wrapper"
               >
-                <Icon
+                <Mrv2Icon
                   name="arrow-down"
                   scale={16}
                   weight="bold"
@@ -9745,7 +9745,7 @@ exports[`Select snapshot should match snapshot with placeholder 1`] = `
                       suppressHydrationWarning={true}
                     />
                   </Icon>
-                </Icon>
+                </Mrv2Icon>
               </span>
             </button>
             <Portal
@@ -10106,7 +10106,7 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
             aria-hidden="true"
             className="md-select-icon-wrapper"
           >
-            <Icon
+            <Mrv2Icon
               name="arrow-down"
               scale={16}
               weight="bold"
@@ -10317,7 +10317,7 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
                 aria-hidden="true"
                 className="md-select-icon-wrapper"
               >
-                <Icon
+                <Mrv2Icon
                   name="arrow-down"
                   scale={16}
                   weight="bold"
@@ -10339,7 +10339,7 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
                       suppressHydrationWarning={true}
                     />
                   </Icon>
-                </Icon>
+                </Mrv2Icon>
               </span>
             </button>
             <Portal
@@ -10702,7 +10702,7 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
             aria-hidden="true"
             className="md-select-icon-wrapper"
           >
-            <Icon
+            <Mrv2Icon
               name="arrow-up"
               scale={16}
               weight="bold"
@@ -10913,7 +10913,7 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
                 aria-hidden="true"
                 className="md-select-icon-wrapper"
               >
-                <Icon
+                <Mrv2Icon
                   name="arrow-up"
                   scale={16}
                   weight="bold"
@@ -10935,7 +10935,7 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
                       suppressHydrationWarning={true}
                     />
                   </Icon>
-                </Icon>
+                </Mrv2Icon>
               </span>
             </button>
             <Portal
@@ -11397,7 +11397,7 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
                                           <div
                                             data-position="end"
                                           >
-                                            <Icon
+                                            <Mrv2Icon
                                               fillColor="var(--mds-color-theme-control-active-normal)"
                                               name="check"
                                               scale={16}
@@ -11428,7 +11428,7 @@ exports[`Select snapshot should match snapshot with selected option and listbox 
                                                   suppressHydrationWarning={true}
                                                 />
                                               </Icon>
-                                            </Icon>
+                                            </Mrv2Icon>
                                           </div>
                                         </ListItemBaseSection>
                                       </li>
@@ -11876,7 +11876,7 @@ exports[`Select snapshot should match snapshot with shallowDisabled 1`] = `
             aria-hidden="true"
             className="md-select-icon-wrapper"
           >
-            <Icon
+            <Mrv2Icon
               name="arrow-down"
               scale={16}
               weight="bold"
@@ -12085,7 +12085,7 @@ exports[`Select snapshot should match snapshot with shallowDisabled 1`] = `
                 aria-hidden="true"
                 className="md-select-icon-wrapper"
               >
-                <Icon
+                <Mrv2Icon
                   name="arrow-down"
                   scale={16}
                   weight="bold"
@@ -12107,7 +12107,7 @@ exports[`Select snapshot should match snapshot with shallowDisabled 1`] = `
                       suppressHydrationWarning={true}
                     />
                   </Icon>
-                </Icon>
+                </Mrv2Icon>
               </span>
             </button>
             <Portal
@@ -12444,7 +12444,7 @@ exports[`Select snapshot should match snapshot with style 1`] = `
             aria-hidden="true"
             className="md-select-icon-wrapper"
           >
-            <Icon
+            <Mrv2Icon
               name="arrow-down"
               scale={16}
               weight="bold"
@@ -12652,7 +12652,7 @@ exports[`Select snapshot should match snapshot with style 1`] = `
                 aria-hidden="true"
                 className="md-select-icon-wrapper"
               >
-                <Icon
+                <Mrv2Icon
                   name="arrow-down"
                   scale={16}
                   weight="bold"
@@ -12674,7 +12674,7 @@ exports[`Select snapshot should match snapshot with style 1`] = `
                       suppressHydrationWarning={true}
                     />
                   </Icon>
-                </Icon>
+                </Mrv2Icon>
               </span>
             </button>
             <Portal
@@ -13004,7 +13004,7 @@ exports[`Select snapshot should match snapshot with title 1`] = `
             aria-hidden="true"
             className="md-select-icon-wrapper"
           >
-            <Icon
+            <Mrv2Icon
               name="arrow-down"
               scale={16}
               weight="bold"
@@ -13212,7 +13212,7 @@ exports[`Select snapshot should match snapshot with title 1`] = `
                 aria-hidden="true"
                 className="md-select-icon-wrapper"
               >
-                <Icon
+                <Mrv2Icon
                   name="arrow-down"
                   scale={16}
                   weight="bold"
@@ -13234,7 +13234,7 @@ exports[`Select snapshot should match snapshot with title 1`] = `
                       suppressHydrationWarning={true}
                     />
                   </Icon>
-                </Icon>
+                </Mrv2Icon>
               </span>
             </button>
             <Portal

--- a/src/components/SpaceListItem/SpaceListItem.stories.tsx
+++ b/src/components/SpaceListItem/SpaceListItem.stories.tsx
@@ -35,6 +35,7 @@ Example.args = {
   firstLine: 'Cisco Webex',
   secondLine: 'Webex Teams',
   onPress: action(`Space List Item Press`),
+  menuItems: [{ key: 'item-1', text: 'Item 1' }],
 };
 
 const Common = MultiTemplate<SpaceListItemProps>(SpaceListItem).bind({});

--- a/src/components/SpaceListItem/SpaceListItem.unit.test.tsx.snap
+++ b/src/components/SpaceListItem/SpaceListItem.unit.test.tsx.snap
@@ -783,7 +783,7 @@ exports[`<SpaceListItem /> snapshot should match snapshot with isAlert 1`] = `
               <div
                 data-position="end"
               >
-                <Icon
+                <Mrv2Icon
                   fillColor="var(--mds-color-theme-text-primary-normal)"
                   name="alert"
                   scale={14}
@@ -817,7 +817,7 @@ exports[`<SpaceListItem /> snapshot should match snapshot with isAlert 1`] = `
                       suppressHydrationWarning={true}
                     />
                   </Icon>
-                </Icon>
+                </Mrv2Icon>
               </div>
             </ListItemBaseSection>
           </SpaceRowContent>
@@ -922,7 +922,7 @@ exports[`<SpaceListItem /> snapshot should match snapshot with isAlertMuted 1`] 
               <div
                 data-position="end"
               >
-                <Icon
+                <Mrv2Icon
                   fillColor="var(--mds-color-theme-text-primary-normal)"
                   name="alert-muted"
                   scale={14}
@@ -956,7 +956,7 @@ exports[`<SpaceListItem /> snapshot should match snapshot with isAlertMuted 1`] 
                       suppressHydrationWarning={true}
                     />
                   </Icon>
-                </Icon>
+                </Mrv2Icon>
               </div>
             </ListItemBaseSection>
           </SpaceRowContent>
@@ -1163,7 +1163,7 @@ exports[`<SpaceListItem /> snapshot should match snapshot with isEnterRoom 1`] =
               <div
                 data-position="end"
               >
-                <Icon
+                <Mrv2Icon
                   fillColor="var(--mds-color-theme-control-active-normal)"
                   name="enter-room"
                   scale={14}
@@ -1197,7 +1197,7 @@ exports[`<SpaceListItem /> snapshot should match snapshot with isEnterRoom 1`] =
                       suppressHydrationWarning={true}
                     />
                   </Icon>
-                </Icon>
+                </Mrv2Icon>
               </div>
             </ListItemBaseSection>
           </SpaceRowContent>
@@ -1302,7 +1302,7 @@ exports[`<SpaceListItem /> snapshot should match snapshot with isError 1`] = `
               <div
                 data-position="end"
               >
-                <Icon
+                <Mrv2Icon
                   fillColor="var(--mds-color-theme-text-error-normal)"
                   name="priority-circle"
                   scale={14}
@@ -1336,7 +1336,7 @@ exports[`<SpaceListItem /> snapshot should match snapshot with isError 1`] = `
                       suppressHydrationWarning={true}
                     />
                   </Icon>
-                </Icon>
+                </Mrv2Icon>
               </div>
             </ListItemBaseSection>
           </SpaceRowContent>
@@ -1441,7 +1441,7 @@ exports[`<SpaceListItem /> snapshot should match snapshot with isMention 1`] = `
               <div
                 data-position="end"
               >
-                <Icon
+                <Mrv2Icon
                   fillColor="var(--mds-color-theme-control-active-normal)"
                   name="mention"
                   scale={14}
@@ -1475,7 +1475,7 @@ exports[`<SpaceListItem /> snapshot should match snapshot with isMention 1`] = `
                       suppressHydrationWarning={true}
                     />
                   </Icon>
-                </Icon>
+                </Mrv2Icon>
               </div>
             </ListItemBaseSection>
           </SpaceRowContent>
@@ -1790,7 +1790,7 @@ exports[`<SpaceListItem /> snapshot should match snapshot with isSelected and dr
               <div
                 data-position="end"
               >
-                <Icon
+                <Mrv2Icon
                   fillColor="var(--mds-color-theme-text-primary-normal)"
                   name="draft-indicator"
                   scale={14}
@@ -1824,7 +1824,7 @@ exports[`<SpaceListItem /> snapshot should match snapshot with isSelected and dr
                       suppressHydrationWarning={true}
                     />
                   </Icon>
-                </Icon>
+                </Mrv2Icon>
               </div>
             </ListItemBaseSection>
           </SpaceRowContent>
@@ -1929,7 +1929,7 @@ exports[`<SpaceListItem /> snapshot should match snapshot with isUnread 1`] = `
               <div
                 data-position="end"
               >
-                <Icon
+                <Mrv2Icon
                   fillColor="var(--mds-color-theme-control-active-normal)"
                   name="unread"
                   scale={14}
@@ -1963,7 +1963,7 @@ exports[`<SpaceListItem /> snapshot should match snapshot with isUnread 1`] = `
                       suppressHydrationWarning={true}
                     />
                   </Icon>
-                </Icon>
+                </Mrv2Icon>
               </div>
             </ListItemBaseSection>
           </SpaceRowContent>

--- a/src/components/SpaceRowContent/SpaceRowContent.stories.tsx
+++ b/src/components/SpaceRowContent/SpaceRowContent.stories.tsx
@@ -34,6 +34,7 @@ Example.args = {
   firstLine: 'Cisco Webex',
   secondLine: 'Webex Teams',
   onPress: action(`Space Row Content Press`),
+  menuItems: [{ key: 'item-1', text: 'Item 1' }],
 };
 
 const Common = MultiTemplate<SpaceRowContentProps>(SpaceRowContent).bind({});

--- a/src/components/SpaceRowContent/SpaceRowContent.unit.test.tsx
+++ b/src/components/SpaceRowContent/SpaceRowContent.unit.test.tsx
@@ -8,8 +8,9 @@ import Icon from '../Icon';
 import { mountAndWait } from '../../../test/utils';
 import DividerDot from '../DividerDot';
 import ListItemBaseSection from '../ListItemBaseSection';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
 
 // poppy uses uuid, which causes snapshot comparison failures
 jest.mock('uuid', () => {
@@ -524,8 +525,6 @@ describe('<SpaceRowContent />', () => {
     it('should show menu when menuItems is provided', async () => {
       expect.assertions(2);
 
-      const user = userEvent.setup();
-
       render(
         <SpaceRowContent
           menuItems={[{ key: 'item-1', text: 'Item 1' }]}
@@ -536,8 +535,11 @@ describe('<SpaceRowContent />', () => {
       const triggerButton = screen.getByTestId('menu-trigger-button');
       expect(triggerButton.getAttribute('aria-label')).toBe('Menu trigger label');
 
-      await user.click(triggerButton);
-      expect(screen.getByRole('menuitemradio', { name: 'Item 1' })).toBeTruthy();
+      fireEvent.click(triggerButton);
+
+      await waitFor(() => {
+        expect(screen.getByRole('menuitemradio', { name: 'Item 1' })).toBeInTheDocument();
+      });
     });
   });
 });

--- a/src/components/SpaceRowContent/SpaceRowContent.unit.test.tsx.snap
+++ b/src/components/SpaceRowContent/SpaceRowContent.unit.test.tsx.snap
@@ -324,7 +324,7 @@ exports[`<SpaceRowContent /> snapshot should match snapshot with isAlert 1`] = `
     <div
       data-position="end"
     >
-      <Icon
+      <Mrv2Icon
         fillColor="var(--mds-color-theme-text-primary-normal)"
         name="alert"
         scale={14}
@@ -358,7 +358,7 @@ exports[`<SpaceRowContent /> snapshot should match snapshot with isAlert 1`] = `
             suppressHydrationWarning={true}
           />
         </Icon>
-      </Icon>
+      </Mrv2Icon>
     </div>
   </ListItemBaseSection>
 </SpaceRowContent>
@@ -412,7 +412,7 @@ exports[`<SpaceRowContent /> snapshot should match snapshot with isAlertMuted 1`
     <div
       data-position="end"
     >
-      <Icon
+      <Mrv2Icon
         fillColor="var(--mds-color-theme-text-primary-normal)"
         name="alert-muted"
         scale={14}
@@ -446,7 +446,7 @@ exports[`<SpaceRowContent /> snapshot should match snapshot with isAlertMuted 1`
             suppressHydrationWarning={true}
           />
         </Icon>
-      </Icon>
+      </Mrv2Icon>
     </div>
   </ListItemBaseSection>
 </SpaceRowContent>
@@ -552,7 +552,7 @@ exports[`<SpaceRowContent /> snapshot should match snapshot with isEnterRoom 1`]
     <div
       data-position="end"
     >
-      <Icon
+      <Mrv2Icon
         fillColor="var(--mds-color-theme-control-active-normal)"
         name="enter-room"
         scale={14}
@@ -586,7 +586,7 @@ exports[`<SpaceRowContent /> snapshot should match snapshot with isEnterRoom 1`]
             suppressHydrationWarning={true}
           />
         </Icon>
-      </Icon>
+      </Mrv2Icon>
     </div>
   </ListItemBaseSection>
 </SpaceRowContent>
@@ -640,7 +640,7 @@ exports[`<SpaceRowContent /> snapshot should match snapshot with isError 1`] = `
     <div
       data-position="end"
     >
-      <Icon
+      <Mrv2Icon
         fillColor="var(--mds-color-theme-text-error-normal)"
         name="priority-circle"
         scale={14}
@@ -674,7 +674,7 @@ exports[`<SpaceRowContent /> snapshot should match snapshot with isError 1`] = `
             suppressHydrationWarning={true}
           />
         </Icon>
-      </Icon>
+      </Mrv2Icon>
     </div>
   </ListItemBaseSection>
 </SpaceRowContent>
@@ -728,7 +728,7 @@ exports[`<SpaceRowContent /> snapshot should match snapshot with isMention 1`] =
     <div
       data-position="end"
     >
-      <Icon
+      <Mrv2Icon
         fillColor="var(--mds-color-theme-control-active-normal)"
         name="mention"
         scale={14}
@@ -762,7 +762,7 @@ exports[`<SpaceRowContent /> snapshot should match snapshot with isMention 1`] =
             suppressHydrationWarning={true}
           />
         </Icon>
-      </Icon>
+      </Mrv2Icon>
     </div>
   </ListItemBaseSection>
 </SpaceRowContent>
@@ -869,7 +869,7 @@ exports[`<SpaceRowContent /> snapshot should match snapshot with isSelected and 
     <div
       data-position="end"
     >
-      <Icon
+      <Mrv2Icon
         fillColor="var(--mds-color-theme-text-primary-normal)"
         name="draft-indicator"
         scale={14}
@@ -903,7 +903,7 @@ exports[`<SpaceRowContent /> snapshot should match snapshot with isSelected and 
             suppressHydrationWarning={true}
           />
         </Icon>
-      </Icon>
+      </Mrv2Icon>
     </div>
   </ListItemBaseSection>
 </SpaceRowContent>
@@ -957,7 +957,7 @@ exports[`<SpaceRowContent /> snapshot should match snapshot with isUnread 1`] = 
     <div
       data-position="end"
     >
-      <Icon
+      <Mrv2Icon
         fillColor="var(--mds-color-theme-control-active-normal)"
         name="unread"
         scale={14}
@@ -991,7 +991,7 @@ exports[`<SpaceRowContent /> snapshot should match snapshot with isUnread 1`] = 
             suppressHydrationWarning={true}
           />
         </Icon>
-      </Icon>
+      </Mrv2Icon>
     </div>
   </ListItemBaseSection>
 </SpaceRowContent>
@@ -1289,6 +1289,8 @@ exports[`<SpaceRowContent /> snapshot should match snapshot with menuItems 1`] =
                     data-testid="menu-trigger-button"
                     id="test-ID"
                     onClick={[Function]}
+                    onPointerDown={[Function]}
+                    onPointerUp={[Function]}
                     onPressStart={[Function]}
                     prefixIcon="more-bold"
                     size={28}
@@ -1301,6 +1303,8 @@ exports[`<SpaceRowContent /> snapshot should match snapshot with menuItems 1`] =
                       aria-label="Menu trigger label"
                       class="md-button-circle-wrapper"
                       data-testid="menu-trigger-button"
+                      onPointerDown={[Function]}
+                      onPointerUp={[Function]}
                       onPressStart={[Function]}
                       suppressHydrationWarning={true}
                     />

--- a/src/components/SpaceTreeNode/SpaceTreeNode.unit.test.tsx.snap
+++ b/src/components/SpaceTreeNode/SpaceTreeNode.unit.test.tsx.snap
@@ -970,7 +970,7 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isAlert 1`] = `
                     <div
                       data-position="end"
                     >
-                      <Icon
+                      <Mrv2Icon
                         fillColor="var(--mds-color-theme-text-primary-normal)"
                         name="alert"
                         scale={14}
@@ -1004,7 +1004,7 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isAlert 1`] = `
                             suppressHydrationWarning={true}
                           />
                         </Icon>
-                      </Icon>
+                      </Mrv2Icon>
                     </div>
                   </ListItemBaseSection>
                 </SpaceRowContent>
@@ -1136,7 +1136,7 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isAlertMuted 1`] 
                     <div
                       data-position="end"
                     >
-                      <Icon
+                      <Mrv2Icon
                         fillColor="var(--mds-color-theme-text-primary-normal)"
                         name="alert-muted"
                         scale={14}
@@ -1170,7 +1170,7 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isAlertMuted 1`] 
                             suppressHydrationWarning={true}
                           />
                         </Icon>
-                      </Icon>
+                      </Mrv2Icon>
                     </div>
                   </ListItemBaseSection>
                 </SpaceRowContent>
@@ -1431,7 +1431,7 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isEnterRoom 1`] =
                     <div
                       data-position="end"
                     >
-                      <Icon
+                      <Mrv2Icon
                         fillColor="var(--mds-color-theme-control-active-normal)"
                         name="enter-room"
                         scale={14}
@@ -1465,7 +1465,7 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isEnterRoom 1`] =
                             suppressHydrationWarning={true}
                           />
                         </Icon>
-                      </Icon>
+                      </Mrv2Icon>
                     </div>
                   </ListItemBaseSection>
                 </SpaceRowContent>
@@ -1597,7 +1597,7 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isError 1`] = `
                     <div
                       data-position="end"
                     >
-                      <Icon
+                      <Mrv2Icon
                         fillColor="var(--mds-color-theme-text-error-normal)"
                         name="priority-circle"
                         scale={14}
@@ -1631,7 +1631,7 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isError 1`] = `
                             suppressHydrationWarning={true}
                           />
                         </Icon>
-                      </Icon>
+                      </Mrv2Icon>
                     </div>
                   </ListItemBaseSection>
                 </SpaceRowContent>
@@ -1763,7 +1763,7 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isMention 1`] = `
                     <div
                       data-position="end"
                     >
-                      <Icon
+                      <Mrv2Icon
                         fillColor="var(--mds-color-theme-control-active-normal)"
                         name="mention"
                         scale={14}
@@ -1797,7 +1797,7 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isMention 1`] = `
                             suppressHydrationWarning={true}
                           />
                         </Icon>
-                      </Icon>
+                      </Mrv2Icon>
                     </div>
                   </ListItemBaseSection>
                 </SpaceRowContent>
@@ -2191,7 +2191,7 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isSelected and dr
                     <div
                       data-position="end"
                     >
-                      <Icon
+                      <Mrv2Icon
                         fillColor="var(--mds-color-theme-text-primary-normal)"
                         name="draft-indicator"
                         scale={14}
@@ -2225,7 +2225,7 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isSelected and dr
                             suppressHydrationWarning={true}
                           />
                         </Icon>
-                      </Icon>
+                      </Mrv2Icon>
                     </div>
                   </ListItemBaseSection>
                 </SpaceRowContent>
@@ -2357,7 +2357,7 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isUnread 1`] = `
                     <div
                       data-position="end"
                     >
-                      <Icon
+                      <Mrv2Icon
                         fillColor="var(--mds-color-theme-control-active-normal)"
                         name="unread"
                         scale={14}
@@ -2391,7 +2391,7 @@ exports[`<SpaceTreeNode /> snapshot should match snapshot with isUnread 1`] = `
                             suppressHydrationWarning={true}
                           />
                         </Icon>
-                      </Icon>
+                      </Mrv2Icon>
                     </div>
                   </ListItemBaseSection>
                 </SpaceRowContent>

--- a/src/components/Tab/Tab.unit.test.tsx.snap
+++ b/src/components/Tab/Tab.unit.test.tsx.snap
@@ -389,7 +389,7 @@ exports[`<Tab /> snapshot Icon children should match snapshot 1`] = `
           onTouchStart={[Function]}
           type="button"
         >
-          <Icon
+          <Mrv2Icon
             key="0"
             name="plus"
             scale={12}
@@ -412,7 +412,7 @@ exports[`<Tab /> snapshot Icon children should match snapshot 1`] = `
                 suppressHydrationWarning={true}
               />
             </Icon>
-          </Icon>
+          </Mrv2Icon>
         </button>
       </FocusRing>
     </FocusRing>
@@ -456,7 +456,7 @@ exports[`<Tab /> snapshot Icon children should match snapshot with active 1`] = 
           onTouchStart={[Function]}
           type="button"
         >
-          <Icon
+          <Mrv2Icon
             key="4"
             name="plus"
             scale={12}
@@ -479,7 +479,7 @@ exports[`<Tab /> snapshot Icon children should match snapshot with active 1`] = 
                 suppressHydrationWarning={true}
               />
             </Icon>
-          </Icon>
+          </Mrv2Icon>
         </button>
       </FocusRing>
     </FocusRing>
@@ -523,7 +523,7 @@ exports[`<Tab /> snapshot Icon children should match snapshot with className 1`]
           onTouchStart={[Function]}
           type="button"
         >
-          <Icon
+          <Mrv2Icon
             key="1"
             name="plus"
             scale={12}
@@ -546,7 +546,7 @@ exports[`<Tab /> snapshot Icon children should match snapshot with className 1`]
                 suppressHydrationWarning={true}
               />
             </Icon>
-          </Icon>
+          </Mrv2Icon>
         </button>
       </FocusRing>
     </FocusRing>
@@ -595,7 +595,7 @@ exports[`<Tab /> snapshot Icon children should match snapshot with disabled 1`] 
           onTouchStart={[Function]}
           type="button"
         >
-          <Icon
+          <Mrv2Icon
             key="5"
             name="plus"
             scale={12}
@@ -618,7 +618,7 @@ exports[`<Tab /> snapshot Icon children should match snapshot with disabled 1`] 
                 suppressHydrationWarning={true}
               />
             </Icon>
-          </Icon>
+          </Mrv2Icon>
         </button>
       </FocusRing>
     </FocusRing>
@@ -664,7 +664,7 @@ exports[`<Tab /> snapshot Icon children should match snapshot with id 1`] = `
           onTouchStart={[Function]}
           type="button"
         >
-          <Icon
+          <Mrv2Icon
             key="2"
             name="plus"
             scale={12}
@@ -687,7 +687,7 @@ exports[`<Tab /> snapshot Icon children should match snapshot with id 1`] = `
                 suppressHydrationWarning={true}
               />
             </Icon>
-          </Icon>
+          </Mrv2Icon>
         </button>
       </FocusRing>
     </FocusRing>
@@ -731,7 +731,7 @@ exports[`<Tab /> snapshot Icon children should match snapshot with shallowDisabl
           onTouchStart={[Function]}
           type="button"
         >
-          <Icon
+          <Mrv2Icon
             key="5"
             name="plus"
             scale={12}
@@ -754,7 +754,7 @@ exports[`<Tab /> snapshot Icon children should match snapshot with shallowDisabl
                 suppressHydrationWarning={true}
               />
             </Icon>
-          </Icon>
+          </Mrv2Icon>
         </button>
       </FocusRing>
     </FocusRing>
@@ -812,7 +812,7 @@ exports[`<Tab /> snapshot Icon children should match snapshot with style 1`] = `
           }
           type="button"
         >
-          <Icon
+          <Mrv2Icon
             key="3"
             name="plus"
             scale={12}
@@ -835,7 +835,7 @@ exports[`<Tab /> snapshot Icon children should match snapshot with style 1`] = `
                 suppressHydrationWarning={true}
               />
             </Icon>
-          </Icon>
+          </Mrv2Icon>
         </button>
       </FocusRing>
     </FocusRing>

--- a/src/components/TextInput/TextInput.unit.test.tsx.snap
+++ b/src/components/TextInput/TextInput.unit.test.tsx.snap
@@ -330,7 +330,7 @@ exports[`<TextInput/> snapshot should match snapshot with error text 1`] = `
               <div
                 className="md-input-message--icon"
               >
-                <Icon
+                <Mrv2Icon
                   fillColor="var(--mds-color-theme-text-error-normal)"
                   name="warning"
                   scale={16}
@@ -361,7 +361,7 @@ exports[`<TextInput/> snapshot should match snapshot with error text 1`] = `
                       suppressHydrationWarning={true}
                     />
                   </Icon>
-                </Icon>
+                </Mrv2Icon>
               </div>
               <Text
                 className="md-input-message--text"

--- a/src/components/TextToast/TextToast.unit.test.tsx.snap
+++ b/src/components/TextToast/TextToast.unit.test.tsx.snap
@@ -74,7 +74,7 @@ exports[`<TextToast /> snapshot should match snapshot with icon 1`] = `
     className="md-text-toast-wrapper"
     data-text-alignment="center"
   >
-    <Icon
+    <Mrv2Icon
       name="noise-removal"
     >
       <Icon
@@ -92,7 +92,7 @@ exports[`<TextToast /> snapshot should match snapshot with icon 1`] = `
           suppressHydrationWarning={true}
         />
       </Icon>
-    </Icon>
+    </Mrv2Icon>
     <Text
       className="md-text-toast-text"
       tagName="small"

--- a/src/components/Toast/Toast.unit.test.tsx.snap
+++ b/src/components/Toast/Toast.unit.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`<Toast /> snapshot should match snapshot 1`] = `
             outline={true}
             size={28}
           >
-            <Icon
+            <Mrv2Icon
               autoScale={125}
               name="alarm"
               weight="bold"
@@ -186,7 +186,7 @@ exports[`<Toast /> snapshot should match snapshot 1`] = `
                     onTouchStart={[Function]}
                     type="button"
                   >
-                    <Icon
+                    <Mrv2Icon
                       autoScale={true}
                       name="cancel"
                       weight="bold"
@@ -208,7 +208,7 @@ exports[`<Toast /> snapshot should match snapshot 1`] = `
                           suppressHydrationWarning={true}
                         />
                       </Icon>
-                    </Icon>
+                    </Mrv2Icon>
                   </button>
                 </FocusRing>
               </FocusRing>
@@ -247,7 +247,7 @@ exports[`<Toast /> snapshot should match snapshot 1`] = `
                     onTouchStart={[Function]}
                     type="button"
                   >
-                    <Icon
+                    <Mrv2Icon
                       autoScale={true}
                       name="arrow-up"
                       weight="bold"
@@ -269,7 +269,7 @@ exports[`<Toast /> snapshot should match snapshot 1`] = `
                           suppressHydrationWarning={true}
                         />
                       </Icon>
-                    </Icon>
+                    </Mrv2Icon>
                   </button>
                 </FocusRing>
               </FocusRing>
@@ -308,7 +308,7 @@ exports[`<Toast /> snapshot should match snapshot 1`] = `
                     onTouchStart={[Function]}
                     type="button"
                   >
-                    <Icon
+                    <Mrv2Icon
                       autoScale={true}
                       name="arrow-down"
                       weight="bold"
@@ -330,7 +330,7 @@ exports[`<Toast /> snapshot should match snapshot 1`] = `
                           suppressHydrationWarning={true}
                         />
                       </Icon>
-                    </Icon>
+                    </Mrv2Icon>
                   </button>
                 </FocusRing>
               </FocusRing>
@@ -350,7 +350,7 @@ exports[`<Toast /> snapshot should match snapshot 1`] = `
             outline={true}
             size={28}
           >
-            <Icon
+            <Mrv2Icon
               autoScale={125}
               name="alarm"
               weight="bold"
@@ -421,12 +421,17 @@ exports[`<Toast /> snapshot should match snapshot 1`] = `
               <Button
                 className="md-button-circle-width-override md-button-circle-wrapper"
                 color="default"
+                onClick={[Function]}
+                onPointerDown={[Function]}
+                onPointerUp={[Function]}
                 prefixIcon="alarm-bold"
                 size={28}
                 variant="secondary"
               >
                 <mdc-button
                   class="md-button-circle-width-override md-button-circle-wrapper"
+                  onPointerDown={[Function]}
+                  onPointerUp={[Function]}
                   suppressHydrationWarning={true}
                 />
               </Button>
@@ -625,7 +630,7 @@ exports[`<Toast /> snapshot should match snapshot with aria-live 1`] = `
             outline={true}
             size={28}
           >
-            <Icon
+            <Mrv2Icon
               autoScale={125}
               name="alarm"
               weight="bold"
@@ -798,7 +803,7 @@ exports[`<Toast /> snapshot should match snapshot with aria-live 1`] = `
                     onTouchStart={[Function]}
                     type="button"
                   >
-                    <Icon
+                    <Mrv2Icon
                       autoScale={true}
                       name="cancel"
                       weight="bold"
@@ -820,7 +825,7 @@ exports[`<Toast /> snapshot should match snapshot with aria-live 1`] = `
                           suppressHydrationWarning={true}
                         />
                       </Icon>
-                    </Icon>
+                    </Mrv2Icon>
                   </button>
                 </FocusRing>
               </FocusRing>
@@ -859,7 +864,7 @@ exports[`<Toast /> snapshot should match snapshot with aria-live 1`] = `
                     onTouchStart={[Function]}
                     type="button"
                   >
-                    <Icon
+                    <Mrv2Icon
                       autoScale={true}
                       name="arrow-up"
                       weight="bold"
@@ -881,7 +886,7 @@ exports[`<Toast /> snapshot should match snapshot with aria-live 1`] = `
                           suppressHydrationWarning={true}
                         />
                       </Icon>
-                    </Icon>
+                    </Mrv2Icon>
                   </button>
                 </FocusRing>
               </FocusRing>
@@ -920,7 +925,7 @@ exports[`<Toast /> snapshot should match snapshot with aria-live 1`] = `
                     onTouchStart={[Function]}
                     type="button"
                   >
-                    <Icon
+                    <Mrv2Icon
                       autoScale={true}
                       name="arrow-down"
                       weight="bold"
@@ -942,7 +947,7 @@ exports[`<Toast /> snapshot should match snapshot with aria-live 1`] = `
                           suppressHydrationWarning={true}
                         />
                       </Icon>
-                    </Icon>
+                    </Mrv2Icon>
                   </button>
                 </FocusRing>
               </FocusRing>
@@ -962,7 +967,7 @@ exports[`<Toast /> snapshot should match snapshot with aria-live 1`] = `
             outline={true}
             size={28}
           >
-            <Icon
+            <Mrv2Icon
               autoScale={125}
               name="alarm"
               weight="bold"
@@ -1033,12 +1038,17 @@ exports[`<Toast /> snapshot should match snapshot with aria-live 1`] = `
               <Button
                 className="md-button-circle-width-override md-button-circle-wrapper"
                 color="default"
+                onClick={[Function]}
+                onPointerDown={[Function]}
+                onPointerUp={[Function]}
                 prefixIcon="alarm-bold"
                 size={28}
                 variant="secondary"
               >
                 <mdc-button
                   class="md-button-circle-width-override md-button-circle-wrapper"
+                  onPointerDown={[Function]}
+                  onPointerUp={[Function]}
                   suppressHydrationWarning={true}
                 />
               </Button>
@@ -1237,7 +1247,7 @@ exports[`<Toast /> snapshot should match snapshot with className 1`] = `
             outline={true}
             size={28}
           >
-            <Icon
+            <Mrv2Icon
               autoScale={125}
               name="alarm"
               weight="bold"
@@ -1409,7 +1419,7 @@ exports[`<Toast /> snapshot should match snapshot with className 1`] = `
                     onTouchStart={[Function]}
                     type="button"
                   >
-                    <Icon
+                    <Mrv2Icon
                       autoScale={true}
                       name="cancel"
                       weight="bold"
@@ -1431,7 +1441,7 @@ exports[`<Toast /> snapshot should match snapshot with className 1`] = `
                           suppressHydrationWarning={true}
                         />
                       </Icon>
-                    </Icon>
+                    </Mrv2Icon>
                   </button>
                 </FocusRing>
               </FocusRing>
@@ -1470,7 +1480,7 @@ exports[`<Toast /> snapshot should match snapshot with className 1`] = `
                     onTouchStart={[Function]}
                     type="button"
                   >
-                    <Icon
+                    <Mrv2Icon
                       autoScale={true}
                       name="arrow-up"
                       weight="bold"
@@ -1492,7 +1502,7 @@ exports[`<Toast /> snapshot should match snapshot with className 1`] = `
                           suppressHydrationWarning={true}
                         />
                       </Icon>
-                    </Icon>
+                    </Mrv2Icon>
                   </button>
                 </FocusRing>
               </FocusRing>
@@ -1531,7 +1541,7 @@ exports[`<Toast /> snapshot should match snapshot with className 1`] = `
                     onTouchStart={[Function]}
                     type="button"
                   >
-                    <Icon
+                    <Mrv2Icon
                       autoScale={true}
                       name="arrow-down"
                       weight="bold"
@@ -1553,7 +1563,7 @@ exports[`<Toast /> snapshot should match snapshot with className 1`] = `
                           suppressHydrationWarning={true}
                         />
                       </Icon>
-                    </Icon>
+                    </Mrv2Icon>
                   </button>
                 </FocusRing>
               </FocusRing>
@@ -1573,7 +1583,7 @@ exports[`<Toast /> snapshot should match snapshot with className 1`] = `
             outline={true}
             size={28}
           >
-            <Icon
+            <Mrv2Icon
               autoScale={125}
               name="alarm"
               weight="bold"
@@ -1644,12 +1654,17 @@ exports[`<Toast /> snapshot should match snapshot with className 1`] = `
               <Button
                 className="md-button-circle-width-override md-button-circle-wrapper"
                 color="default"
+                onClick={[Function]}
+                onPointerDown={[Function]}
+                onPointerUp={[Function]}
                 prefixIcon="alarm-bold"
                 size={28}
                 variant="secondary"
               >
                 <mdc-button
                   class="md-button-circle-width-override md-button-circle-wrapper"
+                  onPointerDown={[Function]}
+                  onPointerUp={[Function]}
                   suppressHydrationWarning={true}
                 />
               </Button>
@@ -1976,7 +1991,7 @@ exports[`<Toast /> snapshot should match snapshot with content children and deta
                     onTouchStart={[Function]}
                     type="button"
                   >
-                    <Icon
+                    <Mrv2Icon
                       autoScale={true}
                       name="cancel"
                       weight="bold"
@@ -1998,7 +2013,7 @@ exports[`<Toast /> snapshot should match snapshot with content children and deta
                           suppressHydrationWarning={true}
                         />
                       </Icon>
-                    </Icon>
+                    </Mrv2Icon>
                   </button>
                 </FocusRing>
               </FocusRing>
@@ -2037,7 +2052,7 @@ exports[`<Toast /> snapshot should match snapshot with content children and deta
                     onTouchStart={[Function]}
                     type="button"
                   >
-                    <Icon
+                    <Mrv2Icon
                       autoScale={true}
                       name="arrow-up"
                       weight="bold"
@@ -2059,7 +2074,7 @@ exports[`<Toast /> snapshot should match snapshot with content children and deta
                           suppressHydrationWarning={true}
                         />
                       </Icon>
-                    </Icon>
+                    </Mrv2Icon>
                   </button>
                 </FocusRing>
               </FocusRing>
@@ -2098,7 +2113,7 @@ exports[`<Toast /> snapshot should match snapshot with content children and deta
                     onTouchStart={[Function]}
                     type="button"
                   >
-                    <Icon
+                    <Mrv2Icon
                       autoScale={true}
                       name="arrow-down"
                       weight="bold"
@@ -2120,7 +2135,7 @@ exports[`<Toast /> snapshot should match snapshot with content children and deta
                           suppressHydrationWarning={true}
                         />
                       </Icon>
-                    </Icon>
+                    </Mrv2Icon>
                   </button>
                 </FocusRing>
               </FocusRing>
@@ -2140,7 +2155,7 @@ exports[`<Toast /> snapshot should match snapshot with content children and deta
             outline={true}
             size={28}
           >
-            <Icon
+            <Mrv2Icon
               autoScale={125}
               name="alarm"
               weight="bold"
@@ -2212,12 +2227,17 @@ exports[`<Toast /> snapshot should match snapshot with content children and deta
               <Button
                 className="md-button-circle-width-override md-button-circle-wrapper"
                 color="default"
+                onClick={[Function]}
+                onPointerDown={[Function]}
+                onPointerUp={[Function]}
                 prefixIcon="alarm-bold"
                 size={28}
                 variant="secondary"
               >
                 <mdc-button
                   class="md-button-circle-width-override md-button-circle-wrapper"
+                  onPointerDown={[Function]}
+                  onPointerUp={[Function]}
                   suppressHydrationWarning={true}
                 />
               </Button>
@@ -2531,7 +2551,7 @@ exports[`<Toast /> snapshot should match snapshot with details and content child
                     onTouchStart={[Function]}
                     type="button"
                   >
-                    <Icon
+                    <Mrv2Icon
                       autoScale={true}
                       name="cancel"
                       weight="bold"
@@ -2553,7 +2573,7 @@ exports[`<Toast /> snapshot should match snapshot with details and content child
                           suppressHydrationWarning={true}
                         />
                       </Icon>
-                    </Icon>
+                    </Mrv2Icon>
                   </button>
                 </FocusRing>
               </FocusRing>
@@ -2592,7 +2612,7 @@ exports[`<Toast /> snapshot should match snapshot with details and content child
                     onTouchStart={[Function]}
                     type="button"
                   >
-                    <Icon
+                    <Mrv2Icon
                       autoScale={true}
                       name="arrow-up"
                       weight="bold"
@@ -2614,7 +2634,7 @@ exports[`<Toast /> snapshot should match snapshot with details and content child
                           suppressHydrationWarning={true}
                         />
                       </Icon>
-                    </Icon>
+                    </Mrv2Icon>
                   </button>
                 </FocusRing>
               </FocusRing>
@@ -2653,7 +2673,7 @@ exports[`<Toast /> snapshot should match snapshot with details and content child
                     onTouchStart={[Function]}
                     type="button"
                   >
-                    <Icon
+                    <Mrv2Icon
                       autoScale={true}
                       name="arrow-down"
                       weight="bold"
@@ -2675,7 +2695,7 @@ exports[`<Toast /> snapshot should match snapshot with details and content child
                           suppressHydrationWarning={true}
                         />
                       </Icon>
-                    </Icon>
+                    </Mrv2Icon>
                   </button>
                 </FocusRing>
               </FocusRing>
@@ -2695,7 +2715,7 @@ exports[`<Toast /> snapshot should match snapshot with details and content child
             outline={true}
             size={28}
           >
-            <Icon
+            <Mrv2Icon
               autoScale={125}
               name="alarm"
               weight="bold"
@@ -2767,12 +2787,17 @@ exports[`<Toast /> snapshot should match snapshot with details and content child
               <Button
                 className="md-button-circle-width-override md-button-circle-wrapper"
                 color="default"
+                onClick={[Function]}
+                onPointerDown={[Function]}
+                onPointerUp={[Function]}
                 prefixIcon="alarm-bold"
                 size={28}
                 variant="secondary"
               >
                 <mdc-button
                   class="md-button-circle-width-override md-button-circle-wrapper"
+                  onPointerDown={[Function]}
+                  onPointerUp={[Function]}
                   suppressHydrationWarning={true}
                 />
               </Button>
@@ -2970,7 +2995,7 @@ exports[`<Toast /> snapshot should match snapshot with details children and cont
             outline={true}
             size={28}
           >
-            <Icon
+            <Mrv2Icon
               autoScale={125}
               name="alarm"
               weight="bold"
@@ -3129,7 +3154,7 @@ exports[`<Toast /> snapshot should match snapshot with details children and cont
                     onTouchStart={[Function]}
                     type="button"
                   >
-                    <Icon
+                    <Mrv2Icon
                       autoScale={true}
                       name="cancel"
                       weight="bold"
@@ -3151,7 +3176,7 @@ exports[`<Toast /> snapshot should match snapshot with details children and cont
                           suppressHydrationWarning={true}
                         />
                       </Icon>
-                    </Icon>
+                    </Mrv2Icon>
                   </button>
                 </FocusRing>
               </FocusRing>
@@ -3190,7 +3215,7 @@ exports[`<Toast /> snapshot should match snapshot with details children and cont
                     onTouchStart={[Function]}
                     type="button"
                   >
-                    <Icon
+                    <Mrv2Icon
                       autoScale={true}
                       name="arrow-up"
                       weight="bold"
@@ -3212,7 +3237,7 @@ exports[`<Toast /> snapshot should match snapshot with details children and cont
                           suppressHydrationWarning={true}
                         />
                       </Icon>
-                    </Icon>
+                    </Mrv2Icon>
                   </button>
                 </FocusRing>
               </FocusRing>
@@ -3251,7 +3276,7 @@ exports[`<Toast /> snapshot should match snapshot with details children and cont
                     onTouchStart={[Function]}
                     type="button"
                   >
-                    <Icon
+                    <Mrv2Icon
                       autoScale={true}
                       name="arrow-down"
                       weight="bold"
@@ -3273,7 +3298,7 @@ exports[`<Toast /> snapshot should match snapshot with details children and cont
                           suppressHydrationWarning={true}
                         />
                       </Icon>
-                    </Icon>
+                    </Mrv2Icon>
                   </button>
                 </FocusRing>
               </FocusRing>
@@ -3293,7 +3318,7 @@ exports[`<Toast /> snapshot should match snapshot with details children and cont
             outline={true}
             size={28}
           >
-            <Icon
+            <Mrv2Icon
               autoScale={125}
               name="alarm"
               weight="bold"
@@ -3364,12 +3389,17 @@ exports[`<Toast /> snapshot should match snapshot with details children and cont
               <Button
                 className="md-button-circle-width-override md-button-circle-wrapper"
                 color="default"
+                onClick={[Function]}
+                onPointerDown={[Function]}
+                onPointerUp={[Function]}
                 prefixIcon="alarm-bold"
                 size={28}
                 variant="secondary"
               >
                 <mdc-button
                   class="md-button-circle-width-override md-button-circle-wrapper"
+                  onPointerDown={[Function]}
+                  onPointerUp={[Function]}
                   suppressHydrationWarning={true}
                 />
               </Button>
@@ -3567,7 +3597,7 @@ exports[`<Toast /> snapshot should match snapshot with id 1`] = `
             outline={true}
             size={28}
           >
-            <Icon
+            <Mrv2Icon
               autoScale={125}
               name="alarm"
               weight="bold"
@@ -3741,7 +3771,7 @@ exports[`<Toast /> snapshot should match snapshot with id 1`] = `
                     onTouchStart={[Function]}
                     type="button"
                   >
-                    <Icon
+                    <Mrv2Icon
                       autoScale={true}
                       name="cancel"
                       weight="bold"
@@ -3763,7 +3793,7 @@ exports[`<Toast /> snapshot should match snapshot with id 1`] = `
                           suppressHydrationWarning={true}
                         />
                       </Icon>
-                    </Icon>
+                    </Mrv2Icon>
                   </button>
                 </FocusRing>
               </FocusRing>
@@ -3802,7 +3832,7 @@ exports[`<Toast /> snapshot should match snapshot with id 1`] = `
                     onTouchStart={[Function]}
                     type="button"
                   >
-                    <Icon
+                    <Mrv2Icon
                       autoScale={true}
                       name="arrow-up"
                       weight="bold"
@@ -3824,7 +3854,7 @@ exports[`<Toast /> snapshot should match snapshot with id 1`] = `
                           suppressHydrationWarning={true}
                         />
                       </Icon>
-                    </Icon>
+                    </Mrv2Icon>
                   </button>
                 </FocusRing>
               </FocusRing>
@@ -3863,7 +3893,7 @@ exports[`<Toast /> snapshot should match snapshot with id 1`] = `
                     onTouchStart={[Function]}
                     type="button"
                   >
-                    <Icon
+                    <Mrv2Icon
                       autoScale={true}
                       name="arrow-down"
                       weight="bold"
@@ -3885,7 +3915,7 @@ exports[`<Toast /> snapshot should match snapshot with id 1`] = `
                           suppressHydrationWarning={true}
                         />
                       </Icon>
-                    </Icon>
+                    </Mrv2Icon>
                   </button>
                 </FocusRing>
               </FocusRing>
@@ -3905,7 +3935,7 @@ exports[`<Toast /> snapshot should match snapshot with id 1`] = `
             outline={true}
             size={28}
           >
-            <Icon
+            <Mrv2Icon
               autoScale={125}
               name="alarm"
               weight="bold"
@@ -3976,12 +4006,17 @@ exports[`<Toast /> snapshot should match snapshot with id 1`] = `
               <Button
                 className="md-button-circle-width-override md-button-circle-wrapper"
                 color="default"
+                onClick={[Function]}
+                onPointerDown={[Function]}
+                onPointerUp={[Function]}
                 prefixIcon="alarm-bold"
                 size={28}
                 variant="secondary"
               >
                 <mdc-button
                   class="md-button-circle-width-override md-button-circle-wrapper"
+                  onPointerDown={[Function]}
+                  onPointerUp={[Function]}
                   suppressHydrationWarning={true}
                 />
               </Button>
@@ -4179,7 +4214,7 @@ exports[`<Toast /> snapshot should match snapshot with style 1`] = `
             outline={true}
             size={28}
           >
-            <Icon
+            <Mrv2Icon
               autoScale={125}
               name="alarm"
               weight="bold"
@@ -4361,7 +4396,7 @@ exports[`<Toast /> snapshot should match snapshot with style 1`] = `
                     onTouchStart={[Function]}
                     type="button"
                   >
-                    <Icon
+                    <Mrv2Icon
                       autoScale={true}
                       name="cancel"
                       weight="bold"
@@ -4383,7 +4418,7 @@ exports[`<Toast /> snapshot should match snapshot with style 1`] = `
                           suppressHydrationWarning={true}
                         />
                       </Icon>
-                    </Icon>
+                    </Mrv2Icon>
                   </button>
                 </FocusRing>
               </FocusRing>
@@ -4422,7 +4457,7 @@ exports[`<Toast /> snapshot should match snapshot with style 1`] = `
                     onTouchStart={[Function]}
                     type="button"
                   >
-                    <Icon
+                    <Mrv2Icon
                       autoScale={true}
                       name="arrow-up"
                       weight="bold"
@@ -4444,7 +4479,7 @@ exports[`<Toast /> snapshot should match snapshot with style 1`] = `
                           suppressHydrationWarning={true}
                         />
                       </Icon>
-                    </Icon>
+                    </Mrv2Icon>
                   </button>
                 </FocusRing>
               </FocusRing>
@@ -4483,7 +4518,7 @@ exports[`<Toast /> snapshot should match snapshot with style 1`] = `
                     onTouchStart={[Function]}
                     type="button"
                   >
-                    <Icon
+                    <Mrv2Icon
                       autoScale={true}
                       name="arrow-down"
                       weight="bold"
@@ -4505,7 +4540,7 @@ exports[`<Toast /> snapshot should match snapshot with style 1`] = `
                           suppressHydrationWarning={true}
                         />
                       </Icon>
-                    </Icon>
+                    </Mrv2Icon>
                   </button>
                 </FocusRing>
               </FocusRing>
@@ -4525,7 +4560,7 @@ exports[`<Toast /> snapshot should match snapshot with style 1`] = `
             outline={true}
             size={28}
           >
-            <Icon
+            <Mrv2Icon
               autoScale={125}
               name="alarm"
               weight="bold"
@@ -4596,12 +4631,17 @@ exports[`<Toast /> snapshot should match snapshot with style 1`] = `
               <Button
                 className="md-button-circle-width-override md-button-circle-wrapper"
                 color="default"
+                onClick={[Function]}
+                onPointerDown={[Function]}
+                onPointerUp={[Function]}
                 prefixIcon="alarm-bold"
                 size={28}
                 variant="secondary"
               >
                 <mdc-button
                   class="md-button-circle-width-override md-button-circle-wrapper"
+                  onPointerDown={[Function]}
+                  onPointerUp={[Function]}
                   suppressHydrationWarning={true}
                 />
               </Button>
@@ -4799,7 +4839,7 @@ exports[`<Toast /> snapshot should match snapshot with title 1`] = `
             outline={true}
             size={28}
           >
-            <Icon
+            <Mrv2Icon
               autoScale={125}
               name="alarm"
               weight="bold"
@@ -4916,7 +4956,7 @@ exports[`<Toast /> snapshot should match snapshot with title 1`] = `
                   onTouchStart={[Function]}
                   type="button"
                 >
-                  <Icon
+                  <Mrv2Icon
                     autoScale={true}
                     name="cancel"
                     weight="bold"
@@ -4938,7 +4978,7 @@ exports[`<Toast /> snapshot should match snapshot with title 1`] = `
                         suppressHydrationWarning={true}
                       />
                     </Icon>
-                  </Icon>
+                  </Mrv2Icon>
                 </button>
               </FocusRing>
             </FocusRing>
@@ -4974,7 +5014,7 @@ exports[`<Toast /> snapshot should match snapshot with title 1`] = `
                   onTouchStart={[Function]}
                   type="button"
                 >
-                  <Icon
+                  <Mrv2Icon
                     autoScale={true}
                     name="arrow-up"
                     weight="bold"
@@ -4996,7 +5036,7 @@ exports[`<Toast /> snapshot should match snapshot with title 1`] = `
                         suppressHydrationWarning={true}
                       />
                     </Icon>
-                  </Icon>
+                  </Mrv2Icon>
                 </button>
               </FocusRing>
             </FocusRing>
@@ -5032,7 +5072,7 @@ exports[`<Toast /> snapshot should match snapshot with title 1`] = `
                   onTouchStart={[Function]}
                   type="button"
                 >
-                  <Icon
+                  <Mrv2Icon
                     autoScale={true}
                     name="arrow-down"
                     weight="bold"
@@ -5054,7 +5094,7 @@ exports[`<Toast /> snapshot should match snapshot with title 1`] = `
                         suppressHydrationWarning={true}
                       />
                     </Icon>
-                  </Icon>
+                  </Mrv2Icon>
                 </button>
               </FocusRing>
             </FocusRing>
@@ -5136,7 +5176,7 @@ exports[`<Toast /> snapshot should match snapshot with title 1`] = `
             outline={true}
             size={28}
           >
-            <Icon
+            <Mrv2Icon
               autoScale={125}
               name="alarm"
               weight="bold"
@@ -5207,12 +5247,17 @@ exports[`<Toast /> snapshot should match snapshot with title 1`] = `
               <Button
                 className="md-button-circle-width-override md-button-circle-wrapper"
                 color="default"
+                onClick={[Function]}
+                onPointerDown={[Function]}
+                onPointerUp={[Function]}
                 prefixIcon="alarm-bold"
                 size={28}
                 variant="secondary"
               >
                 <mdc-button
                   class="md-button-circle-width-override md-button-circle-wrapper"
+                  onPointerDown={[Function]}
+                  onPointerUp={[Function]}
                   suppressHydrationWarning={true}
                 />
               </Button>

--- a/src/components/ToastDetails/ToastDetails.unit.test.tsx.snap
+++ b/src/components/ToastDetails/ToastDetails.unit.test.tsx.snap
@@ -344,7 +344,7 @@ exports[`<ToastDetails /> snapshot should match snapshot with complete props 1`]
                 onTouchStart={[Function]}
                 type="button"
               >
-                <Icon
+                <Mrv2Icon
                   autoScale={true}
                   name="cancel"
                   weight="bold"
@@ -366,7 +366,7 @@ exports[`<ToastDetails /> snapshot should match snapshot with complete props 1`]
                       suppressHydrationWarning={true}
                     />
                   </Icon>
-                </Icon>
+                </Mrv2Icon>
               </button>
             </FocusRing>
           </FocusRing>
@@ -405,7 +405,7 @@ exports[`<ToastDetails /> snapshot should match snapshot with complete props 1`]
                 onTouchStart={[Function]}
                 type="button"
               >
-                <Icon
+                <Mrv2Icon
                   autoScale={true}
                   name="alert-muted"
                   weight="bold"
@@ -427,7 +427,7 @@ exports[`<ToastDetails /> snapshot should match snapshot with complete props 1`]
                       suppressHydrationWarning={true}
                     />
                   </Icon>
-                </Icon>
+                </Mrv2Icon>
               </button>
             </FocusRing>
           </FocusRing>
@@ -466,7 +466,7 @@ exports[`<ToastDetails /> snapshot should match snapshot with complete props 1`]
                 onTouchStart={[Function]}
                 type="button"
               >
-                <Icon
+                <Mrv2Icon
                   autoScale={true}
                   fillColor="var(--mds-color-theme-text-warning-normal)"
                   name="favorite"
@@ -497,7 +497,7 @@ exports[`<ToastDetails /> snapshot should match snapshot with complete props 1`]
                       suppressHydrationWarning={true}
                     />
                   </Icon>
-                </Icon>
+                </Mrv2Icon>
               </button>
             </FocusRing>
           </FocusRing>
@@ -636,7 +636,7 @@ exports[`<ToastDetails /> snapshot should match snapshot with complete props and
                 onTouchStart={[Function]}
                 type="button"
               >
-                <Icon
+                <Mrv2Icon
                   autoScale={true}
                   name="cancel"
                   weight="bold"
@@ -658,7 +658,7 @@ exports[`<ToastDetails /> snapshot should match snapshot with complete props and
                       suppressHydrationWarning={true}
                     />
                   </Icon>
-                </Icon>
+                </Mrv2Icon>
               </button>
             </FocusRing>
           </FocusRing>
@@ -697,7 +697,7 @@ exports[`<ToastDetails /> snapshot should match snapshot with complete props and
                 onTouchStart={[Function]}
                 type="button"
               >
-                <Icon
+                <Mrv2Icon
                   autoScale={true}
                   name="alert-muted"
                   weight="bold"
@@ -719,7 +719,7 @@ exports[`<ToastDetails /> snapshot should match snapshot with complete props and
                       suppressHydrationWarning={true}
                     />
                   </Icon>
-                </Icon>
+                </Mrv2Icon>
               </button>
             </FocusRing>
           </FocusRing>
@@ -758,7 +758,7 @@ exports[`<ToastDetails /> snapshot should match snapshot with complete props and
                 onTouchStart={[Function]}
                 type="button"
               >
-                <Icon
+                <Mrv2Icon
                   autoScale={true}
                   fillColor="var(--mds-color-theme-text-warning-normal)"
                   name="favorite"
@@ -789,7 +789,7 @@ exports[`<ToastDetails /> snapshot should match snapshot with complete props and
                       suppressHydrationWarning={true}
                     />
                   </Icon>
-                </Icon>
+                </Mrv2Icon>
               </button>
             </FocusRing>
           </FocusRing>
@@ -895,7 +895,7 @@ exports[`<ToastDetails /> snapshot should match snapshot with controls 1`] = `
                 onTouchStart={[Function]}
                 type="button"
               >
-                <Icon
+                <Mrv2Icon
                   autoScale={true}
                   name="cancel"
                   weight="bold"
@@ -917,7 +917,7 @@ exports[`<ToastDetails /> snapshot should match snapshot with controls 1`] = `
                       suppressHydrationWarning={true}
                     />
                   </Icon>
-                </Icon>
+                </Mrv2Icon>
               </button>
             </FocusRing>
           </FocusRing>
@@ -956,7 +956,7 @@ exports[`<ToastDetails /> snapshot should match snapshot with controls 1`] = `
                 onTouchStart={[Function]}
                 type="button"
               >
-                <Icon
+                <Mrv2Icon
                   autoScale={true}
                   name="alert-muted"
                   weight="bold"
@@ -978,7 +978,7 @@ exports[`<ToastDetails /> snapshot should match snapshot with controls 1`] = `
                       suppressHydrationWarning={true}
                     />
                   </Icon>
-                </Icon>
+                </Mrv2Icon>
               </button>
             </FocusRing>
           </FocusRing>
@@ -1017,7 +1017,7 @@ exports[`<ToastDetails /> snapshot should match snapshot with controls 1`] = `
                 onTouchStart={[Function]}
                 type="button"
               >
-                <Icon
+                <Mrv2Icon
                   autoScale={true}
                   fillColor="var(--mds-color-theme-text-warning-normal)"
                   name="favorite"
@@ -1048,7 +1048,7 @@ exports[`<ToastDetails /> snapshot should match snapshot with controls 1`] = `
                       suppressHydrationWarning={true}
                     />
                   </Icon>
-                </Icon>
+                </Mrv2Icon>
               </button>
             </FocusRing>
           </FocusRing>

--- a/src/components/ToastNotification/ToastNotification.tsx
+++ b/src/components/ToastNotification/ToastNotification.tsx
@@ -55,6 +55,7 @@ const ToastNotification: FC<Props> = (props: Props) => {
               onClick={onClose}
               aria-label={closeButtonLabel}
               prefixIcon="cancel-bold"
+              stopPropagation={false}
             />
           </div>
         )}

--- a/src/components/ToastNotification/ToastNotification.unit.test.tsx.snap
+++ b/src/components/ToastNotification/ToastNotification.unit.test.tsx.snap
@@ -626,6 +626,7 @@ exports[`<ToastNotification /> snapshot should match snapshot with onClose and c
             onClick={[Function]}
             prefixIcon="cancel-bold"
             size={20}
+            stopPropagation={false}
             variant="tertiary"
           >
             <Button

--- a/src/components/ToastNotification/ToastNotification.unit.test.tsx.snap
+++ b/src/components/ToastNotification/ToastNotification.unit.test.tsx.snap
@@ -447,7 +447,7 @@ exports[`<ToastNotification /> snapshot should match snapshot with leading visua
   aria-label="Some label"
   content="Example text"
   leadingVisual={
-    <Icon
+    <Mrv2Icon
       name="help-circle"
       scale={24}
       weight="bold"
@@ -479,7 +479,7 @@ exports[`<ToastNotification /> snapshot should match snapshot with leading visua
         <div
           className="md-toast-notification-leading-visual"
         >
-          <Icon
+          <Mrv2Icon
             name="help-circle"
             scale={24}
             weight="bold"
@@ -501,7 +501,7 @@ exports[`<ToastNotification /> snapshot should match snapshot with leading visua
                 suppressHydrationWarning={true}
               />
             </Icon>
-          </Icon>
+          </Mrv2Icon>
         </div>
         <Text
           className="md-toast-notification-content"
@@ -633,6 +633,8 @@ exports[`<ToastNotification /> snapshot should match snapshot with onClose and c
               className="md-button-circle-wrapper"
               color="default"
               onClick={[Function]}
+              onPointerDown={[Function]}
+              onPointerUp={[Function]}
               prefixIcon="cancel-bold"
               size={20}
               variant="tertiary"
@@ -640,6 +642,8 @@ exports[`<ToastNotification /> snapshot should match snapshot with onClose and c
               <mdc-button
                 aria-label="Close toast"
                 class="md-button-circle-wrapper"
+                onPointerDown={[Function]}
+                onPointerUp={[Function]}
                 suppressHydrationWarning={true}
               />
             </Button>

--- a/src/legacy/Lightbox/tests/index.spec.js.snap
+++ b/src/legacy/Lightbox/tests/index.spec.js.snap
@@ -352,7 +352,7 @@ exports[`tests for <Lightbox /> should match SnapShot 1`] = `
                                       className="md-lightbox__control md-lightbox__control-close"
                                       onPress={[Function]}
                                     >
-                                      <Icon
+                                      <Mrv2Icon
                                         fillColor="var(--mds-color-theme-common-text-primary-normal)"
                                         name="cancel"
                                         scale={20}
@@ -383,7 +383,7 @@ exports[`tests for <Lightbox /> should match SnapShot 1`] = `
                                         className="md-lightbox__control md-lightbox__control-close"
                                         onPress={[Function]}
                                       >
-                                        <Icon
+                                        <Mrv2Icon
                                           fillColor="var(--mds-color-theme-common-text-primary-normal)"
                                           name="cancel"
                                           scale={20}
@@ -585,7 +585,7 @@ exports[`tests for <Lightbox /> should match SnapShot 1`] = `
                                                   onTouchStart={[Function]}
                                                   type="button"
                                                 >
-                                                  <Icon
+                                                  <Mrv2Icon
                                                     fillColor="var(--mds-color-theme-common-text-primary-normal)"
                                                     name="cancel"
                                                     scale={20}
@@ -616,7 +616,7 @@ exports[`tests for <Lightbox /> should match SnapShot 1`] = `
                                                         suppressHydrationWarning={true}
                                                       />
                                                     </Icon>
-                                                  </Icon>
+                                                  </Mrv2Icon>
                                                 </button>
                                               </FocusRing>
                                             </FocusRing>
@@ -725,7 +725,7 @@ exports[`tests for <Lightbox /> should match SnapShot 1`] = `
                                           data-test="zoom-out-button"
                                           onPress={[Function]}
                                         >
-                                          <Icon
+                                          <Mrv2Icon
                                             fillColor="var(--mds-color-theme-common-text-primary-normal)"
                                             name="zoom-out"
                                             scale={20}
@@ -757,7 +757,7 @@ exports[`tests for <Lightbox /> should match SnapShot 1`] = `
                                             data-test="zoom-out-button"
                                             onPress={[Function]}
                                           >
-                                            <Icon
+                                            <Mrv2Icon
                                               fillColor="var(--mds-color-theme-common-text-primary-normal)"
                                               name="zoom-out"
                                               scale={20}
@@ -961,7 +961,7 @@ exports[`tests for <Lightbox /> should match SnapShot 1`] = `
                                                       onTouchStart={[Function]}
                                                       type="button"
                                                     >
-                                                      <Icon
+                                                      <Mrv2Icon
                                                         fillColor="var(--mds-color-theme-common-text-primary-normal)"
                                                         name="zoom-out"
                                                         scale={20}
@@ -992,7 +992,7 @@ exports[`tests for <Lightbox /> should match SnapShot 1`] = `
                                                             suppressHydrationWarning={true}
                                                           />
                                                         </Icon>
-                                                      </Icon>
+                                                      </Mrv2Icon>
                                                     </button>
                                                   </FocusRing>
                                                 </FocusRing>
@@ -1033,7 +1033,7 @@ exports[`tests for <Lightbox /> should match SnapShot 1`] = `
                                           data-test="zoom-in-button"
                                           onPress={[Function]}
                                         >
-                                          <Icon
+                                          <Mrv2Icon
                                             fillColor="var(--mds-color-theme-common-text-primary-normal)"
                                             name="zoom-in"
                                             scale={20}
@@ -1065,7 +1065,7 @@ exports[`tests for <Lightbox /> should match SnapShot 1`] = `
                                             data-test="zoom-in-button"
                                             onPress={[Function]}
                                           >
-                                            <Icon
+                                            <Mrv2Icon
                                               fillColor="var(--mds-color-theme-common-text-primary-normal)"
                                               name="zoom-in"
                                               scale={20}
@@ -1269,7 +1269,7 @@ exports[`tests for <Lightbox /> should match SnapShot 1`] = `
                                                       onTouchStart={[Function]}
                                                       type="button"
                                                     >
-                                                      <Icon
+                                                      <Mrv2Icon
                                                         fillColor="var(--mds-color-theme-common-text-primary-normal)"
                                                         name="zoom-in"
                                                         scale={20}
@@ -1300,7 +1300,7 @@ exports[`tests for <Lightbox /> should match SnapShot 1`] = `
                                                             suppressHydrationWarning={true}
                                                           />
                                                         </Icon>
-                                                      </Icon>
+                                                      </Mrv2Icon>
                                                     </button>
                                                   </FocusRing>
                                                 </FocusRing>
@@ -1345,7 +1345,7 @@ exports[`tests for <Lightbox /> should match SnapShot 1`] = `
                                         className="md-lightbox__control md-lightbox__control-download"
                                         onPress={[Function]}
                                       >
-                                        <Icon
+                                        <Mrv2Icon
                                           fillColor="var(--mds-color-theme-common-text-primary-normal)"
                                           name="download"
                                           scale={20}
@@ -1376,7 +1376,7 @@ exports[`tests for <Lightbox /> should match SnapShot 1`] = `
                                           className="md-lightbox__control md-lightbox__control-download"
                                           onPress={[Function]}
                                         >
-                                          <Icon
+                                          <Mrv2Icon
                                             fillColor="var(--mds-color-theme-common-text-primary-normal)"
                                             name="download"
                                             scale={20}
@@ -1578,7 +1578,7 @@ exports[`tests for <Lightbox /> should match SnapShot 1`] = `
                                                     onTouchStart={[Function]}
                                                     type="button"
                                                   >
-                                                    <Icon
+                                                    <Mrv2Icon
                                                       fillColor="var(--mds-color-theme-common-text-primary-normal)"
                                                       name="download"
                                                       scale={20}
@@ -1609,7 +1609,7 @@ exports[`tests for <Lightbox /> should match SnapShot 1`] = `
                                                           suppressHydrationWarning={true}
                                                         />
                                                       </Icon>
-                                                    </Icon>
+                                                    </Mrv2Icon>
                                                   </button>
                                                 </FocusRing>
                                               </FocusRing>

--- a/src/legacy/Menu/examples/WithButtonCircle.js
+++ b/src/legacy/Menu/examples/WithButtonCircle.js
@@ -11,7 +11,7 @@ export default class MenuOverlayDefault extends React.PureComponent {
         menuTrigger={
           <div>
             <Tooltip tooltip="Text">
-              <ButtonCircle id="default" ariaLabel="Show Menu">
+              <ButtonCircle id="default" ariaLabel="Show Menu" stopPropagation={false}>
                 A
               </ButtonCircle>
             </Tooltip>


### PR DESCRIPTION
# Description

- Fixes for buttoncircle, in particular:
  - Making sure the check of the Icon as Children passed to ButtonCircle also works on production (using displayName)
  - Clicking on Buttons inside of ListItems should not trigger ListItems. This is avoided by stopping propagation. 
  - Fixing unit tests
