### PR TITLE
feat(button-toggles): controlled and uncontrolled should work consistently

### DIFF
--- a/src/components/ButtonCircleToggle/ButtonCircleToggle.stories.args.ts
+++ b/src/components/ButtonCircleToggle/ButtonCircleToggle.stories.args.ts
@@ -2,6 +2,7 @@ import { commonStyles, commonAriaButtonToggle } from '../../storybook/helper.sto
 import { DEFAULTS } from './ButtonCircleToggle.constants';
 
 const buttonCircleToggleArgTypes = {
+  ...commonAriaButtonToggle,
   prefixIcon: {
     description: 'The icon to display in the button.',
     control: { type: 'text' },
@@ -15,9 +16,9 @@ const buttonCircleToggleArgTypes = {
     },
   },
   isSelected: {
-    description: 'Whether the element should be selected (controlled).',
-    options: [true, false],
-    control: { type: 'boolean' },
+    description: 'For controlled toggle: whether toggle button is selected or not.',
+    options: [true, false, undefined],
+    control: { type: 'select' },
     table: {
       type: {
         summary: 'boolean',
@@ -27,7 +28,19 @@ const buttonCircleToggleArgTypes = {
       },
     },
   },
-  ...commonAriaButtonToggle,
+  initialIsSelected: {
+    description: 'For uncontrolled toggle: whether toggle button starts selected or not.',
+    options: [true, false, undefined],
+    control: { type: 'select' },
+    table: {
+      type: {
+        summary: 'boolean',
+      },
+      defaultValue: {
+        summary: DEFAULTS.SELECTED,
+      },
+    },
+  },
 };
 
 export { buttonCircleToggleArgTypes };

--- a/src/components/ButtonCircleToggle/ButtonCircleToggle.tsx
+++ b/src/components/ButtonCircleToggle/ButtonCircleToggle.tsx
@@ -7,28 +7,34 @@ import type { Props } from './ButtonCircleToggle.types';
 
 const ButtonCircleToggle = forwardRef((props: Props, providedRef: RefObject<Button>) => {
   const {
-    isSelected = DEFAULTS.SELECTED,
+    isSelected = DEFAULTS.SELECTED, // controlled
+    initialIsSelected = DEFAULTS.SELECTED, // uncontrolled
     className,
     outline = DEFAULTS.OUTLINE,
     size = DEFAULTS.SIZE,
     ...otherProps
   } = props;
 
+  const isControlled = isSelected !== undefined;
+
   const internalRef = useRef();
   const ref = providedRef || internalRef;
-
-  const [selected, setSelected] = useState(isSelected);
+  const [selected, setSelected] = useState(isControlled ? isSelected : initialIsSelected);
 
   useEffect(() => {
-    setSelected(isSelected);
-  }, [isSelected]);
+    if (isControlled) {
+      setSelected(isSelected);
+    }
+  }, [isControlled, isSelected]);
 
   // MdcButton is uncontrolled, so we need to handle the state manually
   const handleToggle = useCallback(() => {
-    const newValue = !selected;
-    setSelected(newValue);
-    otherProps.onChange?.(newValue);
-  }, [selected, otherProps]);
+    const newValue = isControlled ? isSelected : !selected;
+    if (!isControlled) {
+      setSelected(newValue);
+    }
+    otherProps.onChange?.(newValue); // when the toggle is controlled, onChange is, ironically, the one causing the change of isSelected
+  }, [isControlled, isSelected, selected, otherProps]);
 
   return (
     <MdcButton

--- a/src/components/ButtonCircleToggle/ButtonCircleToggle.types.ts
+++ b/src/components/ButtonCircleToggle/ButtonCircleToggle.types.ts
@@ -1,7 +1,21 @@
 import type { MdcButtonProps } from '../../types';
 
 export type Props = Omit<MdcButtonProps, 'active'> & {
+  /**
+   * For controlled toggle: whether toggle button is selected or not.
+   */
   isSelected?: boolean;
+  /**
+   * For uncontrolled toggle: whether toggle button starts selected or not.
+   */
+  initialIsSelected?: boolean;
+  /**
+   * Whether the button should be outlined (secondary) or not (tertiary).
+   */
   outline?: boolean;
+  /**
+   * For controlled toggle: the callback function on press of the toggle button.
+   * For uncontrolled toggle: the callback function to call after the button has toggled and changed value.
+   */
   onChange?: (isSelected: boolean) => void;
 };

--- a/src/components/ButtonCircleToggle/ButtonCircleToggle.unit.test.tsx
+++ b/src/components/ButtonCircleToggle/ButtonCircleToggle.unit.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { renderWithWebComponent } from '../../../test/utils';
 
 import ButtonCircleToggle from './';
@@ -163,17 +163,51 @@ describe('<ButtonCircleToggle />', () => {
   describe('actions', () => {
     const user = userEvent.setup();
 
-    it('onChange callback is called correctly when provided', async () => {
-      expect.assertions(1);
+    it('onChange callback is called correctly when provided when component is uncontrolled', async () => {
+      expect.assertions(4);
 
       const mockCallback = jest.fn();
 
-      await setup(<ButtonCircleToggle onChange={mockCallback} />);
-      const element = screen.getByRole('button');
+      const initialIsSelected = false;
 
-      await user.click(element);
+      await setup(
+        <ButtonCircleToggle onChange={mockCallback} initialIsSelected={initialIsSelected} />
+      );
 
-      expect(mockCallback).toHaveBeenCalledWith(true);
+      const button = screen.getByRole('button');
+      expect(button.attributes['aria-pressed'].value).toBe('false');
+
+      await user.click(button);
+
+      expect(button.attributes['aria-pressed'].value).toBe('true');
+      expect(mockCallback).toBeCalledTimes(1);
+      expect(mockCallback).toHaveBeenCalledWith(!initialIsSelected);
+    });
+
+    it('onChange callback is called correctly when provided when component is controlled', async () => {
+      expect.assertions(2);
+
+      const mockCallback = jest.fn();
+
+      const ExampleParent = () => {
+        const [isSelected, setIsSelected] = useState(false);
+
+        const onPress = () => {
+          setIsSelected(true);
+          mockCallback();
+        };
+
+        return <ButtonCircleToggle onChange={onPress} isSelected={isSelected} />;
+      };
+
+      await renderWithWebComponent(<ExampleParent />);
+
+      const button = screen.getByRole('button');
+      expect(button.attributes['aria-pressed'].value).toBe('false');
+
+      await user.click(button);
+
+      expect(button.attributes['aria-pressed'].value).toBe('true');
     });
 
     it('should handle mouse press events', async () => {

--- a/src/components/ButtonPillToggle/ButtonPillToggle.stories.args.ts
+++ b/src/components/ButtonPillToggle/ButtonPillToggle.stories.args.ts
@@ -5,6 +5,32 @@ import buttonPillArgTypes from '../ButtonPill/ButtonPill.stories.args';
 const buttonPillToggleArgTypes = {
   ...buttonPillArgTypes,
   ...commonAriaButtonToggle,
+  isSelected: {
+    description: 'For controlled toggle: whether toggle button is selected or not.',
+    options: [true, false, undefined],
+    control: { type: 'select' },
+    table: {
+      type: {
+        summary: 'boolean',
+      },
+      defaultValue: {
+        summary: CONSTANTS.DEFAULTS.SELECTED,
+      },
+    },
+  },
+  initialIsSelected: {
+    description: 'For uncontrolled toggle: whether toggle button starts selected or not.',
+    options: [true, false, undefined],
+    control: { type: 'select' },
+    table: {
+      type: {
+        summary: 'boolean',
+      },
+      defaultValue: {
+        summary: CONSTANTS.DEFAULTS.SELECTED,
+      },
+    },
+  },
 };
 
 delete buttonPillToggleArgTypes.color;

--- a/src/components/ButtonPillToggle/ButtonPillToggle.tsx
+++ b/src/components/ButtonPillToggle/ButtonPillToggle.tsx
@@ -9,28 +9,34 @@ import { Props } from './ButtonPillToggle.types';
 
 const ButtonPillToggle = forwardRef((props: Props, providedRef: RefObject<Button>) => {
   const {
-    isSelected = DEFAULTS.SELECTED,
+    isSelected = DEFAULTS.SELECTED, // controlled
+    initialIsSelected = DEFAULTS.SELECTED, // uncontrolled
     className,
     outline = DEFAULTS.OUTLINE,
     size = BUTTON_PILL_DEFAULTS.SIZE,
     ...otherProps
   } = props;
 
+  const isControlled = isSelected !== undefined;
+
   const internalRef = useRef();
   const ref = providedRef || internalRef;
-
-  const [selected, setSelected] = useState(isSelected);
+  const [selected, setSelected] = useState(isControlled ? isSelected : initialIsSelected);
 
   useEffect(() => {
-    setSelected(isSelected);
-  }, [isSelected]);
+    if (isControlled) {
+      setSelected(isSelected);
+    }
+  }, [isControlled, isSelected]);
 
   // MdcButton is uncontrolled, so we need to handle the state manually
   const handleToggle = useCallback(() => {
-    const newValue = !selected;
-    setSelected(newValue);
-    otherProps.onChange?.(newValue);
-  }, [selected, otherProps]);
+    const newValue = isControlled ? isSelected : !selected;
+    if (!isControlled) {
+      setSelected(newValue);
+    }
+    otherProps.onChange?.(newValue); // when the toggle is controlled, onChange is, ironically, the one causing the change of isSelected
+  }, [isControlled, isSelected, selected, otherProps]);
 
   return (
     <MdcButton

--- a/src/components/ButtonPillToggle/ButtonPillToggle.types.ts
+++ b/src/components/ButtonPillToggle/ButtonPillToggle.types.ts
@@ -1,7 +1,21 @@
 import type { MdcButtonProps } from '../../types';
 
 export type Props = Omit<MdcButtonProps, 'active'> & {
+  /**
+   * For controlled toggle: whether toggle button is selected or not.
+   */
   isSelected?: boolean;
+  /**
+   * For uncontrolled toggle: whether toggle button starts selected or not.
+   */
+  initialIsSelected?: boolean;
+  /**
+   * Whether the button should be outlined (secondary) or not (tertiary).
+   */
   outline?: boolean;
+  /**
+   * For controlled toggle: the callback function on press of the toggle button.
+   * For uncontrolled toggle: the callback function to call after the button has toggled and changed value.
+   */
   onChange?: (isSelected: boolean) => void;
 };

--- a/src/components/ButtonPillToggle/ButtonPillToggle.unit.test.tsx
+++ b/src/components/ButtonPillToggle/ButtonPillToggle.unit.test.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { renderWithWebComponent } from '../../../test/utils';
 
 import ButtonPillToggle, { BUTTON_PILL_TOGGLE_CONSTANTS as CONSTANTS } from './';
-import { screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 describe('<ButtonPillToggle />', () => {
@@ -166,19 +166,51 @@ describe('<ButtonPillToggle />', () => {
   describe('actions', () => {
     const user = userEvent.setup();
 
-    it('onChange callback is called correctly when provided', async () => {
-      expect.assertions(1);
+    it('onChange callback is called correctly when provided when component is uncontrolled', async () => {
+      expect.assertions(4);
 
       const mockCallback = jest.fn();
 
       const initialIsSelected = false;
 
-      await setup(<ButtonPillToggle onChange={mockCallback} isSelected={initialIsSelected} />);
+      await setup(
+        <ButtonPillToggle onChange={mockCallback} initialIsSelected={initialIsSelected} />
+      );
 
       const button = screen.getByRole('button');
+      expect(button.attributes['aria-pressed'].value).toBe('false');
+
       await user.click(button);
 
+      expect(button.attributes['aria-pressed'].value).toBe('true');
       expect(mockCallback).toBeCalledTimes(1);
+      expect(mockCallback).toHaveBeenCalledWith(!initialIsSelected);
+    });
+
+    it('onChange callback is called correctly when provided when component is controlled', async () => {
+      expect.assertions(2);
+
+      const mockCallback = jest.fn();
+
+      const ExampleParent = () => {
+        const [isSelected, setIsSelected] = useState(false);
+
+        const onPress = () => {
+          setIsSelected(true);
+          mockCallback();
+        };
+
+        return <ButtonPillToggle onChange={onPress} isSelected={isSelected} />;
+      };
+
+      await renderWithWebComponent(<ExampleParent />);
+
+      const button = screen.getByRole('button');
+      expect(button.attributes['aria-pressed'].value).toBe('false');
+
+      await user.click(button);
+
+      expect(button.attributes['aria-pressed'].value).toBe('true');
     });
 
     it('should handle mouse press events', async () => {

--- a/src/components/ButtonPillToggle/ButtonPillToggle.unit.test.tsx
+++ b/src/components/ButtonPillToggle/ButtonPillToggle.unit.test.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
 import { renderWithWebComponent } from '../../../test/utils';
 
-import ButtonPillToggle, { BUTTON_PILL_TOGGLE_CONSTANTS as CONSTANTS } from './';
-import { render, screen } from '@testing-library/react';
+import ButtonPillToggle from './';
+import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 describe('<ButtonPillToggle />', () => {


### PR DESCRIPTION
Button toggles, when controlled, were not working properly:

Parents were passing an isSelected and the selected value was still getting changed internally ignoring the isSelected value. 