### PR TITLE
feat(list-header): support focusable button as child of header

### DIFF
--- a/src/components/ListHeader/ListHeader.stories.tsx
+++ b/src/components/ListHeader/ListHeader.stories.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import ListHeader, { ListHeaderProps } from './';
 import argTypes from './ListHeader.stories.args';
 import Documentation from './ListHeader.stories.docs.mdx';
-import { Icon, ListItemBaseSection, Text } from '..';
+import { ButtonPill, Icon, ListItemBaseSection, Text } from '..';
 import { OUTLINE_COLOR, OUTLINE_POSITION } from './ListHeader.constants';
 
 export default {
@@ -143,6 +143,25 @@ Common.parameters = {
     {
       outline: true,
       style: { marginTop: '1rem' },
+    },
+    {
+      outline: true,
+      outlineColor: OUTLINE_COLOR.SECONDARY,
+      children: (
+        <>
+          <ListItemBaseSection position="start">
+            <Text type="body-secondary" tagName="small">
+              List header with focusable button
+            </Text>
+          </ListItemBaseSection>
+          <ListItemBaseSection position="end">
+            <ButtonPill variant="secondary" size={24} tabIndex={0}>
+              Test
+            </ButtonPill>
+          </ListItemBaseSection>
+        </>
+      ),
+      listItemBaseProps: { interactive: true, focusChild: true },
     },
   ],
 };

--- a/src/components/ListHeader/ListHeader.tsx
+++ b/src/components/ListHeader/ListHeader.tsx
@@ -8,7 +8,7 @@ import ListItemBase from '../ListItemBase';
 
 /**
  * The ListHeader component.
- * This is just the non-interactive version. (non-collapsible)
+ * By default, this is just the non-interactive version. (non-collapsible)
  */
 const ListHeader: FC<Props> = (props: Props) => {
   const {
@@ -20,6 +20,7 @@ const ListHeader: FC<Props> = (props: Props) => {
     outlinePosition = DEFAULTS.OUTLINE_POSITION,
     outlineColor = DEFAULTS.OUTLINE_COLOR,
     bold = DEFAULTS.BOLD,
+    listItemBaseProps = {},
   } = props;
 
   return (
@@ -34,7 +35,13 @@ const ListHeader: FC<Props> = (props: Props) => {
       id={id}
     >
       {outline && outlinePosition === 'top' && <div role="separator" className={STYLE.separator} />}
-      <ListItemBase interactive={false} isPadded={true} size={32} className={STYLE.listItemBase}>
+      <ListItemBase
+        interactive={false}
+        isPadded={true}
+        size={32}
+        className={STYLE.listItemBase}
+        {...listItemBaseProps}
+      >
         {children}
       </ListItemBase>
       {outline && outlinePosition === 'bottom' && (

--- a/src/components/ListHeader/ListHeader.types.ts
+++ b/src/components/ListHeader/ListHeader.types.ts
@@ -1,4 +1,5 @@
 import { CSSProperties, ReactNode } from 'react';
+import { ListItemBaseProps } from '../ListItemBase';
 
 export type OutlinePosition = 'top' | 'bottom';
 export type OutlineColor = 'primary' | 'secondary';
@@ -47,4 +48,11 @@ export interface Props {
    * @default false
    */
   bold?: boolean;
+
+  /**
+   * Props to pass to the ListItemBase component.
+   * This is useful for passing additional props like `interactive`, `focusChild`, etc.
+   * @default {}
+   */
+  listItemBaseProps?: ListItemBaseProps;
 }

--- a/src/components/ListHeader/ListHeader.unit.test.tsx
+++ b/src/components/ListHeader/ListHeader.unit.test.tsx
@@ -3,6 +3,7 @@ import { mount } from 'enzyme';
 
 import ListHeader, { LIST_HEADER_CONSTANTS as CONSTANTS } from './';
 import { OUTLINE_COLOR, OUTLINE_POSITION } from './ListHeader.constants';
+import ListItemBase from '../ListItemBase';
 
 jest.mock('uuid', () => {
   return {
@@ -195,6 +196,28 @@ describe('<ListHeader />', () => {
         .getDOMNode();
 
       expect(element.getAttribute('data-bold')).toBe(`${bold}`);
+    });
+
+    it('should pass listItemBaseProps through as expected', () => {
+      expect.assertions(1);
+
+      const listItemBaseProps = {
+        interactive: true,
+        focusChild: true,
+      };
+
+      const element = mount(<ListHeader listItemBaseProps={listItemBaseProps} />).find(
+        ListItemBase
+      );
+
+      expect(element.props()).toStrictEqual({
+        children: undefined,
+        className: 'md-list-header-list-item-base',
+        focusChild: true,
+        interactive: true,
+        isPadded: true,
+        size: 32,
+      });
     });
   });
 });


### PR DESCRIPTION
# Description
figma
<img width="519" height="628" alt="Screenshot 2025-07-17 at 14 40 01" src="https://github.com/user-attachments/assets/55cf350b-db89-4006-bfa4-bc8eac0af20c" />

storybook
https://github.com/user-attachments/assets/a6cbace0-010e-4f2c-bbc8-fe59b06921b5

The ListHeader is currently always non-interactive. I'm adding support for a focusable button child (as in figma above). To do this I'm just adding a prop that will override the props in the ListItemBase.

# Links
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-688773
